### PR TITLE
Use -crt suffix for certificate filename

### DIFF
--- a/service/create/encrypt.go
+++ b/service/create/encrypt.go
@@ -52,7 +52,7 @@ func readRawTLSAssets(tlsAssetsDir string) (*rawTLSAssets, error) {
 	for _, file := range files {
 		caPath := filepath.Join(tlsAssetsDir, file.name+"-ca.pem")
 		keyPath := filepath.Join(tlsAssetsDir, file.name+"-key.pem")
-		certPath := filepath.Join(tlsAssetsDir, file.name+".pem")
+		certPath := filepath.Join(tlsAssetsDir, file.name+"-crt.pem")
 
 		caData, err := ioutil.ReadFile(caPath)
 		if err != nil {


### PR DESCRIPTION
Following the [naming scheme](https://github.com/giantswarm/k8scloudconfig/pull/9/files#r106192826).