### PR TITLE
[WIP] Make master node work

### DIFF
--- a/examples/cluster-cool.yml
+++ b/examples/cluster-cool.yml
@@ -1,0 +1,42 @@
+apiVersion: "cluster.giantswarm.io/v1"
+kind: Aws
+metadata:
+  name: test-iago-cluster
+spec:
+  cluster:
+    docker:
+      imageNamespace: "giantswarm"
+    etcd:
+      domain: "k8s.cluster.giantswarm.io"
+      prefix: "test-iago-cluster"
+    calico:
+      subnet: "192.168.0.0"
+      cidr: "24"
+    operator:
+      networkSetup:
+        docker:
+          image: "giantswarm/setup-network-env:0.1"
+    cluster:
+      id: "test-iago-cluster"
+
+    customer:
+      id: "iago"
+
+    masters:
+    - hostname: "master-1"
+
+    kubernetes:
+      api:
+        domain: "k8s.cluster.giantswarm.io"
+        insecurePort: 8080
+        securePort: 6443
+        clusterIPRange: "192.168.0.0/24"
+      hyperkube:
+        docker:
+          image: "giantswarm/hyperkube:v1.5.2_coreos.0"
+
+  aws:
+    region: "eu-central-1"
+    masters:
+    - imageid: "ami-9501c8fa"
+      instancetype: "t2.medium"

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -29,8 +29,7 @@ rkt run \
 
 rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :`
 
-	decryptTLSAssetsServiceTemplate = `
-[Unit]
+	decryptTLSAssetsServiceTemplate = `[Unit]
 Description=Decrypt TLS certificates
 
 [Service]

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -34,7 +34,8 @@ rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :`
 Description=Decrypt TLS certificates
 
 [Service]
-ExecStart=/opt/bin/decrypt-tls-assets`
+ExecStart=/opt/bin/decrypt-tls-assets
+ExecStartPost=/usr/bin/chown -R etcd:etcd /etc/kubernetes/ssl/etcd`
 
 	userDataScriptTemplate = `#!/bin/bash
 

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -34,8 +34,9 @@ rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :`
 Description=Decrypt TLS certificates
 
 [Service]
+Type=oneshot
 ExecStart=/opt/bin/decrypt-tls-assets
-ExecStartPost=/usr/bin/chown -R etcd:etcd /etc/kubernetes/ssl/etcd`
+ExecStart=/usr/bin/chown -R etcd:etcd /etc/kubernetes/ssl/etcd`
 
 	userDataScriptTemplate = `#!/bin/bash
 

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -527,18 +527,18 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      EnvironmentFile=/etc/network-environment
-      ExecStartPre=/usr/bin/etcdctl --endpoint=http://{{.Node.Hostname}}:2379 set /k8s/master/{{.Cluster.Etcd.Prefix}} '${DEFAULT_IPV4}'
+      EnvironmentFile=/etc/environment
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
-      ExecStart=/usr/bin/etcd2 --advertise-client-urls=https://{{.Cluster.Etcd.Domain}}:443,http://127.0.0.1:2383 \
+
+      # TODO, switch to {{.Cluster.Etcd.Domain}}:443 when the ingress controllers are set up
+      ExecStart=/usr/bin/etcd2 --advertise-client-urls=https://${COREOS_PRIVATE_IPV4}:2379,http://127.0.0.1:2383 \
                                --data-dir=/etc/kubernetes/data/etcd/ \
-                               --initial-advertise-peer-urls=https://{{.Cluster.Etcd.Domain}}:443 \
                                --listen-client-urls=https://0.0.0.0:2379,http://127.0.0.1:2383 \
-                               --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
+                               --listen-peer-urls=https://${COREOS_PRIVATE_IPV4}:2380 \
                                --initial-cluster-token k8s-etcd-cluster \
-                               --initial-cluster etcd0=https://{{.Cluster.Etcd.Domain}}:443 \
+                               --initial-cluster etcd0=https://${COREOS_PRIVATE_IPV4}:2379
                                --initial-cluster-state new \
                                --ca-file=/etc/kubernetes/ssl/etcd/server-ca.pem \
                                --cert-file=/etc/kubernetes/ssl/etcd/server.pem \

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -516,8 +516,8 @@ coreos:
     content: |
       [Unit]
       Description=etcd2
-      Requires=k8s-setup-network-env.service
-      After=k8s-setup-network-env.service
+      Requires=k8s-setup-network-env.service decrypt-tls-assets.service
+      After=k8s-setup-network-env.service decrypt-tls-assets.service
       Conflicts=etcd.service
       Wants=calico-node.service
       StartLimitIntervalSec=0

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -680,6 +680,7 @@ coreos:
       ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/ssl/apiserver-crt.pem /etc/kubernetes/ssl/apiserver.pem
       # TODO change 0.0.0.0 to ${DEFAULT_IP}
       # TODO change 2379 to 443
+      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/secrets/token_sign_key.pem ]; do echo 'Waiting for /etc/kubernetes/secrets/token_sign_key.pem to be written' && sleep 1; done"
       ExecStart=/usr/bin/docker run --rm --name $NAME --net=host \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/secrets/token_sign_key.pem:/etc/kubernetes/secrets/token_sign_key.pem \
@@ -772,6 +773,7 @@ coreos:
       ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/secrets/token_sign_key.pem ]; do echo 'Waiting for /etc/kubernetes/secrets/token_sign_key.pem to be written' && sleep 1; done"
       ExecStart=/usr/bin/docker run --rm --net=host --name $NAME \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -1184,8 +1184,8 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       StartLimitIntervalSec=0
-      EnvironmentFile=/etc/environment
-      Environment="ETCD_AUTHORITY=${COREOS_PRIVATE_IPV4}:2379"
+      EnvironmentFile=/etc/network-environment
+      Environment="ETCD_AUTHORITY=${DEFAULT_IPV4}:2379"
       Environment="ETCD_SCHEME=https"
       Environment="ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/calico/client-ca.pem"
       Environment="ETCD_CERT_FILE=/etc/kubernetes/ssl/calico/client-crt.pem"
@@ -1202,7 +1202,7 @@ coreos:
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/calico/client-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/calico/client-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/calico/client-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/calico/client-key.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while ! curl --output /dev/null --silent --fail --cacert /etc/kubernetes/ssl/calico/client-ca.pem --cert /etc/kubernetes/ssl/calico/client-crt.pem --key /etc/kubernetes/ssl/calico/client-key.pem https://{{.Cluster.Etcd.Domain}}/version; do sleep 1 && echo 'Waiting for etcd master to be responsive'; done"
-      ExecStart=/opt/bin/calicoctl node --ip=${COREOS_PRIVATE_IPV4} --detach=false --node-image=giantswarm/node:v0.22.0
+      ExecStart=/opt/bin/calicoctl node --ip=${DEFAULT_IPV4} --detach=false --node-image=giantswarm/node:v0.22.0
       ExecStartPost=/bin/bash -c "/opt/bin/calicoctl bgp peer add $(echo ${IP_BRIDGE}} | cut -d'.' -f1-3).0 as $(/opt/bin/calicoctl bgp default-node-as)"
       ExecStop=/opt/bin/calicoctl node stop --force
       ExecStopPost=/bin/bash -c "find /tmp/ -name '_MEI*' | xargs -I {} rm -rf {}"

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -660,8 +660,8 @@ coreos:
     content: |
       [Unit]
       Description=k8s-api-server
-      Requires=calico-node.service
-      After=calico-node.service
+      Requires=calico-node.service k8s-key-generator.service
+      After=calico-node.service k8s-key-generator.service
       StartLimitIntervalSec=0
 
       [Service]
@@ -758,8 +758,8 @@ coreos:
     content: |
       [Unit]
       Description=k8s-controller-manager Service
-      Requires=calico-node.service
-      After=calico-node.service
+      Requires=calico-node.service k8s-key-generator.service
+      After=calico-node.service k8s-key-generator.service
       StartLimitIntervalSec=0
 
       [Service]


### PR DESCRIPTION
This adds a working configuration for a master node.

## Caveats

- There're some hacks involved (see TODOs)
- The changes to the cloudconfig are applied directly to the `vendor` directory.
- We add the domain `k8s.cluster.giantswarm.io` to `/etc/hosts` pointing to `127.0.0.1` and we use ports `6443` (k8s secure) and `2379` (etcd) instead of `443` because we don't have the ingress controllers set up.

## Testing

You need to issue some certificates using certctl with "CN=*.cluster.giantswarm.io"  for the apiserver, etcd and calico and put them in a directory to pass them to the operator:

```
> tree certs
certs
├── apiserver-ca.pem
├── apiserver-crt.pem
├── apiserver-key.pem
├── calico
│   ├── client-ca.pem
│   ├── client-crt.pem
│   └── client-key.pem
└── etcd
    ├── server-ca.pem
    ├── server-crt.pem
    └── server-key.pem

2 directories, 9 files
```

Then, you can start the test "cluster" (only one master):

```
$ kubectl create -f examples/cluster-cool.yml
```

On your host, you can add the IP of the instance to `/etc/hosts`:

```
> cat /etc/hosts
#
# /etc/hosts: static lookup table for host names
#

#<ip-address>	<hostname.domain.org>	<hostname>
127.0.0.1	localhost.localdomain	localhost
::1		localhost.localdomain	localhost
XX.XX.XX.XX     k8s.cluster.giantswarm.io

```

Then you can create a kubeconfig similar to this:

```
apiVersion: v1
clusters:
- cluster:
    user: iago
    certificate-authority: /path/to/certs/apiserver-ca.pem
    server: https://k8s.cluster.giantswarm.io:6443
  name: operator
contexts:
- context:
    cluster: operator
    user: iago
  name: operator
current-context: operator
kind: Config
preferences: {}
users:
- name: iago
  user:
    client-certificate: /path/to/certs/apiserver-crt.pem
    client-key: /path/to/certs/apiserver-key.pem
```

After that you should have a working kubectl:

```
$ kubectl cluster-info
Kubernetes master is running at https://k8s.cluster.giantswarm.io:6443

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
```

Pods can't be scheduled because we need workers for that.