### PR TITLE
Changes circle to fetch architect unauthed if token not present

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,11 @@ machine:
 dependencies:
   override:
     - |
-      wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      if [ -z $RELEASE_TOKEN ]; then
+         wget -q $(curl -sS https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      else
+         wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      fi
     - chmod +x ./architect
     - ./architect version 
 


### PR DESCRIPTION
We usually fetch architect's latest binary authenticated, to
avoid any issues with rate limiting.
However, we don't pass secrets to forked builds, for security
reasons, so forked builds can't fetch the architect binary at all.

This changeset makes the fetch fall back to unauthenticated if the
token is not present - this means that forked builds work, but may
be subjected to GitHub rate limiting.