### PR TITLE
create: Use AWS keypairs

### DIFF
--- a/client/aws/errors.go
+++ b/client/aws/errors.go
@@ -1,0 +1,5 @@
+package aws
+
+const (
+	KeyPairDuplicate = "InvalidKeyPair.Duplicate"
+)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 
 	"github.com/giantswarm/microkit/command"
 	"github.com/giantswarm/microkit/logger"
@@ -29,7 +30,8 @@ var Flags = struct {
 			ID     string
 			Secret string
 		}
-		CertsDir string
+		CertsDir   string
+		PubKeyFile string
 	}
 	Kubernetes struct {
 		InCluster   bool
@@ -90,6 +92,7 @@ func main() {
 			}
 
 			serviceConfig.CertsDir = Flags.Aws.CertsDir
+			serviceConfig.PubKeyFile = Flags.Aws.PubKeyFile
 
 			serviceConfig.Description = description
 			serviceConfig.GitCommit = gitCommit
@@ -145,8 +148,9 @@ func main() {
 
 	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.AccessKey.ID, "aws.accesskey.id", "", "ID of the AWS access key")
 	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.AccessKey.Secret, "aws.accesskey.secret", "", "Secret of the AWS access key")
-	// TODO(nhlfr): Deprecate this option when cert-operator will be implemented.
-	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.CertsDir, "aws.certsdir", "", "Certificated to be placed in /etc/kubernetes/ssl")
+	// TODO(nhlfr): Deprecate these options when cert-operator will be implemented.
+	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.CertsDir, "aws.certsdir", "", "Certificates to be placed in /etc/kubernetes/ssl")
+	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.PubKeyFile, "aws.pubkeyfile", path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "Public key to be imported as a keypair in AWS")
 
 	daemonCommand.PersistentFlags().BoolVar(&Flags.Kubernetes.InCluster, "kubernetes.incluster", false, "Whether to use the in-cluster config to authenticate with Kubernetes")
 	daemonCommand.PersistentFlags().StringVar(&Flags.Kubernetes.APIServer, "kubernetes.apiserver", "http://127.0.0.1:8080", "Address and port of Giantnetes API server")

--- a/service/create/keypair.go
+++ b/service/create/keypair.go
@@ -1,0 +1,63 @@
+package create
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+)
+
+type keyPairProvider interface {
+	pubKeyContent() ([]byte, error)
+}
+
+type fsKeyPairProvider struct {
+	pubKeyFile string
+}
+
+func newFsKeyPairProvider(pubKeyFile string) *fsKeyPairProvider {
+	return &fsKeyPairProvider{
+		pubKeyFile: pubKeyFile,
+	}
+}
+
+func (f *fsKeyPairProvider) pubKeyContent() ([]byte, error) {
+	return ioutil.ReadFile(f.pubKeyFile)
+}
+
+type keyPairInput struct {
+	ec2Client   *ec2.EC2
+	clusterName string
+	provider    keyPairProvider
+}
+
+func (s *Service) keyPair(input keyPairInput) (string, error) {
+	pkc, err := input.provider.pubKeyContent()
+	if err != nil {
+		return "", microerror.MaskAny(err)
+	}
+
+	keyPair, err := input.ec2Client.ImportKeyPair(&ec2.ImportKeyPairInput{
+		KeyName:           aws.String(input.clusterName),
+		PublicKeyMaterial: pkc,
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == awsclient.KeyPairDuplicate {
+			s.logger.Log("info", fmt.Sprintf("keypair '%s' exists, reusing", input.clusterName))
+			return input.clusterName, nil
+		} else {
+			return "", microerror.MaskAny(err)
+		}
+	}
+
+	if keyPair == nil || keyPair.KeyName == nil {
+		return "", fmt.Errorf("Couln't create and find the keypair '%s'", input.clusterName)
+	}
+
+	return *keyPair.KeyName, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -26,7 +26,8 @@ type Config struct {
 	K8sConfig k8sutil.Config
 
 	// AWS cerfificates options.
-	CertsDir string
+	CertsDir   string
+	PubKeyFile string
 
 	Description string
 	GitCommit   string
@@ -46,7 +47,8 @@ func DefaultConfig() Config {
 		K8sConfig: k8sutil.Config{},
 
 		// AWS certificates optionts.
-		CertsDir: "",
+		CertsDir:   "",
+		PubKeyFile: "",
 
 		Description: "",
 		GitCommit:   "",
@@ -81,13 +83,13 @@ func New(config Config) (*Service, error) {
 		createConfig.K8sClient = k8sClient
 		createConfig.Logger = config.Logger
 		createConfig.CertsDir = config.CertsDir
+		createConfig.PubKeyFile = config.PubKeyFile
 
 		createService, err = create.New(createConfig)
 		if err != nil {
 			return nil, microerror.MaskAny(err)
 		}
 	}
-	fmt.Println(config.AwsConfig)
 
 	var versionService *version.Service
 	{


### PR DESCRIPTION
Import the provided SSH public key as the keypair in AWS and use it for logging in into instances.

Fixes #32