### PR TITLE
service: add etcd client port to security group

### DIFF
--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -7,6 +7,7 @@ const sshPort = 22
 func extractMasterPortsFromTPR(cluster awstpr.CustomObject) []int {
 	var ports = []int{
 		cluster.Spec.Cluster.Kubernetes.API.SecurePort,
+		cluster.Spec.Cluster.Etcd.Port,
 		sshPort,
 	}
 


### PR DESCRIPTION
This allows incoming traffic on port 2379 on the master node.