### PR TITLE
create: don't continue if there's an error

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -403,9 +403,8 @@ func (s *Service) runMachine(input runMachineInput) error {
 					time.Sleep(2 * time.Second)
 					continue
 				}
-			} else {
-				return microerror.MaskAny(err)
 			}
+			return microerror.MaskAny(err)
 		}
 		break
 	}


### PR DESCRIPTION
If there's an error which is an AWS error but is not
"Invalid IAM Instance Profile", we should return an error and not
continue.