### PR TITLE
ELB for Ingress

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -25,7 +25,7 @@ spec:
 
     kubernetes:
       api:
-        domain: "apiserver.example.aws.giantswarm.io"
+        domain: "api.example.aws.giantswarm.io"
         insecurePort: 8080
         securePort: 443
         clusterIPRange: "192.168.0.0/24"
@@ -35,6 +35,7 @@ spec:
       ingressController:
         insecurePort: 30010
         securePort: 30011
+        domain: "ingress.example.aws.gigantic.io"
 
     operator:
       networkSetup:

--- a/resources/aws/hostedzone.go
+++ b/resources/aws/hostedzone.go
@@ -72,9 +72,9 @@ func (hz HostedZone) Delete() error {
 
 }
 
-// NewExistingHostedZone initializes a struct with some fields fetched from the API
-// It's used to delete Hosted Zones, since at deletion time, we don't know the ID.
-func NewExistingHostedZone(name string, client *route53.Route53) (*HostedZone, error) {
+// NewHostedZoneFromExisting initializes a Hosted Zone, setting some fields it has retrieved from an existing HZ
+// It's used when deleting a RecordSet. It does not create a new HZ on AWS.
+func NewHostedZoneFromExisting(name string, client *route53.Route53) (*HostedZone, error) {
 	hz := HostedZone{
 		Name:   name,
 		Client: client,

--- a/resources/aws/recordset.go
+++ b/resources/aws/recordset.go
@@ -8,10 +8,14 @@ import (
 )
 
 type RecordSet struct {
-	Domain       string
+	// Domain is the domain name for the record.
+	Domain string
+	// HostedZoneID is the ID of the Hosted Zone the record should be created in.
 	HostedZoneID string
-	Client       *route53.Route53
-	Resource     resources.DNSNamedResource
+	// Client is the AWS client.
+	Client *route53.Route53
+	// Resource is the AWS resource the record should be created for.
+	Resource resources.DNSNamedResource
 }
 
 // CreateIfNotExists is not implemented because AWS provides UPSERT functionality for DNS records

--- a/service/create/domains.go
+++ b/service/create/domains.go
@@ -1,0 +1,111 @@
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/giantswarm/aws-operator/resources"
+	awsresources "github.com/giantswarm/aws-operator/resources/aws"
+	"github.com/giantswarm/awstpr"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+type hostedZoneInput struct {
+	Cluster awstpr.CustomObject
+	Domain  string
+	Client  *route53.Route53
+}
+
+type recordSetInput struct {
+	Cluster      awstpr.CustomObject
+	Client       *route53.Route53
+	Resource     resources.DNSNamedResource
+	Domain       string
+	HostedZoneID string
+}
+
+func (s *Service) createHostedZone(input hostedZoneInput) (*awsresources.HostedZone, error) {
+	hzName, err := hostedZoneName(input.Domain)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	hz := &awsresources.HostedZone{
+		Name:    hzName,
+		Comment: hostedZoneComment(input.Cluster),
+		Client:  input.Client,
+	}
+
+	hzCreated, err := hz.CreateIfNotExists()
+	if err != nil {
+		return nil, microerror.MaskAnyf(err, "error creating hosted zone '%s'", hz.Name)
+	}
+
+	if hzCreated {
+		s.logger.Log("debug", fmt.Sprintf("created hosted zone '%s'", hz.Name))
+	} else {
+		s.logger.Log("debug", fmt.Sprintf("hosted zone '%s' already exists, reusing", hz.Name))
+	}
+
+	return hz, nil
+}
+
+func (s *Service) deleteRecordSet(input recordSetInput) error {
+	hzName, err := hostedZoneName(input.Domain)
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	hz, err := awsresources.NewHostedZoneFromExisting(hzName, input.Client)
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	rs := &awsresources.RecordSet{
+		Client:       input.Client,
+		Resource:     input.Resource,
+		Domain:       input.Domain,
+		HostedZoneID: hz.ID(),
+	}
+
+	if err := rs.Delete(); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (s *Service) createRecordSet(input recordSetInput) error {
+	// Create DNS records for LB.
+	apiRecordSet := &awsresources.RecordSet{
+		Client:       input.Client,
+		Resource:     input.Resource,
+		Domain:       input.Domain,
+		HostedZoneID: input.HostedZoneID,
+	}
+
+	if err := apiRecordSet.CreateOrFail(); err != nil {
+		return microerror.MaskAnyf(err, "error registering DNS record for '%s'", apiRecordSet.Domain)
+	}
+
+	s.logger.Log("debug", "created or reused DNS record for api")
+
+	return nil
+}
+
+func hostedZoneComment(cluster awstpr.CustomObject) string {
+	return fmt.Sprintf("Hosted zone for cluster %s", cluster.Spec.Cluster.Cluster.ID)
+}
+
+// hostedZoneName removes the first 2 subdomains from the domain
+// e.g.  apiserver.foobar.aws.giantswarm.io -> aws.giantswarm.io
+func hostedZoneName(domain string) (string, error) {
+	tmp := strings.SplitN(domain, ".", 3)
+
+	if len(tmp) != 3 {
+		return "", microerror.MaskAny(malformedCloudConfigKeyError)
+	}
+
+	return strings.Join(tmp[2:], ""), nil
+}

--- a/service/create/domains_test.go
+++ b/service/create/domains_test.go
@@ -1,0 +1,52 @@
+package create
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/juju/errgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostedZoneName(t *testing.T) {
+	tests := []struct {
+		desc   string
+		domain string
+		res    string
+		err    error
+	}{
+		{
+			desc:   "well-formed domain",
+			domain: "api.foobar.example.customer.com",
+			res:    "example.customer.com",
+		},
+		{
+			desc:   "another well-formed domain",
+			domain: "this.is.a.well.formed.domain",
+			res:    "a.well.formed.domain",
+		},
+		{
+			desc:   "empty domain",
+			domain: "",
+			res:    "",
+			err:    malformedCloudConfigKeyError,
+		},
+		{
+			desc:   "malformed domain",
+			domain: "not a domain",
+			res:    "",
+			err:    malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := hostedZoneName(tc.domain)
+
+		if err != nil {
+			underlying := errgo.Cause(err)
+			assert.Equal(t, tc.err, underlying, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}

--- a/service/create/error.go
+++ b/service/create/error.go
@@ -5,12 +5,21 @@ import (
 )
 
 var (
-	invalidConfigError          = errgo.New("invalid config")
-	secretsRetrievalFailedError = errgo.New("could not retrieve secrets")
-	malformedDNSNameError       = errgo.New("could not parse DNS name in TPR")
+	invalidConfigError           = errgo.New("invalid config")
+	secretsRetrievalFailedError  = errgo.New("could not retrieve secrets")
+	missingCloudConfigKeyError   = errgo.New("missing required key in the cloudconfig")
+	malformedCloudConfigKeyError = errgo.New("malformed key in the cloudconfig")
 )
 
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return errgo.Cause(err) == invalidConfigError
+}
+
+func IsMissingCloudConfigKey(err error) bool {
+	return errgo.Cause(err) == missingCloudConfigKeyError
+}
+
+func IsMalformedCloudConfigKey(err error) bool {
+	return errgo.Cause(err) == malformedCloudConfigKeyError
 }

--- a/service/create/load_balancer.go
+++ b/service/create/load_balancer.go
@@ -10,32 +10,42 @@ import (
 	awsresources "github.com/giantswarm/aws-operator/resources/aws"
 	"github.com/giantswarm/awstpr"
 	microerror "github.com/giantswarm/microkit/error"
-	"github.com/juju/errgo"
 )
 
 type LoadBalancerInput struct {
-	Clients         awsutil.Clients
-	Cluster         awstpr.CustomObject
-	InstanceIDs     []string
+	// Name is the ELB name. It must be unique within a region.
+	Name string
+	// Clients are the AWS clients.
+	Clients awsutil.Clients
+	// Cluster is the cluster TPO.
+	Cluster awstpr.CustomObject
+	// InstanceIDs are the IDs of the instances that should be registered with the ELB.
+	InstanceIDs []string
+	// PortsToOpen are the ports the ELB should listen to and forward on.
+	PortsToOpen awsresources.PortPairs
+	// SecurityGroupID is the ID of the security group that will be assigned to the ELB.
 	SecurityGroupID string
-	SubnetID        string
+	// SubnetID is the ID of the subnet the ELB will be placed in.
+	SubnetID string
 }
 
-func (s *Service) createLoadBalancer(input LoadBalancerInput) error {
+func (s *Service) createLoadBalancer(input LoadBalancerInput) (*awsresources.ELB, error) {
+	lbName, err := loadBalancerName(input.Name, input.Cluster)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
 	lb := &awsresources.ELB{
-		Name:          input.Cluster.Spec.Cluster.Cluster.ID,
+		Name:          lbName,
 		SecurityGroup: input.SecurityGroupID,
 		SubnetID:      input.SubnetID,
-		PortsToOpen: []int{
-			input.Cluster.Spec.Cluster.Kubernetes.API.SecurePort,
-			input.Cluster.Spec.Cluster.Etcd.Port,
-		},
-		Client: input.Clients.ELB,
+		PortsToOpen:   input.PortsToOpen,
+		Client:        input.Clients.ELB,
 	}
 
 	lbCreated, err := lb.CreateIfNotExists()
 	if err != nil {
-		return microerror.MaskAny(fmt.Errorf("could not create ELB: %s", errgo.Details(err)))
+		return nil, microerror.MaskAny(err)
 	}
 
 	if lbCreated {
@@ -43,55 +53,6 @@ func (s *Service) createLoadBalancer(input LoadBalancerInput) error {
 	} else {
 		s.logger.Log("debug", fmt.Sprintf("ELB '%s' already exists, reusing", lb.Name))
 	}
-
-	// Create DNS records for LB.
-	hzName, err := hostedZoneName(input.Cluster)
-	if err != nil {
-		return microerror.MaskAny(fmt.Errorf("could not generate hosted zone name: %s", err))
-	}
-
-	hz := awsresources.HostedZone{
-		Name:    hzName,
-		Comment: hostedZoneComment(input.Cluster),
-		Client:  input.Clients.Route53,
-	}
-
-	hzCreated, err := hz.CreateIfNotExists()
-	if err != nil {
-		return microerror.MaskAny(fmt.Errorf("error creating hosted zone '%s'", errgo.Details(err)))
-	}
-
-	if hzCreated {
-		s.logger.Log("debug", fmt.Sprintf("created hosted zone '%s'", hz.Name))
-	} else {
-		s.logger.Log("debug", fmt.Sprintf("hosted zone '%s' already exists, reusing", hz.Name))
-	}
-
-	apiRecordSet := &awsresources.RecordSet{
-		Client:       input.Clients.Route53,
-		Resource:     lb,
-		Domain:       input.Cluster.Spec.Cluster.Kubernetes.API.Domain,
-		HostedZoneID: hz.ID(),
-	}
-
-	if err := apiRecordSet.CreateOrFail(); err != nil {
-		return microerror.MaskAny(fmt.Errorf("error registering DNS '%s'", errgo.Details(err)))
-	}
-
-	s.logger.Log("debug", "created or reused DNS record for api")
-
-	etcdRecordSet := &awsresources.RecordSet{
-		Client:       input.Clients.Route53,
-		Resource:     lb,
-		Domain:       input.Cluster.Spec.Cluster.Etcd.Domain,
-		HostedZoneID: hz.ID(),
-	}
-
-	if err := etcdRecordSet.CreateOrFail(); err != nil {
-		return microerror.MaskAny(fmt.Errorf("error registering DNS '%s'", errgo.Details(err)))
-	}
-
-	s.logger.Log("debug", "created or reused DNS record for etcd")
 
 	s.logger.Log("debug", "waiting for masters to be ready...")
 
@@ -103,90 +64,63 @@ func (s *Service) createLoadBalancer(input LoadBalancerInput) error {
 	if err := input.Clients.EC2.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
 		InstanceIds: awsFlavouredInstanceIDs,
 	}); err != nil {
-		return microerror.MaskAny(fmt.Errorf("masters took too long to get running, aborting: %v", err))
+		return nil, microerror.MaskAnyf(err, "masters took too long to get running, aborting")
 	}
 
 	if err := lb.RegisterInstances(input.InstanceIDs); err != nil {
-		return microerror.MaskAny(fmt.Errorf("could not register instances with LB: %s", errgo.Details(err)))
+		return nil, microerror.MaskAnyf(err, "could not register instances with LB: %s")
 	}
 
 	s.logger.Log("debug", fmt.Sprintf("instances registered with ELB"))
 
-	return nil
+	return lb, nil
 }
 
 func (s *Service) deleteLoadBalancer(input LoadBalancerInput) error {
-	// Delete ELB
-	lb, err := awsresources.NewExistingELB(input.Cluster.Spec.Cluster.Cluster.ID, input.Clients.ELB)
+	// Delete ELB.
+	lbName, err := loadBalancerName(input.Name, input.Cluster)
 	if err != nil {
 		return microerror.MaskAny(err)
+	}
+
+	lb := awsresources.ELB{
+		Name:   lbName,
+		Client: input.Clients.ELB,
 	}
 
 	if err := lb.Delete(); err != nil {
 		return microerror.MaskAny(err)
 	}
-	s.logger.Log("debug", "deleted ELB")
-
-	hzName, err := hostedZoneName(input.Cluster)
-	if err != nil {
-		return microerror.MaskAny(err)
-	}
-
-	hz, err := awsresources.NewExistingHostedZone(hzName, input.Clients.Route53)
-	if err != nil {
-		underlying := errgo.Cause(err)
-		switch underlying.(type) {
-		case awsresources.DomainNamedResourceNotFoundError:
-			s.logger.Log("debug", "could not find existing hosted zone, continuing")
-		default:
-			return microerror.MaskAny(err)
-		}
-	}
-
-	// Delete DNS record, if the Hosted Zone was found
-	if hz != nil {
-		apiRecordSet := &awsresources.RecordSet{
-			Client:       input.Clients.Route53,
-			Resource:     lb,
-			Domain:       input.Cluster.Spec.Cluster.Kubernetes.API.Domain,
-			HostedZoneID: hz.ID(),
-		}
-
-		if err := apiRecordSet.Delete(); err != nil {
-			return microerror.MaskAny(err)
-		}
-
-		s.logger.Log("debug", "deleted DNS entry for api")
-
-		etcdRecordSet := &awsresources.RecordSet{
-			Client:       input.Clients.Route53,
-			Resource:     lb,
-			Domain:       input.Cluster.Spec.Cluster.Etcd.Domain,
-			HostedZoneID: hz.ID(),
-		}
-
-		if err := etcdRecordSet.Delete(); err != nil {
-			return microerror.MaskAny(err)
-		}
-
-		s.logger.Log("debug", "deleted DNS entry for etcd")
-	}
+	s.logger.Log("debug", fmt.Sprintf("deleted ELB '%s'", lb.Name))
 
 	return nil
 }
 
-// hostedZoneName removes the first 2 subdomains from the API domain
-// e.g.  apiserver.foobar.aws.giantswarm.io -> aws.giantswarm.io
-func hostedZoneName(cluster awstpr.CustomObject) (string, error) {
-	tmp := strings.SplitN(cluster.Spec.Cluster.Kubernetes.API.Domain, ".", 3)
-
-	if len(tmp) == 0 {
-		return "", microerror.MaskAny(malformedDNSNameError)
+// loadBalancerName produces a unique name for the load balancer.
+// It takes the domain name, extracts the first subdomain, and combines it with the cluster name.
+func loadBalancerName(domainName string, cluster awstpr.CustomObject) (string, error) {
+	if cluster.Spec.Cluster.Cluster.ID == "" {
+		return "", microerror.MaskAnyf(missingCloudConfigKeyError, "spec.cluster.cluster.id")
 	}
 
-	return strings.Join(tmp[2:], ""), nil
+	componentName, err := componentName(domainName)
+	if err != nil {
+		return "", microerror.MaskAnyf(malformedCloudConfigKeyError, "spec.cluster.cluster.id")
+	}
+
+	lbName := fmt.Sprintf("%s-%s", cluster.Spec.Cluster.Cluster.ID, componentName)
+
+	return lbName, nil
 }
 
-func hostedZoneComment(cluster awstpr.CustomObject) string {
-	return fmt.Sprintf("Hosted zone for cluster %s", cluster.Spec.Cluster.Cluster.ID)
+// componentName returns the first component of a domain name.
+// e.g. apiserver.example.customer.cloud.com -> apiserver
+func componentName(domainName string) (string, error) {
+	splits := strings.SplitN(domainName, ".", 2)
+
+	if len(splits) != 2 {
+		return "", microerror.MaskAny(malformedCloudConfigKeyError)
+	}
+
+	return splits[0], nil
 }

--- a/service/create/load_balancer_test.go
+++ b/service/create/load_balancer_test.go
@@ -1,0 +1,149 @@
+package create
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/cluster"
+	"github.com/juju/errgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadBalancerName(t *testing.T) {
+	tests := []struct {
+		desc       string
+		domainName string
+		tpo        awstpr.CustomObject
+		res        string
+		err        error
+	}{
+		{
+			desc:       "works",
+			domainName: "component.foo.bar.example.com",
+			tpo: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Cluster{
+						Cluster: cluster.Cluster{
+							ID: "foo-customer",
+						},
+					},
+				},
+			},
+			res: "foo-customer-component",
+		},
+		{
+			desc:       "also works",
+			domainName: "component.of.a.well.formed.domain",
+			tpo: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Cluster{
+						Cluster: cluster.Cluster{
+							ID: "quux-the-customer",
+						},
+					},
+				},
+			},
+			res: "quux-the-customer-component",
+		},
+		{
+			desc:       "missing ID key in cloudconfig",
+			domainName: "component.foo.bar.example.com",
+			tpo: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Cluster{
+						Cluster: cluster.Cluster{
+							ID: "",
+						},
+					},
+				},
+			},
+			res: "",
+			err: missingCloudConfigKeyError,
+		},
+		{
+			desc:       "malformed domain name",
+			domainName: "not a domain name",
+			tpo: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Cluster{
+						Cluster: cluster.Cluster{
+							ID: "foo-customer",
+						},
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "missing domain name",
+			domainName: "",
+			tpo: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Cluster{
+						Cluster: cluster.Cluster{
+							ID: "foo-customer",
+						},
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := loadBalancerName(tc.domainName, tc.tpo)
+
+		if err != nil {
+			underlying := errgo.Cause(err)
+			assert.Equal(t, tc.err, underlying, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}
+
+func TestComponentName(t *testing.T) {
+	tests := []struct {
+		desc       string
+		domainName string
+		res        string
+		err        error
+	}{
+		{
+			desc:       "one level of subdomains",
+			domainName: "foo.bar.com",
+			res:        "foo",
+		},
+		{
+			desc:       "two levels of subdomains",
+			domainName: "foo.bar.quux.com",
+			res:        "foo",
+		},
+		{
+			desc:       "malformed domain",
+			domainName: "not a domain name",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "empty domain",
+			domainName: "",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := componentName(tc.domainName)
+
+		if err != nil {
+			assert.True(t, IsMalformedCloudConfigKey(err), fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}

--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -2,7 +2,11 @@ package create
 
 import "github.com/giantswarm/awstpr"
 
-const sshPort = 22
+const (
+	sshPort   = 22
+	httpPort  = 80
+	httpsPort = 443
+)
 
 func extractMasterPortsFromTPR(cluster awstpr.CustomObject) []int {
 	var ports = []int{

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -49,7 +49,7 @@ func (s *Service) deleteSecurityGroup(input securityGroupInput) error {
 	if err := securityGroup.Delete(); err != nil {
 		return microerror.MaskAny(err)
 	} else {
-		s.logger.Log("info", "deleted security group '%s'", input.GroupName)
+		s.logger.Log("info", fmt.Sprintf("deleted security group '%s'", input.GroupName))
 	}
 
 	return nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1381.

## Changes

* Workers are in the public subnet
* The load balancer name is inferred from the first subdomain specified in the TPO. e.g. `apiserver.example.giantswarm.io` -> `apiserver`
* Load balancer creation has been decoupled from DNS stuff (which has moved to `service/create/domains.go`), since the coupling proved too tight
* This means that there's more lower level stuff happening in `service.go`, which is becoming very large