### PR TITLE
Open secure port for API Server in masters security group

### DIFF
--- a/resources/aws/securitygroup.go
+++ b/resources/aws/securitygroup.go
@@ -69,7 +69,7 @@ func (s *SecurityGroup) openPort(port int) error {
 		CidrIp:     aws.String("0.0.0.0/0"),
 		GroupId:    aws.String(s.ID()),
 		IpProtocol: aws.String("tcp"),
-		FromPort:   aws.Int64(0),
+		FromPort:   aws.Int64(int64(port)),
 		ToPort:     aws.Int64(int64(port)),
 	}); err != nil {
 		return microerror.MaskAny(err)

--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -6,7 +6,6 @@ const sshPort = 22
 
 func extractPortsFromTPR(cluster awstpr.CustomObject) []int {
 	var ports = []int{
-		cluster.Spec.Cluster.Kubernetes.API.InsecurePort,
 		cluster.Spec.Cluster.Kubernetes.API.SecurePort,
 		sshPort,
 	}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -311,10 +311,8 @@ func (s *Service) Boot() {
 						Description: cluster.Name,
 						GroupName:   cluster.Name,
 						VpcID:       vpc.ID(),
-						PortsToOpen: []int{
-							portSSH,
-						},
-						AWSEntity: awsresources.AWSEntity{Clients: clients},
+						PortsToOpen: extractPortsFromTPR(cluster),
+						AWSEntity:   awsresources.AWSEntity{Clients: clients},
 					}
 					securityGroupCreated, err := securityGroup.CreateIfNotExists()
 					if err != nil {


### PR DESCRIPTION
Implements #119 

This PR opens the secure port for the API Server in the masters security group. It also fixes a bug where the from port for the SG rules was not set correctly.