### PR TITLE
resources: error if KMS key has no name

### DIFF
--- a/resources/aws/errors.go
+++ b/resources/aws/errors.go
@@ -21,6 +21,8 @@ var (
 
 	resourceDeleteError       = errgo.New("Couldn't delete resource, it lacks the necessary data (ID)")
 	clientNotInitializedError = errgo.New("The client has not been initialized")
+
+	kmsKeyAliasEmptyError = errgo.New("the KMS key alias cannot be empty")
 )
 
 type DomainNamedResourceNotFoundError struct {
@@ -62,4 +64,8 @@ func IsSubnetFind(err error) bool {
 
 func IsVpcFindError(err error) bool {
 	return errgo.Cause(err) == vpcFindError
+}
+
+func IsKMSKeyAliasEmpty(err error) bool {
+	return errgo.Cause(err) == kmsKeyAliasEmptyError
 }

--- a/resources/aws/kms.go
+++ b/resources/aws/kms.go
@@ -19,6 +19,10 @@ func (kk KMSKey) fullAlias() string {
 }
 
 func (kk *KMSKey) CreateOrFail() error {
+	if kk.Name == "" {
+		return microerror.MaskAny(kmsKeyAliasEmptyError)
+	}
+
 	key, err := kk.Clients.KMS.CreateKey(&kms.CreateKeyInput{})
 	if err != nil {
 		return microerror.MaskAny(err)


### PR DESCRIPTION
We use the name for the alias, and we need to make sure all keys have aliases for sanity.