### PR TITLE
resources: custom exponential backoff

### DIFF
--- a/resources/aws/backoff.go
+++ b/resources/aws/backoff.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+const maxElapsedTime = 2 * time.Minute
+
+// NewCustomExponentialBackoff returns pointer to a backoff.ExponentialBackOff,
+// initialized with custom values. At the moment, we only override the
+// MaxElapsedTime.
+func NewCustomExponentialBackoff() *backoff.ExponentialBackOff {
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     backoff.DefaultInitialInterval,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         backoff.DefaultMaxInterval,
+		MaxElapsedTime:      maxElapsedTime,
+		Clock:               backoff.SystemClock,
+	}
+
+	b.Reset()
+
+	return b
+}

--- a/resources/aws/gateway.go
+++ b/resources/aws/gateway.go
@@ -114,7 +114,7 @@ func (g *Gateway) Delete() error {
 		}
 		return nil
 	}
-	if err := backoff.Retry(detachOperation, backoff.NewExponentialBackOff()); err != nil {
+	if err := backoff.Retry(detachOperation, NewCustomExponentialBackoff()); err != nil {
 		return microerror.MaskAny(err)
 	}
 
@@ -126,7 +126,7 @@ func (g *Gateway) Delete() error {
 		}
 		return nil
 	}
-	if err := backoff.Retry(deleteOperation, backoff.NewExponentialBackOff()); err != nil {
+	if err := backoff.Retry(deleteOperation, NewCustomExponentialBackoff()); err != nil {
 		return microerror.MaskAny(err)
 	}
 

--- a/resources/aws/instance.go
+++ b/resources/aws/instance.go
@@ -155,7 +155,7 @@ func (i *Instance) CreateOrFail() error {
 		return nil
 	}
 
-	if err := backoff.Retry(reserveOperation, backoff.NewExponentialBackOff()); err != nil {
+	if err := backoff.Retry(reserveOperation, NewCustomExponentialBackoff()); err != nil {
 		return microerror.MaskAny(err)
 	}
 

--- a/resources/aws/subnet.go
+++ b/resources/aws/subnet.go
@@ -112,7 +112,7 @@ func (s *Subnet) Delete() error {
 		}
 		return nil
 	}
-	if err := backoff.Retry(deleteOperation, backoff.NewExponentialBackOff()); err != nil {
+	if err := backoff.Retry(deleteOperation, NewCustomExponentialBackoff()); err != nil {
 		return microerror.MaskAny(err)
 	}
 


### PR DESCRIPTION
Reduces the maximum time the backoff runs to 2 minutes, instead of the default 15.

Not sure if we need to add logging as per #174 at this point.