### PR TITLE
compare first result of API call with HZ

### DIFF
--- a/resources/aws/hostedzone.go
+++ b/resources/aws/hostedzone.go
@@ -109,7 +109,15 @@ func (hz *HostedZone) findExisting() (*route53.HostedZone, error) {
 		return nil, microerror.MaskAny(DomainNamedResourceNotFoundError{Domain: hz.Name})
 	}
 
-	return hostedZones[0], nil
+	// this AWS endpoint returns all hosted zones, even ones that don't match the query
+	// if there was a HZ that matched the DNSName, it will be the first one returned
+	// so we need to match the first result by name
+	hostedZone := hostedZones[0]
+	if *hostedZone.Name != hz.Name {
+		return nil, microerror.MaskAny(DomainNamedResourceNotFoundError{Domain: hz.Name})
+	}
+
+	return hostedZone, nil
 }
 
 func (hz *HostedZone) checkIfExists() (bool, error) {

--- a/resources/aws/kms.go
+++ b/resources/aws/kms.go
@@ -17,7 +17,6 @@ func (kk *KMSKey) CreateIfNotExists() (bool, error) {
 }
 
 func (kk *KMSKey) CreateOrFail() error {
-	// TODO we should give it a name
 	key, err := kk.Clients.KMS.CreateKey(&kms.CreateKeyInput{})
 	if err != nil {
 		return microerror.MaskAny(err)

--- a/service/create/loadbalancer.go
+++ b/service/create/loadbalancer.go
@@ -61,7 +61,7 @@ func (s *Service) createLoadBalancer(input LoadBalancerInput) error {
 	if hzCreated {
 		s.logger.Log("debug", fmt.Sprintf("created hosted zone"))
 	} else {
-		s.logger.Log("debug", fmt.Sprintf("hosted zone already exists, reusing"))
+		s.logger.Log("debug", fmt.Sprintf("hosted zone '%s' already exists, reusing", hz.Name))
 	}
 
 	recordSet := &awsresources.RecordSet{


### PR DESCRIPTION
the API endpoint returns all existing HZ, with the one matching the
DNSName argument listed first, if existing.

therefore, we need to match the first result with our hz, in case there
was no match and the first result is unrelated to our hz.