### PR TITLE
Assign ProxyProtocol policy to API, Ingress ELBs

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -403,7 +403,7 @@ func (s *Service) Boot() {
 						return
 					}
 
-					// Create apiserver Load Balancer.
+					// Create apiserver load balancer.
 					lbInput := LoadBalancerInput{
 						Name:        cluster.Spec.Cluster.Kubernetes.API.Domain,
 						Clients:     clients,
@@ -425,7 +425,13 @@ func (s *Service) Boot() {
 						return
 					}
 
-					// Create etcd Load Balancer.
+					// Assign the ProxyProtocol policy to the apiserver load balancer.
+					if err := apiLB.AssignProxyProtocolPolicy(); err != nil {
+						s.logger.Log("error", errgo.Details(err))
+						return
+					}
+
+					// Create etcd load balancer.
 					lbInput = LoadBalancerInput{
 						Name:        cluster.Spec.Cluster.Etcd.Domain,
 						Clients:     clients,
@@ -521,6 +527,12 @@ func (s *Service) Boot() {
 
 					ingressLB, err := s.createLoadBalancer(lbInput)
 					if err != nil {
+						s.logger.Log("error", errgo.Details(err))
+						return
+					}
+
+					// Assign the ProxyProtocol policy to the Ingress load balancer.
+					if err := ingressLB.AssignProxyProtocolPolicy(); err != nil {
 						s.logger.Log("error", errgo.Details(err))
 						return
 					}


### PR DESCRIPTION
With this PR, the api and ingress ELBs get a ProxyProtocol policy added
to them, which makes sure that packets flowing through them have headers
with the IP and port of the source/destination.

Closes https://github.com/giantswarm/k8scloudconfig/issues/89.