### PR TITLE
Add route for traffic from outside the VPC

### DIFF
--- a/resources/aws/errors.go
+++ b/resources/aws/errors.go
@@ -12,6 +12,7 @@ var (
 	noBucketInBucketObjectError = errgo.New("Object needs to belong to some bucket")
 
 	gatewayFindError       = errgo.New("Couldn't find gateway")
+	routeFindError         = errgo.New("couldn't find route")
 	routeTableFindError    = errgo.New("Couldn't find route table")
 	securityGroupFindError = errgo.New("Couldn't find security group")
 	subnetFindError        = errgo.New("Couldn't find subnet")
@@ -40,4 +41,9 @@ func (e NamedResourceNotFoundError) Error() string {
 
 func IsInstanceFindError(err error) bool {
 	return errgo.Cause(err) == instanceFindError
+}
+
+// IsRouteFindError asserts routeFindError.
+func IsRouteFindError(err error) bool {
+	return errgo.Cause(err) == routeFindError
 }


### PR DESCRIPTION
* Only instances with a public IP will be reachable.
* We only pass the EC2 client to the struct, since it's the only one it needs.

@nhlfr do you know if you have to delete each custom route (i.e. apart from the default `local` one)  before you can delete the route table?

Closes #120.