### PR TITLE
Support for service-account certificate

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 72be97f8ed68900751baf9a242b1e6ed666e3a060fdbdbb4a13f4f09d987e892
-updated: 2017-05-04T00:01:14.767748553+02:00
+updated: 2017-05-04T15:20:08.474999402+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -7,7 +7,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/aws/aws-sdk-go
-  version: 0accf32f7d4f008ba6b524da34a92d346e955acd
+  version: 7b500fb68da739fe86c35681c7379d91ad757849
   subpackages:
   - aws
   - aws/awserr
@@ -100,7 +100,7 @@ imports:
   - aws
   - aws/vpc
 - name: github.com/giantswarm/certificatetpr
-  version: 87347c8640c969e28529b52af635b1a16a72bfb3
+  version: 8e24e223b213128be8b87039e26001bb88284452
 - name: github.com/giantswarm/clustertpr
   version: bc3c7a26ee5fce2814d03ee61dacb719bc88d822
   subpackages:
@@ -133,7 +133,7 @@ imports:
   - operator/networksetup/docker
   - vault
 - name: github.com/giantswarm/k8scloudconfig
-  version: 92d86d7421d6860d864b9196799ade429b21d07d
+  version: 250143cb667b43239154618419bc35b6361e3053
 - name: github.com/giantswarm/microkit
   version: 27e3ac11e763712e0d0dc5294aea8937e66458da
   subpackages:
@@ -237,7 +237,7 @@ imports:
 - name: github.com/pelletier/go-buffruneio
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: fe206efb84b2bc8e8cfafe6b4c1826622be969e3
+  version: 97253b98df84f9eef872866d079e74b8265150f1
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:

--- a/service/create/encrypt.go
+++ b/service/create/encrypt.go
@@ -13,18 +13,21 @@ import (
 )
 
 type TLSassets struct {
-	APIServerCA     []byte
-	APIServerKey    []byte
-	APIServerCrt    []byte
-	WorkerCA        []byte
-	WorkerKey       []byte
-	WorkerCrt       []byte
-	CalicoClientCA  []byte
-	CalicoClientKey []byte
-	CalicoClientCrt []byte
-	EtcdServerCA    []byte
-	EtcdServerKey   []byte
-	EtcdServerCrt   []byte
+	APIServerCA       []byte
+	APIServerKey      []byte
+	APIServerCrt      []byte
+	WorkerCA          []byte
+	WorkerKey         []byte
+	WorkerCrt         []byte
+	ServiceAccountCA  []byte
+	ServiceAccountKey []byte
+	ServiceAccountCrt []byte
+	CalicoClientCA    []byte
+	CalicoClientKey   []byte
+	CalicoClientCrt   []byte
+	EtcdServerCA      []byte
+	EtcdServerKey     []byte
+	EtcdServerCrt     []byte
 }
 
 // PEM encoded TLS assets.
@@ -36,18 +39,21 @@ type encryptedTLSAssets TLSassets
 func createRawTLSAssets(assets certificatetpr.AssetsBundle) *rawTLSAssets {
 	// TODO refactor this with a for loop iterating over components and asset types
 	return &rawTLSAssets{
-		APIServerCA:     assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.CA}],
-		APIServerCrt:    assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Crt}],
-		APIServerKey:    assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Key}],
-		WorkerCA:        assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.CA}],
-		WorkerCrt:       assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Crt}],
-		WorkerKey:       assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Key}],
-		EtcdServerCA:    assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}],
-		EtcdServerCrt:   assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}],
-		EtcdServerKey:   assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}],
-		CalicoClientCA:  assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}],
-		CalicoClientCrt: assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}],
-		CalicoClientKey: assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}],
+		APIServerCA:       assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.CA}],
+		APIServerCrt:      assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Crt}],
+		APIServerKey:      assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Key}],
+		WorkerCA:          assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.CA}],
+		WorkerCrt:         assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Crt}],
+		WorkerKey:         assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Key}],
+		ServiceAccountCA:  assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.CA}],
+		ServiceAccountCrt: assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Crt}],
+		ServiceAccountKey: assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Key}],
+		EtcdServerCA:      assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}],
+		EtcdServerCrt:     assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}],
+		EtcdServerKey:     assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}],
+		CalicoClientCA:    assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}],
+		CalicoClientCrt:   assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}],
+		CalicoClientKey:   assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}],
 	}
 }
 
@@ -70,18 +76,21 @@ func (r *rawTLSAssets) encrypt(svc *kms.KMS, kmsKeyARN string) (*encryptedTLSAss
 		return encryptOutput.CiphertextBlob
 	}
 	encryptedAssets := encryptedTLSAssets{
-		APIServerCA:     encrypt(r.APIServerCA),
-		APIServerKey:    encrypt(r.APIServerKey),
-		APIServerCrt:    encrypt(r.APIServerCrt),
-		WorkerCA:        encrypt(r.WorkerCA),
-		WorkerCrt:       encrypt(r.WorkerCrt),
-		WorkerKey:       encrypt(r.WorkerKey),
-		CalicoClientCA:  encrypt(r.CalicoClientCA),
-		CalicoClientKey: encrypt(r.CalicoClientKey),
-		CalicoClientCrt: encrypt(r.CalicoClientCrt),
-		EtcdServerCA:    encrypt(r.EtcdServerCA),
-		EtcdServerKey:   encrypt(r.EtcdServerKey),
-		EtcdServerCrt:   encrypt(r.EtcdServerCrt),
+		APIServerCA:       encrypt(r.APIServerCA),
+		APIServerKey:      encrypt(r.APIServerKey),
+		APIServerCrt:      encrypt(r.APIServerCrt),
+		WorkerCA:          encrypt(r.WorkerCA),
+		WorkerCrt:         encrypt(r.WorkerCrt),
+		WorkerKey:         encrypt(r.WorkerKey),
+		ServiceAccountCA:  encrypt(r.ServiceAccountCA),
+		ServiceAccountCrt: encrypt(r.ServiceAccountCrt),
+		ServiceAccountKey: encrypt(r.ServiceAccountKey),
+		CalicoClientCA:    encrypt(r.CalicoClientCA),
+		CalicoClientKey:   encrypt(r.CalicoClientKey),
+		CalicoClientCrt:   encrypt(r.CalicoClientCrt),
+		EtcdServerCA:      encrypt(r.EtcdServerCA),
+		EtcdServerKey:     encrypt(r.EtcdServerKey),
+		EtcdServerCrt:     encrypt(r.EtcdServerCrt),
 	}
 	if err != nil {
 		return nil, microerror.MaskAny(err)
@@ -108,18 +117,21 @@ func (r *encryptedTLSAssets) compact() (*cloudconfig.CompactTLSAssets, error) {
 	}
 
 	compactAssets := cloudconfig.CompactTLSAssets{
-		APIServerCA:     compact(r.APIServerCA),
-		APIServerKey:    compact(r.APIServerKey),
-		APIServerCrt:    compact(r.APIServerCrt),
-		WorkerCA:        compact(r.WorkerCA),
-		WorkerKey:       compact(r.WorkerKey),
-		WorkerCrt:       compact(r.WorkerCrt),
-		CalicoClientCA:  compact(r.CalicoClientCA),
-		CalicoClientKey: compact(r.CalicoClientKey),
-		CalicoClientCrt: compact(r.CalicoClientCrt),
-		EtcdServerCA:    compact(r.EtcdServerCA),
-		EtcdServerKey:   compact(r.EtcdServerKey),
-		EtcdServerCrt:   compact(r.EtcdServerCrt),
+		APIServerCA:       compact(r.APIServerCA),
+		APIServerKey:      compact(r.APIServerKey),
+		APIServerCrt:      compact(r.APIServerCrt),
+		WorkerCA:          compact(r.WorkerCA),
+		WorkerKey:         compact(r.WorkerKey),
+		WorkerCrt:         compact(r.WorkerCrt),
+		ServiceAccountCA:  compact(r.ServiceAccountCA),
+		ServiceAccountKey: compact(r.ServiceAccountKey),
+		ServiceAccountCrt: compact(r.ServiceAccountCrt),
+		CalicoClientCA:    compact(r.CalicoClientCA),
+		CalicoClientKey:   compact(r.CalicoClientKey),
+		CalicoClientCrt:   compact(r.CalicoClientCrt),
+		EtcdServerCA:      compact(r.EtcdServerCA),
+		EtcdServerKey:     compact(r.EtcdServerKey),
+		EtcdServerCrt:     compact(r.EtcdServerCrt),
 	}
 
 	if err != nil {

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
@@ -124,9 +124,8 @@ file (~/.aws/config) and shared credentials file (~/.aws/credentials). Both
 files have the same format.
 
 If both config files are present the configuration from both files will be
-read. The Session will be created from  configuration values from the shared
-credentials file (~/.aws/credentials) over those in the shared credentials
-file (~/.aws/config).
+read. The Session will be created from configuration values from the shared
+credentials file (~/.aws/credentials) over those in the shared config file (~/.aws/config).
 
 Credentials are the values the SDK should use for authenticating requests with
 AWS Services. They arfrom a configuration file will need to include both

--- a/vendor/github.com/giantswarm/certificatetpr/glide.lock
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.lock
@@ -1,15 +1,10 @@
-hash: 7ba20a61e377d0bdf5357dff237d2a71710c4264f311882018936dd634384a0f
-updated: 2017-03-29T11:15:28.145955349+02:00
+hash: 8d4fe3a0bd769843b8ab2fc5e9a409ad85b3db44984a5948b4ed8e2a39b44792
+updated: 2017-05-04T11:59:45.487287218+02:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
-  subpackages:
-  - digest
-  - reference
 - name: github.com/emicklei/go-restful
   version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
   subpackages:
@@ -48,6 +43,11 @@ imports:
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  repo: git://github.com/stretchr/testify.git
+  subpackages:
+  - assert
 - name: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
@@ -87,9 +87,6 @@ imports:
   - pkg/api/resource
   - pkg/api/unversioned
   - pkg/api/v1
-  - pkg/apis/autoscaling
-  - pkg/apis/batch
-  - pkg/apis/extensions
   - pkg/auth/user
   - pkg/conversion
   - pkg/conversion/queryparams
@@ -101,36 +98,24 @@ imports:
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/third_party/forked/golang/reflect
   - pkg/types
-  - pkg/util
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/labels
-  - pkg/util/net
-  - pkg/util/parsers
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
-  - pkg/util/wait
   - pkg/util/yaml
-  - pkg/watch
-  - pkg/watch/versioned
 testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
-  repo: git://github.com/stretchr/testify.git
-  subpackages:
-  - assert

--- a/vendor/github.com/giantswarm/certificatetpr/glide.yaml
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.yaml
@@ -5,7 +5,6 @@ import:
   subpackages:
   - pkg/api/unversioned
   - pkg/api/v1
-testImport:
 - package: github.com/stretchr/testify
   version: v1.1.4
   repo: git://github.com/stretchr/testify.git

--- a/vendor/github.com/giantswarm/certificatetpr/tls_assets.go
+++ b/vendor/github.com/giantswarm/certificatetpr/tls_assets.go
@@ -1,68 +1,84 @@
 package certificatetpr
 
-// ClusterComponent represents the individual component of a k8s cluster, e.g. the API server, or etcd
-// These are used when getting a secret from the k8s API, to identify the component the secret belongs to
+// ClusterComponent represents the individual component of a k8s cluster, e.g.
+// the API server, or etcd These are used when getting a secret from the k8s
+// API, to identify the component the secret belongs to.
 type ClusterComponent string
 
 func (c ClusterComponent) String() string {
 	return string(c)
 }
 
-// TLSAssetType represents the type of TLS asset, e.g. a CA certificate, or a certificate key
-// These are used when getting a secret from the k8s API, to identify the specific type of TLS asset that is contained in the secret
+// TLSAssetType represents the type of TLS asset, e.g. a CA certificate, or a
+// certificate key These are used when getting a secret from the k8s API, to
+// identify the specific type of TLS asset that is contained in the secret.
 type TLSAssetType string
 
 func (t TLSAssetType) String() string {
 	return string(t)
 }
 
-// These constants are used to match each asset in the secret
+// These constants are used to match each asset in the secret.
 const (
-	// CA is the key for the CA certificate
+	// CA is the key for the CA certificate.
 	CA TLSAssetType = "ca"
-	// Crt is the key for the certificate
+	// Crt is the key for the certificate.
 	Crt TLSAssetType = "crt"
-	// Key is the key for the key
+	// Key is the key for the key.
 	Key TLSAssetType = "key"
 )
 
-// These constants are used to match different components of the cluster when parsing a secret received from the API
+// These constants are used to match different components of the cluster when
+// parsing a secret received from the API.
 const (
-	// APIComponent is the API server
+	// APIComponent is the API server component.
 	APIComponent ClusterComponent = "api"
-	// WorkerComponent is a worker
+	// WorkerComponent is a worker component.
 	WorkerComponent ClusterComponent = "worker"
-	// EtcdComponent is the etcd cluster
+	// EtcdComponent is the etcd cluster component.
 	EtcdComponent ClusterComponent = "etcd"
-	// CalicoComponent is the calico component
+	// CalicoComponent is the calico component.
 	CalicoComponent ClusterComponent = "calico"
+	// ServiceAccountComponent is the service-account component.
+	ServiceAccountComponent ClusterComponent = "service-account"
 )
 
-// These constants are used when filtering the secrets, to only retrieve the ones we are interested in
+// These constants are used when filtering the secrets, to only retrieve the
+// ones we are interested in.
 const (
-	// ComponentLabel is the label used in the secret to identify a cluster component
+	// ComponentLabel is the label used in the secret to identify a cluster
+	// component.
 	ComponentLabel string = "clusterComponent"
-	// ClusterIDLabel is the label used in the secret to identify a cluster
+	// ClusterIDLabel is the label used in the secret to identify a cluster.
 	ClusterIDLabel string = "clusterID"
 )
 
-// AssetsBundleKey is a struct key for an AssetsBundle
-// cfr. https://blog.golang.org/go-maps-in-action
+// AssetsBundleKey is a struct key for an AssetsBundle cfr.
+// https://blog.golang.org/go-maps-in-action
 type AssetsBundleKey struct {
 	Component ClusterComponent
 	Type      TLSAssetType
 }
 
-// AssetsBundle is a structure that contains all the assets for all the components
+// AssetsBundle is a structure that contains all the assets for all the
+// components.
 type AssetsBundle map[AssetsBundleKey][]byte
 
-// ClusterComponents is a slice enumerating all the components that make up the cluster
-var ClusterComponents = []ClusterComponent{APIComponent, WorkerComponent, EtcdComponent, CalicoComponent}
+// ClusterComponents is a slice enumerating all the components that make up the
+// cluster.
+var ClusterComponents = []ClusterComponent{
+	APIComponent,
+	WorkerComponent,
+	EtcdComponent,
+	CalicoComponent,
+	ServiceAccountComponent,
+}
 
-// TLSAssetTypes is a slice enumerating all the TLS assets we need to boot the cluster
+// TLSAssetTypes is a slice enumerating all the TLS assets we need to boot the
+// cluster.
 var TLSAssetTypes = []TLSAssetType{CA, Crt, Key}
 
-// ValidComponent looks for el among the components
+// ValidComponent looks for el among the components.
 func ValidComponent(el ClusterComponent, components []ClusterComponent) bool {
 	for _, v := range components {
 		if el == v {

--- a/vendor/github.com/giantswarm/k8scloudconfig/encrypt.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/encrypt.go
@@ -1,16 +1,19 @@
 package cloudconfig
 
 type CompactTLSAssets struct {
-	APIServerCA     string
-	APIServerKey    string
-	APIServerCrt    string
-	WorkerCA        string
-	WorkerKey       string
-	WorkerCrt       string
-	CalicoClientCA  string
-	CalicoClientKey string
-	CalicoClientCrt string
-	EtcdServerCA    string
-	EtcdServerKey   string
-	EtcdServerCrt   string
+	APIServerCA       string
+	APIServerKey      string
+	APIServerCrt      string
+	WorkerCA          string
+	WorkerKey         string
+	WorkerCrt         string
+	ServiceAccountCA  string
+	ServiceAccountKey string
+	ServiceAccountCrt string
+	CalicoClientCA    string
+	CalicoClientKey   string
+	CalicoClientCrt   string
+	EtcdServerCA      string
+	EtcdServerKey     string
+	EtcdServerCrt     string
 }

--- a/vendor/github.com/giantswarm/k8scloudconfig/templates.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/templates.go
@@ -429,6 +429,18 @@ write_files:
   encoding: gzip+base64
   content: {{.TLSAssets.APIServerKey}}
 
+- path: /etc/kubernetes/ssl/service-account-crt.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountCrt}}
+
+- path: /etc/kubernetes/ssl/service-account-ca.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountCA}}
+
+- path: /etc/kubernetes/ssl/service-account-key.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountKey}}
+
 - path: /etc/kubernetes/ssl/calico/client-crt.pem.enc
   encoding: gzip+base64
   content: {{.TLSAssets.CalicoClientCrt}}
@@ -725,7 +737,7 @@ coreos:
       --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-api-server-restart.service
@@ -787,7 +799,7 @@ coreos:
       --v=2 \
       --kubeconfig=/etc/kubernetes/config/controller-manager-kubeconfig.yml \
       --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-private-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager-restart.service

--- a/vendor/github.com/pelletier/go-toml/toml.go
+++ b/vendor/github.com/pelletier/go-toml/toml.go
@@ -52,9 +52,11 @@ func (t *TomlTree) HasPath(keys []string) bool {
 // Keys returns the keys of the toplevel tree.
 // Warning: this is a costly operation.
 func (t *TomlTree) Keys() []string {
-	var keys []string
+	keys := make([]string, len(t.values))
+	i := 0
 	for k := range t.values {
-		keys = append(keys, k)
+		keys[i] = k
+		i++
 	}
 	return keys
 }
@@ -169,14 +171,14 @@ func (t *TomlTree) GetDefault(key string, def interface{}) interface{} {
 
 // Set an element in the tree.
 // Key is a dot-separated path (e.g. a.b.c).
-// Creates all necessary intermediates trees, if needed.
+// Creates all necessary intermediate trees, if needed.
 func (t *TomlTree) Set(key string, value interface{}) {
 	t.SetPath(strings.Split(key, "."), value)
 }
 
 // SetPath sets an element in the tree.
 // Keys is an array of path elements (e.g. {"a","b","c"}).
-// Creates all necessary intermediates trees, if needed.
+// Creates all necessary intermediate trees, if needed.
 func (t *TomlTree) SetPath(keys []string, value interface{}) {
 	subtree := t
 	for _, intermediateKey := range keys[:len(keys)-1] {


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388 and giantswarm/k8scloudconfig#70

This PR adds support for the service-account certificate. The keypair for this cert is used as the service account key for apiserver and controller-manager.