### PR TITLE
cluster: make region and az match

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -52,7 +52,7 @@ spec:
 
   aws:
     region: "eu-central-1"
-    az: "eu-west-1a"
+    az: "eu-central-1a"
     vpc:
       cidr: "10.0.0.0/16"
       privateSubnetCidr: "10.0.0.0/19"


### PR DESCRIPTION
By the way, this has happened a few times already, so I'm wondering if it would make sense to only have a letter for the region in the TPO, as it was before.