### PR TITLE
Get certs from kubernetes secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ go build github.com/giantswarm/awstpr
 
 ## Running aws-operator
 
-After building the project, the `aws-operator` binary will be there. To use it in very standard way,
-we recommend to do:
+After building the project, you will have a `aws-operator` binary.
+
+The operator needs some Kubernetes secrets to be present. The secrets contain
+the TLS assets (CAs, keys, certificates) for the various components of the
+cluster.
+
+An easy way to create these secrets for development is running:
+
+
+```
+kubectl create -f examples/secrets.yml
+```
+
+Afterwards, you can run:
 
 ```
 ./aws-operator daemon --aws.accesskey.id <aws_acces_key_id> --aws.accesskey.secret <aws_access_key_secret> --aws.region <aws_region>

--- a/examples/secrets.yml
+++ b/examples/secrets.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: example-api-secret
+    labels:
+        clusterComponent: api
+        clusterID: example-cluster
+type: Opaque
+data:
+    crt: Zm9vYmFyCg==
+    ca: Zm9vYmFyCg==
+    key: Zm9vYmFyCg==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: example-worker-secret
+    labels:
+        clusterComponent: worker
+        clusterID: example-cluster
+type: Opaque
+data:
+    crt: Zm9vYmFyCg==
+    ca: Zm9vYmFyCg==
+    key: Zm9vYmFyCg==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: example-calico-secret
+    labels:
+        clusterComponent: calico
+        clusterID: example-cluster
+type: Opaque
+data:
+    crt: Zm9vYmFyCg==
+    ca: Zm9vYmFyCg==
+    key: Zm9vYmFyCg==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: example-etcd-secret
+    labels:
+        clusterComponent: etcd
+        clusterID: example-cluster
+type: Opaque
+data:
+    crt: Zm9vYmFyCg==
+    ca: Zm9vYmFyCg==
+    key: Zm9vYmFyCg==

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5d71c7bcd8f6232160ac44f98db0018bc98545a80f1fa1bbe681f541cd08b310
-updated: 2017-03-24T15:13:46.806721225+01:00
+hash: d17b627d6fb76fe1f67660578bc74c7a98674607650f87a303703054f8b2cbdc
+updated: 2017-03-31T16:08:54.090907655+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -7,7 +7,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/aws/aws-sdk-go
-  version: 2c0ef11c03b8f28d694021d4a6bda2e24b040cd4
+  version: 38dd25dcbd6cec1983fe05abc880d6a3aa49a962
   subpackages:
   - aws
   - aws/awserr
@@ -46,9 +46,9 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/cenkalti/backoff
-  version: 3db60c813733fce657c114634171689bbf1f8dee
+  version: 5d150e7eec023ce7a124856b37c68e54b4050ac7
 - name: github.com/coreos/etcd
-  version: 41e52ebc22add2f9b91a59f90db8e31f7e5c0538
+  version: 20490caaf0dcd96bb4a95e40625559def8ef5b04
   subpackages:
   - auth/authpb
   - client
@@ -88,13 +88,15 @@ imports:
   - log
   - swagger
 - name: github.com/fsnotify/fsnotify
-  version: ff7bc41d4007f67e5456703c34342df4e0113f64
+  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/giantswarm/awstpr
   version: 288f3d1dff098b1cca30c3d88c461b71b203bbd0
   subpackages:
   - aws
+- name: github.com/giantswarm/certificatetpr
+  version: fa554d09f0137a91aa6ef007b92e170b31dbefd2
 - name: github.com/giantswarm/clustertpr
   version: 47bae764f0a168b9dac27e274515b1a5d03eea6b
   subpackages:
@@ -144,7 +146,7 @@ imports:
   - transaction/context/id
   - transaction/context/tracked
 - name: github.com/go-ini/ini
-  version: 1730955e3146956d6a087861380f9b4667ed5071
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/go-kit/kit
   version: f66b0e13579bfc5a48b9e2a94b1209c107ea1f41
   subpackages:
@@ -232,7 +234,7 @@ imports:
 - name: github.com/pelletier/go-buffruneio
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: f6e7596e8daafd44dc9e5c208dc73035020c8481
+  version: e32a2e04744250647a72bf17da1b09befc03b6b1
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,6 +28,8 @@ import:
 - package: github.com/giantswarm/awstpr
   version: 288f3d1dff098b1cca30c3d88c461b71b203bbd0
 - package: github.com/giantswarm/clustertpr
+- package: github.com/giantswarm/certificatetpr
+  version: fa554d09f0137a91aa6ef007b92e170b31dbefd2
 - package: github.com/giantswarm/k8scloudconfig
   version: b31c9407200797ca4be735c3a73ec51ae34b31fd
 - package: github.com/golang/protobuf

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ var Flags = struct {
 			Secret string
 		}
 		S3Bucket   string
-		CertsDir   string
 		PubKeyFile string
 	}
 	Kubernetes struct {
@@ -94,7 +93,6 @@ func main() {
 			}
 
 			serviceConfig.S3Bucket = Flags.Aws.S3Bucket
-			serviceConfig.CertsDir = Flags.Aws.CertsDir
 			serviceConfig.PubKeyFile = Flags.Aws.PubKeyFile
 
 			serviceConfig.Description = description
@@ -153,7 +151,6 @@ func main() {
 	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.AccessKey.Secret, "aws.accesskey.secret", "", "Secret of the AWS access key")
 	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.S3Bucket, "aws.s3bucket", uuid.New().String(), "S3 bucket in which to store cloudconfigs")
 	// TODO(nhlfr): Deprecate these options when cert-operator will be implemented.
-	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.CertsDir, "aws.certsdir", "", "Certificates to be placed in /etc/kubernetes/ssl")
 	daemonCommand.PersistentFlags().StringVar(&Flags.Aws.PubKeyFile, "aws.pubkeyfile", path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "Public key to be imported as a keypair in AWS")
 
 	daemonCommand.PersistentFlags().BoolVar(&Flags.Kubernetes.InCluster, "kubernetes.incluster", false, "Whether to use the in-cluster config to authenticate with Kubernetes")

--- a/service/create/assets.go
+++ b/service/create/assets.go
@@ -2,15 +2,13 @@ package create
 
 import (
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/certificatetpr"
 	"github.com/giantswarm/k8scloudconfig"
 	microerror "github.com/giantswarm/microkit/error"
 )
 
-func (s *Service) encodeTLSAssets(svc *kms.KMS, kmsKeyArn string) (*cloudconfig.CompactTLSAssets, error) {
-	rawTLS, err := readRawTLSAssets(s.certsDir)
-	if err != nil {
-		return nil, microerror.MaskAny(err)
-	}
+func (s *Service) encodeTLSAssets(assets certificatetpr.AssetsBundle, svc *kms.KMS, kmsKeyArn string) (*cloudconfig.CompactTLSAssets, error) {
+	rawTLS := createRawTLSAssets(assets)
 
 	encTLS, err := rawTLS.encrypt(svc, kmsKeyArn)
 	if err != nil {

--- a/service/create/encrypt.go
+++ b/service/create/encrypt.go
@@ -4,20 +4,21 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/certificatetpr"
 	"github.com/giantswarm/k8scloudconfig"
 	microerror "github.com/giantswarm/microkit/error"
 )
 
-// PEM encoded TLS assets.
-type rawTLSAssets struct {
+type TLSassets struct {
 	APIServerCA     []byte
 	APIServerKey    []byte
 	APIServerCrt    []byte
+	WorkerCA        []byte
+	WorkerKey       []byte
+	WorkerCrt       []byte
 	CalicoClientCA  []byte
 	CalicoClientKey []byte
 	CalicoClientCrt []byte
@@ -25,54 +26,29 @@ type rawTLSAssets struct {
 	EtcdServerKey   []byte
 	EtcdServerCrt   []byte
 }
+
+// PEM encoded TLS assets.
+type rawTLSAssets TLSassets
 
 // Encrypted PEM encoded TLS assets
-type encryptedTLSAssets struct {
-	APIServerCA     []byte
-	APIServerKey    []byte
-	APIServerCrt    []byte
-	CalicoClientCA  []byte
-	CalicoClientKey []byte
-	CalicoClientCrt []byte
-	EtcdServerCA    []byte
-	EtcdServerKey   []byte
-	EtcdServerCrt   []byte
-}
+type encryptedTLSAssets TLSassets
 
-func readRawTLSAssets(tlsAssetsDir string) (*rawTLSAssets, error) {
-	r := new(rawTLSAssets)
-	files := []struct {
-		name          string
-		ca, key, cert *[]byte
-	}{
-		{"apiserver", &r.APIServerCA, &r.APIServerKey, &r.APIServerCrt},
-		{"calico/client", &r.CalicoClientCA, &r.CalicoClientKey, &r.CalicoClientCrt},
-		{"etcd/server", &r.EtcdServerCA, &r.EtcdServerKey, &r.EtcdServerCrt},
+func createRawTLSAssets(assets certificatetpr.AssetsBundle) *rawTLSAssets {
+	// TODO refactor this with a for loop iterating over components and asset types
+	return &rawTLSAssets{
+		APIServerCA:     assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.CA}],
+		APIServerCrt:    assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Crt}],
+		APIServerKey:    assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Key}],
+		WorkerCA:        assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.CA}],
+		WorkerCrt:       assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Crt}],
+		WorkerKey:       assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Key}],
+		EtcdServerCA:    assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}],
+		EtcdServerCrt:   assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}],
+		EtcdServerKey:   assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}],
+		CalicoClientCA:  assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}],
+		CalicoClientCrt: assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}],
+		CalicoClientKey: assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}],
 	}
-	for _, file := range files {
-		caPath := filepath.Join(tlsAssetsDir, file.name+"-ca.pem")
-		keyPath := filepath.Join(tlsAssetsDir, file.name+"-key.pem")
-		certPath := filepath.Join(tlsAssetsDir, file.name+"-crt.pem")
-
-		caData, err := ioutil.ReadFile(caPath)
-		if err != nil {
-			return nil, microerror.MaskAny(err)
-		}
-		*file.ca = caData
-
-		certData, err := ioutil.ReadFile(certPath)
-		if err != nil {
-			return nil, microerror.MaskAny(err)
-		}
-		*file.cert = certData
-
-		keyData, err := ioutil.ReadFile(keyPath)
-		if err != nil {
-			return nil, microerror.MaskAny(err)
-		}
-		*file.key = keyData
-	}
-	return r, nil
 }
 
 func (r *rawTLSAssets) encrypt(svc *kms.KMS, kmsKeyARN string) (*encryptedTLSAssets, error) {
@@ -97,6 +73,9 @@ func (r *rawTLSAssets) encrypt(svc *kms.KMS, kmsKeyARN string) (*encryptedTLSAss
 		APIServerCA:     encrypt(r.APIServerCA),
 		APIServerKey:    encrypt(r.APIServerKey),
 		APIServerCrt:    encrypt(r.APIServerCrt),
+		WorkerCA:        encrypt(r.WorkerCA),
+		WorkerCrt:       encrypt(r.WorkerCrt),
+		WorkerKey:       encrypt(r.WorkerKey),
 		CalicoClientCA:  encrypt(r.CalicoClientCA),
 		CalicoClientKey: encrypt(r.CalicoClientKey),
 		CalicoClientCrt: encrypt(r.CalicoClientCrt),
@@ -132,6 +111,9 @@ func (r *encryptedTLSAssets) compact() (*cloudconfig.CompactTLSAssets, error) {
 		APIServerCA:     compact(r.APIServerCA),
 		APIServerKey:    compact(r.APIServerKey),
 		APIServerCrt:    compact(r.APIServerCrt),
+		WorkerCA:        compact(r.WorkerCA),
+		WorkerKey:       compact(r.WorkerKey),
+		WorkerCrt:       compact(r.WorkerCrt),
 		CalicoClientCA:  compact(r.CalicoClientCA),
 		CalicoClientKey: compact(r.CalicoClientKey),
 		CalicoClientCrt: compact(r.CalicoClientCrt),

--- a/service/create/error.go
+++ b/service/create/error.go
@@ -4,7 +4,10 @@ import (
 	"github.com/juju/errgo"
 )
 
-var invalidConfigError = errgo.New("invalid config")
+var (
+	invalidConfigError          = errgo.New("invalid config")
+	secretsRetrievalFailedError = errgo.New("could not retrieve secrets")
+)
 
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {

--- a/service/create/secrets.go
+++ b/service/create/secrets.go
@@ -1,0 +1,80 @@
+package create
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/giantswarm/certificatetpr"
+	microerror "github.com/giantswarm/microkit/error"
+	"k8s.io/client-go/pkg/api"
+	apierrs "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/watch"
+)
+
+const secretsTimeOut time.Duration = 90 * time.Second
+
+func (s *Service) getCertsFromSecrets(clusterID string) (certificatetpr.AssetsBundle, error) {
+	assetsBundle := make(certificatetpr.AssetsBundle)
+
+	var err error
+	for _, componentName := range certificatetpr.ClusterComponents {
+		assetsBundle, err = s.getComponentSecret(componentName.String(), clusterID, assetsBundle)
+
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+	}
+
+	return assetsBundle, nil
+}
+
+// gets the secret for a single cluster component, and saves in the shared assets bundle
+func (s *Service) getComponentSecret(componentName, clusterID string, bundle certificatetpr.AssetsBundle) (certificatetpr.AssetsBundle, error) {
+	watcher, err := s.k8sClient.Core().Secrets(api.NamespaceDefault).Watch(v1.ListOptions{
+		// select only secrets that pertain to the component AND have a matching clusterID
+		LabelSelector: fmt.Sprintf("%s=%s, %s=%s", certificatetpr.ComponentLabel, componentName, certificatetpr.ClusterIDLabel, clusterID),
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	defer watcher.Stop()
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return nil, microerror.MaskAnyf(secretsRetrievalFailedError, "secrets channel was already closed")
+			}
+
+			switch event.Type {
+			case watch.Added:
+				secret := event.Object.(*v1.Secret)
+
+				component := certificatetpr.ClusterComponent(secret.Labels[certificatetpr.ComponentLabel])
+
+				if !certificatetpr.ValidComponent(component, certificatetpr.ClusterComponents) {
+					return nil, microerror.MaskAnyf(secretsRetrievalFailedError, "unknown clusterComponent %s", component)
+				}
+
+				for _, assetType := range certificatetpr.TLSAssetTypes {
+					asset, ok := secret.Data[assetType.String()]
+					if !ok {
+						return nil, microerror.MaskAnyf(secretsRetrievalFailedError, "malformed secret was missing %v asset", assetType)
+					}
+
+					bundle[certificatetpr.AssetsBundleKey{component, assetType}] = asset
+				}
+
+				return bundle, nil
+			case watch.Deleted:
+				// noop; ignore deleted events
+			case watch.Error:
+				return nil, microerror.MaskAnyf(secretsRetrievalFailedError, "there was an error in the watcher: %v", apierrs.FromObject(event.Object))
+			}
+
+		case <-time.After(secretsTimeOut):
+			return nil, microerror.MaskAnyf(secretsRetrievalFailedError, "timed out waiting for secrets")
+		}
+	}
+}

--- a/service/error.go
+++ b/service/error.go
@@ -4,7 +4,9 @@ import (
 	"github.com/juju/errgo"
 )
 
-var invalidConfigError = errgo.New("invalid config")
+var (
+	invalidConfigError = errgo.New("invalid config")
+)
 
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {

--- a/service/service.go
+++ b/service/service.go
@@ -26,7 +26,6 @@ type Config struct {
 	K8sConfig k8sutil.Config
 
 	// AWS cerfificates options.
-	CertsDir   string
 	PubKeyFile string
 
 	S3Bucket string
@@ -50,7 +49,6 @@ func DefaultConfig() Config {
 
 		S3Bucket: "",
 		// AWS certificates optionts.
-		CertsDir:   "",
 		PubKeyFile: "",
 
 		Description: "",
@@ -86,7 +84,6 @@ func New(config Config) (*Service, error) {
 		createConfig.K8sClient = k8sClient
 		createConfig.Logger = config.Logger
 		createConfig.S3Bucket = config.S3Bucket
-		createConfig.CertsDir = config.CertsDir
 		createConfig.PubKeyFile = config.PubKeyFile
 
 		createService, err = create.New(createConfig)

--- a/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
+++ b/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
@@ -1,3 +1,52 @@
+Release v1.8.5 (2017-03-30)
+===
+
+### Service Client Updates
+* `service/cloudformation`: Updates service waiters and paginators
+  * Adding paginators for ListExports and ListImports
+* `service/cloudfront`: Adds new service
+  * Amazon CloudFront now supports user configurable HTTP Read and Keep-Alive Idle Timeouts for your Custom Origin Servers
+* `service/configservice`: Updates service documentation
+* `aws/endpoints`: Updated Regions and Endpoints metadata.
+* `service/resourcegroupstaggingapi`: Adds new service
+* `service/storagegateway`: Updates service API and documentation
+  * File gateway mode in AWS Storage gateway provides access to objects in S3 as files on a Network File System (NFS) mount point. Once a file share is created, any changes made externally to the S3 bucket will not be reflected by the gateway. Using the cache refresh feature in this update, the customer can trigger an on-demand scan of the keys in their S3 bucket and refresh the file namespace cached on the gateway. It takes as an input the fileShare ARN and refreshes the cache for only that file share. Additionally there is new functionality on file gateway that allows you configure what squash options they would like on their file share, this allows a customer to configure their gateway to not squash root permissions. This can be done by setting options in NfsOptions for CreateNfsFileShare and UpdateNfsFileShare APIs.
+
+Release v1.8.4 (2017-03-28)
+===
+
+### Service Client Updates
+* `service/batch`: Updates service API, documentation, and paginators
+  * Customers can now provide a retryStrategy as part of the RegisterJobDefinition and SubmitJob API calls. The retryStrategy object has a number value for attempts. This is the number of non successful executions before a job is considered FAILED. In addition, the JobDetail object now has an attempts field and shows all execution attempts.
+* `service/ec2`: Updates service API and documentation
+	* Customers can now tag their Amazon EC2 Instances and Amazon EBS Volumes at
+	the time of their creation. You can do this from the EC2 Instance launch
+	wizard or through the RunInstances or CreateVolume APIs. By tagging
+	resources at the time of creation, you can eliminate the need to run custom
+	tagging scripts after resource creation. In addition, you can now set
+	resource-level permissions on the CreateVolume, CreateTags, DeleteTags, and
+	the RunInstances APIs. This allows you to implement stronger security
+	policies by giving you more granular control over which users and groups
+	have access to these APIs. You can also enforce the use of tagging and
+	control what tag keys and values are set on your resources. When you combine
+	tag usage and resource-level IAM policies together, you can ensure your
+	instances and volumes are properly secured upon creation and achieve more
+	accurate cost allocation reporting. These new features are provided at no
+	additional cost.
+
+### SDK Enhancements
+* `aws/request`: Add retry support for RequestTimeoutException (#1158)
+  * Adds support for retrying RequestTimeoutException error code that is returned by some services.
+
+### SDK Bugs
+* `private/model/api`: Fix Waiter and Paginators panic on nil param inputs (#1157)
+  * Corrects the code generation for Paginators and waiters that caused a panic if nil input parameters were used with the operations.
+Release v1.8.3 (2017-03-27)
+===
+
+## Service Client Updates
+* `service/ssm`: Updates service API, documentation, and paginators
+  * Updated validation rules for SendCommand and RegisterTaskWithMaintenanceWindow APIs.
 Release v1.8.2 (2017-03-24)
 ===
 

--- a/vendor/github.com/aws/aws-sdk-go/CHANGELOG_PENDING.md
+++ b/vendor/github.com/aws/aws-sdk-go/CHANGELOG_PENDING.md
@@ -1,5 +1,5 @@
-## SDK Features
+### SDK Features
 
-## SDK Enhancements
+### SDK Enhancements
 
-## SDK Bugs 
+### SDK Bugs 

--- a/vendor/github.com/aws/aws-sdk-go/CONTRIBUTING.md
+++ b/vendor/github.com/aws/aws-sdk-go/CONTRIBUTING.md
@@ -64,6 +64,11 @@ Please be aware of the following notes prior to opening a pull request:
    SDK's test coverage percentage are unlikely to be merged until tests have
    been added.
 
+5. The JSON files under the SDK's `models` folder are sourced from outside the SDK.
+   Such as `models/apis/ec2/2016-11-15/api.json`. We will not accept pull requests
+   directly on these models. If you discover an issue with the models please
+   create a Github [issue](issues) describing the issue.
+
 ### Testing
 
 To run the tests locally, running the `make unit` command will `go get` the 

--- a/vendor/github.com/aws/aws-sdk-go/README.md
+++ b/vendor/github.com/aws/aws-sdk-go/README.md
@@ -1,9 +1,4 @@
-# AWS SDK for Go
-
-[![API Reference](http://img.shields.io/badge/api-reference-blue.svg)](http://docs.aws.amazon.com/sdk-for-go/api)
-[![Join the chat at https://gitter.im/aws/aws-sdk-go](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-sdk-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://img.shields.io/travis/aws/aws-sdk-go.svg)](https://travis-ci.org/aws/aws-sdk-go)
-[![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/aws/aws-sdk-go/blob/master/LICENSE.txt)
+# AWS SDK for Go [![API Reference](http://img.shields.io/badge/api-reference-blue.svg)](http://docs.aws.amazon.com/sdk-for-go/api) [![Join the chat at https://gitter.im/aws/aws-sdk-go](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-sdk-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://img.shields.io/travis/aws/aws-sdk-go.svg)](https://travis-ci.org/aws/aws-sdk-go) [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/aws/aws-sdk-go/blob/master/LICENSE.txt)
 
 aws-sdk-go is the official AWS SDK for the Go programming language.
 
@@ -83,44 +78,77 @@ To use a service in the SDK, create a service variable by calling the `New()`
 function. Once you have a service client, you can call API operations which each
 return response data and a possible error.
 
-To list a set of instance IDs from EC2, you could run:
+For example the following code shows how to upload an object to Amazon S3 with a Context timeout.
 
 ```go
 package main
 
 import (
+	"context"
+	"flag"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+// Uploads a file to S3 given a bucket and object key. Also takes a duration
+// value to terminate the update if it doesn't complete within that time.
+//
+// The AWS Region needs to be provided in the AWS shared config or on the
+// environment variable as `AWS_REGION`. Credentials also must be provided
+// Will default to shared config file, but can load from environment if provided.
+//
+// Usage:
+//   # Upload myfile.txt to myBucket/myKey. Must complete within 10 minutes or will fail
+//   go run withContext.go -b mybucket -k myKey -d 10m < myfile.txt
 func main() {
-	sess, err := session.NewSession()
-	if err != nil {
-		panic(err)
+	var bucket, key string
+	var timeout time.Duration
+
+	flag.StringVar(&bucket, "b", "", "Bucket name.")
+	flag.StringVar(&key, "k", "", "Object key name.")
+	flag.DurationVar(&timeout, "d", 0, "Upload timeout.")
+	flag.Parse()
+
+	sess := session.Must(session.NewSession())
+	svc := s3.New(sess)
+
+	// Create a context with a timeout that will abort the upload if it takes
+	// more than the passed in timeout.
+	ctx := context.Background()
+	var cancelFn func()
+	if timeout > 0 {
+		ctx, cancelFn = context.WithTimeout(ctx, timeout)
 	}
+	// Ensure the context is canceled to prevent leaking.
+	// See context package for more information, https://golang.org/pkg/context/
+	defer cancelFn()
 
-	// Create an EC2 service object in the "us-west-2" region
-	// Note that you can also configure your region globally by
-	// exporting the AWS_REGION environment variable
-	svc := ec2.New(sess, &aws.Config{Region: aws.String("us-west-2")})
-
-	// Call the DescribeInstances Operation
-	resp, err := svc.DescribeInstances(nil)
+	// Uploads the object to S3. The Context will interrupt the request if the
+	// timeout expires.
+	_, err := svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   os.Stdin,
+	})
 	if err != nil {
-		panic(err)
-	}
-
-	// resp has all of the response data, pull out instance IDs:
-	fmt.Println("> Number of reservation sets: ", len(resp.Reservations))
-	for idx, res := range resp.Reservations {
-		fmt.Println("  > Number of instances: ", len(res.Instances))
-		for _, inst := range resp.Reservations[idx].Instances {
-			fmt.Println("    - Instance ID: ", *inst.InstanceId)
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == request.CanceledErrorCode {
+			// If the SDK can determine the request or retry delay was canceled
+			// by a context the CanceledErrorCode error code will be returned.
+			fmt.Fprintf(os.Stderr, "upload canceled due to timeout, %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "failed to upload object, %v\n", err)
 		}
+		os.Exit(1)
 	}
+
+	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, key)
 }
 ```
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
@@ -88,7 +88,7 @@ type Value struct {
 // The Provider should not need to implement its own mutexes, because
 // that will be managed by Credentials.
 type Provider interface {
-	// Refresh returns nil if it successfully retrieved the value.
+	// Retrieve returns nil if it successfully retrieved the value.
 	// Error is returned if the value were not obtainable, or empty.
 	Retrieve() (Value, error)
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -249,6 +249,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
@@ -1027,6 +1028,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
@@ -1677,6 +1679,12 @@ var awscnPartition = partition{
 			},
 		},
 		"cloudtrail": service{
+
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
+		"codedeploy": service{
 
 			Endpoints: endpoints{
 				"cn-north-1": endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -114,6 +114,40 @@ func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 // using a WithContext API operation method.
 type Option func(*Request)
 
+// WithGetResponseHeader builds a request Option which will retrieve a single
+// header value from the HTTP Response. If there are multiple values for the
+// header key use WithGetResponseHeaders instead to access the http.Header
+// map directly. The passed in val pointer must be non-nil.
+//
+// This Option can be used multiple times with a single API operation.
+//
+//    var id2, versionID string
+//    svc.PutObjectWithContext(ctx, params,
+//        request.WithGetResponseHeader("x-amz-id-2", &id2),
+//        request.WithGetResponseHeader("x-amz-version-id", &versionID),
+//    )
+func WithGetResponseHeader(key string, val *string) Option {
+	return func(r *Request) {
+		r.Handlers.Complete.PushBack(func(req *Request) {
+			*val = req.HTTPResponse.Header.Get(key)
+		})
+	}
+}
+
+// WithGetResponseHeaders builds a request Option which will retrieve the
+// headers from the HTTP response and assign them to the passed in headers
+// variable. The passed in headers pointer must be non-nil.
+//
+//    var headers http.Header
+//    svc.PutObjectWithContext(ctx, params, request.WithGetResponseHeaders(&headers))
+func WithGetResponseHeaders(headers *http.Header) Option {
+	return func(r *Request) {
+		r.Handlers.Complete.PushBack(func(req *Request) {
+			*headers = req.HTTPResponse.Header
+		})
+	}
+}
+
 // WithLogLevel is a request option that will set the request to use a specific
 // log level when the request is made.
 //

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_pagination_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_pagination_test.go
@@ -381,6 +381,79 @@ func TestPaginationNilToken(t *testing.T) {
 	assert.Equal(t, []string{"first.example.com.", "second.example.com.", "third.example.com."}, results)
 }
 
+func TestPaginationNilInput(t *testing.T) {
+	// Code generation doesn't have a great way to verify the code is correct
+	// other than being run via unit tests in the SDK. This should be fixed
+	// So code generation can be validated independently.
+
+	client := s3.New(unit.Session)
+	client.Handlers.Validate.Clear()
+	client.Handlers.Send.Clear() // mock sending
+	client.Handlers.Unmarshal.Clear()
+	client.Handlers.UnmarshalMeta.Clear()
+	client.Handlers.ValidateResponse.Clear()
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
+		r.Data = &s3.ListObjectsOutput{}
+	})
+
+	gotToEnd := false
+	numPages := 0
+	err := client.ListObjectsPages(nil, func(p *s3.ListObjectsOutput, last bool) bool {
+		numPages++
+		if last {
+			gotToEnd = true
+		}
+		return true
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, numPages; e != a {
+		t.Errorf("expect %d number pages but got %d", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect to of gotten to end, did not")
+	}
+}
+
+func TestPaginationWithContextNilInput(t *testing.T) {
+	// Code generation doesn't have a great way to verify the code is correct
+	// other than being run via unit tests in the SDK. This should be fixed
+	// So code generation can be validated independently.
+
+	client := s3.New(unit.Session)
+	client.Handlers.Validate.Clear()
+	client.Handlers.Send.Clear() // mock sending
+	client.Handlers.Unmarshal.Clear()
+	client.Handlers.UnmarshalMeta.Clear()
+	client.Handlers.ValidateResponse.Clear()
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
+		r.Data = &s3.ListObjectsOutput{}
+	})
+
+	gotToEnd := false
+	numPages := 0
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
+	err := client.ListObjectsPagesWithContext(ctx, nil, func(p *s3.ListObjectsOutput, last bool) bool {
+		numPages++
+		if last {
+			gotToEnd = true
+		}
+		return true
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, numPages; e != a {
+		t.Errorf("expect %d number pages but got %d", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect to of gotten to end, did not")
+	}
+}
+
 type testPageInput struct {
 	NextToken string
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -91,9 +89,15 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 2, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q", e, a)
+	}
 }
 
 // test that retries occur for 4xx status codes with a response type that can be retried - see `shouldRetry`
@@ -117,9 +121,15 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 2, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q", e, a)
+	}
 }
 
 // test that retries don't occur for 4xx status codes with a response type that can't be retried
@@ -135,15 +145,22 @@ func TestRequest4xxUnretryable(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 401, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "SignatureDoesNotMatch", err.(awserr.Error).Code())
-	assert.Equal(t, "Signature does not match.", err.(awserr.Error).Message())
-	assert.Equal(t, 0, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 401, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "SignatureDoesNotMatch", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "Signature does not match.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 0, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 }
 
 func TestRequestExhaustRetries(t *testing.T) {
@@ -171,22 +188,31 @@ func TestRequestExhaustRetries(t *testing.T) {
 	})
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 500, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "UnknownError", err.(awserr.Error).Code())
-	assert.Equal(t, "An error occurred.", err.(awserr.Error).Message())
-	assert.Equal(t, 3, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 500, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "UnknownError", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "An error occurred.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 3, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 
 	expectDelays := []struct{ min, max time.Duration }{{30, 59}, {60, 118}, {120, 236}}
 	for i, v := range delays {
 		min := expectDelays[i].min * time.Millisecond
 		max := expectDelays[i].max * time.Millisecond
-		assert.True(t, min <= v && v <= max,
-			"Expect delay to be within range, i:%d, v:%s, min:%s, max:%s", i, v, min, max)
+		if !(min <= v && v <= max) {
+			t.Errorf("Expect delay to be within range, i:%d, v:%s, min:%s, max:%s",
+				i, v, min, max)
+		}
 	}
 }
 
@@ -222,14 +248,26 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.False(t, credExpiredBeforeRetry, "Expect valid creds before retry check")
-	assert.True(t, credExpiredAfterRetry, "Expect expired creds after retry check")
-	assert.False(t, s.Config.Credentials.IsExpired(), "Expect valid creds after cred expired recovery")
+	if credExpiredBeforeRetry {
+		t.Errorf("Expect valid creds before retry check")
+	}
+	if !credExpiredAfterRetry {
+		t.Errorf("Expect expired creds after retry check")
+	}
+	if s.Config.Credentials.IsExpired() {
+		t.Errorf("Expect valid creds after cred expired recovery")
+	}
 
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q", e, a)
+	}
 }
 
 func TestMakeAddtoUserAgentHandler(t *testing.T) {
@@ -238,7 +276,9 @@ func TestMakeAddtoUserAgentHandler(t *testing.T) {
 	r.HTTPRequest.Header.Set("User-Agent", "foo/bar")
 	fn(r)
 
-	assert.Equal(t, "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestMakeAddtoUserAgentFreeFormHandler(t *testing.T) {
@@ -247,7 +287,9 @@ func TestMakeAddtoUserAgentFreeFormHandler(t *testing.T) {
 	r.HTTPRequest.Header.Set("User-Agent", "foo/bar")
 	fn(r)
 
-	assert.Equal(t, "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := "foo/bar name/version (extra1; extra2)", r.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestRequestUserAgent(t *testing.T) {
@@ -256,11 +298,15 @@ func TestRequestUserAgent(t *testing.T) {
 
 	req := s.NewRequest(&request.Operation{Name: "Operation"}, nil, &testData{})
 	req.HTTPRequest.Header.Set("User-Agent", "foo/bar")
-	assert.NoError(t, req.Build())
+	if err := req.Build(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	expectUA := fmt.Sprintf("foo/bar %s/%s (%s; %s; %s)",
 		aws.SDKName, aws.SDKVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-	assert.Equal(t, expectUA, req.HTTPRequest.Header.Get("User-Agent"))
+	if e, a := expectUA, req.HTTPRequest.Header.Get("User-Agent"); e != a {
+		t.Errorf("expect %q user agent, got %q", e, a)
+	}
 }
 
 func TestRequestThrottleRetries(t *testing.T) {
@@ -288,22 +334,31 @@ func TestRequestThrottleRetries(t *testing.T) {
 	})
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := r.Send()
-	assert.NotNil(t, err)
-	if e, ok := err.(awserr.RequestFailure); ok {
-		assert.Equal(t, 500, e.StatusCode())
-	} else {
-		assert.Fail(t, "Expected error to be a service failure")
+	if err == nil {
+		t.Fatalf("expect error, but did not get one")
 	}
-	assert.Equal(t, "Throttling", err.(awserr.Error).Code())
-	assert.Equal(t, "An error occurred.", err.(awserr.Error).Message())
-	assert.Equal(t, 3, int(r.RetryCount))
+	aerr := err.(awserr.RequestFailure)
+	if e, a := 500, aerr.StatusCode(); e != a {
+		t.Errorf("expect %d status code, got %d", e, a)
+	}
+	if e, a := "Throttling", aerr.Code(); e != a {
+		t.Errorf("expect %q error code, got %q", e, a)
+	}
+	if e, a := "An error occurred.", aerr.Message(); e != a {
+		t.Errorf("expect %q error message, got %q", e, a)
+	}
+	if e, a := 3, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
 
 	expectDelays := []struct{ min, max time.Duration }{{500, 999}, {1000, 1998}, {2000, 3996}}
 	for i, v := range delays {
 		min := expectDelays[i].min * time.Millisecond
 		max := expectDelays[i].max * time.Millisecond
-		assert.True(t, min <= v && v <= max,
-			"Expect delay to be within range, i:%d, v:%s, min:%s, max:%s", i, v, min, max)
+		if !(min <= v && v <= max) {
+			t.Errorf("Expect delay to be within range, i:%d, v:%s, min:%s, max:%s",
+				i, v, min, max)
+		}
 	}
 }
 
@@ -339,9 +394,15 @@ func TestRequestRecoverTimeoutWithNilBody(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q", e, a)
+	}
 }
 
 func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
@@ -376,9 +437,15 @@ func TestRequestRecoverTimeoutWithNilResponse(t *testing.T) {
 	out := &testData{}
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
-	assert.Nil(t, err)
-	assert.Equal(t, 1, int(r.RetryCount))
-	assert.Equal(t, "valid", out.Data)
+	if err != nil {
+		t.Fatalf("expect no error, but got %v", err)
+	}
+	if e, a := 1, int(r.RetryCount); e != a {
+		t.Errorf("expect %d retry count, got %d", e, a)
+	}
+	if e, a := "valid", out.Data; e != a {
+		t.Errorf("expect %q output got %q", e, a)
+	}
 }
 
 func TestRequest_NoBody(t *testing.T) {
@@ -436,5 +503,66 @@ func TestRequest_NoBody(t *testing.T) {
 		if err := r.Send(); err != nil {
 			t.Fatalf("%d, expect no error sending request, got %v", i, err)
 		}
+	}
+}
+
+func TestWithLogLevel(t *testing.T) {
+	r := &request.Request{}
+
+	opt := request.WithLogLevel(aws.LogDebugWithHTTPBody)
+	r.ApplyOptions(opt)
+
+	if !r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody) {
+		t.Errorf("expect log level to be set, but was not, %v",
+			r.Config.LogLevel.Value())
+	}
+}
+
+func TestWithGetResponseHeader(t *testing.T) {
+	r := &request.Request{}
+
+	var val, val2 string
+	r.ApplyOptions(
+		request.WithGetResponseHeader("x-a-header", &val),
+		request.WithGetResponseHeader("x-second-header", &val2),
+	)
+
+	r.HTTPResponse = &http.Response{
+		Header: func() http.Header {
+			h := http.Header{}
+			h.Set("x-a-header", "first")
+			h.Set("x-second-header", "second")
+			return h
+		}(),
+	}
+	r.Handlers.Complete.Run(r)
+
+	if e, a := "first", val; e != a {
+		t.Errorf("expect %q header value got %q", e, a)
+	}
+	if e, a := "second", val2; e != a {
+		t.Errorf("expect %q header value got %q", e, a)
+	}
+}
+
+func TestWithGetResponseHeaders(t *testing.T) {
+	r := &request.Request{}
+
+	var headers http.Header
+	opt := request.WithGetResponseHeaders(&headers)
+
+	r.ApplyOptions(opt)
+
+	r.HTTPResponse = &http.Response{
+		Header: func() http.Header {
+			h := http.Header{}
+			h.Set("x-a-header", "headerValue")
+			return h
+		}(),
+	}
+	r.Handlers.Complete.Run(r)
+
+	if e, a := "headerValue", headers.Get("x-a-header"); e != a {
+		t.Errorf("expect %q header value got %q", e, a)
 	}
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -26,8 +26,9 @@ func WithRetryer(cfg *aws.Config, retryer Retryer) *aws.Config {
 // retryableCodes is a collection of service response codes which are retry-able
 // without any further action.
 var retryableCodes = map[string]struct{}{
-	"RequestError":   {},
-	"RequestTimeout": {},
+	"RequestError":            {},
+	"RequestTimeout":          {},
+	"RequestTimeoutException": {}, // Glacier's flavor of RequestTimeout
 }
 
 var throttleCodes = map[string]struct{}{

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.2"
+const SDKVersion = "1.8.5"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/ec2query/build_test.go
@@ -1298,14 +1298,14 @@ const opInputService9TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputService9TestCaseOperation2Input) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService9TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService9TestShapeInputShape{}
+		input = &InputService9TestShapeInputService9TestCaseOperation2Input{}
 	}
 
 	output = &InputService9TestShapeInputService9TestCaseOperation1Output{}
@@ -1323,7 +1323,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService9TestCaseOperation1 for usage and error information.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *InputService9TestShapeInputShape) (*InputService9TestShapeInputService9TestCaseOperation1Output, error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *InputService9TestShapeInputService9TestCaseOperation2Input) (*InputService9TestShapeInputService9TestCaseOperation1Output, error) {
 	req, out := c.InputService9TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -1337,7 +1337,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1WithContext(ctx aws.Context, input *InputService9TestShapeInputShape, opts ...request.Option) (*InputService9TestShapeInputService9TestCaseOperation1Output, error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1WithContext(ctx aws.Context, input *InputService9TestShapeInputService9TestCaseOperation2Input, opts ...request.Option) (*InputService9TestShapeInputService9TestCaseOperation1Output, error) {
 	req, out := c.InputService9TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1369,14 +1369,14 @@ const opInputService9TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputService9TestCaseOperation2Input) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService9TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService9TestShapeInputShape{}
+		input = &InputService9TestShapeInputService9TestCaseOperation2Input{}
 	}
 
 	output = &InputService9TestShapeInputService9TestCaseOperation2Output{}
@@ -1394,7 +1394,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService9TestCaseOperation2 for usage and error information.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation2(input *InputService9TestShapeInputShape) (*InputService9TestShapeInputService9TestCaseOperation2Output, error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation2(input *InputService9TestShapeInputService9TestCaseOperation2Input) (*InputService9TestShapeInputService9TestCaseOperation2Output, error) {
 	req, out := c.InputService9TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -1408,7 +1408,7 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation2WithContext(ctx aws.Context, input *InputService9TestShapeInputShape, opts ...request.Option) (*InputService9TestShapeInputService9TestCaseOperation2Output, error) {
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation2WithContext(ctx aws.Context, input *InputService9TestShapeInputService9TestCaseOperation2Input, opts ...request.Option) (*InputService9TestShapeInputService9TestCaseOperation2Output, error) {
 	req, out := c.InputService9TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1419,20 +1419,20 @@ type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService9TestShapeInputService9TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService9TestShapeInputShape struct {
+type InputService9TestShapeInputService9TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
 
 // SetToken sets the Token field's value.
-func (s *InputService9TestShapeInputShape) SetToken(v string) *InputService9TestShapeInputShape {
+func (s *InputService9TestShapeInputService9TestCaseOperation2Input) SetToken(v string) *InputService9TestShapeInputService9TestCaseOperation2Input {
 	s.Token = &v
 	return s
+}
+
+type InputService9TestShapeInputService9TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 //
@@ -1650,7 +1650,7 @@ func TestInputService8ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	svc := NewInputService9ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService9TestShapeInputShape{
+	input := &InputService9TestShapeInputService9TestCaseOperation2Input{
 		Token: aws.String("abc123"),
 	}
 	req, _ := svc.InputService9TestCaseOperation1Request(input)
@@ -1674,7 +1674,7 @@ func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 func TestInputService9ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	svc := NewInputService9ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService9TestShapeInputShape{}
+	input := &InputService9TestShapeInputService9TestCaseOperation2Input{}
 	req, _ := svc.InputService9TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/build_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/build_test.go
@@ -416,14 +416,14 @@ const opInputService3TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService3TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation1Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation1Output{}
@@ -441,7 +441,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation1 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputService3TestCaseOperation1Input) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -455,7 +455,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation1Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -487,14 +487,14 @@ const opInputService3TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService3TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation1Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation2Output{}
@@ -512,7 +512,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation2 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputService3TestCaseOperation1Input) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -526,22 +526,14 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation1Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 
-type InputService3TestShapeInputService3TestCaseOperation1Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService3TestShapeInputShape struct {
+type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
 	// BlobArg is automatically base64 encoded/decoded by the SDK.
@@ -551,15 +543,23 @@ type InputService3TestShapeInputShape struct {
 }
 
 // SetBlobArg sets the BlobArg field's value.
-func (s *InputService3TestShapeInputShape) SetBlobArg(v []byte) *InputService3TestShapeInputShape {
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetBlobArg(v []byte) *InputService3TestShapeInputService3TestCaseOperation1Input {
 	s.BlobArg = v
 	return s
 }
 
 // SetBlobMap sets the BlobMap field's value.
-func (s *InputService3TestShapeInputShape) SetBlobMap(v map[string][]byte) *InputService3TestShapeInputShape {
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetBlobMap(v map[string][]byte) *InputService3TestShapeInputService3TestCaseOperation1Input {
 	s.BlobMap = v
 	return s
+}
+
+type InputService3TestShapeInputService3TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
+type InputService3TestShapeInputService3TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -789,14 +789,14 @@ const opInputService5TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation1Output{}
@@ -814,7 +814,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation1 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
 	req, out := c.InputService5TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -828,7 +828,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation1Output, error) {
 	req, out := c.InputService5TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -860,14 +860,14 @@ const opInputService5TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation2Output{}
@@ -885,7 +885,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation2 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -899,7 +899,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation2Output, error) {
 	req, out := c.InputService5TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -931,14 +931,14 @@ const opInputService5TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation3,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation3Output{}
@@ -956,7 +956,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation3 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
 	req, out := c.InputService5TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -970,7 +970,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation3Output, error) {
 	req, out := c.InputService5TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1002,14 +1002,14 @@ const opInputService5TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation4,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation4Output{}
@@ -1027,7 +1027,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation4 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
 	req, out := c.InputService5TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -1041,7 +1041,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation4Output, error) {
 	req, out := c.InputService5TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1073,14 +1073,14 @@ const opInputService5TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation5,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation5Output{}
@@ -1098,7 +1098,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation5 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
 	req, out := c.InputService5TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -1112,7 +1112,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation5Output, error) {
 	req, out := c.InputService5TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1144,14 +1144,14 @@ const opInputService5TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputService5TestCaseOperation6Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:     opInputService5TestCaseOperation6,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService5TestShapeInputShape{}
+		input = &InputService5TestShapeInputService5TestCaseOperation6Input{}
 	}
 
 	output = &InputService5TestShapeInputService5TestCaseOperation6Output{}
@@ -1169,7 +1169,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService5TestCaseOperation6 for usage and error information.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputShape) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *InputService5TestShapeInputService5TestCaseOperation6Input) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -1183,7 +1183,7 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation6(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6WithContext(ctx aws.Context, input *InputService5TestShapeInputShape, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6WithContext(ctx aws.Context, input *InputService5TestShapeInputService5TestCaseOperation6Input, opts ...request.Option) (*InputService5TestShapeInputService5TestCaseOperation6Output, error) {
 	req, out := c.InputService5TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1210,20 +1210,20 @@ type InputService5TestShapeInputService5TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService5TestShapeInputService5TestCaseOperation6Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService5TestShapeInputShape struct {
+type InputService5TestShapeInputService5TestCaseOperation6Input struct {
 	_ struct{} `type:"structure"`
 
 	RecursiveStruct *InputService5TestShapeRecursiveStructType `type:"structure"`
 }
 
 // SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService5TestShapeInputShape) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeInputShape {
+func (s *InputService5TestShapeInputService5TestCaseOperation6Input) SetRecursiveStruct(v *InputService5TestShapeRecursiveStructType) *InputService5TestShapeInputService5TestCaseOperation6Input {
 	s.RecursiveStruct = v
 	return s
+}
+
+type InputService5TestShapeInputService5TestCaseOperation6Output struct {
+	_ struct{} `type:"structure"`
 }
 
 type InputService5TestShapeRecursiveStructType struct {
@@ -1487,7 +1487,7 @@ const opInputService7TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation2Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -1495,7 +1495,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input
 	}
 
 	if input == nil {
-		input = &InputService7TestShapeInputShape{}
+		input = &InputService7TestShapeInputService7TestCaseOperation2Input{}
 	}
 
 	output = &InputService7TestShapeInputService7TestCaseOperation1Output{}
@@ -1513,7 +1513,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService7TestCaseOperation1 for usage and error information.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *InputService7TestShapeInputShape) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *InputService7TestShapeInputService7TestCaseOperation2Input) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
 	req, out := c.InputService7TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -1527,7 +1527,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1WithContext(ctx aws.Context, input *InputService7TestShapeInputShape, opts ...request.Option) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1WithContext(ctx aws.Context, input *InputService7TestShapeInputService7TestCaseOperation2Input, opts ...request.Option) (*InputService7TestShapeInputService7TestCaseOperation1Output, error) {
 	req, out := c.InputService7TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1559,7 +1559,7 @@ const opInputService7TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation2Output) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input *InputService7TestShapeInputService7TestCaseOperation2Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -1567,7 +1567,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input
 	}
 
 	if input == nil {
-		input = &InputService7TestShapeInputShape{}
+		input = &InputService7TestShapeInputService7TestCaseOperation2Input{}
 	}
 
 	output = &InputService7TestShapeInputService7TestCaseOperation2Output{}
@@ -1585,7 +1585,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService7TestCaseOperation2 for usage and error information.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation2(input *InputService7TestShapeInputShape) (*InputService7TestShapeInputService7TestCaseOperation2Output, error) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2(input *InputService7TestShapeInputService7TestCaseOperation2Input) (*InputService7TestShapeInputService7TestCaseOperation2Output, error) {
 	req, out := c.InputService7TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -1599,7 +1599,7 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation2WithContext(ctx aws.Context, input *InputService7TestShapeInputShape, opts ...request.Option) (*InputService7TestShapeInputService7TestCaseOperation2Output, error) {
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2WithContext(ctx aws.Context, input *InputService7TestShapeInputService7TestCaseOperation2Input, opts ...request.Option) (*InputService7TestShapeInputService7TestCaseOperation2Output, error) {
 	req, out := c.InputService7TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -1610,20 +1610,20 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService7TestShapeInputService7TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService7TestShapeInputShape struct {
+type InputService7TestShapeInputService7TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
 
 // SetToken sets the Token field's value.
-func (s *InputService7TestShapeInputShape) SetToken(v string) *InputService7TestShapeInputShape {
+func (s *InputService7TestShapeInputService7TestCaseOperation2Input) SetToken(v string) *InputService7TestShapeInputService7TestCaseOperation2Input {
 	s.Token = &v
 	return s
+}
+
+type InputService7TestShapeInputService7TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 //
@@ -1684,7 +1684,7 @@ func TestInputService2ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation1Input{
 		BlobArg: []byte("foo"),
 	}
 	req, _ := svc.InputService3TestCaseOperation1Request(input)
@@ -1710,7 +1710,7 @@ func TestInputService3ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestBase64EncodedBlobsCase2(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation1Input{
 		BlobMap: map[string][]byte{
 			"key1": []byte("foo"),
 			"key2": []byte("bar"),
@@ -1768,7 +1768,7 @@ func TestInputService4ProtocolTestNestedBlobsCase1(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -1796,7 +1796,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -1826,7 +1826,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService5TestShapeRecursiveStructType{
@@ -1860,7 +1860,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveList: []*InputService5TestShapeRecursiveStructType{
 				{
@@ -1895,7 +1895,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveList: []*InputService5TestShapeRecursiveStructType{
 				{
@@ -1932,7 +1932,7 @@ func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService5ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService5ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService5TestShapeInputShape{
+	input := &InputService5TestShapeInputService5TestCaseOperation6Input{
 		RecursiveStruct: &InputService5TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService5TestShapeRecursiveStructType{
 				"bar": {
@@ -1993,7 +1993,7 @@ func TestInputService6ProtocolTestEmptyMapsCase1(t *testing.T) {
 
 func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	svc := NewInputService7ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService7TestShapeInputShape{
+	input := &InputService7TestShapeInputService7TestCaseOperation2Input{
 		Token: aws.String("abc123"),
 	}
 	req, _ := svc.InputService7TestCaseOperation1Request(input)
@@ -2017,7 +2017,7 @@ func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 func TestInputService7ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	svc := NewInputService7ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService7TestShapeInputShape{}
+	input := &InputService7TestShapeInputService7TestCaseOperation2Input{}
 	req, _ := svc.InputService7TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/jsonrpc/unmarshal_test.go
@@ -643,7 +643,7 @@ const opOutputService4TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputShape) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService4TestCaseOperation1,
 		HTTPPath: "/",
@@ -653,7 +653,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(inp
 		input = &OutputService4TestShapeOutputService4TestCaseOperation1Input{}
 	}
 
-	output = &OutputService4TestShapeOutputShape{}
+	output = &OutputService4TestShapeOutputService4TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -666,7 +666,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService4TestCaseOperation1 for usage and error information.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (*OutputService4TestShapeOutputShape, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
 	req, out := c.OutputService4TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -680,7 +680,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation1Input, opts ...request.Option) (*OutputService4TestShapeOutputShape, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation1Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
 	req, out := c.OutputService4TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -712,7 +712,7 @@ const opOutputService4TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (req *request.Request, output *OutputService4TestShapeOutputShape) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService4TestCaseOperation2,
 		HTTPPath: "/",
@@ -722,7 +722,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(inp
 		input = &OutputService4TestShapeOutputService4TestCaseOperation2Input{}
 	}
 
-	output = &OutputService4TestShapeOutputShape{}
+	output = &OutputService4TestShapeOutputService4TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -735,7 +735,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService4TestCaseOperation2 for usage and error information.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (*OutputService4TestShapeOutputShape, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *OutputService4TestShapeOutputService4TestCaseOperation2Input) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
 	req, out := c.OutputService4TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -749,7 +749,7 @@ func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation2Input, opts ...request.Option) (*OutputService4TestShapeOutputShape, error) {
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation2WithContext(ctx aws.Context, input *OutputService4TestShapeOutputService4TestCaseOperation2Input, opts ...request.Option) (*OutputService4TestShapeOutputService4TestCaseOperation2Output, error) {
 	req, out := c.OutputService4TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -764,7 +764,7 @@ type OutputService4TestShapeOutputService4TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 }
 
-type OutputService4TestShapeOutputShape struct {
+type OutputService4TestShapeOutputService4TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 
 	ListMember []*string `type:"list"`
@@ -775,19 +775,19 @@ type OutputService4TestShapeOutputShape struct {
 }
 
 // SetListMember sets the ListMember field's value.
-func (s *OutputService4TestShapeOutputShape) SetListMember(v []*string) *OutputService4TestShapeOutputShape {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
 	s.ListMember = v
 	return s
 }
 
 // SetListMemberMap sets the ListMemberMap field's value.
-func (s *OutputService4TestShapeOutputShape) SetListMemberMap(v []map[string]*string) *OutputService4TestShapeOutputShape {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMemberMap(v []map[string]*string) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
 	s.ListMemberMap = v
 	return s
 }
 
 // SetListMemberStruct sets the ListMemberStruct field's value.
-func (s *OutputService4TestShapeOutputShape) SetListMemberStruct(v []*OutputService4TestShapeStructType) *OutputService4TestShapeOutputShape {
+func (s *OutputService4TestShapeOutputService4TestCaseOperation2Output) SetListMemberStruct(v []*OutputService4TestShapeStructType) *OutputService4TestShapeOutputService4TestCaseOperation2Output {
 	s.ListMemberStruct = v
 	return s
 }

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/query/build_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/query/build_test.go
@@ -125,14 +125,14 @@ const opInputService1TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation3Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService1TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService1TestShapeInputShape{}
+		input = &InputService1TestShapeInputService1TestCaseOperation3Input{}
 	}
 
 	output = &InputService1TestShapeInputService1TestCaseOperation1Output{}
@@ -150,7 +150,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService1TestCaseOperation1 for usage and error information.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *InputService1TestShapeInputShape) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *InputService1TestShapeInputService1TestCaseOperation3Input) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
 	req, out := c.InputService1TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -164,7 +164,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1WithContext(ctx aws.Context, input *InputService1TestShapeInputShape, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1WithContext(ctx aws.Context, input *InputService1TestShapeInputService1TestCaseOperation3Input, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
 	req, out := c.InputService1TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -196,14 +196,14 @@ const opInputService1TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputService1TestCaseOperation3Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService1TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService1TestShapeInputShape{}
+		input = &InputService1TestShapeInputService1TestCaseOperation3Input{}
 	}
 
 	output = &InputService1TestShapeInputService1TestCaseOperation2Output{}
@@ -221,7 +221,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService1TestCaseOperation2 for usage and error information.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *InputService1TestShapeInputShape) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *InputService1TestShapeInputService1TestCaseOperation3Input) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
 	req, out := c.InputService1TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -235,7 +235,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2WithContext(ctx aws.Context, input *InputService1TestShapeInputShape, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2WithContext(ctx aws.Context, input *InputService1TestShapeInputService1TestCaseOperation3Input, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
 	req, out := c.InputService1TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -267,14 +267,14 @@ const opInputService1TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation3Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation3Output) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation3Request(input *InputService1TestShapeInputService1TestCaseOperation3Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:     opInputService1TestCaseOperation3,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService1TestShapeInputShape{}
+		input = &InputService1TestShapeInputService1TestCaseOperation3Input{}
 	}
 
 	output = &InputService1TestShapeInputService1TestCaseOperation3Output{}
@@ -292,7 +292,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation3Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService1TestCaseOperation3 for usage and error information.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation3(input *InputService1TestShapeInputShape) (*InputService1TestShapeInputService1TestCaseOperation3Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation3(input *InputService1TestShapeInputService1TestCaseOperation3Input) (*InputService1TestShapeInputService1TestCaseOperation3Output, error) {
 	req, out := c.InputService1TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -306,7 +306,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation3(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation3WithContext(ctx aws.Context, input *InputService1TestShapeInputShape, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation3Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation3WithContext(ctx aws.Context, input *InputService1TestShapeInputService1TestCaseOperation3Input, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation3Output, error) {
 	req, out := c.InputService1TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -321,11 +321,7 @@ type InputService1TestShapeInputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService1TestShapeInputService1TestCaseOperation3Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService1TestShapeInputShape struct {
+type InputService1TestShapeInputService1TestCaseOperation3Input struct {
 	_ struct{} `type:"structure"`
 
 	Bar *string `type:"string"`
@@ -336,21 +332,25 @@ type InputService1TestShapeInputShape struct {
 }
 
 // SetBar sets the Bar field's value.
-func (s *InputService1TestShapeInputShape) SetBar(v string) *InputService1TestShapeInputShape {
+func (s *InputService1TestShapeInputService1TestCaseOperation3Input) SetBar(v string) *InputService1TestShapeInputService1TestCaseOperation3Input {
 	s.Bar = &v
 	return s
 }
 
 // SetBaz sets the Baz field's value.
-func (s *InputService1TestShapeInputShape) SetBaz(v bool) *InputService1TestShapeInputShape {
+func (s *InputService1TestShapeInputService1TestCaseOperation3Input) SetBaz(v bool) *InputService1TestShapeInputService1TestCaseOperation3Input {
 	s.Baz = &v
 	return s
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService1TestShapeInputShape) SetFoo(v string) *InputService1TestShapeInputShape {
+func (s *InputService1TestShapeInputService1TestCaseOperation3Input) SetFoo(v string) *InputService1TestShapeInputService1TestCaseOperation3Input {
 	s.Foo = &v
 	return s
+}
+
+type InputService1TestShapeInputService1TestCaseOperation3Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -587,14 +587,14 @@ const opInputService3TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation2Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService3TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation2Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation1Output{}
@@ -612,7 +612,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation1 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputService3TestCaseOperation2Input) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -626,7 +626,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation2Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -658,14 +658,14 @@ const opInputService3TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputService3TestCaseOperation2Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService3TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation2Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation2Output{}
@@ -683,7 +683,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation2 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputService3TestCaseOperation2Input) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -697,7 +697,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation2Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -708,20 +708,20 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService3TestShapeInputShape struct {
+type InputService3TestShapeInputService3TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `type:"list"`
 }
 
 // SetListArg sets the ListArg field's value.
-func (s *InputService3TestShapeInputShape) SetListArg(v []*string) *InputService3TestShapeInputShape {
+func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetListArg(v []*string) *InputService3TestShapeInputService3TestCaseOperation2Input {
 	s.ListArg = v
 	return s
+}
+
+type InputService3TestShapeInputService3TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -804,14 +804,14 @@ const opInputService4TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputShape) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation2Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService4TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService4TestShapeInputShape{}
+		input = &InputService4TestShapeInputService4TestCaseOperation2Input{}
 	}
 
 	output = &InputService4TestShapeInputService4TestCaseOperation1Output{}
@@ -829,7 +829,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService4TestCaseOperation1 for usage and error information.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *InputService4TestShapeInputShape) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *InputService4TestShapeInputService4TestCaseOperation2Input) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
 	req, out := c.InputService4TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -843,7 +843,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1WithContext(ctx aws.Context, input *InputService4TestShapeInputShape, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation2Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation1Output, error) {
 	req, out := c.InputService4TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -875,14 +875,14 @@ const opInputService4TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputShape) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputService4TestCaseOperation2Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService4TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService4TestShapeInputShape{}
+		input = &InputService4TestShapeInputService4TestCaseOperation2Input{}
 	}
 
 	output = &InputService4TestShapeInputService4TestCaseOperation2Output{}
@@ -900,7 +900,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService4TestCaseOperation2 for usage and error information.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *InputService4TestShapeInputShape) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *InputService4TestShapeInputService4TestCaseOperation2Input) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
 	req, out := c.InputService4TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -914,7 +914,7 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2WithContext(ctx aws.Context, input *InputService4TestShapeInputShape, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2WithContext(ctx aws.Context, input *InputService4TestShapeInputService4TestCaseOperation2Input, opts ...request.Option) (*InputService4TestShapeInputService4TestCaseOperation2Output, error) {
 	req, out := c.InputService4TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -925,11 +925,7 @@ type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService4TestShapeInputService4TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService4TestShapeInputShape struct {
+type InputService4TestShapeInputService4TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	ListArg []*string `type:"list" flattened:"true"`
@@ -940,21 +936,25 @@ type InputService4TestShapeInputShape struct {
 }
 
 // SetListArg sets the ListArg field's value.
-func (s *InputService4TestShapeInputShape) SetListArg(v []*string) *InputService4TestShapeInputShape {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.ListArg = v
 	return s
 }
 
 // SetNamedListArg sets the NamedListArg field's value.
-func (s *InputService4TestShapeInputShape) SetNamedListArg(v []*string) *InputService4TestShapeInputShape {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetNamedListArg(v []*string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.NamedListArg = v
 	return s
 }
 
 // SetScalarArg sets the ScalarArg field's value.
-func (s *InputService4TestShapeInputShape) SetScalarArg(v string) *InputService4TestShapeInputShape {
+func (s *InputService4TestShapeInputService4TestCaseOperation2Input) SetScalarArg(v string) *InputService4TestShapeInputService4TestCaseOperation2Input {
 	s.ScalarArg = &v
 	return s
+}
+
+type InputService4TestShapeInputService4TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -2040,14 +2040,14 @@ const opInputService12TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation1,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation1Output{}
@@ -2065,7 +2065,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation1 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
 	req, out := c.InputService12TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2079,7 +2079,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation1Output, error) {
 	req, out := c.InputService12TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2111,14 +2111,14 @@ const opInputService12TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation2Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation2,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation2Output{}
@@ -2136,7 +2136,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation2 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
 	req, out := c.InputService12TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2150,7 +2150,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation2WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation2WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation2Output, error) {
 	req, out := c.InputService12TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2182,14 +2182,14 @@ const opInputService12TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation3Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation3,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation3Output{}
@@ -2207,7 +2207,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation3 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
 	req, out := c.InputService12TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -2221,7 +2221,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation3WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation3WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation3Output, error) {
 	req, out := c.InputService12TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2253,14 +2253,14 @@ const opInputService12TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation4Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation4,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation4Output{}
@@ -2278,7 +2278,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation4 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
 	req, out := c.InputService12TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -2292,7 +2292,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation4WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation4WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation4Output, error) {
 	req, out := c.InputService12TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2324,14 +2324,14 @@ const opInputService12TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation5Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation5,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation5Output{}
@@ -2349,7 +2349,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation5Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation5 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
 	req, out := c.InputService12TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -2363,7 +2363,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation5(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation5WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation5WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation5Output, error) {
 	req, out := c.InputService12TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2395,14 +2395,14 @@ const opInputService12TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(input *InputService12TestShapeInputShape) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation6Output) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:     opInputService12TestCaseOperation6,
 		HTTPPath: "/",
 	}
 
 	if input == nil {
-		input = &InputService12TestShapeInputShape{}
+		input = &InputService12TestShapeInputService12TestCaseOperation1Input{}
 	}
 
 	output = &InputService12TestShapeInputService12TestCaseOperation6Output{}
@@ -2420,7 +2420,7 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation6Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService12TestCaseOperation6 for usage and error information.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *InputService12TestShapeInputShape) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *InputService12TestShapeInputService12TestCaseOperation1Input) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
 	req, out := c.InputService12TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -2434,11 +2434,23 @@ func (c *InputService12ProtocolTest) InputService12TestCaseOperation6(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation6WithContext(ctx aws.Context, input *InputService12TestShapeInputShape, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation6WithContext(ctx aws.Context, input *InputService12TestShapeInputService12TestCaseOperation1Input, opts ...request.Option) (*InputService12TestShapeInputService12TestCaseOperation6Output, error) {
 	req, out := c.InputService12TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+type InputService12TestShapeInputService12TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
+	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeInputService12TestCaseOperation1Input {
+	s.RecursiveStruct = v
+	return s
 }
 
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
@@ -2463,18 +2475,6 @@ type InputService12TestShapeInputService12TestCaseOperation5Output struct {
 
 type InputService12TestShapeInputService12TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService12TestShapeInputShape struct {
-	_ struct{} `type:"structure"`
-
-	RecursiveStruct *InputService12TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService12TestShapeInputShape) SetRecursiveStruct(v *InputService12TestShapeRecursiveStructType) *InputService12TestShapeInputShape {
-	s.RecursiveStruct = v
-	return s
 }
 
 type InputService12TestShapeRecursiveStructType struct {
@@ -2593,7 +2593,7 @@ const opInputService13TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputShape) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputService13TestCaseOperation2Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2601,7 +2601,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService13TestShapeInputShape{}
+		input = &InputService13TestShapeInputService13TestCaseOperation2Input{}
 	}
 
 	output = &InputService13TestShapeInputService13TestCaseOperation1Output{}
@@ -2619,7 +2619,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService13TestCaseOperation1 for usage and error information.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *InputService13TestShapeInputShape) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *InputService13TestShapeInputService13TestCaseOperation2Input) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
 	req, out := c.InputService13TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2633,7 +2633,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1WithContext(ctx aws.Context, input *InputService13TestShapeInputShape, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation2Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation1Output, error) {
 	req, out := c.InputService13TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2665,7 +2665,7 @@ const opInputService13TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputShape) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputService13TestCaseOperation2Input) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -2673,7 +2673,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService13TestShapeInputShape{}
+		input = &InputService13TestShapeInputService13TestCaseOperation2Input{}
 	}
 
 	output = &InputService13TestShapeInputService13TestCaseOperation2Output{}
@@ -2691,7 +2691,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService13TestCaseOperation2 for usage and error information.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *InputService13TestShapeInputShape) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *InputService13TestShapeInputService13TestCaseOperation2Input) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
 	req, out := c.InputService13TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2705,7 +2705,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2WithContext(ctx aws.Context, input *InputService13TestShapeInputShape, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2WithContext(ctx aws.Context, input *InputService13TestShapeInputService13TestCaseOperation2Input, opts ...request.Option) (*InputService13TestShapeInputService13TestCaseOperation2Output, error) {
 	req, out := c.InputService13TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2716,20 +2716,20 @@ type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService13TestShapeInputService13TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService13TestShapeInputShape struct {
+type InputService13TestShapeInputService13TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
 
 // SetToken sets the Token field's value.
-func (s *InputService13TestShapeInputShape) SetToken(v string) *InputService13TestShapeInputShape {
+func (s *InputService13TestShapeInputService13TestCaseOperation2Input) SetToken(v string) *InputService13TestShapeInputService13TestCaseOperation2Input {
 	s.Token = &v
 	return s
+}
+
+type InputService13TestShapeInputService13TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 //
@@ -2738,7 +2738,7 @@ func (s *InputService13TestShapeInputShape) SetToken(v string) *InputService13Te
 
 func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	svc := NewInputService1ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService1TestShapeInputShape{
+	input := &InputService1TestShapeInputService1TestCaseOperation3Input{
 		Bar: aws.String("val2"),
 		Foo: aws.String("val1"),
 	}
@@ -2763,7 +2763,7 @@ func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 func TestInputService1ProtocolTestScalarMembersCase2(t *testing.T) {
 	svc := NewInputService1ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService1TestShapeInputShape{
+	input := &InputService1TestShapeInputService1TestCaseOperation3Input{
 		Baz: aws.Bool(true),
 	}
 	req, _ := svc.InputService1TestCaseOperation2Request(input)
@@ -2787,7 +2787,7 @@ func TestInputService1ProtocolTestScalarMembersCase2(t *testing.T) {
 
 func TestInputService1ProtocolTestScalarMembersCase3(t *testing.T) {
 	svc := NewInputService1ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService1TestShapeInputShape{
+	input := &InputService1TestShapeInputService1TestCaseOperation3Input{
 		Baz: aws.Bool(false),
 	}
 	req, _ := svc.InputService1TestCaseOperation3Request(input)
@@ -2837,7 +2837,7 @@ func TestInputService2ProtocolTestNestedStructureMembersCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestListTypesCase1(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation2Input{
 		ListArg: []*string{
 			aws.String("foo"),
 			aws.String("bar"),
@@ -2865,7 +2865,7 @@ func TestInputService3ProtocolTestListTypesCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestListTypesCase2(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation2Input{
 		ListArg: []*string{},
 	}
 	req, _ := svc.InputService3TestCaseOperation2Request(input)
@@ -2889,7 +2889,7 @@ func TestInputService3ProtocolTestListTypesCase2(t *testing.T) {
 
 func TestInputService4ProtocolTestFlattenedListCase1(t *testing.T) {
 	svc := NewInputService4ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService4TestShapeInputShape{
+	input := &InputService4TestShapeInputService4TestCaseOperation2Input{
 		ListArg: []*string{
 			aws.String("a"),
 			aws.String("b"),
@@ -2918,7 +2918,7 @@ func TestInputService4ProtocolTestFlattenedListCase1(t *testing.T) {
 
 func TestInputService4ProtocolTestFlattenedListCase2(t *testing.T) {
 	svc := NewInputService4ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService4TestShapeInputShape{
+	input := &InputService4TestShapeInputService4TestCaseOperation2Input{
 		NamedListArg: []*string{
 			aws.String("a"),
 		},
@@ -3130,7 +3130,7 @@ func TestInputService11ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -3156,7 +3156,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -3184,7 +3184,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService12TestShapeRecursiveStructType{
@@ -3216,7 +3216,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveList: []*InputService12TestShapeRecursiveStructType{
 				{
@@ -3249,7 +3249,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveList: []*InputService12TestShapeRecursiveStructType{
 				{
@@ -3284,7 +3284,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService12ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService12TestShapeInputShape{
+	input := &InputService12TestShapeInputService12TestCaseOperation1Input{
 		RecursiveStruct: &InputService12TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService12TestShapeRecursiveStructType{
 				"bar": {
@@ -3317,7 +3317,7 @@ func TestInputService12ProtocolTestRecursiveShapesCase6(t *testing.T) {
 
 func TestInputService13ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputShape{
+	input := &InputService13TestShapeInputService13TestCaseOperation2Input{
 		Token: aws.String("abc123"),
 	}
 	req, _ := svc.InputService13TestCaseOperation1Request(input)
@@ -3341,7 +3341,7 @@ func TestInputService13ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 func TestInputService13ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	svc := NewInputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService13TestShapeInputShape{}
+	input := &InputService13TestShapeInputService13TestCaseOperation2Input{}
 	req, _ := svc.InputService13TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/build_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/build_test.go
@@ -125,7 +125,7 @@ const opInputService1TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation2Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -133,7 +133,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input
 	}
 
 	if input == nil {
-		input = &InputService1TestShapeInputShape{}
+		input = &InputService1TestShapeInputService1TestCaseOperation2Input{}
 	}
 
 	output = &InputService1TestShapeInputService1TestCaseOperation1Output{}
@@ -151,7 +151,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService1TestCaseOperation1 for usage and error information.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *InputService1TestShapeInputShape) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *InputService1TestShapeInputService1TestCaseOperation2Input) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
 	req, out := c.InputService1TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -165,7 +165,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1WithContext(ctx aws.Context, input *InputService1TestShapeInputShape, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1WithContext(ctx aws.Context, input *InputService1TestShapeInputService1TestCaseOperation2Input, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation1Output, error) {
 	req, out := c.InputService1TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -197,7 +197,7 @@ const opInputService1TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputService1TestCaseOperation2Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation2,
 		HTTPMethod: "PUT",
@@ -205,7 +205,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input
 	}
 
 	if input == nil {
-		input = &InputService1TestShapeInputShape{}
+		input = &InputService1TestShapeInputService1TestCaseOperation2Input{}
 	}
 
 	output = &InputService1TestShapeInputService1TestCaseOperation2Output{}
@@ -223,7 +223,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService1TestCaseOperation2 for usage and error information.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *InputService1TestShapeInputShape) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *InputService1TestShapeInputService1TestCaseOperation2Input) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
 	req, out := c.InputService1TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -237,7 +237,7 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2WithContext(ctx aws.Context, input *InputService1TestShapeInputShape, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2WithContext(ctx aws.Context, input *InputService1TestShapeInputService1TestCaseOperation2Input, opts ...request.Option) (*InputService1TestShapeInputService1TestCaseOperation2Output, error) {
 	req, out := c.InputService1TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -320,6 +320,26 @@ type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+type InputService1TestShapeInputService1TestCaseOperation2Input struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	Description *string `type:"string"`
+
+	Name *string `type:"string"`
+}
+
+// SetDescription sets the Description field's value.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Input) SetDescription(v string) *InputService1TestShapeInputService1TestCaseOperation2Input {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Input) SetName(v string) *InputService1TestShapeInputService1TestCaseOperation2Input {
+	s.Name = &v
+	return s
+}
+
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -330,26 +350,6 @@ type InputService1TestShapeInputService1TestCaseOperation3Input struct {
 
 type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService1TestShapeInputShape struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
-
-	Description *string `type:"string"`
-
-	Name *string `type:"string"`
-}
-
-// SetDescription sets the Description field's value.
-func (s *InputService1TestShapeInputShape) SetDescription(v string) *InputService1TestShapeInputShape {
-	s.Description = &v
-	return s
-}
-
-// SetName sets the Name field's value.
-func (s *InputService1TestShapeInputShape) SetName(v string) *InputService1TestShapeInputShape {
-	s.Name = &v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -599,7 +599,7 @@ const opInputService3TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation2Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService3TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -607,7 +607,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation2Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation1Output{}
@@ -625,7 +625,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation1 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *InputService3TestShapeInputService3TestCaseOperation2Input) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -639,7 +639,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation2Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation1Output, error) {
 	req, out := c.InputService3TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -671,7 +671,7 @@ const opInputService3TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputService3TestCaseOperation2Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService3TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -679,7 +679,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input
 	}
 
 	if input == nil {
-		input = &InputService3TestShapeInputShape{}
+		input = &InputService3TestShapeInputService3TestCaseOperation2Input{}
 	}
 
 	output = &InputService3TestShapeInputService3TestCaseOperation2Output{}
@@ -697,7 +697,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input
 //
 // See the AWS API reference guide for 's
 // API operation InputService3TestCaseOperation2 for usage and error information.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputShape) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *InputService3TestShapeInputService3TestCaseOperation2Input) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -711,7 +711,7 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation2(input *Input
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputShape, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2WithContext(ctx aws.Context, input *InputService3TestShapeInputService3TestCaseOperation2Input, opts ...request.Option) (*InputService3TestShapeInputService3TestCaseOperation2Output, error) {
 	req, out := c.InputService3TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -722,11 +722,7 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService3TestShapeInputService3TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService3TestShapeInputShape struct {
+type InputService3TestShapeInputService3TestCaseOperation2Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
 	Description *string `type:"string"`
@@ -735,15 +731,19 @@ type InputService3TestShapeInputShape struct {
 }
 
 // SetDescription sets the Description field's value.
-func (s *InputService3TestShapeInputShape) SetDescription(v string) *InputService3TestShapeInputShape {
+func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetDescription(v string) *InputService3TestShapeInputService3TestCaseOperation2Input {
 	s.Description = &v
 	return s
 }
 
 // SetSubStructure sets the SubStructure field's value.
-func (s *InputService3TestShapeInputShape) SetSubStructure(v *InputService3TestShapeSubStructure) *InputService3TestShapeInputShape {
+func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetSubStructure(v *InputService3TestShapeSubStructure) *InputService3TestShapeInputService3TestCaseOperation2Input {
 	s.SubStructure = v
 	return s
+}
+
+type InputService3TestShapeInputService3TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 type InputService3TestShapeSubStructure struct {
@@ -2496,7 +2496,7 @@ const opInputService15TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation2Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation1,
 		HTTPMethod: "GET",
@@ -2504,7 +2504,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService15TestShapeInputShape{}
+		input = &InputService15TestShapeInputService15TestCaseOperation2Input{}
 	}
 
 	output = &InputService15TestShapeInputService15TestCaseOperation1Output{}
@@ -2522,7 +2522,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService15TestCaseOperation1 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *InputService15TestShapeInputService15TestCaseOperation2Input) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
 	req, out := c.InputService15TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2536,7 +2536,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext(ctx aws.Context, input *InputService15TestShapeInputShape, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation2Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation1Output, error) {
 	req, out := c.InputService15TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2568,7 +2568,7 @@ const opInputService15TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(input *InputService15TestShapeInputShape) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation2Output) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(input *InputService15TestShapeInputService15TestCaseOperation2Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation2,
 		HTTPMethod: "GET",
@@ -2576,7 +2576,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService15TestShapeInputShape{}
+		input = &InputService15TestShapeInputService15TestCaseOperation2Input{}
 	}
 
 	output = &InputService15TestShapeInputService15TestCaseOperation2Output{}
@@ -2594,7 +2594,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService15TestCaseOperation2 for usage and error information.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *InputService15TestShapeInputShape) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *InputService15TestShapeInputService15TestCaseOperation2Input) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
 	req, out := c.InputService15TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2608,7 +2608,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation2WithContext(ctx aws.Context, input *InputService15TestShapeInputShape, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation2WithContext(ctx aws.Context, input *InputService15TestShapeInputService15TestCaseOperation2Input, opts ...request.Option) (*InputService15TestShapeInputService15TestCaseOperation2Output, error) {
 	req, out := c.InputService15TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2619,20 +2619,20 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService15TestShapeInputService15TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService15TestShapeInputShape struct {
+type InputService15TestShapeInputService15TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
 }
 
 // SetBoolQuery sets the BoolQuery field's value.
-func (s *InputService15TestShapeInputShape) SetBoolQuery(v bool) *InputService15TestShapeInputShape {
+func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetBoolQuery(v bool) *InputService15TestShapeInputService15TestCaseOperation2Input {
 	s.BoolQuery = &v
 	return s
+}
+
+type InputService15TestShapeInputService15TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -2858,7 +2858,7 @@ const opInputService17TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputService17TestCaseOperation1Input) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService17TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -2866,7 +2866,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService17TestShapeInputShape{}
+		input = &InputService17TestShapeInputService17TestCaseOperation1Input{}
 	}
 
 	output = &InputService17TestShapeInputService17TestCaseOperation1Output{}
@@ -2884,7 +2884,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService17TestCaseOperation1 for usage and error information.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *InputService17TestShapeInputService17TestCaseOperation1Input) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
 	req, out := c.InputService17TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -2898,7 +2898,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1WithContext(ctx aws.Context, input *InputService17TestShapeInputShape, opts ...request.Option) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1WithContext(ctx aws.Context, input *InputService17TestShapeInputService17TestCaseOperation1Input, opts ...request.Option) (*InputService17TestShapeInputService17TestCaseOperation1Output, error) {
 	req, out := c.InputService17TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -2930,7 +2930,7 @@ const opInputService17TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation2Output) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(input *InputService17TestShapeInputService17TestCaseOperation1Input) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService17TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -2938,7 +2938,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService17TestShapeInputShape{}
+		input = &InputService17TestShapeInputService17TestCaseOperation1Input{}
 	}
 
 	output = &InputService17TestShapeInputService17TestCaseOperation2Output{}
@@ -2956,7 +2956,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService17TestCaseOperation2 for usage and error information.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *InputService17TestShapeInputShape) (*InputService17TestShapeInputService17TestCaseOperation2Output, error) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *InputService17TestShapeInputService17TestCaseOperation1Input) (*InputService17TestShapeInputService17TestCaseOperation2Output, error) {
 	req, out := c.InputService17TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -2970,11 +2970,23 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation2WithContext(ctx aws.Context, input *InputService17TestShapeInputShape, opts ...request.Option) (*InputService17TestShapeInputService17TestCaseOperation2Output, error) {
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2WithContext(ctx aws.Context, input *InputService17TestShapeInputService17TestCaseOperation1Input, opts ...request.Option) (*InputService17TestShapeInputService17TestCaseOperation2Output, error) {
 	req, out := c.InputService17TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+type InputService17TestShapeInputService17TestCaseOperation1Input struct {
+	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo []byte `locationName:"foo" type:"blob"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Input) SetFoo(v []byte) *InputService17TestShapeInputService17TestCaseOperation1Input {
+	s.Foo = v
+	return s
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Output struct {
@@ -2983,18 +2995,6 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService17TestShapeInputShape struct {
-	_ struct{} `type:"structure" payload:"Foo"`
-
-	Foo []byte `locationName:"foo" type:"blob"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *InputService17TestShapeInputShape) SetFoo(v []byte) *InputService17TestShapeInputShape {
-	s.Foo = v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3077,7 +3077,7 @@ const opInputService18TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputService18TestCaseOperation2Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -3085,7 +3085,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputShape{}
+		input = &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation1Output{}
@@ -3103,7 +3103,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation1 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *InputService18TestShapeInputService18TestCaseOperation2Input) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
 	req, out := c.InputService18TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -3117,7 +3117,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1WithContext(ctx aws.Context, input *InputService18TestShapeInputShape, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation2Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation1Output, error) {
 	req, out := c.InputService18TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3149,7 +3149,7 @@ const opInputService18TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputService18TestCaseOperation2Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -3157,7 +3157,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputShape{}
+		input = &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation2Output{}
@@ -3175,7 +3175,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation2 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *InputService18TestShapeInputService18TestCaseOperation2Input) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
 	req, out := c.InputService18TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -3189,7 +3189,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2WithContext(ctx aws.Context, input *InputService18TestShapeInputShape, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation2Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation2Output, error) {
 	req, out := c.InputService18TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3221,7 +3221,7 @@ const opInputService18TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputService18TestCaseOperation2Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation3,
 		HTTPMethod: "POST",
@@ -3229,7 +3229,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputShape{}
+		input = &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation3Output{}
@@ -3247,7 +3247,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation3 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *InputService18TestShapeInputService18TestCaseOperation2Input) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
 	req, out := c.InputService18TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -3261,7 +3261,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3WithContext(ctx aws.Context, input *InputService18TestShapeInputShape, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation2Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation3Output, error) {
 	req, out := c.InputService18TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3293,7 +3293,7 @@ const opInputService18TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputService18TestCaseOperation2Input) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation4,
 		HTTPMethod: "POST",
@@ -3301,7 +3301,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(inp
 	}
 
 	if input == nil {
-		input = &InputService18TestShapeInputShape{}
+		input = &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	}
 
 	output = &InputService18TestShapeInputService18TestCaseOperation4Output{}
@@ -3319,7 +3319,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService18TestCaseOperation4 for usage and error information.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputShape) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *InputService18TestShapeInputService18TestCaseOperation2Input) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
 	req, out := c.InputService18TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -3333,7 +3333,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4WithContext(ctx aws.Context, input *InputService18TestShapeInputShape, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4WithContext(ctx aws.Context, input *InputService18TestShapeInputService18TestCaseOperation2Input, opts ...request.Option) (*InputService18TestShapeInputService18TestCaseOperation4Output, error) {
 	req, out := c.InputService18TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3356,6 +3356,18 @@ type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+type InputService18TestShapeInputService18TestCaseOperation2Input struct {
+	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *InputService18TestShapeFooShape `locationName:"foo" type:"structure"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService18TestShapeInputService18TestCaseOperation2Input) SetFoo(v *InputService18TestShapeFooShape) *InputService18TestShapeInputService18TestCaseOperation2Input {
+	s.Foo = v
+	return s
+}
+
 type InputService18TestShapeInputService18TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
@@ -3366,18 +3378,6 @@ type InputService18TestShapeInputService18TestCaseOperation3Output struct {
 
 type InputService18TestShapeInputService18TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService18TestShapeInputShape struct {
-	_ struct{} `type:"structure" payload:"Foo"`
-
-	Foo *InputService18TestShapeFooShape `locationName:"foo" type:"structure"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *InputService18TestShapeInputShape) SetFoo(v *InputService18TestShapeFooShape) *InputService18TestShapeInputShape {
-	s.Foo = v
-	return s
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -3786,7 +3786,7 @@ const opInputService21TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation1Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation1Output) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation1Request(input *InputService21TestShapeInputService21TestCaseOperation2Input) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService21TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -3794,7 +3794,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService21TestShapeInputShape{}
+		input = &InputService21TestShapeInputService21TestCaseOperation2Input{}
 	}
 
 	output = &InputService21TestShapeInputService21TestCaseOperation1Output{}
@@ -3812,7 +3812,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService21TestCaseOperation1 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation1Output, error) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *InputService21TestShapeInputService21TestCaseOperation2Input) (*InputService21TestShapeInputService21TestCaseOperation1Output, error) {
 	req, out := c.InputService21TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -3826,7 +3826,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation1WithContext(ctx aws.Context, input *InputService21TestShapeInputShape, opts ...request.Option) (*InputService21TestShapeInputService21TestCaseOperation1Output, error) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation1WithContext(ctx aws.Context, input *InputService21TestShapeInputService21TestCaseOperation2Input, opts ...request.Option) (*InputService21TestShapeInputService21TestCaseOperation1Output, error) {
 	req, out := c.InputService21TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3858,7 +3858,7 @@ const opInputService21TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(input *InputService21TestShapeInputShape) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation2Output) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(input *InputService21TestShapeInputService21TestCaseOperation2Input) (req *request.Request, output *InputService21TestShapeInputService21TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService21TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -3866,7 +3866,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService21TestShapeInputShape{}
+		input = &InputService21TestShapeInputService21TestCaseOperation2Input{}
 	}
 
 	output = &InputService21TestShapeInputService21TestCaseOperation2Output{}
@@ -3884,7 +3884,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService21TestCaseOperation2 for usage and error information.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation2(input *InputService21TestShapeInputShape) (*InputService21TestShapeInputService21TestCaseOperation2Output, error) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation2(input *InputService21TestShapeInputService21TestCaseOperation2Input) (*InputService21TestShapeInputService21TestCaseOperation2Output, error) {
 	req, out := c.InputService21TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -3898,7 +3898,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService21ProtocolTest) InputService21TestCaseOperation2WithContext(ctx aws.Context, input *InputService21TestShapeInputShape, opts ...request.Option) (*InputService21TestShapeInputService21TestCaseOperation2Output, error) {
+func (c *InputService21ProtocolTest) InputService21TestCaseOperation2WithContext(ctx aws.Context, input *InputService21TestShapeInputService21TestCaseOperation2Input, opts ...request.Option) (*InputService21TestShapeInputService21TestCaseOperation2Output, error) {
 	req, out := c.InputService21TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -3909,20 +3909,20 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService21TestShapeInputService21TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-}
-
-type InputService21TestShapeInputShape struct {
+type InputService21TestShapeInputService21TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
 
 // SetFoo sets the Foo field's value.
-func (s *InputService21TestShapeInputShape) SetFoo(v string) *InputService21TestShapeInputShape {
+func (s *InputService21TestShapeInputService21TestCaseOperation2Input) SetFoo(v string) *InputService21TestShapeInputService21TestCaseOperation2Input {
 	s.Foo = &v
 	return s
+}
+
+type InputService21TestShapeInputService21TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 }
 
 // The service client's operations are safe to be used concurrently.
@@ -4005,7 +4005,7 @@ const opInputService22TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation1Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -4013,7 +4013,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation1Output{}
@@ -4031,7 +4031,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation1 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation1(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation1(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
 	req, out := c.InputService22TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -4045,7 +4045,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation1WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation1WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation1Output, error) {
 	req, out := c.InputService22TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4077,7 +4077,7 @@ const opInputService22TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation2Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation2Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation2Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -4085,7 +4085,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation2Output{}
@@ -4103,7 +4103,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation2 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation2(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation2Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation2(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation2Output, error) {
 	req, out := c.InputService22TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -4117,7 +4117,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation2WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation2Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation2WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation2Output, error) {
 	req, out := c.InputService22TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4149,7 +4149,7 @@ const opInputService22TestCaseOperation3 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation3Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation3Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation3Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation3Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation3,
 		HTTPMethod: "POST",
@@ -4157,7 +4157,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation3Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation3Output{}
@@ -4175,7 +4175,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation3Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation3 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation3(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation3Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation3(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation3Output, error) {
 	req, out := c.InputService22TestCaseOperation3Request(input)
 	return out, req.Send()
 }
@@ -4189,7 +4189,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation3(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation3WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation3Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation3WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation3Output, error) {
 	req, out := c.InputService22TestCaseOperation3Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4221,7 +4221,7 @@ const opInputService22TestCaseOperation4 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation4Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation4Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation4Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation4Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation4,
 		HTTPMethod: "POST",
@@ -4229,7 +4229,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation4Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation4Output{}
@@ -4247,7 +4247,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation4Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation4 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation4(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation4Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation4(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation4Output, error) {
 	req, out := c.InputService22TestCaseOperation4Request(input)
 	return out, req.Send()
 }
@@ -4261,7 +4261,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation4(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation4WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation4Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation4WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation4Output, error) {
 	req, out := c.InputService22TestCaseOperation4Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4293,7 +4293,7 @@ const opInputService22TestCaseOperation5 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation5Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation5Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation5Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation5Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation5,
 		HTTPMethod: "POST",
@@ -4301,7 +4301,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation5Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation5Output{}
@@ -4319,7 +4319,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation5Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation5 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation5(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation5Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation5(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation5Output, error) {
 	req, out := c.InputService22TestCaseOperation5Request(input)
 	return out, req.Send()
 }
@@ -4333,7 +4333,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation5(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation5WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation5Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation5WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation5Output, error) {
 	req, out := c.InputService22TestCaseOperation5Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4365,7 +4365,7 @@ const opInputService22TestCaseOperation6 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation6Request(input *InputService22TestShapeInputShape) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation6Output) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation6Request(input *InputService22TestShapeInputService22TestCaseOperation2Input) (req *request.Request, output *InputService22TestShapeInputService22TestCaseOperation6Output) {
 	op := &request.Operation{
 		Name:       opInputService22TestCaseOperation6,
 		HTTPMethod: "POST",
@@ -4373,7 +4373,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation6Request(inp
 	}
 
 	if input == nil {
-		input = &InputService22TestShapeInputShape{}
+		input = &InputService22TestShapeInputService22TestCaseOperation2Input{}
 	}
 
 	output = &InputService22TestShapeInputService22TestCaseOperation6Output{}
@@ -4391,7 +4391,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation6Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService22TestCaseOperation6 for usage and error information.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation6(input *InputService22TestShapeInputShape) (*InputService22TestShapeInputService22TestCaseOperation6Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation6(input *InputService22TestShapeInputService22TestCaseOperation2Input) (*InputService22TestShapeInputService22TestCaseOperation6Output, error) {
 	req, out := c.InputService22TestCaseOperation6Request(input)
 	return out, req.Send()
 }
@@ -4405,7 +4405,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation6(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService22ProtocolTest) InputService22TestCaseOperation6WithContext(ctx aws.Context, input *InputService22TestShapeInputShape, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation6Output, error) {
+func (c *InputService22ProtocolTest) InputService22TestCaseOperation6WithContext(ctx aws.Context, input *InputService22TestShapeInputService22TestCaseOperation2Input, opts ...request.Option) (*InputService22TestShapeInputService22TestCaseOperation6Output, error) {
 	req, out := c.InputService22TestCaseOperation6Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4414,6 +4414,18 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation6WithContext
 
 type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+type InputService22TestShapeInputService22TestCaseOperation2Input struct {
+	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
+
+	RecursiveStruct *InputService22TestShapeRecursiveStructType `type:"structure"`
+}
+
+// SetRecursiveStruct sets the RecursiveStruct field's value.
+func (s *InputService22TestShapeInputService22TestCaseOperation2Input) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeInputService22TestCaseOperation2Input {
+	s.RecursiveStruct = v
+	return s
 }
 
 type InputService22TestShapeInputService22TestCaseOperation2Output struct {
@@ -4434,18 +4446,6 @@ type InputService22TestShapeInputService22TestCaseOperation5Output struct {
 
 type InputService22TestShapeInputService22TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
-}
-
-type InputService22TestShapeInputShape struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
-
-	RecursiveStruct *InputService22TestShapeRecursiveStructType `type:"structure"`
-}
-
-// SetRecursiveStruct sets the RecursiveStruct field's value.
-func (s *InputService22TestShapeInputShape) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeInputShape {
-	s.RecursiveStruct = v
-	return s
 }
 
 type InputService22TestShapeRecursiveStructType struct {
@@ -4707,7 +4707,7 @@ const opInputService24TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(input *InputService24TestShapeInputShape) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation1Output) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(input *InputService24TestShapeInputService24TestCaseOperation1Input) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation1Output) {
 	op := &request.Operation{
 		Name:       opInputService24TestCaseOperation1,
 		HTTPMethod: "POST",
@@ -4715,7 +4715,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(inp
 	}
 
 	if input == nil {
-		input = &InputService24TestShapeInputShape{}
+		input = &InputService24TestShapeInputService24TestCaseOperation1Input{}
 	}
 
 	output = &InputService24TestShapeInputService24TestCaseOperation1Output{}
@@ -4733,7 +4733,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService24TestCaseOperation1 for usage and error information.
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation1(input *InputService24TestShapeInputShape) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1(input *InputService24TestShapeInputService24TestCaseOperation1Input) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
 	req, out := c.InputService24TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -4747,7 +4747,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation1(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation1WithContext(ctx aws.Context, input *InputService24TestShapeInputShape, opts ...request.Option) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1WithContext(ctx aws.Context, input *InputService24TestShapeInputService24TestCaseOperation1Input, opts ...request.Option) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
 	req, out := c.InputService24TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -4779,7 +4779,7 @@ const opInputService24TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation2Request(input *InputService24TestShapeInputShape) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation2Output) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation2Request(input *InputService24TestShapeInputService24TestCaseOperation1Input) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService24TestCaseOperation2,
 		HTTPMethod: "POST",
@@ -4787,7 +4787,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation2Request(inp
 	}
 
 	if input == nil {
-		input = &InputService24TestShapeInputShape{}
+		input = &InputService24TestShapeInputService24TestCaseOperation1Input{}
 	}
 
 	output = &InputService24TestShapeInputService24TestCaseOperation2Output{}
@@ -4805,7 +4805,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation InputService24TestCaseOperation2 for usage and error information.
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation2(input *InputService24TestShapeInputShape) (*InputService24TestShapeInputService24TestCaseOperation2Output, error) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation2(input *InputService24TestShapeInputService24TestCaseOperation1Input) (*InputService24TestShapeInputService24TestCaseOperation2Output, error) {
 	req, out := c.InputService24TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -4819,11 +4819,23 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation2(input *Inp
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *InputService24ProtocolTest) InputService24TestCaseOperation2WithContext(ctx aws.Context, input *InputService24TestShapeInputShape, opts ...request.Option) (*InputService24TestShapeInputService24TestCaseOperation2Output, error) {
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation2WithContext(ctx aws.Context, input *InputService24TestShapeInputService24TestCaseOperation1Input, opts ...request.Option) (*InputService24TestShapeInputService24TestCaseOperation2Output, error) {
 	req, out := c.InputService24TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+type InputService24TestShapeInputService24TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
+	Token *string `type:"string" idempotencyToken:"true"`
+}
+
+// SetToken sets the Token field's value.
+func (s *InputService24TestShapeInputService24TestCaseOperation1Input) SetToken(v string) *InputService24TestShapeInputService24TestCaseOperation1Input {
+	s.Token = &v
+	return s
 }
 
 type InputService24TestShapeInputService24TestCaseOperation1Output struct {
@@ -4834,25 +4846,13 @@ type InputService24TestShapeInputService24TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
-type InputService24TestShapeInputShape struct {
-	_ struct{} `type:"structure"`
-
-	Token *string `type:"string" idempotencyToken:"true"`
-}
-
-// SetToken sets the Token field's value.
-func (s *InputService24TestShapeInputShape) SetToken(v string) *InputService24TestShapeInputShape {
-	s.Token = &v
-	return s
-}
-
 //
 // Tests begin here
 //
 
 func TestInputService1ProtocolTestBasicXMLSerializationCase1(t *testing.T) {
 	svc := NewInputService1ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService1TestShapeInputShape{
+	input := &InputService1TestShapeInputService1TestCaseOperation2Input{
 		Description: aws.String("bar"),
 		Name:        aws.String("foo"),
 	}
@@ -4866,7 +4866,7 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(string(body)), InputService1TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(string(body)), InputService1TestShapeInputService1TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -4877,7 +4877,7 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase1(t *testing.T) {
 
 func TestInputService1ProtocolTestBasicXMLSerializationCase2(t *testing.T) {
 	svc := NewInputService1ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService1TestShapeInputShape{
+	input := &InputService1TestShapeInputService1TestCaseOperation2Input{
 		Description: aws.String("bar"),
 		Name:        aws.String("foo"),
 	}
@@ -4891,7 +4891,7 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(string(body)), InputService1TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(string(body)), InputService1TestShapeInputService1TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -4946,7 +4946,7 @@ func TestInputService2ProtocolTestSerializeOtherScalarTypesCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestNestedStructuresCase1(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation2Input{
 		Description: aws.String("baz"),
 		SubStructure: &InputService3TestShapeSubStructure{
 			Bar: aws.String("b"),
@@ -4963,7 +4963,7 @@ func TestInputService3ProtocolTestNestedStructuresCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Bar xmlns="https://foo/">b</Bar><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(string(body)), InputService3TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Bar xmlns="https://foo/">b</Bar><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(string(body)), InputService3TestShapeInputService3TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -4974,7 +4974,7 @@ func TestInputService3ProtocolTestNestedStructuresCase1(t *testing.T) {
 
 func TestInputService3ProtocolTestNestedStructuresCase2(t *testing.T) {
 	svc := NewInputService3ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService3TestShapeInputShape{
+	input := &InputService3TestShapeInputService3TestCaseOperation2Input{
 		Description: aws.String("baz"),
 		SubStructure: &InputService3TestShapeSubStructure{
 			Foo: aws.String("a"),
@@ -4990,7 +4990,7 @@ func TestInputService3ProtocolTestNestedStructuresCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(string(body)), InputService3TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(string(body)), InputService3TestShapeInputService3TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -5297,7 +5297,7 @@ func TestInputService14ProtocolTestStringToStringListMapsInQuerystringCase1(t *t
 
 func TestInputService15ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
+	input := &InputService15TestShapeInputService15TestCaseOperation2Input{
 		BoolQuery: aws.Bool(true),
 	}
 	req, _ := svc.InputService15TestCaseOperation1Request(input)
@@ -5316,7 +5316,7 @@ func TestInputService15ProtocolTestBooleanInQuerystringCase1(t *testing.T) {
 
 func TestInputService15ProtocolTestBooleanInQuerystringCase2(t *testing.T) {
 	svc := NewInputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService15TestShapeInputShape{
+	input := &InputService15TestShapeInputService15TestCaseOperation2Input{
 		BoolQuery: aws.Bool(false),
 	}
 	req, _ := svc.InputService15TestCaseOperation2Request(input)
@@ -5359,7 +5359,7 @@ func TestInputService16ProtocolTestStringPayloadCase1(t *testing.T) {
 
 func TestInputService17ProtocolTestBlobPayloadCase1(t *testing.T) {
 	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService17TestShapeInputShape{
+	input := &InputService17TestShapeInputService17TestCaseOperation1Input{
 		Foo: []byte("bar"),
 	}
 	req, _ := svc.InputService17TestCaseOperation1Request(input)
@@ -5383,7 +5383,7 @@ func TestInputService17ProtocolTestBlobPayloadCase1(t *testing.T) {
 
 func TestInputService17ProtocolTestBlobPayloadCase2(t *testing.T) {
 	svc := NewInputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService17TestShapeInputShape{}
+	input := &InputService17TestShapeInputService17TestCaseOperation1Input{}
 	req, _ := svc.InputService17TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -5400,7 +5400,7 @@ func TestInputService17ProtocolTestBlobPayloadCase2(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputShape{
+	input := &InputService18TestShapeInputService18TestCaseOperation2Input{
 		Foo: &InputService18TestShapeFooShape{
 			Baz: aws.String("bar"),
 		},
@@ -5415,7 +5415,7 @@ func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService18TestShapeInputShape{})
+	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -5426,7 +5426,7 @@ func TestInputService18ProtocolTestStructurePayloadCase1(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase2(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputShape{}
+	input := &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	req, _ := svc.InputService18TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -5443,7 +5443,7 @@ func TestInputService18ProtocolTestStructurePayloadCase2(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputShape{
+	input := &InputService18TestShapeInputService18TestCaseOperation2Input{
 		Foo: &InputService18TestShapeFooShape{},
 	}
 	req, _ := svc.InputService18TestCaseOperation3Request(input)
@@ -5456,7 +5456,7 @@ func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService18TestShapeInputShape{})
+	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(string(body)), InputService18TestShapeInputService18TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -5467,7 +5467,7 @@ func TestInputService18ProtocolTestStructurePayloadCase3(t *testing.T) {
 
 func TestInputService18ProtocolTestStructurePayloadCase4(t *testing.T) {
 	svc := NewInputService18ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService18TestShapeInputShape{}
+	input := &InputService18TestShapeInputService18TestCaseOperation2Input{}
 	req, _ := svc.InputService18TestCaseOperation4Request(input)
 	r := req.HTTPRequest
 
@@ -5533,7 +5533,7 @@ func TestInputService20ProtocolTestGreedyKeysCase1(t *testing.T) {
 
 func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase1(t *testing.T) {
 	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{}
+	input := &InputService21TestShapeInputService21TestCaseOperation2Input{}
 	req, _ := svc.InputService21TestCaseOperation1Request(input)
 	r := req.HTTPRequest
 
@@ -5550,7 +5550,7 @@ func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStringsCase2(t *testing.T) {
 	svc := NewInputService21ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService21TestShapeInputShape{
+	input := &InputService21TestShapeInputService21TestCaseOperation2Input{
 		Foo: aws.String(""),
 	}
 	req, _ := svc.InputService21TestCaseOperation2Request(input)
@@ -5569,7 +5569,7 @@ func TestInputService21ProtocolTestOmitsNullQueryParamsButSerializesEmptyStrings
 
 func TestInputService22ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			NoRecurse: aws.String("foo"),
 		},
@@ -5584,7 +5584,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5595,7 +5595,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 func TestInputService22ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 				NoRecurse: aws.String("foo"),
@@ -5612,7 +5612,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5623,7 +5623,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 func TestInputService22ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 				RecursiveStruct: &InputService22TestShapeRecursiveStructType{
@@ -5644,7 +5644,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5655,7 +5655,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 func TestInputService22ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			RecursiveList: []*InputService22TestShapeRecursiveStructType{
 				{
@@ -5677,7 +5677,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5688,7 +5688,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 func TestInputService22ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			RecursiveList: []*InputService22TestShapeRecursiveStructType{
 				{
@@ -5712,7 +5712,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5723,7 +5723,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 func TestInputService22ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	svc := NewInputService22ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService22TestShapeInputShape{
+	input := &InputService22TestShapeInputService22TestCaseOperation2Input{
 		RecursiveStruct: &InputService22TestShapeRecursiveStructType{
 			RecursiveMap: map[string]*InputService22TestShapeRecursiveStructType{
 				"bar": {
@@ -5745,7 +5745,7 @@ func TestInputService22ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveMap xmlns="https://foo/"><entry xmlns="https://foo/"><key xmlns="https://foo/">foo</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></value></entry><entry xmlns="https://foo/"><key xmlns="https://foo/">bar</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputShape{})
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveMap xmlns="https://foo/"><entry xmlns="https://foo/"><key xmlns="https://foo/">foo</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></value></entry><entry xmlns="https://foo/"><key xmlns="https://foo/">bar</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)), InputService22TestShapeInputService22TestCaseOperation2Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5776,7 +5776,7 @@ func TestInputService23ProtocolTestTimestampInHeaderCase1(t *testing.T) {
 
 func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	svc := NewInputService24ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService24TestShapeInputShape{
+	input := &InputService24TestShapeInputService24TestCaseOperation1Input{
 		Token: aws.String("abc123"),
 	}
 	req, _ := svc.InputService24TestCaseOperation1Request(input)
@@ -5789,7 +5789,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputShape{})
+	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputService24TestCaseOperation1Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -5800,7 +5800,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 
 func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	svc := NewInputService24ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService24TestShapeInputShape{}
+	input := &InputService24TestShapeInputService24TestCaseOperation1Input{}
 	req, _ := svc.InputService24TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -5811,7 +5811,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	// assert body
 	assert.NotNil(t, r.Body)
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputShape{})
+	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(string(body)), InputService24TestShapeInputService24TestCaseOperation1Input{})
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/unmarshal_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/unmarshal_test.go
@@ -125,7 +125,7 @@ const opOutputService1TestCaseOperation1 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputShape) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService1TestCaseOperation1,
 		HTTPPath: "/",
@@ -135,7 +135,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 		input = &OutputService1TestShapeOutputService1TestCaseOperation1Input{}
 	}
 
-	output = &OutputService1TestShapeOutputShape{}
+	output = &OutputService1TestShapeOutputService1TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -148,7 +148,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService1TestCaseOperation1 for usage and error information.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (*OutputService1TestShapeOutputShape, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	return out, req.Send()
 }
@@ -162,7 +162,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation1Input, opts ...request.Option) (*OutputService1TestShapeOutputShape, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation1Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation1Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -194,7 +194,7 @@ const opOutputService1TestCaseOperation2 = "OperationName"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *request.Request, output *OutputService1TestShapeOutputShape) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:     opOutputService1TestCaseOperation2,
 		HTTPPath: "/",
@@ -204,7 +204,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(inp
 		input = &OutputService1TestShapeOutputService1TestCaseOperation2Input{}
 	}
 
-	output = &OutputService1TestShapeOutputShape{}
+	output = &OutputService1TestShapeOutputService1TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
 	return
 }
@@ -217,7 +217,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(inp
 //
 // See the AWS API reference guide for 's
 // API operation OutputService1TestCaseOperation2 for usage and error information.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (*OutputService1TestShapeOutputShape, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation2Request(input)
 	return out, req.Send()
 }
@@ -231,7 +231,7 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2(input *Out
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation2Input, opts ...request.Option) (*OutputService1TestShapeOutputShape, error) {
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2WithContext(ctx aws.Context, input *OutputService1TestShapeOutputService1TestCaseOperation2Input, opts ...request.Option) (*OutputService1TestShapeOutputService1TestCaseOperation2Output, error) {
 	req, out := c.OutputService1TestCaseOperation2Request(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
@@ -246,7 +246,7 @@ type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 }
 
-type OutputService1TestShapeOutputShape struct {
+type OutputService1TestShapeOutputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 
 	Char *string `type:"character"`
@@ -273,67 +273,67 @@ type OutputService1TestShapeOutputShape struct {
 }
 
 // SetChar sets the Char field's value.
-func (s *OutputService1TestShapeOutputShape) SetChar(v string) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetChar(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Char = &v
 	return s
 }
 
 // SetDouble sets the Double field's value.
-func (s *OutputService1TestShapeOutputShape) SetDouble(v float64) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetDouble(v float64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Double = &v
 	return s
 }
 
 // SetFalseBool sets the FalseBool field's value.
-func (s *OutputService1TestShapeOutputShape) SetFalseBool(v bool) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetFalseBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.FalseBool = &v
 	return s
 }
 
 // SetFloat sets the Float field's value.
-func (s *OutputService1TestShapeOutputShape) SetFloat(v float64) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetFloat(v float64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Float = &v
 	return s
 }
 
 // SetImaHeader sets the ImaHeader field's value.
-func (s *OutputService1TestShapeOutputShape) SetImaHeader(v string) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetImaHeader(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.ImaHeader = &v
 	return s
 }
 
 // SetImaHeaderLocation sets the ImaHeaderLocation field's value.
-func (s *OutputService1TestShapeOutputShape) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetImaHeaderLocation(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.ImaHeaderLocation = &v
 	return s
 }
 
 // SetLong sets the Long field's value.
-func (s *OutputService1TestShapeOutputShape) SetLong(v int64) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetLong(v int64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Long = &v
 	return s
 }
 
 // SetNum sets the Num field's value.
-func (s *OutputService1TestShapeOutputShape) SetNum(v int64) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetNum(v int64) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Num = &v
 	return s
 }
 
 // SetStr sets the Str field's value.
-func (s *OutputService1TestShapeOutputShape) SetStr(v string) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetStr(v string) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Str = &v
 	return s
 }
 
 // SetTimestamp sets the Timestamp field's value.
-func (s *OutputService1TestShapeOutputShape) SetTimestamp(v time.Time) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTimestamp(v time.Time) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.Timestamp = &v
 	return s
 }
 
 // SetTrueBool sets the TrueBool field's value.
-func (s *OutputService1TestShapeOutputShape) SetTrueBool(v bool) *OutputService1TestShapeOutputShape {
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.TrueBool = &v
 	return s
 }

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -1374,8 +1374,11 @@ func (c *EC2) AttachVpnGatewayRequest(input *AttachVpnGatewayInput) (req *reques
 
 // AttachVpnGateway API operation for Amazon Elastic Compute Cloud.
 //
-// Attaches a virtual private gateway to a VPC. For more information, see Adding
-// a Hardware Virtual Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
+// Attaches a virtual private gateway to a VPC. You can attach one virtual private
+// gateway to one VPC at a time.
+//
+// For more information, see Adding a Hardware Virtual Private Gateway to Your
+// VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4400,7 +4403,10 @@ func (c *EC2) CreateVolumeRequest(input *CreateVolumeInput) (req *request.Reques
 // encrypted. For more information, see Amazon EBS Encryption (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 //
-// For more information, see Creating or Restoring an Amazon EBS Volume (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-volume.html)
+// You can tag your volumes during creation. For more information, see Tagging
+// Your Amazon EC2 Resources (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+//
+// For more information, see Creating an Amazon EBS Volume (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-volume.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -8892,8 +8898,12 @@ func (c *EC2) DescribeInstanceStatusPages(input *DescribeInstanceStatusInput, fn
 func (c *EC2) DescribeInstanceStatusPagesWithContext(ctx aws.Context, input *DescribeInstanceStatusInput, fn func(*DescribeInstanceStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeInstanceStatusRequest(&inCpy)
+			var inCpy *DescribeInstanceStatusInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstanceStatusRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9034,8 +9044,12 @@ func (c *EC2) DescribeInstancesPages(input *DescribeInstancesInput, fn func(*Des
 func (c *EC2) DescribeInstancesPagesWithContext(ctx aws.Context, input *DescribeInstancesInput, fn func(*DescribeInstancesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeInstancesRequest(&inCpy)
+			var inCpy *DescribeInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstancesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9391,8 +9405,12 @@ func (c *EC2) DescribeNatGatewaysPages(input *DescribeNatGatewaysInput, fn func(
 func (c *EC2) DescribeNatGatewaysPagesWithContext(ctx aws.Context, input *DescribeNatGatewaysInput, fn func(*DescribeNatGatewaysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeNatGatewaysRequest(&inCpy)
+			var inCpy *DescribeNatGatewaysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeNatGatewaysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -10161,8 +10179,12 @@ func (c *EC2) DescribeReservedInstancesModificationsPages(input *DescribeReserve
 func (c *EC2) DescribeReservedInstancesModificationsPagesWithContext(ctx aws.Context, input *DescribeReservedInstancesModificationsInput, fn func(*DescribeReservedInstancesModificationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeReservedInstancesModificationsRequest(&inCpy)
+			var inCpy *DescribeReservedInstancesModificationsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReservedInstancesModificationsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -10299,8 +10321,12 @@ func (c *EC2) DescribeReservedInstancesOfferingsPages(input *DescribeReservedIns
 func (c *EC2) DescribeReservedInstancesOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedInstancesOfferingsInput, fn func(*DescribeReservedInstancesOfferingsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeReservedInstancesOfferingsRequest(&inCpy)
+			var inCpy *DescribeReservedInstancesOfferingsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReservedInstancesOfferingsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -10949,8 +10975,12 @@ func (c *EC2) DescribeSnapshotsPages(input *DescribeSnapshotsInput, fn func(*Des
 func (c *EC2) DescribeSnapshotsPagesWithContext(ctx aws.Context, input *DescribeSnapshotsInput, fn func(*DescribeSnapshotsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeSnapshotsRequest(&inCpy)
+			var inCpy *DescribeSnapshotsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSnapshotsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -11311,8 +11341,12 @@ func (c *EC2) DescribeSpotFleetRequestsPages(input *DescribeSpotFleetRequestsInp
 func (c *EC2) DescribeSpotFleetRequestsPagesWithContext(ctx aws.Context, input *DescribeSpotFleetRequestsInput, fn func(*DescribeSpotFleetRequestsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeSpotFleetRequestsRequest(&inCpy)
+			var inCpy *DescribeSpotFleetRequestsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSpotFleetRequestsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -11534,8 +11568,12 @@ func (c *EC2) DescribeSpotPriceHistoryPages(input *DescribeSpotPriceHistoryInput
 func (c *EC2) DescribeSpotPriceHistoryPagesWithContext(ctx aws.Context, input *DescribeSpotPriceHistoryInput, fn func(*DescribeSpotPriceHistoryOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeSpotPriceHistoryRequest(&inCpy)
+			var inCpy *DescribeSpotPriceHistoryInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSpotPriceHistoryRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -11820,8 +11858,12 @@ func (c *EC2) DescribeTagsPages(input *DescribeTagsInput, fn func(*DescribeTagsO
 func (c *EC2) DescribeTagsPagesWithContext(ctx aws.Context, input *DescribeTagsInput, fn func(*DescribeTagsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeTagsRequest(&inCpy)
+			var inCpy *DescribeTagsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeTagsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -12060,8 +12102,12 @@ func (c *EC2) DescribeVolumeStatusPages(input *DescribeVolumeStatusInput, fn fun
 func (c *EC2) DescribeVolumeStatusPagesWithContext(ctx aws.Context, input *DescribeVolumeStatusInput, fn func(*DescribeVolumeStatusOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeVolumeStatusRequest(&inCpy)
+			var inCpy *DescribeVolumeStatusInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVolumeStatusRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -12197,8 +12243,12 @@ func (c *EC2) DescribeVolumesPages(input *DescribeVolumesInput, fn func(*Describ
 func (c *EC2) DescribeVolumesPagesWithContext(ctx aws.Context, input *DescribeVolumesInput, fn func(*DescribeVolumesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.DescribeVolumesRequest(&inCpy)
+			var inCpy *DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVolumesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -17086,8 +17136,8 @@ func (c *EC2) RegisterImageRequest(input *RegisterImageInput) (req *request.Requ
 //
 // You can also use RegisterImage to create an Amazon EBS-backed Linux AMI from
 // a snapshot of a root device volume. You specify the snapshot using the block
-// device mapping. For more information, see Launching an Instance from a Snapshot
-// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_LaunchingInstanceFromSnapshot.html)
+// device mapping. For more information, see Launching a Linux Instance from
+// a Backup (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-launch-snapshot.html)
 // in the Amazon Elastic Compute Cloud User Guide.
 //
 // You can't register an image where a secondary (non-root) snapshot has AWS
@@ -18703,9 +18753,9 @@ func (c *EC2) RunInstancesRequest(input *RunInstancesInput) (req *request.Reques
 // each instead of 1 launch request for 500 instances.
 //
 // An instance is ready for you to use when it's in the running state. You can
-// check the state of your instance using DescribeInstances. After launch, you
-// can apply tags to your running instance (requires a resource ID). For more
-// information, see CreateTags and Tagging Your Amazon EC2 Resources (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+// check the state of your instance using DescribeInstances. You can tag instances
+// and EBS volumes during launch, after launch, or both. For more information,
+// see CreateTags and Tagging Your Amazon EC2 Resources (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
 //
 // Linux instances have access to the public key of the key pair at boot. You
 // can use this key to provide secure access to the instance. Amazon EC2 public
@@ -19580,8 +19630,8 @@ func (s *AccountAttributeValue) SetAttributeValue(v string) *AccountAttributeVal
 type ActiveInstance struct {
 	_ struct{} `type:"structure"`
 
-	// The health status of the instance. If the status of both the instance status
-	// check and the system status check is impaired, the health status of the instance
+	// The health status of the instance. If the status of either the instance status
+	// check or the system status check is impaired, the health status of the instance
 	// is unhealthy. Otherwise, the health status is healthy.
 	InstanceHealth *string `locationName:"instanceHealth" type:"string" enum:"InstanceHealthStatus"`
 
@@ -25461,6 +25511,9 @@ type CreateVolumeInput struct {
 	// The snapshot from which to create the volume.
 	SnapshotId *string `type:"string"`
 
+	// The tags to apply to the volume during creation.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
+
 	// The volume type. This can be gp2 for General Purpose SSD, io1 for Provisioned
 	// IOPS SSD, st1 for Throughput Optimized HDD, sc1 for Cold HDD, or standard
 	// for Magnetic volumes.
@@ -25531,6 +25584,12 @@ func (s *CreateVolumeInput) SetSize(v int64) *CreateVolumeInput {
 // SetSnapshotId sets the SnapshotId field's value.
 func (s *CreateVolumeInput) SetSnapshotId(v string) *CreateVolumeInput {
 	s.SnapshotId = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CreateVolumeInput) SetTagSpecifications(v []*TagSpecification) *CreateVolumeInput {
+	s.TagSpecifications = v
 	return s
 }
 
@@ -46882,7 +46941,9 @@ type RegisterImageInput struct {
 	// the architecture specified in the manifest file.
 	Architecture *string `locationName:"architecture" type:"string" enum:"ArchitectureValues"`
 
-	// The billing product codes.
+	// The billing product codes. Your account must be authorized to specify billing
+	// product codes. Otherwise, you can use the AWS Marketplace to bill for the
+	// use of an AMI.
 	BillingProducts []*string `locationName:"BillingProduct" locationNameList:"item" type:"list"`
 
 	// One or more block device mapping entries.
@@ -50431,6 +50492,11 @@ type RunInstancesInput struct {
 	// [EC2-VPC] The ID of the subnet to launch the instance into.
 	SubnetId *string `type:"string"`
 
+	// The tags to apply to the resources during launch. You can tag instances and
+	// volumes. The specified tags are applied to all instances or volumes that
+	// are created during launch.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
+
 	// The user data to make available to the instance. For more information, see
 	// Running Commands on Your Linux Instance at Launch (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)
 	// (Linux) and Adding User Data (http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-instance-metadata.html#instancedata-add-user-data)
@@ -50625,6 +50691,12 @@ func (s *RunInstancesInput) SetSecurityGroups(v []*string) *RunInstancesInput {
 // SetSubnetId sets the SubnetId field's value.
 func (s *RunInstancesInput) SetSubnetId(v string) *RunInstancesInput {
 	s.SubnetId = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *RunInstancesInput) SetTagSpecifications(v []*TagSpecification) *RunInstancesInput {
+	s.TagSpecifications = v
 	return s
 }
 
@@ -54165,6 +54237,41 @@ func (s *TagDescription) SetResourceType(v string) *TagDescription {
 // SetValue sets the Value field's value.
 func (s *TagDescription) SetValue(v string) *TagDescription {
 	s.Value = &v
+	return s
+}
+
+// The tags to apply to a resource when the resource is being created.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/TagSpecification
+type TagSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// The type of resource to tag. Currently, the resource types that support tagging
+	// on creation are instance and volume.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+
+	// The tags to apply to the resource.
+	Tags []*Tag `locationName:"Tag" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s TagSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagSpecification) GoString() string {
+	return s.String()
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *TagSpecification) SetResourceType(v string) *TagSpecification {
+	s.ResourceType = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagSpecification) SetTags(v []*Tag) *TagSpecification {
+	s.Tags = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/examples_test.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/examples_test.go
@@ -1424,7 +1424,20 @@ func ExampleEC2_CreateVolume() {
 		KmsKeyId:         aws.String("String"),
 		Size:             aws.Int64(1),
 		SnapshotId:       aws.String("String"),
-		VolumeType:       aws.String("VolumeType"),
+		TagSpecifications: []*ec2.TagSpecification{
+			{ // Required
+				ResourceType: aws.String("ResourceType"),
+				Tags: []*ec2.Tag{
+					{ // Required
+						Key:   aws.String("String"),
+						Value: aws.String("String"),
+					},
+					// More values...
+				},
+			},
+			// More values...
+		},
+		VolumeType: aws.String("VolumeType"),
 	}
 	resp, err := svc.CreateVolume(params)
 
@@ -6642,6 +6655,19 @@ func ExampleEC2_RunInstances() {
 			// More values...
 		},
 		SubnetId: aws.String("String"),
+		TagSpecifications: []*ec2.TagSpecification{
+			{ // Required
+				ResourceType: aws.String("ResourceType"),
+				Tags: []*ec2.Tag{
+					{ // Required
+						Key:   aws.String("String"),
+						Value: aws.String("String"),
+					},
+					// More values...
+				},
+			},
+			// More values...
+		},
 		UserData: aws.String("String"),
 	}
 	resp, err := svc.RunInstances(params)

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/waiters.go
@@ -44,7 +44,12 @@ func (c *EC2) WaitUntilBundleTaskCompleteWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeBundleTasksRequest(input)
+			var inCpy *DescribeBundleTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeBundleTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -85,7 +90,12 @@ func (c *EC2) WaitUntilConversionTaskCancelledWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy *DescribeConversionTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeConversionTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -136,7 +146,12 @@ func (c *EC2) WaitUntilConversionTaskCompletedWithContext(ctx aws.Context, input
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy *DescribeConversionTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeConversionTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -177,7 +192,12 @@ func (c *EC2) WaitUntilConversionTaskDeletedWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeConversionTasksRequest(input)
+			var inCpy *DescribeConversionTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeConversionTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -228,7 +248,12 @@ func (c *EC2) WaitUntilCustomerGatewayAvailableWithContext(ctx aws.Context, inpu
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeCustomerGatewaysRequest(input)
+			var inCpy *DescribeCustomerGatewaysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeCustomerGatewaysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -269,7 +294,12 @@ func (c *EC2) WaitUntilExportTaskCancelledWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeExportTasksRequest(input)
+			var inCpy *DescribeExportTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeExportTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -310,7 +340,12 @@ func (c *EC2) WaitUntilExportTaskCompletedWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeExportTasksRequest(input)
+			var inCpy *DescribeExportTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeExportTasksRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -356,7 +391,12 @@ func (c *EC2) WaitUntilImageAvailableWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeImagesRequest(input)
+			var inCpy *DescribeImagesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImagesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -402,7 +442,12 @@ func (c *EC2) WaitUntilImageExistsWithContext(ctx aws.Context, input *DescribeIm
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeImagesRequest(input)
+			var inCpy *DescribeImagesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImagesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -448,7 +493,12 @@ func (c *EC2) WaitUntilInstanceExistsWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy *DescribeInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstancesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -509,7 +559,12 @@ func (c *EC2) WaitUntilInstanceRunningWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy *DescribeInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstancesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -555,7 +610,12 @@ func (c *EC2) WaitUntilInstanceStatusOkWithContext(ctx aws.Context, input *Descr
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceStatusRequest(input)
+			var inCpy *DescribeInstanceStatusInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstanceStatusRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -606,7 +666,12 @@ func (c *EC2) WaitUntilInstanceStoppedWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy *DescribeInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstancesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -657,7 +722,12 @@ func (c *EC2) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input *Des
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstancesRequest(input)
+			var inCpy *DescribeInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstancesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -703,7 +773,12 @@ func (c *EC2) WaitUntilKeyPairExistsWithContext(ctx aws.Context, input *Describe
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeKeyPairsRequest(input)
+			var inCpy *DescribeKeyPairsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeKeyPairsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -764,7 +839,12 @@ func (c *EC2) WaitUntilNatGatewayAvailableWithContext(ctx aws.Context, input *De
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeNatGatewaysRequest(input)
+			var inCpy *DescribeNatGatewaysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeNatGatewaysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -810,7 +890,12 @@ func (c *EC2) WaitUntilNetworkInterfaceAvailableWithContext(ctx aws.Context, inp
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeNetworkInterfacesRequest(input)
+			var inCpy *DescribeNetworkInterfacesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeNetworkInterfacesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -851,7 +936,12 @@ func (c *EC2) WaitUntilPasswordDataAvailableWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetPasswordDataRequest(input)
+			var inCpy *GetPasswordDataInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetPasswordDataRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -892,7 +982,12 @@ func (c *EC2) WaitUntilSnapshotCompletedWithContext(ctx aws.Context, input *Desc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSnapshotsRequest(input)
+			var inCpy *DescribeSnapshotsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSnapshotsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -953,7 +1048,12 @@ func (c *EC2) WaitUntilSpotInstanceRequestFulfilledWithContext(ctx aws.Context, 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSpotInstanceRequestsRequest(input)
+			var inCpy *DescribeSpotInstanceRequestsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSpotInstanceRequestsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -994,7 +1094,12 @@ func (c *EC2) WaitUntilSubnetAvailableWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeSubnetsRequest(input)
+			var inCpy *DescribeSubnetsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeSubnetsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1035,7 +1140,12 @@ func (c *EC2) WaitUntilSystemStatusOkWithContext(ctx aws.Context, input *Describ
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeInstanceStatusRequest(input)
+			var inCpy *DescribeInstanceStatusInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeInstanceStatusRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1081,7 +1191,12 @@ func (c *EC2) WaitUntilVolumeAvailableWithContext(ctx aws.Context, input *Descri
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy *DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVolumesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1127,7 +1242,12 @@ func (c *EC2) WaitUntilVolumeDeletedWithContext(ctx aws.Context, input *Describe
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy *DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVolumesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1173,7 +1293,12 @@ func (c *EC2) WaitUntilVolumeInUseWithContext(ctx aws.Context, input *DescribeVo
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVolumesRequest(input)
+			var inCpy *DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVolumesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1214,7 +1339,12 @@ func (c *EC2) WaitUntilVpcAvailableWithContext(ctx aws.Context, input *DescribeV
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcsRequest(input)
+			var inCpy *DescribeVpcsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpcsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1260,7 +1390,12 @@ func (c *EC2) WaitUntilVpcExistsWithContext(ctx aws.Context, input *DescribeVpcs
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcsRequest(input)
+			var inCpy *DescribeVpcsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpcsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1306,7 +1441,12 @@ func (c *EC2) WaitUntilVpcPeeringConnectionDeletedWithContext(ctx aws.Context, i
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcPeeringConnectionsRequest(input)
+			var inCpy *DescribeVpcPeeringConnectionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpcPeeringConnectionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1352,7 +1492,12 @@ func (c *EC2) WaitUntilVpcPeeringConnectionExistsWithContext(ctx aws.Context, in
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpcPeeringConnectionsRequest(input)
+			var inCpy *DescribeVpcPeeringConnectionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpcPeeringConnectionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1403,7 +1548,12 @@ func (c *EC2) WaitUntilVpnConnectionAvailableWithContext(ctx aws.Context, input 
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpnConnectionsRequest(input)
+			var inCpy *DescribeVpnConnectionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpnConnectionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -1449,7 +1599,12 @@ func (c *EC2) WaitUntilVpnConnectionDeletedWithContext(ctx aws.Context, input *D
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.DescribeVpnConnectionsRequest(input)
+			var inCpy *DescribeVpnConnectionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeVpnConnectionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
@@ -4827,8 +4827,12 @@ func (c *IAM) GetAccountAuthorizationDetailsPages(input *GetAccountAuthorization
 func (c *IAM) GetAccountAuthorizationDetailsPagesWithContext(ctx aws.Context, input *GetAccountAuthorizationDetailsInput, fn func(*GetAccountAuthorizationDetailsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.GetAccountAuthorizationDetailsRequest(&inCpy)
+			var inCpy *GetAccountAuthorizationDetailsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetAccountAuthorizationDetailsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -5424,8 +5428,12 @@ func (c *IAM) GetGroupPages(input *GetGroupInput, fn func(*GetGroupOutput, bool)
 func (c *IAM) GetGroupPagesWithContext(ctx aws.Context, input *GetGroupInput, fn func(*GetGroupOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.GetGroupRequest(&inCpy)
+			var inCpy *GetGroupInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetGroupRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -6811,8 +6819,12 @@ func (c *IAM) ListAccessKeysPages(input *ListAccessKeysInput, fn func(*ListAcces
 func (c *IAM) ListAccessKeysPagesWithContext(ctx aws.Context, input *ListAccessKeysInput, fn func(*ListAccessKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAccessKeysRequest(&inCpy)
+			var inCpy *ListAccessKeysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAccessKeysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -6947,8 +6959,12 @@ func (c *IAM) ListAccountAliasesPages(input *ListAccountAliasesInput, fn func(*L
 func (c *IAM) ListAccountAliasesPagesWithContext(ctx aws.Context, input *ListAccountAliasesInput, fn func(*ListAccountAliasesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAccountAliasesRequest(&inCpy)
+			var inCpy *ListAccountAliasesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAccountAliasesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7099,8 +7115,12 @@ func (c *IAM) ListAttachedGroupPoliciesPages(input *ListAttachedGroupPoliciesInp
 func (c *IAM) ListAttachedGroupPoliciesPagesWithContext(ctx aws.Context, input *ListAttachedGroupPoliciesInput, fn func(*ListAttachedGroupPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAttachedGroupPoliciesRequest(&inCpy)
+			var inCpy *ListAttachedGroupPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAttachedGroupPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7251,8 +7271,12 @@ func (c *IAM) ListAttachedRolePoliciesPages(input *ListAttachedRolePoliciesInput
 func (c *IAM) ListAttachedRolePoliciesPagesWithContext(ctx aws.Context, input *ListAttachedRolePoliciesInput, fn func(*ListAttachedRolePoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAttachedRolePoliciesRequest(&inCpy)
+			var inCpy *ListAttachedRolePoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAttachedRolePoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7403,8 +7427,12 @@ func (c *IAM) ListAttachedUserPoliciesPages(input *ListAttachedUserPoliciesInput
 func (c *IAM) ListAttachedUserPoliciesPagesWithContext(ctx aws.Context, input *ListAttachedUserPoliciesInput, fn func(*ListAttachedUserPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAttachedUserPoliciesRequest(&inCpy)
+			var inCpy *ListAttachedUserPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAttachedUserPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7552,8 +7580,12 @@ func (c *IAM) ListEntitiesForPolicyPages(input *ListEntitiesForPolicyInput, fn f
 func (c *IAM) ListEntitiesForPolicyPagesWithContext(ctx aws.Context, input *ListEntitiesForPolicyInput, fn func(*ListEntitiesForPolicyOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListEntitiesForPolicyRequest(&inCpy)
+			var inCpy *ListEntitiesForPolicyInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListEntitiesForPolicyRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7700,8 +7732,12 @@ func (c *IAM) ListGroupPoliciesPages(input *ListGroupPoliciesInput, fn func(*Lis
 func (c *IAM) ListGroupPoliciesPagesWithContext(ctx aws.Context, input *ListGroupPoliciesInput, fn func(*ListGroupPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListGroupPoliciesRequest(&inCpy)
+			var inCpy *ListGroupPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListGroupPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7835,8 +7871,12 @@ func (c *IAM) ListGroupsPages(input *ListGroupsInput, fn func(*ListGroupsOutput,
 func (c *IAM) ListGroupsPagesWithContext(ctx aws.Context, input *ListGroupsInput, fn func(*ListGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListGroupsRequest(&inCpy)
+			var inCpy *ListGroupsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListGroupsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -7974,8 +8014,12 @@ func (c *IAM) ListGroupsForUserPages(input *ListGroupsForUserInput, fn func(*Lis
 func (c *IAM) ListGroupsForUserPagesWithContext(ctx aws.Context, input *ListGroupsForUserInput, fn func(*ListGroupsForUserOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListGroupsForUserRequest(&inCpy)
+			var inCpy *ListGroupsForUserInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListGroupsForUserRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8111,8 +8155,12 @@ func (c *IAM) ListInstanceProfilesPages(input *ListInstanceProfilesInput, fn fun
 func (c *IAM) ListInstanceProfilesPagesWithContext(ctx aws.Context, input *ListInstanceProfilesInput, fn func(*ListInstanceProfilesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListInstanceProfilesRequest(&inCpy)
+			var inCpy *ListInstanceProfilesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListInstanceProfilesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8252,8 +8300,12 @@ func (c *IAM) ListInstanceProfilesForRolePages(input *ListInstanceProfilesForRol
 func (c *IAM) ListInstanceProfilesForRolePagesWithContext(ctx aws.Context, input *ListInstanceProfilesForRoleInput, fn func(*ListInstanceProfilesForRoleOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListInstanceProfilesForRoleRequest(&inCpy)
+			var inCpy *ListInstanceProfilesForRoleInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListInstanceProfilesForRoleRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8394,8 +8446,12 @@ func (c *IAM) ListMFADevicesPages(input *ListMFADevicesInput, fn func(*ListMFADe
 func (c *IAM) ListMFADevicesPagesWithContext(ctx aws.Context, input *ListMFADevicesInput, fn func(*ListMFADevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListMFADevicesRequest(&inCpy)
+			var inCpy *ListMFADevicesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListMFADevicesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8621,8 +8677,12 @@ func (c *IAM) ListPoliciesPages(input *ListPoliciesInput, fn func(*ListPoliciesO
 func (c *IAM) ListPoliciesPagesWithContext(ctx aws.Context, input *ListPoliciesInput, fn func(*ListPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListPoliciesRequest(&inCpy)
+			var inCpy *ListPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8767,8 +8827,12 @@ func (c *IAM) ListPolicyVersionsPages(input *ListPolicyVersionsInput, fn func(*L
 func (c *IAM) ListPolicyVersionsPagesWithContext(ctx aws.Context, input *ListPolicyVersionsInput, fn func(*ListPolicyVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListPolicyVersionsRequest(&inCpy)
+			var inCpy *ListPolicyVersionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListPolicyVersionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -8914,8 +8978,12 @@ func (c *IAM) ListRolePoliciesPages(input *ListRolePoliciesInput, fn func(*ListR
 func (c *IAM) ListRolePoliciesPagesWithContext(ctx aws.Context, input *ListRolePoliciesInput, fn func(*ListRolePoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListRolePoliciesRequest(&inCpy)
+			var inCpy *ListRolePoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListRolePoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9051,8 +9119,12 @@ func (c *IAM) ListRolesPages(input *ListRolesInput, fn func(*ListRolesOutput, bo
 func (c *IAM) ListRolesPagesWithContext(ctx aws.Context, input *ListRolesInput, fn func(*ListRolesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListRolesRequest(&inCpy)
+			var inCpy *ListRolesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListRolesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9277,8 +9349,12 @@ func (c *IAM) ListSSHPublicKeysPages(input *ListSSHPublicKeysInput, fn func(*Lis
 func (c *IAM) ListSSHPublicKeysPagesWithContext(ctx aws.Context, input *ListSSHPublicKeysInput, fn func(*ListSSHPublicKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListSSHPublicKeysRequest(&inCpy)
+			var inCpy *ListSSHPublicKeysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListSSHPublicKeysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9418,8 +9494,12 @@ func (c *IAM) ListServerCertificatesPages(input *ListServerCertificatesInput, fn
 func (c *IAM) ListServerCertificatesPagesWithContext(ctx aws.Context, input *ListServerCertificatesInput, fn func(*ListServerCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListServerCertificatesRequest(&inCpy)
+			var inCpy *ListServerCertificatesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListServerCertificatesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9655,8 +9735,12 @@ func (c *IAM) ListSigningCertificatesPages(input *ListSigningCertificatesInput, 
 func (c *IAM) ListSigningCertificatesPagesWithContext(ctx aws.Context, input *ListSigningCertificatesInput, fn func(*ListSigningCertificatesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListSigningCertificatesRequest(&inCpy)
+			var inCpy *ListSigningCertificatesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListSigningCertificatesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9801,8 +9885,12 @@ func (c *IAM) ListUserPoliciesPages(input *ListUserPoliciesInput, fn func(*ListU
 func (c *IAM) ListUserPoliciesPagesWithContext(ctx aws.Context, input *ListUserPoliciesInput, fn func(*ListUserPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListUserPoliciesRequest(&inCpy)
+			var inCpy *ListUserPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListUserPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -9938,8 +10026,12 @@ func (c *IAM) ListUsersPages(input *ListUsersInput, fn func(*ListUsersOutput, bo
 func (c *IAM) ListUsersPagesWithContext(ctx aws.Context, input *ListUsersInput, fn func(*ListUsersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListUsersRequest(&inCpy)
+			var inCpy *ListUsersInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListUsersRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -10070,8 +10162,12 @@ func (c *IAM) ListVirtualMFADevicesPages(input *ListVirtualMFADevicesInput, fn f
 func (c *IAM) ListVirtualMFADevicesPagesWithContext(ctx aws.Context, input *ListVirtualMFADevicesInput, fn func(*ListVirtualMFADevicesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListVirtualMFADevicesRequest(&inCpy)
+			var inCpy *ListVirtualMFADevicesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListVirtualMFADevicesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -11137,8 +11233,12 @@ func (c *IAM) SimulateCustomPolicyPages(input *SimulateCustomPolicyInput, fn fun
 func (c *IAM) SimulateCustomPolicyPagesWithContext(ctx aws.Context, input *SimulateCustomPolicyInput, fn func(*SimulatePolicyResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.SimulateCustomPolicyRequest(&inCpy)
+			var inCpy *SimulateCustomPolicyInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.SimulateCustomPolicyRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -11304,8 +11404,12 @@ func (c *IAM) SimulatePrincipalPolicyPages(input *SimulatePrincipalPolicyInput, 
 func (c *IAM) SimulatePrincipalPolicyPagesWithContext(ctx aws.Context, input *SimulatePrincipalPolicyInput, fn func(*SimulatePolicyResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.SimulatePrincipalPolicyRequest(&inCpy)
+			var inCpy *SimulatePrincipalPolicyInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.SimulatePrincipalPolicyRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/aws/aws-sdk-go/service/iam/waiters.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iam/waiters.go
@@ -44,7 +44,12 @@ func (c *IAM) WaitUntilInstanceProfileExistsWithContext(ctx aws.Context, input *
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetInstanceProfileRequest(input)
+			var inCpy *GetInstanceProfileInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetInstanceProfileRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -90,7 +95,12 @@ func (c *IAM) WaitUntilUserExistsWithContext(ctx aws.Context, input *GetUserInpu
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.GetUserRequest(input)
+			var inCpy *GetUserInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetUserRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -2419,8 +2419,12 @@ func (c *KMS) ListAliasesPages(input *ListAliasesInput, fn func(*ListAliasesOutp
 func (c *KMS) ListAliasesPagesWithContext(ctx aws.Context, input *ListAliasesInput, fn func(*ListAliasesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListAliasesRequest(&inCpy)
+			var inCpy *ListAliasesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAliasesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -2575,8 +2579,12 @@ func (c *KMS) ListGrantsPages(input *ListGrantsInput, fn func(*ListGrantsRespons
 func (c *KMS) ListGrantsPagesWithContext(ctx aws.Context, input *ListGrantsInput, fn func(*ListGrantsResponse, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListGrantsRequest(&inCpy)
+			var inCpy *ListGrantsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListGrantsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -2727,8 +2735,12 @@ func (c *KMS) ListKeyPoliciesPages(input *ListKeyPoliciesInput, fn func(*ListKey
 func (c *KMS) ListKeyPoliciesPagesWithContext(ctx aws.Context, input *ListKeyPoliciesInput, fn func(*ListKeyPoliciesOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListKeyPoliciesRequest(&inCpy)
+			var inCpy *ListKeyPoliciesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListKeyPoliciesRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -2868,8 +2880,12 @@ func (c *KMS) ListKeysPages(input *ListKeysInput, fn func(*ListKeysOutput, bool)
 func (c *KMS) ListKeysPagesWithContext(ctx aws.Context, input *ListKeysInput, fn func(*ListKeysOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListKeysRequest(&inCpy)
+			var inCpy *ListKeysInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListKeysRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -3668,8 +3668,12 @@ func (c *S3) ListMultipartUploadsPages(input *ListMultipartUploadsInput, fn func
 func (c *S3) ListMultipartUploadsPagesWithContext(ctx aws.Context, input *ListMultipartUploadsInput, fn func(*ListMultipartUploadsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListMultipartUploadsRequest(&inCpy)
+			var inCpy *ListMultipartUploadsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListMultipartUploadsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -3795,8 +3799,12 @@ func (c *S3) ListObjectVersionsPages(input *ListObjectVersionsInput, fn func(*Li
 func (c *S3) ListObjectVersionsPagesWithContext(ctx aws.Context, input *ListObjectVersionsInput, fn func(*ListObjectVersionsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListObjectVersionsRequest(&inCpy)
+			var inCpy *ListObjectVersionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListObjectVersionsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -3929,8 +3937,12 @@ func (c *S3) ListObjectsPages(input *ListObjectsInput, fn func(*ListObjectsOutpu
 func (c *S3) ListObjectsPagesWithContext(ctx aws.Context, input *ListObjectsInput, fn func(*ListObjectsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListObjectsRequest(&inCpy)
+			var inCpy *ListObjectsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListObjectsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -4064,8 +4076,12 @@ func (c *S3) ListObjectsV2Pages(input *ListObjectsV2Input, fn func(*ListObjectsV
 func (c *S3) ListObjectsV2PagesWithContext(ctx aws.Context, input *ListObjectsV2Input, fn func(*ListObjectsV2Output, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListObjectsV2Request(&inCpy)
+			var inCpy *ListObjectsV2Input
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListObjectsV2Request(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -4191,8 +4207,12 @@ func (c *S3) ListPartsPages(input *ListPartsInput, fn func(*ListPartsOutput, boo
 func (c *S3) ListPartsPagesWithContext(ctx aws.Context, input *ListPartsInput, fn func(*ListPartsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
 		NewRequest: func() (*request.Request, error) {
-			inCpy := *input
-			req, _ := c.ListPartsRequest(&inCpy)
+			var inCpy *ListPartsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListPartsRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/waiters.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/waiters.go
@@ -54,7 +54,12 @@ func (c *S3) WaitUntilBucketExistsWithContext(ctx aws.Context, input *HeadBucket
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadBucketRequest(input)
+			var inCpy *HeadBucketInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.HeadBucketRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -95,7 +100,12 @@ func (c *S3) WaitUntilBucketNotExistsWithContext(ctx aws.Context, input *HeadBuc
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadBucketRequest(input)
+			var inCpy *HeadBucketInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.HeadBucketRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -141,7 +151,12 @@ func (c *S3) WaitUntilObjectExistsWithContext(ctx aws.Context, input *HeadObject
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadObjectRequest(input)
+			var inCpy *HeadObjectInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.HeadObjectRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil
@@ -182,7 +197,12 @@ func (c *S3) WaitUntilObjectNotExistsWithContext(ctx aws.Context, input *HeadObj
 		},
 		Logger: c.Config.Logger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
-			req, _ := c.HeadObjectRequest(input)
+			var inCpy *HeadObjectInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.HeadObjectRequest(inCpy)
 			req.SetContext(ctx)
 			req.ApplyOptions(opts...)
 			return req, nil

--- a/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/vendor/github.com/cenkalti/backoff/exponential.go
@@ -89,11 +89,6 @@ func NewExponentialBackOff() *ExponentialBackOff {
 		MaxElapsedTime:      DefaultMaxElapsedTime,
 		Clock:               SystemClock,
 	}
-	if b.RandomizationFactor < 0 {
-		b.RandomizationFactor = 0
-	} else if b.RandomizationFactor > 1 {
-		b.RandomizationFactor = 1
-	}
 	b.Reset()
 	return b
 }

--- a/vendor/github.com/coreos/etcd/Dockerfile-release
+++ b/vendor/github.com/coreos/etcd/Dockerfile-release
@@ -5,6 +5,12 @@ ADD etcdctl /usr/local/bin/
 RUN mkdir -p /var/etcd/
 RUN mkdir -p /var/lib/etcd/
 
+# Alpine Linux doesn't use pam, which means that there is no /etc/nsswitch.conf,
+# but Golang relies on /etc/nsswitch.conf to check the order of DNS resolving
+# (see https://github.com/golang/go/commit/9dee7771f561cf6aee081c0af6658cc81fac3918)
+# To fix this we just create /etc/nsswitch.conf and add the following line:
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
 EXPOSE 2379 2380
 
 # Define default command.

--- a/vendor/github.com/fsnotify/fsnotify/inotify.go
+++ b/vendor/github.com/fsnotify/fsnotify/inotify.go
@@ -24,7 +24,6 @@ type Watcher struct {
 	Events   chan Event
 	Errors   chan error
 	mu       sync.Mutex // Map access
-	cv       *sync.Cond // sync removing on rm_watch with IN_IGNORE
 	fd       int
 	poller   *fdPoller
 	watches  map[string]*watch // Map of inotify watches (key: path)
@@ -56,7 +55,6 @@ func NewWatcher() (*Watcher, error) {
 		done:     make(chan struct{}),
 		doneResp: make(chan struct{}),
 	}
-	w.cv = sync.NewCond(&w.mu)
 
 	go w.readEvents()
 	return w, nil
@@ -137,6 +135,13 @@ func (w *Watcher) Remove(name string) error {
 	if !ok {
 		return fmt.Errorf("can't remove non-existent inotify watch for: %s", name)
 	}
+
+	// We successfully removed the watch if InotifyRmWatch doesn't return an
+	// error, we need to clean up our internal state to ensure it matches
+	// inotify's kernel state.
+	delete(w.paths, int(watch.wd))
+	delete(w.watches, name)
+
 	// inotify_rm_watch will return EINVAL if the file has been deleted;
 	// the inotify will already have been removed.
 	// watches and pathes are deleted in ignoreLinux() implicitly and asynchronously
@@ -152,13 +157,6 @@ func (w *Watcher) Remove(name string) error {
 		// Watch descriptors are invalidated when they are removed explicitly or implicitly;
 		// explicitly by inotify_rm_watch, implicitly when the file they are watching is deleted.
 		return errno
-	}
-
-	// wait until ignoreLinux() deleting maps
-	exists := true
-	for exists {
-		w.cv.Wait()
-		_, exists = w.watches[name]
 	}
 
 	return nil
@@ -261,8 +259,17 @@ func (w *Watcher) readEvents() {
 			// the "Name" field with a valid filename. We retrieve the path of the watch from
 			// the "paths" map.
 			w.mu.Lock()
-			name := w.paths[int(raw.Wd)]
+			name, ok := w.paths[int(raw.Wd)]
+			// IN_DELETE_SELF occurs when the file/directory being watched is removed.
+			// This is a sign to clean up the maps, otherwise we are no longer in sync
+			// with the inotify kernel state which has already deleted the watch
+			// automatically.
+			if ok && mask&unix.IN_DELETE_SELF == unix.IN_DELETE_SELF {
+				delete(w.paths, int(raw.Wd))
+				delete(w.watches, name)
+			}
 			w.mu.Unlock()
+
 			if nameLen > 0 {
 				// Point "bytes" at the first byte of the filename
 				bytes := (*[unix.PathMax]byte)(unsafe.Pointer(&buf[offset+unix.SizeofInotifyEvent]))
@@ -273,7 +280,7 @@ func (w *Watcher) readEvents() {
 			event := newEvent(name, mask)
 
 			// Send the events that are not ignored on the events channel
-			if !event.ignoreLinux(w, raw.Wd, mask) {
+			if !event.ignoreLinux(mask) {
 				select {
 				case w.Events <- event:
 				case <-w.done:
@@ -290,15 +297,9 @@ func (w *Watcher) readEvents() {
 // Certain types of events can be "ignored" and not sent over the Events
 // channel. Such as events marked ignore by the kernel, or MODIFY events
 // against files that do not exist.
-func (e *Event) ignoreLinux(w *Watcher, wd int32, mask uint32) bool {
+func (e *Event) ignoreLinux(mask uint32) bool {
 	// Ignore anything the inotify API says to ignore
 	if mask&unix.IN_IGNORED == unix.IN_IGNORED {
-		w.mu.Lock()
-		defer w.mu.Unlock()
-		name := w.paths[int(wd)]
-		delete(w.paths, int(wd))
-		delete(w.watches, name)
-		w.cv.Broadcast()
 		return true
 	}
 

--- a/vendor/github.com/fsnotify/fsnotify/inotify_test.go
+++ b/vendor/github.com/fsnotify/fsnotify/inotify_test.go
@@ -293,25 +293,23 @@ func TestInotifyRemoveTwice(t *testing.T) {
 		t.Fatalf("Failed to add testFile: %v", err)
 	}
 
-	err = os.Remove(testFile)
+	err = w.Remove(testFile)
 	if err != nil {
-		t.Fatalf("Failed to remove testFile: %v", err)
+		t.Fatalf("wanted successful remove but got:", err)
 	}
 
 	err = w.Remove(testFile)
 	if err == nil {
 		t.Fatalf("no error on removing invalid file")
 	}
-	s1 := fmt.Sprintf("%s", err)
 
-	err = w.Remove(testFile)
-	if err == nil {
-		t.Fatalf("no error on removing invalid file")
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.watches) != 0 {
+		t.Fatalf("Expected watches len is 0, but got: %d, %v", len(w.watches), w.watches)
 	}
-	s2 := fmt.Sprintf("%s", err)
-
-	if s1 != s2 {
-		t.Fatalf("receive different error - %s / %s", s1, s2)
+	if len(w.paths) != 0 {
+		t.Fatalf("Expected paths len is 0, but got: %d, %v", len(w.paths), w.paths)
 	}
 }
 

--- a/vendor/github.com/giantswarm/certificatetpr/.gitignore
+++ b/vendor/github.com/giantswarm/certificatetpr/.gitignore
@@ -1,0 +1,3 @@
+certificatetpr
+TODO
+!vendor/**

--- a/vendor/github.com/giantswarm/certificatetpr/LICENSE
+++ b/vendor/github.com/giantswarm/certificatetpr/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/giantswarm/certificatetpr/README.md
+++ b/vendor/github.com/giantswarm/certificatetpr/README.md
@@ -1,0 +1,8 @@
+# certificatetpr
+
+Specification of the third party object used to issue certificates for Kubernetes clusters running
+on the Giantnetes platform from Giant Swarm. Used by the [cert-operator](https://github.com/giantswarm/cert-operator).
+
+## License
+
+certificatetpr is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/vendor/github.com/giantswarm/certificatetpr/circle.yml
+++ b/vendor/github.com/giantswarm/certificatetpr/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - |
+      if [ -z $RELEASE_TOKEN ]; then
+         wget -q $(curl -sS https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      else
+         wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+      fi
+    - chmod +x ./architect
+    - ./architect version
+
+test:
+  override:
+    - ./architect --organisation=giantswarm build

--- a/vendor/github.com/giantswarm/certificatetpr/custom_object.go
+++ b/vendor/github.com/giantswarm/certificatetpr/custom_object.go
@@ -1,0 +1,15 @@
+package certificatetpr
+
+import (
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// CustomObject represents the Certificate TPR's custom object. It holds the
+// specifications of the resource the Certificate operator is interested in.
+type CustomObject struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	Spec Spec `json:"spec" yaml:"spec"`
+}

--- a/vendor/github.com/giantswarm/certificatetpr/glide.lock
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.lock
@@ -1,0 +1,136 @@
+hash: 7ba20a61e377d0bdf5357dff237d2a71710c4264f311882018936dd634384a0f
+updated: 2017-03-29T11:15:28.145955349+02:00
+imports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  subpackages:
+  - digest
+  - reference
+- name: github.com/emicklei/go-restful
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  subpackages:
+  - log
+  - swagger
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+- name: github.com/gogo/protobuf
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
+  subpackages:
+  - proto
+  - sortkeys
+- name: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/google/gofuzz
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/pflag
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
+- name: golang.org/x/net
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  subpackages:
+  - context
+  - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - lex/httplex
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/client-go
+  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  subpackages:
+  - pkg/api
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/apis/autoscaling
+  - pkg/apis/batch
+  - pkg/apis/extensions
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/third_party/forked/golang/reflect
+  - pkg/types
+  - pkg/util
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/labels
+  - pkg/util/net
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/watch
+  - pkg/watch/versioned
+testImports:
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  repo: git://github.com/stretchr/testify.git
+  subpackages:
+  - assert

--- a/vendor/github.com/giantswarm/certificatetpr/glide.yaml
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.yaml
@@ -1,0 +1,13 @@
+package: github.com/giantswarm/certificatetpr
+import:
+- package: k8s.io/client-go
+  version: ^2.0.0
+  subpackages:
+  - pkg/api/unversioned
+  - pkg/api/v1
+testImport:
+- package: github.com/stretchr/testify
+  version: v1.1.4
+  repo: git://github.com/stretchr/testify.git
+  subpackages:
+  - assert

--- a/vendor/github.com/giantswarm/certificatetpr/list.go
+++ b/vendor/github.com/giantswarm/certificatetpr/list.go
@@ -1,0 +1,12 @@
+package certificatetpr
+
+import (
+	"k8s.io/client-go/pkg/api/unversioned"
+)
+
+type List struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []*CustomObject `json:"items"`
+}

--- a/vendor/github.com/giantswarm/certificatetpr/name.go
+++ b/vendor/github.com/giantswarm/certificatetpr/name.go
@@ -1,0 +1,6 @@
+package certificatetpr
+
+const (
+	// Name represents the name of the third party resource within Kubernetes.
+	Name = "certificate.giantswarm.io"
+)

--- a/vendor/github.com/giantswarm/certificatetpr/spec.go
+++ b/vendor/github.com/giantswarm/certificatetpr/spec.go
@@ -1,0 +1,11 @@
+package certificatetpr
+
+type Spec struct {
+	AllowBareDomains bool     `json:"allowBareDomains" yaml:"allowBareDomains"`
+	AltNames         []string `json:"altNames" yaml:"altNames"`
+	ClusterComponent string   `json:"clusterComponent" yaml:"clusterComponent"`
+	ClusterID        string   `json:"clusterID" yaml:"clusterID"`
+	CommonName       string   `json:"commonName" yaml:"commonName"`
+	IPSANs           []string `json:"ipSans" yaml:"ipSans"`
+	TTL              string   `json:"ttl" yaml:"ttl"`
+}

--- a/vendor/github.com/giantswarm/certificatetpr/tls_assets.go
+++ b/vendor/github.com/giantswarm/certificatetpr/tls_assets.go
@@ -1,0 +1,73 @@
+package certificatetpr
+
+// ClusterComponent represents the individual component of a k8s cluster, e.g. the API server, or etcd
+// These are used when getting a secret from the k8s API, to identify the component the secret belongs to
+type ClusterComponent string
+
+func (c ClusterComponent) String() string {
+	return string(c)
+}
+
+// TLSAssetType represents the type of TLS asset, e.g. a CA certificate, or a certificate key
+// These are used when getting a secret from the k8s API, to identify the specific type of TLS asset that is contained in the secret
+type TLSAssetType string
+
+func (t TLSAssetType) String() string {
+	return string(t)
+}
+
+// These constants are used to match each asset in the secret
+const (
+	// CA is the key for the CA certificate
+	CA TLSAssetType = "ca"
+	// Crt is the key for the certificate
+	Crt TLSAssetType = "crt"
+	// Key is the key for the key
+	Key TLSAssetType = "key"
+)
+
+// These constants are used to match different components of the cluster when parsing a secret received from the API
+const (
+	// APIComponent is the API server
+	APIComponent ClusterComponent = "api"
+	// WorkerComponent is a worker
+	WorkerComponent ClusterComponent = "worker"
+	// EtcdComponent is the etcd cluster
+	EtcdComponent ClusterComponent = "etcd"
+	// CalicoComponent is the calico component
+	CalicoComponent ClusterComponent = "calico"
+)
+
+// These constants are used when filtering the secrets, to only retrieve the ones we are interested in
+const (
+	// ComponentLabel is the label used in the secret to identify a cluster component
+	ComponentLabel string = "clusterComponent"
+	// ClusterIDLabel is the label used in the secret to identify a cluster
+	ClusterIDLabel string = "clusterID"
+)
+
+// AssetsBundleKey is a struct key for an AssetsBundle
+// cfr. https://blog.golang.org/go-maps-in-action
+type AssetsBundleKey struct {
+	Component ClusterComponent
+	Type      TLSAssetType
+}
+
+// AssetsBundle is a structure that contains all the assets for all the components
+type AssetsBundle map[AssetsBundleKey][]byte
+
+// ClusterComponents is a slice enumerating all the components that make up the cluster
+var ClusterComponents = []ClusterComponent{APIComponent, WorkerComponent, EtcdComponent, CalicoComponent}
+
+// TLSAssetTypes is a slice enumerating all the TLS assets we need to boot the cluster
+var TLSAssetTypes = []TLSAssetType{CA, Crt, Key}
+
+// ValidComponent looks for el among the components
+func ValidComponent(el ClusterComponent, components []ClusterComponent) bool {
+	for _, v := range components {
+		if el == v {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/giantswarm/certificatetpr/tls_assets_test.go
+++ b/vendor/github.com/giantswarm/certificatetpr/tls_assets_test.go
@@ -1,0 +1,45 @@
+package certificatetpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidComponent(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []ClusterComponent
+		el         ClusterComponent
+		res        bool
+	}{
+		{
+			name: "el is present",
+			components: []ClusterComponent{
+				ClusterComponent("foobar"),
+			},
+			el:  ClusterComponent("foobar"),
+			res: true,
+		},
+		{
+			name: "el is not present",
+			components: []ClusterComponent{
+				ClusterComponent("foo"),
+			},
+			el:  ClusterComponent("bar"),
+			res: false,
+		},
+		{
+			name:       "components is empty",
+			components: []ClusterComponent{},
+			el:         ClusterComponent("foobar"),
+			res:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		res := ValidComponent(tc.el, tc.components)
+
+		assert.Equal(t, tc.res, res)
+	}
+}

--- a/vendor/github.com/go-ini/ini/ini.go
+++ b/vendor/github.com/go-ini/ini/ini.go
@@ -37,7 +37,7 @@ const (
 
 	// Maximum allowed depth when recursively substituing variable names.
 	_DEPTH_VALUES = 99
-	_VERSION      = "1.26.0"
+	_VERSION      = "1.27.0"
 )
 
 // Version returns current package version literal.
@@ -319,6 +319,11 @@ func (f *File) Sections() []*Section {
 		sections[i] = f.Section(f.sectionList[i])
 	}
 	return sections
+}
+
+// ChildSections returns a list of child sections of given section name.
+func (f *File) ChildSections(name string) []*Section {
+	return f.Section(name).ChildSections()
 }
 
 // SectionStrings returns list of section names.

--- a/vendor/github.com/go-ini/ini/ini_test.go
+++ b/vendor/github.com/go-ini/ini/ini_test.go
@@ -241,6 +241,31 @@ key5
 	})
 }
 
+func Test_File_ChildSections(t *testing.T) {
+	Convey("Find child sections by parent name", t, func() {
+		cfg, err := Load([]byte(`
+[node]
+
+[node.biz1]
+
+[node.biz2]
+
+[node.biz3]
+
+[node.bizN]
+`))
+		So(err, ShouldBeNil)
+		So(cfg, ShouldNotBeNil)
+
+		children := cfg.ChildSections("node")
+		names := make([]string, len(children))
+		for i := range children {
+			names[i] = children[i].name
+		}
+		So(strings.Join(names, ","), ShouldEqual, "node.biz1,node.biz2,node.biz3,node.bizN")
+	})
+}
+
 func Test_LooseLoad(t *testing.T) {
 	Convey("Loose load from data sources", t, func() {
 		Convey("Loose load mixed with nonexistent file", func() {

--- a/vendor/github.com/go-ini/ini/section.go
+++ b/vendor/github.com/go-ini/ini/section.go
@@ -232,3 +232,17 @@ func (s *Section) DeleteKey(name string) {
 		}
 	}
 }
+
+// ChildSections returns a list of child sections of current section.
+// For example, "[parent.child1]" and "[parent.child12]" are child sections
+// of section "[parent]".
+func (s *Section) ChildSections() []*Section {
+	prefix := s.name + "."
+	children := make([]*Section, 0, 3)
+	for _, name := range s.f.sectionList {
+		if strings.HasPrefix(name, prefix) {
+			children = append(children, s.f.sections[name])
+		}
+	}
+	return children
+}

--- a/vendor/github.com/pelletier/go-toml/marshal.go
+++ b/vendor/github.com/pelletier/go-toml/marshal.go
@@ -1,0 +1,459 @@
+package toml
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+/*
+TomlTree structural types and corresponding marshal types
+-------------------------------------------------------------------------------
+*TomlTree                        (*)struct, (*)map[string]interface{}
+[]*TomlTree                      (*)[](*)struct, (*)[](*)map[string]interface{}
+[]interface{} (as interface{})   (*)[]primitive, (*)[]([]interface{})
+interface{}                      (*)primitive
+
+TomlTree primitive types and  corresponding marshal types
+-----------------------------------------------------------
+uint64     uint, uint8-uint64, pointers to same
+int64      int, int8-uint64, pointers to same
+float64    float32, float64, pointers to same
+string     string, pointers to same
+bool       bool, pointers to same
+time.Time  time.Time{}, pointers to same
+*/
+
+type tomlOpts struct {
+	name      string
+	include   bool
+	omitempty bool
+}
+
+var timeType = reflect.TypeOf(time.Time{})
+
+// Check if the given marshall type maps to a TomlTree primitive
+func isPrimitive(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Ptr:
+		return isPrimitive(mtype.Elem())
+	case reflect.Bool:
+		return true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	case reflect.Float32, reflect.Float64:
+		return true
+	case reflect.String:
+		return true
+	case reflect.Struct:
+		return mtype == timeType
+	default:
+		return false
+	}
+}
+
+// Check if the given marshall type maps to a TomlTree slice
+func isTreeSlice(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Slice:
+		return !isOtherSlice(mtype)
+	default:
+		return false
+	}
+}
+
+// Check if the given marshall type maps to a non-TomlTree slice
+func isOtherSlice(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Ptr:
+		return isOtherSlice(mtype.Elem())
+	case reflect.Slice:
+		return isPrimitive(mtype.Elem()) || isOtherSlice(mtype.Elem())
+	default:
+		return false
+	}
+}
+
+// Check if the given marshall type maps to a TomlTree
+func isTree(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Map:
+		return true
+	case reflect.Struct:
+		return !isPrimitive(mtype)
+	default:
+		return false
+	}
+}
+
+/*
+Marshal returns the TOML encoding of v.  Behavior is similar to the Go json
+encoder, except that there is no concept of a Marshaler interface or MarshalTOML
+function for sub-structs, and currently only definite types can be marshaled
+(i.e. no `interface{}`).
+
+Note that pointers are automatically assigned the "omitempty" option, as TOML
+explicity does not handle null values (saying instead the label should be
+dropped).
+*/
+func Marshal(v interface{}) ([]byte, error) {
+	mtype := reflect.TypeOf(v)
+	if mtype.Kind() != reflect.Struct {
+		return []byte{}, errors.New("Only a struct can be marshaled to TOML")
+	}
+	sval := reflect.ValueOf(v)
+	t, err := valueToTree(mtype, sval)
+	if err != nil {
+		return []byte{}, err
+	}
+	s, err := t.ToTomlString()
+	return []byte(s), err
+}
+
+// Convert given marshal struct or map value to toml tree
+func valueToTree(mtype reflect.Type, mval reflect.Value) (*TomlTree, error) {
+	if mtype.Kind() == reflect.Ptr {
+		return valueToTree(mtype.Elem(), mval.Elem())
+	}
+	tval := newTomlTree()
+	switch mtype.Kind() {
+	case reflect.Struct:
+		for i := 0; i < mtype.NumField(); i++ {
+			mtypef, mvalf := mtype.Field(i), mval.Field(i)
+			opts := tomlOptions(mtypef)
+			if opts.include && (!opts.omitempty || !isZero(mvalf)) {
+				val, err := valueToToml(mtypef.Type, mvalf)
+				if err != nil {
+					return nil, err
+				}
+				tval.Set(opts.name, val)
+			}
+		}
+	case reflect.Map:
+		for _, key := range mval.MapKeys() {
+			mvalf := mval.MapIndex(key)
+			val, err := valueToToml(mtype.Elem(), mvalf)
+			if err != nil {
+				return nil, err
+			}
+			tval.Set(key.String(), val)
+		}
+	}
+	return tval, nil
+}
+
+// Convert given marshal slice to slice of Toml trees
+func valueToTreeSlice(mtype reflect.Type, mval reflect.Value) ([]*TomlTree, error) {
+	tval := make([]*TomlTree, mval.Len(), mval.Len())
+	for i := 0; i < mval.Len(); i++ {
+		val, err := valueToTree(mtype.Elem(), mval.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		tval[i] = val
+	}
+	return tval, nil
+}
+
+// Convert given marshal slice to slice of toml values
+func valueToOtherSlice(mtype reflect.Type, mval reflect.Value) (interface{}, error) {
+	tval := make([]interface{}, mval.Len(), mval.Len())
+	for i := 0; i < mval.Len(); i++ {
+		val, err := valueToToml(mtype.Elem(), mval.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		tval[i] = val
+	}
+	return tval, nil
+}
+
+// Convert given marshal value to toml value
+func valueToToml(mtype reflect.Type, mval reflect.Value) (interface{}, error) {
+	if mtype.Kind() == reflect.Ptr {
+		return valueToToml(mtype.Elem(), mval.Elem())
+	}
+	switch {
+	case isTree(mtype):
+		return valueToTree(mtype, mval)
+	case isTreeSlice(mtype):
+		return valueToTreeSlice(mtype, mval)
+	case isOtherSlice(mtype):
+		return valueToOtherSlice(mtype, mval)
+	default:
+		switch mtype.Kind() {
+		case reflect.Bool:
+			return mval.Bool(), nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return mval.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return mval.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return mval.Float(), nil
+		case reflect.String:
+			return mval.String(), nil
+		case reflect.Struct:
+			return mval.Interface().(time.Time), nil
+		default:
+			return nil, fmt.Errorf("Marshal can't handle %v(%v)", mtype, mtype.Kind())
+		}
+	}
+}
+
+/*
+Unmarshal parses the TOML-encoded data and stores the result in the value
+pointed to by v. Behavior is similar to the Go json encoder, except that there
+is no concept of an Unmarshaler interface or UnmarshalTOML function for
+sub-structs, and currently only definite types can be unmarshaled to (i.e. no
+`interface{}`).
+*/
+func Unmarshal(data []byte, v interface{}) error {
+	mtype := reflect.TypeOf(v)
+	if mtype.Kind() != reflect.Ptr || mtype.Elem().Kind() != reflect.Struct {
+		return errors.New("Only a pointer to struct can be unmarshaled from TOML")
+	}
+
+	t, err := Load(string(data))
+	if err != nil {
+		return err
+	}
+
+	sval, err := valueFromTree(mtype.Elem(), t)
+	if err != nil {
+		return err
+	}
+	reflect.ValueOf(v).Elem().Set(sval)
+	return nil
+}
+
+// Convert toml tree to marshal struct or map, using marshal type
+func valueFromTree(mtype reflect.Type, tval *TomlTree) (reflect.Value, error) {
+	if mtype.Kind() == reflect.Ptr {
+		return unwrapPointer(mtype, tval)
+	}
+	var mval reflect.Value
+	switch mtype.Kind() {
+	case reflect.Struct:
+		mval = reflect.New(mtype).Elem()
+		for i := 0; i < mtype.NumField(); i++ {
+			mtypef := mtype.Field(i)
+			opts := tomlOptions(mtypef)
+			if opts.include {
+				key := opts.name
+				exists := tval.Has(key)
+				if exists {
+					val := tval.Get(key)
+					mvalf, err := valueFromToml(mtypef.Type, val)
+					if err != nil {
+						return mval, formatError(err, tval.GetPosition(key))
+					}
+					mval.Field(i).Set(mvalf)
+				}
+			}
+		}
+	case reflect.Map:
+		mval = reflect.MakeMap(mtype)
+		for _, key := range tval.Keys() {
+			val := tval.Get(key)
+			mvalf, err := valueFromToml(mtype.Elem(), val)
+			if err != nil {
+				return mval, formatError(err, tval.GetPosition(key))
+			}
+			mval.SetMapIndex(reflect.ValueOf(key), mvalf)
+		}
+	}
+	return mval, nil
+}
+
+// Convert toml value to marshal struct/map slice, using marshal type
+func valueFromTreeSlice(mtype reflect.Type, tval []*TomlTree) (reflect.Value, error) {
+	mval := reflect.MakeSlice(mtype, len(tval), len(tval))
+	for i := 0; i < len(tval); i++ {
+		val, err := valueFromTree(mtype.Elem(), tval[i])
+		if err != nil {
+			return mval, err
+		}
+		mval.Index(i).Set(val)
+	}
+	return mval, nil
+}
+
+// Convert toml value to marshal primitive slice, using marshal type
+func valueFromOtherSlice(mtype reflect.Type, tval []interface{}) (reflect.Value, error) {
+	mval := reflect.MakeSlice(mtype, len(tval), len(tval))
+	for i := 0; i < len(tval); i++ {
+		val, err := valueFromToml(mtype.Elem(), tval[i])
+		if err != nil {
+			return mval, err
+		}
+		mval.Index(i).Set(val)
+	}
+	return mval, nil
+}
+
+// Convert toml value to marshal value, using marshal type
+func valueFromToml(mtype reflect.Type, tval interface{}) (reflect.Value, error) {
+	if mtype.Kind() == reflect.Ptr {
+		return unwrapPointer(mtype, tval)
+	}
+	switch {
+	case isTree(mtype):
+		return valueFromTree(mtype, tval.(*TomlTree))
+	case isTreeSlice(mtype):
+		return valueFromTreeSlice(mtype, tval.([]*TomlTree))
+	case isOtherSlice(mtype):
+		return valueFromOtherSlice(mtype, tval.([]interface{}))
+	default:
+		switch mtype.Kind() {
+		case reflect.Bool:
+			val, ok := tval.(bool)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to bool", tval, tval)
+			}
+			return reflect.ValueOf(val), nil
+		case reflect.Int:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to int", tval, tval)
+			}
+			return reflect.ValueOf(int(val)), nil
+		case reflect.Int8:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to int", tval, tval)
+			}
+			return reflect.ValueOf(int8(val)), nil
+		case reflect.Int16:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to int", tval, tval)
+			}
+			return reflect.ValueOf(int16(val)), nil
+		case reflect.Int32:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to int", tval, tval)
+			}
+			return reflect.ValueOf(int32(val)), nil
+		case reflect.Int64:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to int", tval, tval)
+			}
+			return reflect.ValueOf(val), nil
+		case reflect.Uint:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to uint", tval, tval)
+			}
+			return reflect.ValueOf(uint(val)), nil
+		case reflect.Uint8:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to uint", tval, tval)
+			}
+			return reflect.ValueOf(uint8(val)), nil
+		case reflect.Uint16:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to uint", tval, tval)
+			}
+			return reflect.ValueOf(uint16(val)), nil
+		case reflect.Uint32:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to uint", tval, tval)
+			}
+			return reflect.ValueOf(uint32(val)), nil
+		case reflect.Uint64:
+			val, ok := tval.(int64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to uint", tval, tval)
+			}
+			return reflect.ValueOf(uint64(val)), nil
+		case reflect.Float32:
+			val, ok := tval.(float64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to float", tval, tval)
+			}
+			return reflect.ValueOf(float32(val)), nil
+		case reflect.Float64:
+			val, ok := tval.(float64)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to float", tval, tval)
+			}
+			return reflect.ValueOf(val), nil
+		case reflect.String:
+			val, ok := tval.(string)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to string", tval, tval)
+			}
+			return reflect.ValueOf(val), nil
+		case reflect.Struct:
+			val, ok := tval.(time.Time)
+			if !ok {
+				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to time", tval, tval)
+			}
+			return reflect.ValueOf(val), nil
+		default:
+			return reflect.ValueOf(nil), fmt.Errorf("Unmarshal can't handle %v(%v)", mtype, mtype.Kind())
+		}
+	}
+}
+
+func unwrapPointer(mtype reflect.Type, tval interface{}) (reflect.Value, error) {
+	val, err := valueFromToml(mtype.Elem(), tval)
+	if err != nil {
+		return reflect.ValueOf(nil), err
+	}
+	mval := reflect.New(mtype.Elem())
+	mval.Elem().Set(val)
+	return mval, nil
+}
+
+func tomlOptions(vf reflect.StructField) tomlOpts {
+	tag := vf.Tag.Get("toml")
+	parse := strings.Split(tag, ",")
+	result := tomlOpts{vf.Name, true, false}
+	if parse[0] != "" {
+		if parse[0] == "-" && len(parse) == 1 {
+			result.include = false
+		} else {
+			result.name = strings.Trim(parse[0], " ")
+		}
+	}
+	if vf.PkgPath != "" {
+		result.include = false
+	}
+	if len(parse) > 1 && strings.Trim(parse[1], " ") == "omitempty" {
+		result.omitempty = true
+	}
+	if vf.Type.Kind() == reflect.Ptr {
+		result.omitempty = true
+	}
+	return result
+}
+
+func isZero(val reflect.Value) bool {
+	switch val.Type().Kind() {
+	case reflect.Map:
+		fallthrough
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		return val.Len() == 0
+	default:
+		return reflect.DeepEqual(val.Interface(), reflect.Zero(val.Type()).Interface())
+	}
+}
+
+func formatError(err error, pos Position) error {
+	if err.Error()[0] == '(' { // Error already contains position information
+		return err
+	}
+	return fmt.Errorf("%s: %s", pos, err)
+}

--- a/vendor/github.com/pelletier/go-toml/marshal_test.go
+++ b/vendor/github.com/pelletier/go-toml/marshal_test.go
@@ -1,0 +1,535 @@
+package toml
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type basicMarshalTestStruct struct {
+	String     string                      `toml:"string"`
+	StringList []string                    `toml:"strlist"`
+	Sub        basicMarshalTestSubStruct   `toml:"subdoc"`
+	SubList    []basicMarshalTestSubStruct `toml:"sublist"`
+}
+
+type basicMarshalTestSubStruct struct {
+	String2 string
+}
+
+var basicTestData = basicMarshalTestStruct{
+	String:     "Hello",
+	StringList: []string{"Howdy", "Hey There"},
+	Sub:        basicMarshalTestSubStruct{"One"},
+	SubList:    []basicMarshalTestSubStruct{{"Two"}, {"Three"}},
+}
+
+var basicTestToml = []byte(`string = "Hello"
+strlist = ["Howdy","Hey There"]
+
+[subdoc]
+  String2 = "One"
+
+[[sublist]]
+  String2 = "Two"
+
+[[sublist]]
+  String2 = "Three"
+`)
+
+func TestBasicMarshal(t *testing.T) {
+	result, err := Marshal(basicTestData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := basicTestToml
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestBasicUnmarshal(t *testing.T) {
+	result := basicMarshalTestStruct{}
+	err := Unmarshal(basicTestToml, &result)
+	expected := basicTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+type testDoc struct {
+	Title       string            `toml:"title"`
+	Basics      testDocBasics     `toml:"basic"`
+	BasicLists  testDocBasicLists `toml:"basic_lists"`
+	BasicMap    map[string]string `toml:"basic_map"`
+	Subdocs     testDocSubs       `toml:"subdoc"`
+	SubDocList  []testSubDoc      `toml:"subdoclist"`
+	SubDocPtrs  []*testSubDoc     `toml:"subdocptrs"`
+	err         int               `toml:"shouldntBeHere"`
+	unexported  int               `toml:"shouldntBeHere"`
+	Unexported2 int               `toml:"-"`
+}
+
+type testDocBasics struct {
+	Bool       bool      `toml:"bool"`
+	Date       time.Time `toml:"date"`
+	Float      float32   `toml:"float"`
+	Int        int       `toml:"int"`
+	Uint       uint      `toml:"uint"`
+	String     *string   `toml:"string"`
+	unexported int       `toml:"shouldntBeHere"`
+}
+
+type testDocBasicLists struct {
+	Bools   []bool      `toml:"bools"`
+	Dates   []time.Time `toml:"dates"`
+	Floats  []*float32  `toml:"floats"`
+	Ints    []int       `toml:"ints"`
+	Strings []string    `toml:"strings"`
+	UInts   []uint      `toml:"uints"`
+}
+
+type testDocSubs struct {
+	First  testSubDoc  `toml:"first"`
+	Second *testSubDoc `toml:"second"`
+}
+
+type testSubDoc struct {
+	Name       string `toml:"name"`
+	unexported int    `toml:"shouldntBeHere"`
+}
+
+var biteMe = "Bite me"
+var float1 float32 = 12.3
+var float2 float32 = 45.6
+var float3 float32 = 78.9
+var subdoc = testSubDoc{"Second", 0}
+
+var docData = testDoc{
+	Title:       "TOML Marshal Testing",
+	unexported:  0,
+	Unexported2: 0,
+	Basics: testDocBasics{
+		Bool:       true,
+		Date:       time.Date(1979, 5, 27, 7, 32, 0, 0, time.UTC),
+		Float:      123.4,
+		Int:        5000,
+		Uint:       5001,
+		String:     &biteMe,
+		unexported: 0,
+	},
+	BasicLists: testDocBasicLists{
+		Bools: []bool{true, false, true},
+		Dates: []time.Time{
+			time.Date(1979, 5, 27, 7, 32, 0, 0, time.UTC),
+			time.Date(1980, 5, 27, 7, 32, 0, 0, time.UTC),
+		},
+		Floats:  []*float32{&float1, &float2, &float3},
+		Ints:    []int{8001, 8001, 8002},
+		Strings: []string{"One", "Two", "Three"},
+		UInts:   []uint{5002, 5003},
+	},
+	BasicMap: map[string]string{
+		"one": "one",
+		"two": "two",
+	},
+	Subdocs: testDocSubs{
+		First:  testSubDoc{"First", 0},
+		Second: &subdoc,
+	},
+	SubDocList: []testSubDoc{
+		testSubDoc{"List.First", 0},
+		testSubDoc{"List.Second", 0},
+	},
+	SubDocPtrs: []*testSubDoc{&subdoc},
+}
+
+func TestDocMarshal(t *testing.T) {
+	result, err := Marshal(docData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _ := ioutil.ReadFile("marshal_test.toml")
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestDocUnmarshal(t *testing.T) {
+	result := testDoc{}
+	tomlData, _ := ioutil.ReadFile("marshal_test.toml")
+	err := Unmarshal(tomlData, &result)
+	expected := docData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		resStr, _ := json.MarshalIndent(result, "", "  ")
+		expStr, _ := json.MarshalIndent(expected, "", "  ")
+		t.Errorf("Bad unmarshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expStr, resStr)
+	}
+}
+
+type tomlTypeCheckTest struct {
+	name string
+	item interface{}
+	typ  int //0=primitive, 1=otherslice, 2=treeslice, 3=tree
+}
+
+func TestTypeChecks(t *testing.T) {
+	tests := []tomlTypeCheckTest{
+		{"integer", 2, 0},
+		{"time", time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC), 0},
+		{"stringlist", []string{"hello", "hi"}, 1},
+		{"timelist", []time.Time{time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)}, 1},
+		{"objectlist", []tomlTypeCheckTest{}, 2},
+		{"object", tomlTypeCheckTest{}, 3},
+	}
+
+	for _, test := range tests {
+		expected := []bool{false, false, false, false}
+		expected[test.typ] = true
+		result := []bool{
+			isPrimitive(reflect.TypeOf(test.item)),
+			isOtherSlice(reflect.TypeOf(test.item)),
+			isTreeSlice(reflect.TypeOf(test.item)),
+			isTree(reflect.TypeOf(test.item)),
+		}
+		if !reflect.DeepEqual(expected, result) {
+			t.Errorf("Bad type check on %q: expected %v, got %v", test.name, expected, result)
+		}
+	}
+}
+
+type unexportedMarshalTestStruct struct {
+	String      string                      `toml:"string"`
+	StringList  []string                    `toml:"strlist"`
+	Sub         basicMarshalTestSubStruct   `toml:"subdoc"`
+	SubList     []basicMarshalTestSubStruct `toml:"sublist"`
+	unexported  int                         `toml:"shouldntBeHere"`
+	Unexported2 int                         `toml:"-"`
+}
+
+var unexportedTestData = unexportedMarshalTestStruct{
+	String:      "Hello",
+	StringList:  []string{"Howdy", "Hey There"},
+	Sub:         basicMarshalTestSubStruct{"One"},
+	SubList:     []basicMarshalTestSubStruct{{"Two"}, {"Three"}},
+	unexported:  0,
+	Unexported2: 0,
+}
+
+var unexportedTestToml = []byte(`string = "Hello"
+strlist = ["Howdy","Hey There"]
+unexported = 1
+shouldntBeHere = 2
+
+[subdoc]
+  String2 = "One"
+
+[[sublist]]
+  String2 = "Two"
+
+[[sublist]]
+  String2 = "Three"
+`)
+
+func TestUnexportedUnmarshal(t *testing.T) {
+	result := unexportedMarshalTestStruct{}
+	err := Unmarshal(unexportedTestToml, &result)
+	expected := unexportedTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad unexported unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+type errStruct struct {
+	Bool   bool      `toml:"bool"`
+	Date   time.Time `toml:"date"`
+	Float  float64   `toml:"float"`
+	Int    int16     `toml:"int"`
+	String *string   `toml:"string"`
+}
+
+var errTomls = []string{
+	"bool = truly\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:3200Z\nfloat = 123.4\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123a4\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = j000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = 5000\nstring = Bite me",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = 5000\nstring = Bite me",
+	"bool = 1\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1\nfloat = 123.4\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\n\"sorry\"\nint = 5000\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = \"sorry\"\nstring = \"Bite me\"",
+	"bool = true\ndate = 1979-05-27T07:32:00Z\nfloat = 123.4\nint = 5000\nstring = 1",
+}
+
+type mapErr struct {
+	Vals map[string]float64
+}
+
+type intErr struct {
+	Int1  int
+	Int2  int8
+	Int3  int16
+	Int4  int32
+	Int5  int64
+	UInt1 uint
+	UInt2 uint8
+	UInt3 uint16
+	UInt4 uint32
+	UInt5 uint64
+	Flt1  float32
+	Flt2  float64
+}
+
+var intErrTomls = []string{
+	"Int1 = []\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = []\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = []\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = []\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = []\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = []\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = []\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = []\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = []\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = []\nFlt1 = 1.0\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = []\nFlt2 = 2.0",
+	"Int1 = 1\nInt2 = 2\nInt3 = 3\nInt4 = 4\nInt5 = 5\nUInt1 = 1\nUInt2 = 2\nUInt3 = 3\nUInt4 = 4\nUInt5 = 5\nFlt1 = 1.0\nFlt2 = []",
+}
+
+func TestErrUnmarshal(t *testing.T) {
+	for ind, toml := range errTomls {
+		result := errStruct{}
+		err := Unmarshal([]byte(toml), &result)
+		if err == nil {
+			t.Errorf("Expected err from case %d\n", ind)
+		}
+	}
+	result2 := mapErr{}
+	err := Unmarshal([]byte("[Vals]\nfred=\"1.2\""), &result2)
+	if err == nil {
+		t.Errorf("Expected err from map")
+	}
+	for ind, toml := range intErrTomls {
+		result3 := intErr{}
+		err := Unmarshal([]byte(toml), &result3)
+		if err == nil {
+			t.Errorf("Expected int err from case %d\n", ind)
+		}
+	}
+}
+
+type emptyMarshalTestStruct struct {
+	Title      string                  `toml:"title"`
+	Bool       bool                    `toml:"bool"`
+	Int        int                     `toml:"int"`
+	String     string                  `toml:"string"`
+	StringList []string                `toml:"stringlist"`
+	Ptr        *basicMarshalTestStruct `toml:"ptr"`
+	Map        map[string]string       `toml:"map"`
+}
+
+var emptyTestData = emptyMarshalTestStruct{
+	Title:      "Placeholder",
+	Bool:       false,
+	Int:        0,
+	String:     "",
+	StringList: []string{},
+	Ptr:        nil,
+	Map:        map[string]string{},
+}
+
+var emptyTestToml = []byte(`bool = false
+int = 0
+string = ""
+stringlist = []
+title = "Placeholder"
+
+[map]
+`)
+
+type emptyMarshalTestStruct2 struct {
+	Title      string                  `toml:"title"`
+	Bool       bool                    `toml:"bool,omitempty"`
+	Int        int                     `toml:"int, omitempty"`
+	String     string                  `toml:"string,omitempty "`
+	StringList []string                `toml:"stringlist,omitempty"`
+	Ptr        *basicMarshalTestStruct `toml:"ptr,omitempty"`
+	Map        map[string]string       `toml:"map,omitempty"`
+}
+
+var emptyTestData2 = emptyMarshalTestStruct2{
+	Title:      "Placeholder",
+	Bool:       false,
+	Int:        0,
+	String:     "",
+	StringList: []string{},
+	Ptr:        nil,
+	Map:        map[string]string{},
+}
+
+var emptyTestToml2 = []byte(`title = "Placeholder"
+`)
+
+func TestEmptyMarshal(t *testing.T) {
+	result, err := Marshal(emptyTestData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := emptyTestToml
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad empty marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestEmptyMarshalOmit(t *testing.T) {
+	result, err := Marshal(emptyTestData2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := emptyTestToml2
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad empty omit marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestEmptyUnmarshal(t *testing.T) {
+	result := emptyMarshalTestStruct{}
+	err := Unmarshal(emptyTestToml, &result)
+	expected := emptyTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad empty unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+func TestEmptyUnmarshalOmit(t *testing.T) {
+	result := emptyMarshalTestStruct2{}
+	err := Unmarshal(emptyTestToml, &result)
+	expected := emptyTestData2
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad empty omit unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+type pointerMarshalTestStruct struct {
+	Str       *string
+	List      *[]string
+	ListPtr   *[]*string
+	Map       *map[string]string
+	MapPtr    *map[string]*string
+	EmptyStr  *string
+	EmptyList *[]string
+	EmptyMap  *map[string]string
+	DblPtr    *[]*[]*string
+}
+
+var pointerStr = "Hello"
+var pointerList = []string{"Hello back"}
+var pointerListPtr = []*string{&pointerStr}
+var pointerMap = map[string]string{"response": "Goodbye"}
+var pointerMapPtr = map[string]*string{"alternate": &pointerStr}
+var pointerTestData = pointerMarshalTestStruct{
+	Str:       &pointerStr,
+	List:      &pointerList,
+	ListPtr:   &pointerListPtr,
+	Map:       &pointerMap,
+	MapPtr:    &pointerMapPtr,
+	EmptyStr:  nil,
+	EmptyList: nil,
+	EmptyMap:  nil,
+}
+
+var pointerTestToml = []byte(`List = ["Hello back"]
+ListPtr = ["Hello"]
+Str = "Hello"
+
+[Map]
+  response = "Goodbye"
+
+[MapPtr]
+  alternate = "Hello"
+`)
+
+func TestPointerMarshal(t *testing.T) {
+	result, err := Marshal(pointerTestData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := pointerTestToml
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad pointer marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestPointerUnmarshal(t *testing.T) {
+	result := pointerMarshalTestStruct{}
+	err := Unmarshal(pointerTestToml, &result)
+	expected := pointerTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad pointer unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+type nestedMarshalTestStruct struct {
+	String [][]string
+	//Struct [][]basicMarshalTestSubStruct
+	StringPtr *[]*[]*string
+	// StructPtr *[]*[]*basicMarshalTestSubStruct
+}
+
+var str1 = "Three"
+var str2 = "Four"
+var strPtr = []*string{&str1, &str2}
+var strPtr2 = []*[]*string{&strPtr}
+
+var nestedTestData = nestedMarshalTestStruct{
+	String:    [][]string{[]string{"Five", "Six"}, []string{"One", "Two"}},
+	StringPtr: &strPtr2,
+}
+
+var nestedTestToml = []byte(`String = [["Five","Six"],["One","Two"]]
+StringPtr = [["Three","Four"]]
+`)
+
+func TestNestedMarshal(t *testing.T) {
+	result, err := Marshal(nestedTestData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := nestedTestToml
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad nested marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+
+func TestNestedUnmarshal(t *testing.T) {
+	result := nestedMarshalTestStruct{}
+	err := Unmarshal(nestedTestToml, &result)
+	expected := nestedTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad nested unmarshal: expected %v, got %v", expected, result)
+	}
+}

--- a/vendor/github.com/pelletier/go-toml/marshal_test.toml
+++ b/vendor/github.com/pelletier/go-toml/marshal_test.toml
@@ -1,0 +1,38 @@
+title = "TOML Marshal Testing"
+
+[basic]
+  bool = true
+  date = 1979-05-27T07:32:00Z
+  float = 123.4
+  int = 5000
+  string = "Bite me"
+  uint = 5001
+
+[basic_lists]
+  bools = [true,false,true]
+  dates = [1979-05-27T07:32:00Z,1980-05-27T07:32:00Z]
+  floats = [12.3,45.6,78.9]
+  ints = [8001,8001,8002]
+  strings = ["One","Two","Three"]
+  uints = [5002,5003]
+
+[basic_map]
+  one = "one"
+  two = "two"
+
+[subdoc]
+
+  [subdoc.first]
+    name = "First"
+
+  [subdoc.second]
+    name = "Second"
+
+[[subdoclist]]
+  name = "List.First"
+
+[[subdoclist]]
+  name = "List.Second"
+
+[[subdocptrs]]
+  name = "Second"


### PR DESCRIPTION
With this PR, we get the certificates from K8S secrets instead of loading them from files.

Secrets are retrieved from the default namespace. They are labeled with a `clusterID` label, which identifies the cluster, and a `clusterComponent` one, which identifies one of etcd, calico, apiserver or worker. There is a timeout (currently 10 seconds) for how long we wait for the secrets.

We also remove the `aws.certsDir` CLI option.

To test this, follow the steps in the README. You might want to check what happens when the secrets are not there (either all or a few) - it should wait and time-out.