### PR TITLE
service: delete iam resources

### DIFF
--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 const (
@@ -85,7 +86,7 @@ func deleteRole(svc *iam.IAM, clusterID string) error {
 	if _, err := svc.DeleteRole(&iam.DeleteRoleInput{
 		RoleName: aws.String(clusterRoleName),
 	}); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	return nil
@@ -123,7 +124,7 @@ func deleteInstanceProfile(svc *iam.IAM, clusterID string) error {
 	if _, err := svc.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
 		InstanceProfileName: aws.String(clusterProfileName),
 	}); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	return nil
@@ -137,7 +138,7 @@ func removeRoleFromInstanceProfile(svc *iam.IAM, clusterID string) error {
 		InstanceProfileName: aws.String(clusterProfileName),
 		RoleName:            aws.String(clusterRoleName),
 	}); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	return nil
@@ -151,7 +152,7 @@ func deletePolicy(svc *iam.IAM, clusterID string) error {
 		RoleName:   aws.String(clusterRoleName),
 		PolicyName: aws.String(clusterPolicyName),
 	}); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	return nil
@@ -159,19 +160,19 @@ func deletePolicy(svc *iam.IAM, clusterID string) error {
 
 func deletePolicyResources(svc *iam.IAM, clusterID string) error {
 	if err := removeRoleFromInstanceProfile(svc, clusterID); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	if err := deleteInstanceProfile(svc, clusterID); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	if err := deletePolicy(svc, clusterID); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	if err := deleteRole(svc, clusterID); err != nil {
-		return err
+		return microerror.MaskAny(err)
 	}
 
 	return nil

--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -120,11 +120,9 @@ func createInstanceProfile(svc *iam.IAM, clusterID string) (string, error) {
 func deleteInstanceProfile(svc *iam.IAM, clusterID string) error {
 	clusterProfileName := fmt.Sprintf("%s-%s", clusterID, ProfileNameTemplate)
 
-	_, err := svc.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
+	if _, err := svc.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
 		InstanceProfileName: aws.String(clusterProfileName),
-	})
-
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -135,12 +133,10 @@ func removeRoleFromInstanceProfile(svc *iam.IAM, clusterID string) error {
 	clusterRoleName := fmt.Sprintf("%s-%s", clusterID, RoleNameTemplate)
 	clusterProfileName := fmt.Sprintf("%s-%s", clusterID, ProfileNameTemplate)
 
-	_, err := svc.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+	if _, err := svc.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
 		InstanceProfileName: aws.String(clusterProfileName),
 		RoleName:            aws.String(clusterRoleName),
-	})
-
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -151,12 +147,10 @@ func deletePolicy(svc *iam.IAM, clusterID string) error {
 	clusterRoleName := fmt.Sprintf("%s-%s", clusterID, RoleNameTemplate)
 	clusterPolicyName := fmt.Sprintf("%s-%s", clusterID, PolicyNameTemplate)
 
-	_, err := svc.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
+	if _, err := svc.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
 		RoleName:   aws.String(clusterRoleName),
 		PolicyName: aws.String(clusterPolicyName),
-	})
-
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/service/create/policy.go
+++ b/service/create/policy.go
@@ -66,8 +66,10 @@ func createRole(svc *iam.IAM, kmsKeyArn, s3Bucket, clusterID string) error {
 		return err
 	}
 
+	clusterPolicyName := fmt.Sprintf("%s-%s", clusterID, PolicyNameTemplate)
+
 	if _, err := svc.PutRolePolicy(&iam.PutRolePolicyInput{
-		PolicyName:     aws.String(fmt.Sprintf("%s-%s", clusterID, PolicyNameTemplate)),
+		PolicyName:     aws.String(clusterPolicyName),
 		RoleName:       aws.String(clusterRoleName),
 		PolicyDocument: aws.String(policyDocument),
 	}); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -267,6 +267,14 @@ func (s *Service) Boot() {
 					if err := s.deleteClusterNamespace(cluster.Spec.Cluster); err != nil {
 						s.logger.Log("error", "could not delete cluster namespace:", err)
 					}
+
+					clients := awsutil.NewClients(s.awsConfig)
+					if err := deletePolicyResources(clients.IAM, cluster.Spec.Cluster.Cluster.ID); err != nil {
+						s.logger.Log("error", fmt.Sprintf("could not delete policy resources: %v", err))
+						return
+					}
+
+					s.logger.Log("info", "deleted roles, policies, instance profiles")
 				},
 			},
 		)

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -270,7 +270,7 @@ func (s *Service) Boot() {
 
 					clients := awsutil.NewClients(s.awsConfig)
 					if err := deletePolicyResources(clients.IAM, cluster.Spec.Cluster.Cluster.ID); err != nil {
-						s.logger.Log("error", fmt.Sprintf("could not delete policy resources: %v", err))
+						s.logger.Log("error", fmt.Sprintf("could not delete policy resources: %v", microerror.MaskAny(err)))
 						return
 					}
 

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/k8scloudconfig"
 	microerror "github.com/giantswarm/microkit/error"
 	micrologger "github.com/giantswarm/microkit/logger"
+	"github.com/juju/errgo"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/runtime"
@@ -270,7 +271,7 @@ func (s *Service) Boot() {
 
 					clients := awsutil.NewClients(s.awsConfig)
 					if err := deletePolicyResources(clients.IAM, cluster.Spec.Cluster.Cluster.ID); err != nil {
-						s.logger.Log("error", fmt.Sprintf("could not delete policy resources: %v", microerror.MaskAny(err)))
+						s.logger.Log("error", errgo.Details(err))
 						return
 					}
 


### PR DESCRIPTION
Handle deletion of Role, Policy, Instance Profile.

We don't specifically handle any AWS errors, although in some cases it could be useful, e.g. if any of the resources has already been manually deleted. Right now we fail, whereas we probably should continue. 

WDYT?