### PR TITLE
service: put policy/role code in a better place

### DIFF
--- a/service/create/assets.go
+++ b/service/create/assets.go
@@ -1,92 +1,15 @@
 package create
 
 import (
-	"fmt"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/giantswarm/k8scloudconfig"
 	microerror "github.com/giantswarm/microkit/error"
-)
-
-const (
-	RoleName                 = "EC2-K8S-Role"
-	PolicyName               = "EC2-K8S-Policy"
-	ProfileName              = "EC2-DecryptTLSCerts"
-	AssumeRolePolicyDocument = `{
-		"Version": "2012-10-17",
-		"Statement:" {
-			"Effect": "Allow",
-			"Principal": {
-				"Service": "ec2.amazonaws.com",
-			},
-			"Action": "sts:AssumeRole"
-		}
-	}`
-	PolicyDocumentTempl = `{
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Effect": "Allow",
-				"Action": "kms:Decrypt",
-				"Resource": %q
-			}
-		]
-	}`
 )
 
 func (s *Service) encodeTLSAssets(awsSession *session.Session, kmsKeyArn string) (*cloudconfig.CompactTLSAssets, error) {
 	rawTLS, err := readRawTLSAssets(s.certsDir)
 	if err != nil {
 		return nil, microerror.MaskAny(err)
-	}
-
-	policyDocument := fmt.Sprintf(PolicyDocumentTempl, kmsKeyArn)
-
-	svc := iam.New(awsSession)
-
-	if _, err := svc.CreateRole(&iam.CreateRoleInput{
-		RoleName:                 aws.String(RoleName),
-		AssumeRolePolicyDocument: aws.String(AssumeRolePolicyDocument),
-	}); err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case iam.ErrCodeEntityAlreadyExistsException:
-				s.logger.Log("info", fmt.Sprintf("role '%s' already exists, reusing", RoleName))
-			default:
-				return nil, microerror.MaskAny(err)
-			}
-		}
-	}
-
-	if _, err := svc.PutRolePolicy(&iam.PutRolePolicyInput{
-		PolicyName:     aws.String(PolicyName),
-		RoleName:       aws.String(RoleName),
-		PolicyDocument: aws.String(policyDocument),
-	}); err != nil {
-		return nil, microerror.MaskAny(err)
-	}
-
-	if _, err := svc.CreateInstanceProfile(&iam.CreateInstanceProfileInput{
-		InstanceProfileName: aws.String(ProfileName),
-	}); err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case iam.ErrCodeEntityAlreadyExistsException:
-				s.logger.Log("info", fmt.Sprintf("instance profile '%s' already exists, reusing", RoleName))
-			default:
-				return nil, microerror.MaskAny(err)
-			}
-		}
-	} else {
-		if _, err := svc.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
-			InstanceProfileName: aws.String(ProfileName),
-			RoleName:            aws.String(RoleName),
-		}); err != nil {
-			return nil, microerror.MaskAny(err)
-		}
 	}
 
 	encTLS, err := rawTLS.encrypt(awsSession, kmsKeyArn)

--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -1,0 +1,77 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+const (
+	RoleName                 = "EC2-K8S-Role"
+	PolicyName               = "EC2-K8S-Policy"
+	ProfileName              = "EC2-DecryptTLSCerts"
+	AssumeRolePolicyDocument = `{
+		"Version": "2012-10-17",
+		"Statement:" {
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "ec2.amazonaws.com",
+			},
+			"Action": "sts:AssumeRole"
+		}
+	}`
+	PolicyDocumentTempl = `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": "kms:Decrypt",
+				"Resource": %q
+			}
+		]
+	}`
+)
+
+func createRole(awsSession *session.Session, kmsKeyArn string) error {
+	svc := iam.New(awsSession)
+
+	policyDocument := fmt.Sprintf(PolicyDocumentTempl, kmsKeyArn)
+
+	if _, err := svc.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(RoleName),
+		AssumeRolePolicyDocument: aws.String(AssumeRolePolicyDocument),
+	}); err != nil {
+		return err
+	}
+
+	if _, err := svc.PutRolePolicy(&iam.PutRolePolicyInput{
+		PolicyName:     aws.String(PolicyName),
+		RoleName:       aws.String(RoleName),
+		PolicyDocument: aws.String(policyDocument),
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createInstanceProfile(awsSession *session.Session) (string, error) {
+	svc := iam.New(awsSession)
+
+	if _, err := svc.CreateInstanceProfile(&iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(ProfileName),
+	}); err != nil {
+		return ProfileName, err
+	} else {
+		if _, err := svc.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
+			InstanceProfileName: aws.String(ProfileName),
+			RoleName:            aws.String(RoleName),
+		}); err != nil {
+			return "", err
+		}
+	}
+
+	return ProfileName, nil
+}


### PR DESCRIPTION
It has nothing to do with encoding TLS assets.

This prepares the code for uploading cloudconfig to S3.

Depends on #34 