### PR TITLE
Assign instance ID to struct after creation

### DIFF
--- a/resources/aws/instance.go
+++ b/resources/aws/instance.go
@@ -34,6 +34,7 @@ type Instance struct {
 	ClusterName            string
 	ImageID                string
 	InstanceType           string
+	InstanceID             string
 	KeyName                string
 	MinCount               int
 	MaxCount               int
@@ -119,6 +120,8 @@ func (i *Instance) CreateOrFail() error {
 	}
 
 	for _, rawInstance := range reservation.Instances {
+		i.InstanceID = *rawInstance.InstanceId
+
 		if _, err := i.Clients.EC2.CreateTags(&ec2.CreateTagsInput{
 			Resources: []*string{rawInstance.InstanceId},
 			Tags: []*ec2.Tag{


### PR DESCRIPTION
This allows us to later on query the AWS API using the instance ID.