### PR TITLE
Open http and https ports in the workers SG for the ingress ELB

### DIFF
--- a/service/create/ports.go
+++ b/service/create/ports.go
@@ -26,5 +26,7 @@ func extractWorkersSecurityGroupPorts(cluster awstpr.CustomObject) []int {
 		cluster.Spec.Cluster.Kubernetes.Kubelet.Port,
 		sshPort,
 		calicoBGPNetworkPort,
+		httpsPort, // TODO Move the https and http ports to a separate security group for Ingress ELB.
+		httpPort,
 	}
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1381

This PR opens the http and https ports in the workers SG so the ingress ELB is accessible. But the ingress ELB should be moved to its own SG. See #215 