### PR TITLE
Remove RELEASE_TOKEN usage from CircleCI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - |
-      wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      wget -q $(curl -sS https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
     - chmod +x ./architect
     - ./architect version 
 


### PR DESCRIPTION
Both aws-operator and architect are open source projects, so there is no need to use it. Also, it doesn't seem to work when pull requests are created from forks.