### PR TITLE
Adds region to bucket name

### DIFF
--- a/service/create/bucketnames.go
+++ b/service/create/bucketnames.go
@@ -8,9 +8,10 @@ import (
 
 func (s *Service) bucketName(cluster awstpr.CustomObject) string {
 	accountID := s.awsConfig.AccountID()
+	region := cluster.Spec.AWS.Region
 	customerID := cluster.Spec.Cluster.Customer.ID
 
-	name := fmt.Sprintf("%s-g8s-%s", accountID, customerID)
+	name := fmt.Sprintf("%s-g8s-%s-%s", accountID, region, customerID)
 
 	return name
 }

--- a/service/create/bucketnames.go
+++ b/service/create/bucketnames.go
@@ -8,10 +8,10 @@ import (
 
 func (s *Service) bucketName(cluster awstpr.CustomObject) string {
 	accountID := s.awsConfig.AccountID()
-	region := cluster.Spec.AWS.Region
 	customerID := cluster.Spec.Cluster.Customer.ID
+	region := cluster.Spec.AWS.Region
 
-	name := fmt.Sprintf("%s-g8s-%s-%s", accountID, region, customerID)
+	name := fmt.Sprintf("%s-g8s-%s-%s", accountID, customerID, region)
 
 	return name
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/aws-operator/issues/147

If we create a bucket in a particular region, and then try to create
clusters for the same customer in a different region, we re-use
the previous bucket, which fails as it is in the wrong region.

This changeset adds the region to the bucketname, so the buckets
are correct for each region.