### PR TITLE
Updated example TPO and docs

### DIFF
--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -35,7 +35,7 @@ spec:
       domain: "cluster.local"
       hyperkube:
         docker:
-          image: "giantswarm/hyperkube:v1.6.4_coreos.0"
+          image: "quay.io/giantswarm/hyperkube:v1.6.4_coreos.0"
       ingressController:
         insecurePort: 30010
         securePort: 30011

--- a/examples/cluster.yml
+++ b/examples/cluster.yml
@@ -27,13 +27,15 @@ spec:
       api:
         domain: "api.example.aws.giantswarm.io"
         insecurePort: 8080
+        ip: "172.31.0.1" 
         securePort: 443
-        clusterIPRange: "192.168.0.0/24"
+        clusterIPRange: "172.31.0.0/24"
       dns:
-        ip: "172.29.0.10"
+        ip: "172.31.0.10"
+      domain: "cluster.local"
       hyperkube:
         docker:
-          image: "giantswarm/hyperkube:v1.5.2_coreos.0"
+          image: "giantswarm/hyperkube:v1.6.4_coreos.0"
       ingressController:
         insecurePort: 30010
         securePort: 30011

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -30,6 +30,8 @@ guide, all placeholders must be replaced with sensible values.
 - *AWS_AMI* - AWS image to be used on both master and worker machines.
 - *AWS_INSTANCE_TYPE_MASTER* - Master machines instance type.
 - *AWS_INSTANCE_TYPE_WORKER* - Worker machines instance type.
+- *AWS_API_HOSTED_ZONE* - Route 53 hosted zone for API and Etcd
+- *AWS_INGRESS_HOSTED_ZONE* - Route 53 hosted zone for Ingress
 
 This is a handy snippet that makes it painless - works in bash and zsh.
 
@@ -45,6 +47,8 @@ export AWS_AZ="eu-central-1a"
 export AWS_AMI="ami-d60ad6b9"
 export AWS_INSTANCE_TYPE_MASTER="t2.medium"
 export AWS_INSTANCE_TYPE_WORKER="t2.medium"
+export AWS_API_HOSTED_ZONE="Z*************"
+export AWS_INGRESS_HOSTED_ZONE="Z*************"
 
 for f in *.tmpl.yaml; do
     sed \
@@ -59,6 +63,8 @@ for f in *.tmpl.yaml; do
         -e 's|${AWS_AMI}|'"${AWS_AMI}"'|g' \
         -e 's|${AWS_INSTANCE_TYPE_MASTER}|'"${AWS_INSTANCE_TYPE_MASTER}"'|g' \
         -e 's|${AWS_INSTANCE_TYPE_WORKER}|'"${AWS_INSTANCE_TYPE_WORKER}"'|g' \
+        -e 's|${AWS_API_HOSTED_ZONE}|'"${AWS_API_HOSTED_ZONE}"'|g' \
+        -e 's|${AWS_INGRESS_HOSTED_ZONE}|'"${AWS_INGRESS_HOSTED_ZONE}"'|g' \
         ./$f > ./${f%.tmpl.yaml}.yaml
 done
 ```

--- a/examples/local/cluster.tmpl.yaml
+++ b/examples/local/cluster.tmpl.yaml
@@ -35,7 +35,7 @@ spec:
       domain: "cluster.local"
       hyperkube:
         docker:
-          image: "giantswarm/hyperkube:v1.6.4_coreos.0"
+          image: "quay.io/giantswarm/hyperkube:v1.6.4_coreos.0"
       ingressController:
         insecurePort: 30010
         securePort: 30011

--- a/examples/local/cluster.tmpl.yaml
+++ b/examples/local/cluster.tmpl.yaml
@@ -27,13 +27,15 @@ spec:
       api:
         domain: "api.${CLUSTER_NAME}.${COMMON_DOMAIN}"
         insecurePort: 8080
+        ip: "172.31.0.1" 
         securePort: 443
-        clusterIPRange: "192.168.0.0/24"
+        clusterIPRange: "172.31.0.0/24"
       dns:
-        ip: "172.29.0.10"
+        ip: "172.31.0.10"
+      domain: "cluster.local"
       hyperkube:
         docker:
-          image: "giantswarm/hyperkube:v1.5.2_coreos.0"
+          image: "giantswarm/hyperkube:v1.6.4_coreos.0"
       ingressController:
         insecurePort: 30010
         securePort: 30011
@@ -53,6 +55,10 @@ spec:
   aws:
     region: "${AWS_REGION}"
     az: "${AWS_AZ}"
+    hostedZones:
+      api: "${AWS_API_HOSTED_ZONE}"
+      etcd: "${AWS_API_HOSTED_ZONE}"
+      ingress: "${AWS_INGRESS_HOSTED_ZONE}"
     vpc:
       cidr: "10.0.0.0/16"
       privateSubnetCidr: "10.0.0.0/19"


### PR DESCRIPTION
- Update the example TPO to use 1.6 hyperkube
- Sets Kubernetes.Domain to `cluster.local` for kubedns
- Updates cluster IP ranges to match those in kubernetesd