### PR TITLE
Use oneshot unit to set internal IP in calico env file

### DIFF
--- a/service/create/cloudconfig.go
+++ b/service/create/cloudconfig.go
@@ -14,16 +14,22 @@ var (
 			Permissions:  0700,
 		},
 		cloudconfig.FileMetadata{
-			AssetContent: calicoEnvironmentFileTemplate,
-			Path:         "/etc/calico-environment",
+			AssetContent: createCalicoEnvFileScriptTemplate,
+			Path:         "/opt/bin/create-calico-env-file",
 			Owner:        "root:root",
-			Permissions:  0644,
+			Permissions:  0700,
 		},
 	}
 	unitsMeta []cloudconfig.UnitMetadata = []cloudconfig.UnitMetadata{
 		cloudconfig.UnitMetadata{
 			AssetContent: decryptTLSAssetsServiceTemplate,
 			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		cloudconfig.UnitMetadata{
+			AssetContent: createCalicoEnvFileServiceTemplate,
+			Name:         "create-calico-env-file.service",
 			Enable:       true,
 			Command:      "start",
 		},

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -70,6 +70,23 @@ USERDATA_FILE={{.MachineType}}
 base64 -d /var/run/coreos/temp.txt | gunzip > /var/run/coreos/$USERDATA_FILE
 exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE`
 
-	calicoEnvironmentFileTemplate = `# On AWS use internal IP as bridge IP
-BRIDGE_IP=$DEFAULT_IPV4`
+	createCalicoEnvFileScriptTemplate = `#!/bin/bash
+
+# On AWS use internal IP as the bridge IP.
+echo "BRIDGE_IP=$DEFAULT_IPV4" > /etc/calico-environment
+`
+
+	createCalicoEnvFileServiceTemplate = `
+[Unit]
+Description=Create Calico env file
+Requires=k8s-setup-network-env.service
+After=k8s-setup-network-env.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/network-environment
+ExecStart=/opt/bin/create-calico-env-file
+
+[Install]
+WantedBy=multi-user.target`
 )


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388 and  fixes giantswarm/k8scloudconfig#69

Previous solution didn't work because systemd environment files are not evaluated. Now we create a script and a oneshot unit which sets the correct value in /etc/calico-environment.

This is needed because on KVM we need to set the BRIDGE_IP. On AWS we set it to DEFAULT_IPV4 which is the internal IP.