### PR TITLE
Do not reuse buckets created by someone else

### DIFF
--- a/client/aws/errors.go
+++ b/client/aws/errors.go
@@ -5,8 +5,6 @@ import "github.com/juju/errgo"
 const (
 	AlreadyAssociated        = "Resource.AlreadyAssociated"
 	InvalidSubnetConflict    = "InvalidSubnet.Conflict"
-	BucketAlreadyExists      = "BucketAlreadyExists"
-	BucketAlreadyOwnedByYou  = "BucketAlreadyOwnedByYou"
 	KeyPairDuplicate         = "InvalidKeyPair.Duplicate"
 	SecurityGroupDuplicate   = "InvalidGroup.Duplicate"
 	ELBAlreadyExists         = "DuplicateLoadBalancerName"

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -52,9 +52,6 @@ const (
 	vpcCidrBlock      = "10.0.0.0/16"
 	privateSubnetCidr = "10.0.0.0/19"
 	publicSubnetCidr  = "10.0.128.0/20"
-	// EC2 instance tag keys.
-	tagKeyName    string = "Name"
-	tagKeyCluster string = "Cluster"
 	// Number of retries of RunInstances to wait for Roles to propagate to
 	// Instance Profiles
 	runInstancesRetries = 10


### PR DESCRIPTION
Towards #94.

* Only return `false, nil` if the bucket is present and owned by the current account
* Use type assertion instead of string matching
* Remove a couple unused constants