### PR TITLE
service: Create wildcard record

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -40,6 +40,7 @@ spec:
         insecurePort: 30010
         securePort: 30011
         domain: "ingress.example.aws.gigantic.io"
+        wildcardDomain: "*.example.aws.gigantic.io"
       kubelet:
         port: 10250
       networkSetup:

--- a/service/create/domains.go
+++ b/service/create/domains.go
@@ -14,16 +14,20 @@ type recordSetInput struct {
 	Cluster      awstpr.CustomObject
 	Client       *route53.Route53
 	Resource     resources.DNSNamedResource
+	Value        string
 	Domain       string
 	HostedZoneID string
+	Type         string
 }
 
 func (s *Service) deleteRecordSet(input recordSetInput) error {
 	rs := &awsresources.RecordSet{
 		Client:       input.Client,
 		Resource:     input.Resource,
+		Value:        input.Value,
 		Domain:       input.Domain,
 		HostedZoneID: input.HostedZoneID,
+		Type:         input.Type,
 	}
 
 	if err := rs.Delete(); err != nil {
@@ -38,8 +42,10 @@ func (s *Service) createRecordSet(input recordSetInput) error {
 	apiRecordSet := &awsresources.RecordSet{
 		Client:       input.Client,
 		Resource:     input.Resource,
+		Value:        input.Value,
 		Domain:       input.Domain,
 		HostedZoneID: input.HostedZoneID,
+		Type:         input.Type,
 	}
 
 	if err := apiRecordSet.CreateOrFail(); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/awstpr"
 	awsinfo "github.com/giantswarm/awstpr/aws"
@@ -891,6 +892,7 @@ func (s *Service) onAdd(obj interface{}) {
 			Resource:     apiLB,
 			Domain:       cluster.Spec.Cluster.Kubernetes.API.Domain,
 			HostedZoneID: cluster.Spec.AWS.HostedZones.API,
+			Type:         route53.RRTypeA,
 		},
 		recordSetInput{
 			Cluster:      cluster,
@@ -898,6 +900,7 @@ func (s *Service) onAdd(obj interface{}) {
 			Resource:     etcdLB,
 			Domain:       cluster.Spec.Cluster.Etcd.Domain,
 			HostedZoneID: cluster.Spec.AWS.HostedZones.Etcd,
+			Type:         route53.RRTypeA,
 		},
 		recordSetInput{
 			Cluster:      cluster,
@@ -905,6 +908,15 @@ func (s *Service) onAdd(obj interface{}) {
 			Resource:     ingressLB,
 			Domain:       cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
 			HostedZoneID: cluster.Spec.AWS.HostedZones.Ingress,
+			Type:         route53.RRTypeA,
+		},
+		recordSetInput{
+			Cluster:      cluster,
+			Client:       clients.Route53,
+			Domain:       cluster.Spec.Cluster.Kubernetes.IngressController.WildcardDomain,
+			HostedZoneID: cluster.Spec.AWS.HostedZones.Ingress,
+			Value:        cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
+			Type:         route53.RRTypeCname,
 		},
 	}
 
@@ -1018,6 +1030,12 @@ func (s *Service) onDelete(obj interface{}) {
 					Resource:     ingressLB,
 					Domain:       cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
 					HostedZoneID: cluster.Spec.AWS.HostedZones.Ingress,
+				},
+				recordSetInput{
+					Cluster: cluster,
+					Client:  clients.Route53,
+					Value:   cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
+					Domain:  cluster.Spec.Cluster.Kubernetes.IngressController.WildcardDomain,
 				},
 			}
 


### PR DESCRIPTION
Introduce a wildcard domain record for *.[cluster-id]. that is a CNAME to ingress.[cluster-id]. It will make the ingress easier to use without creating DNS records.

Fixes #253