### PR TITLE
Attach Elastic IP to master

### DIFF
--- a/service/create/elastic_ip.go
+++ b/service/create/elastic_ip.go
@@ -1,0 +1,29 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+const (
+	allocationID = "eipalloc-cc1657a5"
+	elasticIP    = "35.158.16.27"
+)
+
+func (s *Service) associateElasticIP(svc *ec2.EC2, instanceID string) error {
+	params := &ec2.AssociateAddressInput{
+		AllocationId: aws.String(allocationID),
+		InstanceId:   aws.String(instanceID),
+	}
+
+	if _, err := svc.AssociateAddress(params); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	s.logger.Log("info", fmt.Sprintf("attached ip %v to instance %v", elasticIP, instanceID))
+
+	return nil
+}

--- a/service/create/service_test.go
+++ b/service/create/service_test.go
@@ -233,7 +233,57 @@ func TestAllExistingInstancesMatch(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		res := allExistingInstancesMatch(tc.instances, tc.state)
+		_, res := allExistingInstancesMatch(tc.instances, tc.state)
 		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] Some instance didn't match the expected state", tc.name))
+	}
+}
+
+func TestAllInstancesPresent(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  []string
+		res  bool
+	}{
+		{
+			name: "Empty slice",
+			ids:  []string{},
+			res:  false,
+		},
+		{
+			name: "First element in slice is empty",
+			ids: []string{
+				"",
+			},
+			res: false,
+		},
+		{
+			name: "Last element in slice is empty",
+			ids: []string{
+				"foo",
+				"",
+			},
+			res: false,
+		},
+		{
+			name: "No empty strings",
+			ids: []string{
+				"foo",
+				"bar",
+			},
+			res: true,
+		},
+		{
+			name: "All empty",
+			ids: []string{
+				"",
+				"",
+			},
+			res: false,
+		},
+	}
+
+	for _, tc := range tests {
+		res := validateIDs(tc.ids)
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.name))
 	}
 }


### PR DESCRIPTION
As a temporary solution, we associate a pre-created Elastic IP to the master.

The drawback with Elastic IP is that there's a limit on how many can be created for a VPC.
In the long run, we want to have a Load Balancer in front of the masters.

To be able to attach an EIP, we need the `instanceID`, so we change the return values of the `runMachine`/`runMachines` methods.