### PR TITLE
service: open kubelet and calico BGP ports on workers security group

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -38,6 +38,8 @@ spec:
         insecurePort: 30010
         securePort: 30011
         domain: "ingress.example.aws.gigantic.io"
+      kubelet:
+        port: 10250
       networkSetup:
         docker:
           image: "giantswarm/k8s-setup-network-environment:ba2b57155d859a1fc5d378c2a09a77d7c2c755ed"

--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -3,27 +3,28 @@ package create
 import "github.com/giantswarm/awstpr"
 
 const (
-	sshPort   = 22
-	httpPort  = 80
-	httpsPort = 443
+	calicoBGPNetworkPort = 179
+	httpPort             = 80
+	httpsPort            = 443
+	sshPort              = 22
 )
 
-func extractMasterPortsFromTPR(cluster awstpr.CustomObject) []int {
-	var ports = []int{
+// extractMastersSecurityGroupPorts returns the ports that must be opened on the masters security group.
+func extractMastersSecurityGroupPorts(cluster awstpr.CustomObject) []int {
+	return []int{
 		cluster.Spec.Cluster.Kubernetes.API.SecurePort,
 		cluster.Spec.Cluster.Etcd.Port,
 		sshPort,
 	}
-
-	return ports
 }
 
-func extractWorkerPortsFromTPR(cluster awstpr.CustomObject) []int {
-	var ports = []int{
+// extractMastersSecurityGroupPorts returns the ports that must be opened on the workers security group.
+func extractWorkersSecurityGroupPorts(cluster awstpr.CustomObject) []int {
+	return []int{
 		cluster.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
 		cluster.Spec.Cluster.Kubernetes.IngressController.SecurePort,
+		cluster.Spec.Cluster.Kubernetes.Kubelet.Port,
 		sshPort,
+		calicoBGPNetworkPort,
 	}
-
-	return ports
 }

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -317,7 +317,7 @@ func (s *Service) Boot() {
 					mastersSGInput := securityGroupInput{
 						Clients:     clients,
 						GroupName:   securityGroupName(cluster.Name, prefixMaster),
-						PortsToOpen: extractMasterPortsFromTPR(cluster),
+						PortsToOpen: extractMastersSecurityGroupPorts(cluster),
 						VPCID:       vpcID,
 					}
 					mastersSecurityGroup, err := s.createSecurityGroup(mastersSGInput)
@@ -335,7 +335,7 @@ func (s *Service) Boot() {
 					workersSGInput := securityGroupInput{
 						Clients:     clients,
 						GroupName:   securityGroupName(cluster.Name, prefixWorker),
-						PortsToOpen: extractWorkerPortsFromTPR(cluster),
+						PortsToOpen: extractWorkersSecurityGroupPorts(cluster),
 						VPCID:       vpcID,
 					}
 					workersSecurityGroup, err := s.createSecurityGroup(workersSGInput)


### PR DESCRIPTION
The kubelet port comes from the TPO, whereas the BGP network port is hardcoded (since it's a low level detail).

Closes #202.