### PR TITLE
Add calico env file

### DIFF
--- a/service/create/cloudconfig.go
+++ b/service/create/cloudconfig.go
@@ -13,6 +13,12 @@ var (
 			Owner:        "root:root",
 			Permissions:  0700,
 		},
+		cloudconfig.FileMetadata{
+			AssetContent: calicoEnvironmentFileTemplate,
+			Path:         "/etc/calico-environment",
+			Owner:        "root:root",
+			Permissions:  0644,
+		},
 	}
 	unitsMeta []cloudconfig.UnitMetadata = []cloudconfig.UnitMetadata{
 		cloudconfig.UnitMetadata{

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -69,4 +69,7 @@ USERDATA_FILE={{.MachineType}}
     quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 -- aws s3 --region {{.Region}} cp s3://{{.S3DirURI}}/$USERDATA_FILE /var/run/coreos/temp.txt
 base64 -d /var/run/coreos/temp.txt | gunzip > /var/run/coreos/$USERDATA_FILE
 exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE`
+
+	calicoEnvironmentFileTemplate = `# On AWS use internal IP as bridge IP
+BRIDGE_IP=$DEFAULT_IPV4`
 )


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388 and giantswarm/k8scloudconfig#69

This PR adds an environment file for Calico and sets the bridge IP to DEFAULT_IPV4 which is the internal IP set in /etc/network-environment.

See https://github.com/giantswarm/k8scloudconfig/pull/75 for where this file is used.