### PR TITLE
Revert "Update Image ID"

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -56,9 +56,9 @@ spec:
       publicSubnetCidr: "10.0.128.0/20"
 
     masters:
-    - imageid: "ami-f6a49b90"
+    - imageid: "ami-9501c8fa"
       instancetype: "t2.medium"
 
     workers:
-    - imageid: "ami-f6a49b90"
+    - imageid: "ami-9501c8fa"
       instancetype: "t2.medium"


### PR DESCRIPTION
The AMI depends on the region. `ami-f6a49b90` only exists in Ireland.

This reverts commit e7762dccc0c90ddaa11be6b2ac09bea872b6f487.