### PR TITLE
create/resources: Use VPC for network separation of clusters

### DIFF
--- a/client/aws/errors.go
+++ b/client/aws/errors.go
@@ -3,8 +3,10 @@ package aws
 import "github.com/juju/errgo"
 
 const (
+	AlreadyAssociated       = "Resource.AlreadyAssociated"
 	BucketAlreadyExists     = "BucketAlreadyExists"
 	BucketAlreadyOwnedByYou = "BucketAlreadyOwnedByYou"
+	InvalidSubnetConflict   = "InvalidSubnet.Conflict"
 	KeyPairDuplicate        = "InvalidKeyPair.Duplicate"
 	SecurityGroupDuplicate  = "InvalidGroup.Duplicate"
 )

--- a/resources/aws/consts.go
+++ b/resources/aws/consts.go
@@ -1,0 +1,13 @@
+package aws
+
+const (
+	// EC2 instance tag keys.
+	tagKeyName    string = "Name"
+	tagKeyCluster string = "Cluster"
+	// Subnet keys
+	subnetAvailabilityZone string = "availabilityZone"
+	subnetCidrBlock        string = "cidrBlock"
+	subnetDescription      string = "description"
+	subnetGroupName        string = "group-name"
+	subnetVpcID            string = "vpc-id"
+)

--- a/resources/aws/elasticip.go
+++ b/resources/aws/elasticip.go
@@ -38,6 +38,6 @@ func (e *ElasticIP) Delete() error {
 	return microerror.MaskAny(notImplementedMethodError)
 }
 
-func (e *ElasticIP) Name() string {
+func (e ElasticIP) Name() string {
 	return e.name
 }

--- a/resources/aws/errors.go
+++ b/resources/aws/errors.go
@@ -9,5 +9,11 @@ var (
 
 	noBucketInBucketObjectError = errgo.New("Object needs to belong to some bucket")
 
-	securityGroupCreateAndFindError = errgo.New("Couldn't create security group, but couldn't find the existing one either")
+	gatewayFindError       = errgo.New("Couldn't find gateway")
+	routeTableFindError    = errgo.New("Couldn't find route table")
+	securityGroupFindError = errgo.New("Couldn't find security group")
+	subnetFindError        = errgo.New("Couldn't find subnet")
+	vpcFindError           = errgo.New("Couldn't find VPC")
+
+	resourceDeleteError = errgo.New("Couldn't delete resource, it lacks the necessary data (ID)")
 )

--- a/resources/aws/gateway.go
+++ b/resources/aws/gateway.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+type Gateway struct {
+	Name  string
+	VpcID string
+	id    string
+	AWSEntity
+}
+
+func (g Gateway) findExisting() (*ec2.InternetGateway, error) {
+	gateways, err := g.Clients.EC2.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(g.Name),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	if len(gateways.InternetGateways) < 1 {
+		return nil, microerror.MaskAny(gatewayFindError)
+	}
+
+	return gateways.InternetGateways[0], nil
+}
+
+func (g *Gateway) checkIfExists() (bool, error) {
+	gateway, err := g.findExisting()
+	if err != nil {
+		if strings.Contains(err.Error(), gatewayFindError.Error()) {
+			return false, nil
+		}
+		return false, microerror.MaskAny(err)
+	}
+
+	g.id = *gateway.InternetGatewayId
+
+	return true, nil
+}
+
+func (g *Gateway) CreateIfNotExists() (bool, error) {
+	exists, err := g.checkIfExists()
+	if err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	if exists {
+		return false, nil
+	}
+
+	if err := g.CreateOrFail(); err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	return true, nil
+}
+
+func (g *Gateway) CreateOrFail() error {
+	gateway, err := g.Clients.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+	gatewayID := *gateway.InternetGateway.InternetGatewayId
+
+	if _, err := g.Clients.EC2.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(gatewayID),
+		VpcId:             aws.String(g.VpcID),
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := g.Clients.EC2.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{
+			aws.String(gatewayID),
+		},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(tagKeyName),
+				Value: aws.String(g.Name),
+			},
+		},
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	g.id = gatewayID
+
+	return nil
+}
+
+func (g *Gateway) Delete() error {
+	gateway, err := g.findExisting()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := g.Clients.EC2.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: gateway.InternetGatewayId,
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (g Gateway) ID() string {
+	return g.id
+}

--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -203,6 +203,6 @@ func (p *Policy) Delete() error {
 	return nil
 }
 
-func (p *Policy) Name() string {
+func (p Policy) Name() string {
 	return p.name
 }

--- a/resources/aws/profile.go
+++ b/resources/aws/profile.go
@@ -61,6 +61,6 @@ func (ip *InstanceProfile) Delete() error {
 	return nil
 }
 
-func (ip *InstanceProfile) Name() string {
+func (ip InstanceProfile) Name() string {
 	return ip.name
 }

--- a/resources/aws/routetable.go
+++ b/resources/aws/routetable.go
@@ -1,0 +1,114 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+type RouteTable struct {
+	Name  string
+	VpcID string
+	id    string
+	AWSEntity
+}
+
+func (r RouteTable) findExisting() (*ec2.RouteTable, error) {
+	routeTables, err := r.Clients.EC2.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(r.Name),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	if len(routeTables.RouteTables) < 1 {
+		return nil, microerror.MaskAny(routeTableFindError)
+	}
+
+	return routeTables.RouteTables[0], nil
+}
+
+func (r *RouteTable) checkIfExists() (bool, error) {
+	routeTable, err := r.findExisting()
+	if err != nil {
+		if strings.Contains(err.Error(), routeTableFindError.Error()) {
+			return false, nil
+		}
+		return false, microerror.MaskAny(err)
+	}
+
+	r.id = *routeTable.RouteTableId
+
+	return true, nil
+}
+
+func (r *RouteTable) CreateIfNotExists() (bool, error) {
+	exists, err := r.checkIfExists()
+	if err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	if exists {
+		return false, nil
+	}
+
+	if err := r.CreateOrFail(); err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	return true, nil
+}
+
+func (r *RouteTable) CreateOrFail() error {
+	routeTable, err := r.Clients.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{
+		VpcId: aws.String(r.VpcID),
+	})
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := r.Clients.EC2.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{routeTable.RouteTable.RouteTableId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(tagKeyName),
+				Value: aws.String(r.Name),
+			},
+		},
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	r.id = *routeTable.RouteTable.RouteTableId
+
+	return nil
+}
+
+func (r *RouteTable) Delete() error {
+	routeTable, err := r.findExisting()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := r.Clients.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+		RouteTableId: routeTable.RouteTableId,
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (r RouteTable) ID() string {
+	return r.id
+}

--- a/resources/aws/subnet.go
+++ b/resources/aws/subnet.go
@@ -1,0 +1,141 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+)
+
+type Subnet struct {
+	AvailabilityZone string
+	CidrBlock        string
+	Name             string
+	VpcID            string
+	id               string
+	AWSEntity
+}
+
+func (s Subnet) findExisting() (*ec2.Subnet, error) {
+	subnets, err := s.Clients.EC2.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(s.Name),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	if len(subnets.Subnets) < 1 {
+		return nil, microerror.MaskAny(subnetFindError)
+	}
+
+	return subnets.Subnets[0], nil
+}
+
+func (s *Subnet) checkIfExists() (bool, error) {
+	subnet, err := s.findExisting()
+	if err != nil {
+		if strings.Contains(err.Error(), subnetFindError.Error()) {
+			return false, nil
+		}
+		return false, microerror.MaskAny(err)
+	}
+
+	s.id = *subnet.SubnetId
+	return true, nil
+}
+
+func (s *Subnet) CreateIfNotExists() (bool, error) {
+	exists, err := s.checkIfExists()
+	if err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	if exists {
+		return false, nil
+	}
+
+	if err := s.CreateOrFail(); err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	return true, nil
+}
+
+func (s *Subnet) CreateOrFail() error {
+	subnet, err := s.Clients.EC2.CreateSubnet(&ec2.CreateSubnetInput{
+		AvailabilityZone: aws.String(s.AvailabilityZone),
+		CidrBlock:        aws.String(s.CidrBlock),
+		VpcId:            aws.String(s.VpcID),
+	})
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := s.Clients.EC2.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{subnet.Subnet.SubnetId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(tagKeyName),
+				Value: aws.String(s.Name),
+			},
+		},
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	s.id = *subnet.Subnet.SubnetId
+
+	return nil
+}
+
+func (s *Subnet) Delete() error {
+	subnet, err := s.findExisting()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := s.Clients.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{
+		SubnetId: subnet.SubnetId,
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (s Subnet) ID() string {
+	return s.id
+}
+
+func (s *Subnet) MakePublic(routeTable *RouteTable) error {
+	if _, err := s.Clients.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(routeTable.ID()),
+		SubnetId:     aws.String(s.ID()),
+	}); err != nil {
+		if !strings.Contains(err.Error(), awsclient.AlreadyAssociated) {
+			return microerror.MaskAny(err)
+		}
+	}
+
+	if _, err := s.Clients.EC2.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{
+		MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
+			Value: aws.Bool(true),
+		},
+		SubnetId: aws.String(s.ID()),
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/resources/aws/vpc.go
+++ b/resources/aws/vpc.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+type VPC struct {
+	CidrBlock string
+	Name      string
+	id        string
+	AWSEntity
+}
+
+func (v VPC) findExisting() (*ec2.Vpc, error) {
+	vpcs, err := v.Clients.EC2.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(v.Name),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	if len(vpcs.Vpcs) < 1 {
+		return nil, microerror.MaskAny(vpcFindError)
+	}
+
+	return vpcs.Vpcs[0], nil
+}
+
+func (v *VPC) checkIfExists() (bool, error) {
+	vpc, err := v.findExisting()
+	if err != nil {
+		if strings.Contains(err.Error(), vpcFindError.Error()) {
+			return false, nil
+		}
+		return false, microerror.MaskAny(err)
+	}
+
+	v.id = *vpc.VpcId
+	return true, nil
+}
+
+func (v *VPC) CreateIfNotExists() (bool, error) {
+	exists, err := v.checkIfExists()
+	if err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	if exists {
+		return false, nil
+	}
+
+	if err := v.CreateOrFail(); err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	return true, nil
+}
+
+func (v *VPC) CreateOrFail() error {
+	vpc, err := v.Clients.EC2.CreateVpc(&ec2.CreateVpcInput{
+		CidrBlock: aws.String(v.CidrBlock),
+	})
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+	vpcID := *vpc.Vpc.VpcId
+
+	if err := v.Clients.EC2.WaitUntilVpcAvailable(&ec2.DescribeVpcsInput{
+		VpcIds: []*string{
+			aws.String(vpcID),
+		},
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := v.Clients.EC2.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{
+			aws.String(vpcID),
+		},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(tagKeyName),
+				Value: aws.String(v.Name),
+			},
+		},
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	v.id = vpcID
+
+	return nil
+}
+
+func (v *VPC) Delete() error {
+	vpc, err := v.findExisting()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	if _, err := v.Clients.EC2.DeleteVpc(&ec2.DeleteVpcInput{
+		VpcId: vpc.VpcId,
+	}); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (v VPC) ID() string {
+	return v.id
+}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -15,3 +15,8 @@ type ArnResource interface {
 	Arn() string
 	Resource
 }
+
+type ResourceWithID interface {
+	ID() string
+	Resource
+}

--- a/service/create/subnetnames.go
+++ b/service/create/subnetnames.go
@@ -1,0 +1,11 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/awstpr"
+)
+
+func subnetName(cluster awstpr.CustomObject, prefix string) string {
+	return fmt.Sprintf("%s-%s", cluster.Name, prefix)
+}


### PR DESCRIPTION
In order to separate Kubernetes cluster in AWS, we will run each cluster in the separate VPC, with the two submets:
- public - for master nodes
- private - for worker nodes

We also set up security group in order to have control on which ports we want to expose in each machine.

Fixes #27