### PR TITLE
service: rework roles/policies/instance profiles

### DIFF
--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -11,7 +11,7 @@ import (
 const (
 	RoleName                 = "EC2-K8S-Role"
 	PolicyName               = "EC2-K8S-Policy"
-	ProfileName              = "EC2-DecryptTLSCerts"
+	ProfileName              = "EC2-K8S-Role"
 	AssumeRolePolicyDocument = `{
 		"Version": "2012-10-17",
 		"Statement": {

--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	RoleName                 = "EC2-K8S-Role"
-	PolicyName               = "EC2-K8S-Policy"
-	ProfileName              = "EC2-K8S-Role"
+	RoleNameTemplate         = "EC2-K8S-Role"
+	PolicyNameTemplate       = "EC2-K8S-Policy"
+	ProfileNameTemplate      = "EC2-K8S-Role"
 	AssumeRolePolicyDocument = `{
 		"Version": "2012-10-17",
 		"Statement": {
@@ -34,21 +34,23 @@ const (
 	}`
 )
 
-func createRole(awsSession *session.Session, kmsKeyArn string) error {
+func createRole(awsSession *session.Session, kmsKeyArn, clusterID string) error {
 	svc := iam.New(awsSession)
 
 	policyDocument := fmt.Sprintf(PolicyDocumentTempl, kmsKeyArn)
 
+	clusterRoleName := fmt.Sprintf("%s-%s", clusterID, RoleNameTemplate)
+
 	if _, err := svc.CreateRole(&iam.CreateRoleInput{
-		RoleName:                 aws.String(RoleName),
+		RoleName:                 aws.String(clusterRoleName),
 		AssumeRolePolicyDocument: aws.String(AssumeRolePolicyDocument),
 	}); err != nil {
 		return err
 	}
 
 	if _, err := svc.PutRolePolicy(&iam.PutRolePolicyInput{
-		PolicyName:     aws.String(PolicyName),
-		RoleName:       aws.String(RoleName),
+		PolicyName:     aws.String(fmt.Sprintf("%s-%s", clusterID, PolicyNameTemplate)),
+		RoleName:       aws.String(clusterRoleName),
 		PolicyDocument: aws.String(policyDocument),
 	}); err != nil {
 		return err
@@ -57,27 +59,30 @@ func createRole(awsSession *session.Session, kmsKeyArn string) error {
 	return nil
 }
 
-func createInstanceProfile(awsSession *session.Session) (string, error) {
+func createInstanceProfile(awsSession *session.Session, clusterID string) (string, error) {
 	svc := iam.New(awsSession)
 
+	clusterRoleName := fmt.Sprintf("%s-%s", clusterID, RoleNameTemplate)
+	clusterProfileName := fmt.Sprintf("%s-%s", clusterID, ProfileNameTemplate)
+
 	if _, err := svc.CreateInstanceProfile(&iam.CreateInstanceProfileInput{
-		InstanceProfileName: aws.String(ProfileName),
+		InstanceProfileName: aws.String(clusterProfileName),
 	}); err != nil {
-		return ProfileName, err
+		return "", err
 	} else {
 		if _, err := svc.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
-			InstanceProfileName: aws.String(ProfileName),
-			RoleName:            aws.String(RoleName),
+			InstanceProfileName: aws.String(clusterProfileName),
+			RoleName:            aws.String(clusterRoleName),
 		}); err != nil {
 			return "", err
 		}
 	}
 
 	if err := svc.WaitUntilInstanceProfileExists(&iam.GetInstanceProfileInput{
-		InstanceProfileName: aws.String(ProfileName),
+		InstanceProfileName: aws.String(clusterProfileName),
 	}); err != nil {
 		return "", err
 	}
 
-	return ProfileName, nil
+	return clusterProfileName, nil
 }


### PR DESCRIPTION
We now name roles, policies and instance profiles in a per-cluster
basis.

Also, we treat already-existing roles or instance profiles as errors.
Reusing them doesn't really work. In any case, they should've been
removed when we deleted the cluster (for now we need to do it manually
since the delete operator is not implemented yet).

Also, use same name for instance profile and role so we can delete both when deleting the role from the aws console:

"You cannot use the console to delete an instance profile, except when
it has the exact same name as the role and you delete it as part of the
process of deleting a role as described in the preceding procedure."

http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_delete.html#roles-managingrole-deleting-console