### PR TITLE
aws: get rid of *FindError

### DIFF
--- a/resources/aws/errors.go
+++ b/resources/aws/errors.go
@@ -11,12 +11,6 @@ var (
 
 	noBucketInBucketObjectError = errgo.New("Object needs to belong to some bucket")
 
-	gatewayFindError       = errgo.New("Couldn't find gateway")
-	routeTableFindError    = errgo.New("Couldn't find route table")
-	securityGroupFindError = errgo.New("Couldn't find security group")
-	subnetFindError        = errgo.New("Couldn't find subnet")
-	vpcFindError           = errgo.New("Couldn't find VPC")
-
 	resourceDeleteError       = errgo.New("Couldn't delete resource, it lacks the necessary data (ID)")
 	clientNotInitializedError = errgo.New("The client has not been initialized")
 )


### PR DESCRIPTION
All `*FindError`s were used only internally. I think they added only a clutter as they weren't in fact returned outside the package.