### PR TITLE
create: make instance creation more robust

### DIFF
--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -73,5 +73,11 @@ func createInstanceProfile(awsSession *session.Session) (string, error) {
 		}
 	}
 
+	if err := svc.WaitUntilInstanceProfileExists(&iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(ProfileName),
+	}); err != nil {
+		return "", err
+	}
+
 	return ProfileName, nil
 }


### PR DESCRIPTION
* Wait until the instance profile exists before continuing
* Retry instance creation because Roles take some time to propagate to
instance profiles