### PR TITLE
Create separate master and worker security groups

### DIFF
--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -4,9 +4,19 @@ import "github.com/giantswarm/awstpr"
 
 const sshPort = 22
 
-func extractPortsFromTPR(cluster awstpr.CustomObject) []int {
+func extractMasterPortsFromTPR(cluster awstpr.CustomObject) []int {
 	var ports = []int{
 		cluster.Spec.Cluster.Kubernetes.API.SecurePort,
+		sshPort,
+	}
+
+	return ports
+}
+
+func extractWorkerPortsFromTPR(cluster awstpr.CustomObject) []int {
+	var ports = []int{
+		cluster.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
+		cluster.Spec.Cluster.Kubernetes.IngressController.SecurePort,
 		sshPort,
 	}
 

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -18,7 +18,6 @@ type securityGroupInput struct {
 }
 
 func (s *Service) createSecurityGroup(input securityGroupInput) (resources.ResourceWithID, error) {
-
 	var securityGroup resources.ResourceWithID
 	securityGroup = &awsresources.SecurityGroup{
 		Description: input.GroupName,
@@ -41,7 +40,6 @@ func (s *Service) createSecurityGroup(input securityGroupInput) (resources.Resou
 }
 
 func (s *Service) deleteSecurityGroup(input securityGroupInput) error {
-
 	var securityGroup resources.ResourceWithID
 	securityGroup = &awsresources.SecurityGroup{
 		Description: input.GroupName,

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -1,0 +1,62 @@
+package create
+
+import (
+	"fmt"
+
+	microerror "github.com/giantswarm/microkit/error"
+
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/resources"
+	awsresources "github.com/giantswarm/aws-operator/resources/aws"
+)
+
+type securityGroupInput struct {
+	Clients     awsutil.Clients
+	GroupName   string
+	PortsToOpen []int
+	VPCID       string
+}
+
+func (s *Service) createSecurityGroup(input securityGroupInput) (resources.ResourceWithID, error) {
+
+	var securityGroup resources.ResourceWithID
+	securityGroup = &awsresources.SecurityGroup{
+		Description: input.GroupName,
+		GroupName:   input.GroupName,
+		VpcID:       input.VPCID,
+		PortsToOpen: input.PortsToOpen,
+		AWSEntity:   awsresources.AWSEntity{Clients: input.Clients},
+	}
+	securityGroupCreated, err := securityGroup.CreateIfNotExists()
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+	if securityGroupCreated {
+		s.logger.Log("info", fmt.Sprintf("created security group '%s'", input.GroupName))
+	} else {
+		s.logger.Log("info", fmt.Sprintf("security group '%s' already exists, reusing", input.GroupName))
+	}
+
+	return securityGroup, nil
+}
+
+func (s *Service) deleteSecurityGroup(input securityGroupInput) error {
+
+	var securityGroup resources.ResourceWithID
+	securityGroup = &awsresources.SecurityGroup{
+		Description: input.GroupName,
+		GroupName:   input.GroupName,
+		AWSEntity:   awsresources.AWSEntity{Clients: input.Clients},
+	}
+	if err := securityGroup.Delete(); err != nil {
+		return microerror.MaskAny(err)
+	} else {
+		s.logger.Log("info", "deleted security group '%s'", input.GroupName)
+	}
+
+	return nil
+}
+
+func securityGroupName(clusterName string, groupName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, groupName)
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1371 and implements #118 

Creates separate master and worker security groups which is a requirement for guest cluster ingress controller access. The workers security group opens the secure and insecure node ports for the ingress controller as well as SSH.

The SSH access CIDR is 0.0.0.0/0 which is too open but matches the master SG. #99 is already open to lock this down.

