### PR TITLE
resources: Handle situations when AWS API returns many resources

### DIFF
--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -224,8 +224,10 @@ func (lb ELB) findExisting() (*elb.LoadBalancerDescription, error) {
 
 	descriptions := resp.LoadBalancerDescriptions
 
-	if len(descriptions) == 0 {
+	if len(descriptions) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, ELBType, lb.Name)
+	} else if len(descriptions) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return descriptions[0], nil

--- a/resources/aws/errors.go
+++ b/resources/aws/errors.go
@@ -34,6 +34,13 @@ func IsNotFound(err error) bool {
 	return errgo.Cause(err) == notFoundError
 }
 
+var tooManyResultsError = errgo.New("too many results")
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return errgo.Cause(err) == tooManyResultsError
+}
+
 // Delete errors.
 
 var resourceDeleteError = errgo.New("couldn't delete resource, it lacks the necessary data (ID)")

--- a/resources/aws/gateway.go
+++ b/resources/aws/gateway.go
@@ -36,6 +36,8 @@ func (g Gateway) findExisting() (*ec2.InternetGateway, error) {
 
 	if len(gateways.InternetGateways) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, GatewayType, g.Name)
+	} else if len(gateways.InternetGateways) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return gateways.InternetGateways[0], nil

--- a/resources/aws/route_table.go
+++ b/resources/aws/route_table.go
@@ -32,6 +32,8 @@ func (r RouteTable) findExisting() (*ec2.RouteTable, error) {
 
 	if len(routeTables.RouteTables) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, RouteTableType, r.Name)
+	} else if len(routeTables.RouteTables) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return routeTables.RouteTables[0], nil

--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -48,8 +48,10 @@ func (s SecurityGroup) findExisting() (*ec2.SecurityGroup, error) {
 		return nil, microerror.MaskAny(err)
 	}
 
-	if len(securityGroups.SecurityGroups) != 1 {
+	if len(securityGroups.SecurityGroups) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, SecurityGroupType, s.GroupName)
+	} else if len(securityGroups.SecurityGroups) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return securityGroups.SecurityGroups[0], nil

--- a/resources/aws/subnet.go
+++ b/resources/aws/subnet.go
@@ -41,6 +41,8 @@ func (s Subnet) findExisting() (*ec2.Subnet, error) {
 
 	if len(subnets.Subnets) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, SubnetType, s.Name)
+	} else if len(subnets.Subnets) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return subnets.Subnets[0], nil

--- a/resources/aws/vpc.go
+++ b/resources/aws/vpc.go
@@ -32,6 +32,8 @@ func (v VPC) findExisting() (*ec2.Vpc, error) {
 
 	if len(vpcs.Vpcs) < 1 {
 		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, VPCType, v.Name)
+	} else if len(vpcs.Vpcs) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
 	}
 
 	return vpcs.Vpcs[0], nil


### PR DESCRIPTION
If resources were created and tagged properly, they should be unique, but just to be sure and more secure, we check whether we don't receive too many results when checking for an existing resource.

Fixes #170