### PR TITLE
Auto Scaling Group for workers

### DIFF
--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -7,15 +7,28 @@ import (
 )
 
 type AutoScalingGroup struct {
-	Client                  *autoscaling.AutoScaling
-	Name                    string
-	MinSize                 int
-	MaxSize                 int
-	AvailabilityZone        string
+	// AvailabilityZone is the AZ the instances will be placed in.
+	AvailabilityZone string
+	// HealthCheckGracePeriod is the time, in seconds, that the instances are
+	// given after boot before the healtchecks start.
+	HealthCheckGracePeriod int
+	// LaunchConfigurationName is the name of the Launch Configuration used for the instances.
 	LaunchConfigurationName string
-	LoadBalancerName        string
-	VPCZoneIdentifier       string
-	HealthCheckGracePeriod  int
+	// LoadBalancerName is the name of the ELB that will front the instances.
+	LoadBalancerName string
+	// MaxSize is the maximum amount of insances that will be created in this ASG.
+	MaxSize int
+	// MinSize is the minimum amount of insances in this ASG. There will never be
+	// less than MinSize instances running.
+	MinSize int
+	// Name is the ASG name.
+	Name string
+	// VPCZoneIdentifier is the Subnet ID of the subnet the instances should be
+	// placed in.
+	VPCZoneIdentifier string
+
+	// Dependencies.
+	Client *autoscaling.AutoScaling
 }
 
 func (asg *AutoScalingGroup) CreateOrFail() error {
@@ -52,7 +65,8 @@ func (asg *AutoScalingGroup) Delete() error {
 
 	params := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(asg.Name),
-		ForceDelete:          aws.Bool(true),
+		// We force deletion of the ASG even if instances are still terminating.
+		ForceDelete: aws.Bool(true),
 	}
 
 	if _, err := asg.Client.DeleteAutoScalingGroup(params); err != nil {

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -13,6 +13,7 @@ type AutoScalingGroup struct {
 	MaxSize                 int
 	AvailabilityZone        string
 	LaunchConfigurationName string
+	LoadBalancerName        string
 	VPCZoneIdentifier       string
 	HealthCheckGracePeriod  int
 }
@@ -30,8 +31,11 @@ func (asg *AutoScalingGroup) CreateOrFail() error {
 			aws.String(asg.AvailabilityZone),
 		},
 		LaunchConfigurationName: aws.String(asg.LaunchConfigurationName),
-		VPCZoneIdentifier:       aws.String(asg.VPCZoneIdentifier),
-		HealthCheckGracePeriod:  aws.Int64(int64(asg.HealthCheckGracePeriod)),
+		LoadBalancerNames: []*string{
+			aws.String(asg.LoadBalancerName),
+		},
+		VPCZoneIdentifier:      aws.String(asg.VPCZoneIdentifier),
+		HealthCheckGracePeriod: aws.Int64(int64(asg.HealthCheckGracePeriod)),
 	}
 
 	if _, err := asg.Client.CreateAutoScalingGroup(params); err != nil {

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -49,6 +49,18 @@ func (asg *AutoScalingGroup) CreateOrFail() error {
 		},
 		VPCZoneIdentifier:      aws.String(asg.VPCZoneIdentifier),
 		HealthCheckGracePeriod: aws.Int64(int64(asg.HealthCheckGracePeriod)),
+		Tags: []*autoscaling.Tag{
+			{
+				Key:               aws.String(tagKeyName),
+				PropagateAtLaunch: aws.Bool(true),
+				Value:             aws.String(asg.Name),
+			},
+			{
+				Key:               aws.String(tagKeyCluster),
+				PropagateAtLaunch: aws.Bool(true),
+				Value:             aws.String(asg.Name),
+			},
+		},
 	}
 
 	if _, err := asg.Client.CreateAutoScalingGroup(params); err != nil {

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -10,15 +10,15 @@ type AutoScalingGroup struct {
 	// AvailabilityZone is the AZ the instances will be placed in.
 	AvailabilityZone string
 	// HealthCheckGracePeriod is the time, in seconds, that the instances are
-	// given after boot before the healtchecks start.
+	// given after boot before the healthchecks start.
 	HealthCheckGracePeriod int
 	// LaunchConfigurationName is the name of the Launch Configuration used for the instances.
 	LaunchConfigurationName string
 	// LoadBalancerName is the name of the ELB that will front the instances.
 	LoadBalancerName string
-	// MaxSize is the maximum amount of insances that will be created in this ASG.
+	// MaxSize is the maximum amount of instances that will be created in this ASG.
 	MaxSize int
-	// MinSize is the minimum amount of insances in this ASG. There will never be
+	// MinSize is the minimum amount of instances in this ASG. There will never be
 	// less than MinSize instances running.
 	MinSize int
 	// Name is the ASG name.

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+type AutoScalingGroup struct {
+	Client                  *autoscaling.AutoScaling
+	Name                    string
+	MinSize                 int
+	MaxSize                 int
+	AvailabilityZone        string
+	LaunchConfigurationName string
+	VPCZoneIdentifier       string
+	HealthCheckGracePeriod  int
+}
+
+func (asg *AutoScalingGroup) CreateOrFail() error {
+	if asg.Client == nil {
+		return microerror.MaskAny(clientNotInitializedError)
+	}
+
+	params := &autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(asg.Name),
+		MaxSize:              aws.Int64(int64(asg.MaxSize)),
+		MinSize:              aws.Int64(int64(asg.MinSize)),
+		AvailabilityZones: []*string{
+			aws.String(asg.AvailabilityZone),
+		},
+		LaunchConfigurationName: aws.String(asg.LaunchConfigurationName),
+		VPCZoneIdentifier:       aws.String(asg.VPCZoneIdentifier),
+		HealthCheckGracePeriod:  aws.Int64(int64(asg.HealthCheckGracePeriod)),
+	}
+
+	if _, err := asg.Client.CreateAutoScalingGroup(params); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (asg *AutoScalingGroup) Delete() error {
+	if asg.Client == nil {
+		return microerror.MaskAny(clientNotInitializedError)
+	}
+
+	params := &autoscaling.DeleteAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(asg.Name),
+		ForceDelete:          aws.Bool(true),
+	}
+
+	if _, err := asg.Client.DeleteAutoScalingGroup(params); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -14,7 +14,8 @@ type AutoScalingGroup struct {
 	HealthCheckGracePeriod int
 	// LaunchConfigurationName is the name of the Launch Configuration used for the instances.
 	LaunchConfigurationName string
-	// LoadBalancerName is the name of the ELB that will front the instances.
+	// LoadBalancerName is the name of the existing ELB that will be placed in
+	// the ASG to front the instances.
 	LoadBalancerName string
 	// MaxSize is the maximum amount of instances that will be created in this ASG.
 	MaxSize int

--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -65,7 +65,7 @@ func (asg *AutoScalingGroup) Delete() error {
 
 	params := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(asg.Name),
-		// We force deletion of the ASG even if instances are still terminating.
+		// Delete instances too.
 		ForceDelete: aws.Bool(true),
 	}
 

--- a/resources/aws/launch_configuration.go
+++ b/resources/aws/launch_configuration.go
@@ -9,14 +9,14 @@ import (
 // LaunchConfiguration is a template for launching EC2 instances into an auto
 // scaling group.
 type LaunchConfiguration struct {
-	Name                     string
+	AssociatePublicIpAddress bool
 	IamInstanceProfileName   string
 	ImageID                  string
 	InstanceType             string
 	KeyName                  string
+	Name                     string
 	SecurityGroupID          string
 	SmallCloudConfig         string
-	AssociatePublicIpAddress bool
 
 	// Dependencies
 	Client *autoscaling.AutoScaling

--- a/resources/aws/launch_configuration.go
+++ b/resources/aws/launch_configuration.go
@@ -9,13 +9,14 @@ import (
 // LaunchConfiguration is a template for launching EC2 instances into an auto
 // scaling group.
 type LaunchConfiguration struct {
-	Name                   string
-	IamInstanceProfileName string
-	ImageID                string
-	InstanceType           string
-	KeyName                string
-	SecurityGroupID        string
-	SmallCloudConfig       string
+	Name                     string
+	IamInstanceProfileName   string
+	ImageID                  string
+	InstanceType             string
+	KeyName                  string
+	SecurityGroupID          string
+	SmallCloudConfig         string
+	AssociatePublicIpAddress bool
 
 	// Dependencies
 	Client *autoscaling.AutoScaling
@@ -58,7 +59,8 @@ func (lc *LaunchConfiguration) CreateOrFail() error {
 		SecurityGroups: []*string{
 			aws.String(lc.SecurityGroupID),
 		},
-		UserData: aws.String(lc.SmallCloudConfig),
+		UserData:                 aws.String(lc.SmallCloudConfig),
+		AssociatePublicIpAddress: aws.Bool(lc.AssociatePublicIpAddress),
 	}
 	if _, err := lc.Client.CreateLaunchConfiguration(lcInput); err != nil {
 		return microerror.MaskAny(err)

--- a/resources/aws/vpc.go
+++ b/resources/aws/vpc.go
@@ -137,6 +137,7 @@ func (v *VPC) Delete() error {
 	return nil
 }
 
+// GetID retrieves the ID from the API if it isn't defined on the VPC struct.
 func (v VPC) GetID() (string, error) {
 	if v.id != "" {
 		return v.id, nil

--- a/service/create/error.go
+++ b/service/create/error.go
@@ -25,7 +25,7 @@ func IsMalformedCloudConfigKey(err error) bool {
 	return errgo.Cause(err) == malformedCloudConfigKeyError
 }
 
-var missingCloudConfigKeyError = errgo.New("missing cloud config key")
+var missingCloudConfigKeyError = errgo.New("missing key in the cloudconfig")
 
 // IsMissingCloudConfigKey asserts missingCloudConfigKeyError.
 func IsMissingCloudConfigKey(err error) bool {

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -93,7 +93,7 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 		return false, microerror.MaskAny(err)
 	}
 
-	launchConfigName, err := launchConfigurationName(input.cluster, input.prefix)
+	launchConfigName, err := launchConfigurationName(input.cluster, input.prefix, securityGroupID)
 	if err != nil {
 		return false, microerror.MaskAny(err)
 	}
@@ -132,7 +132,7 @@ func (s *Service) deleteLaunchConfiguration(input launchConfigurationInput) erro
 	return nil
 }
 
-func launchConfigurationName(cluster awstpr.CustomObject, prefix string) (string, error) {
+func launchConfigurationName(cluster awstpr.CustomObject, prefix, securityGroupID string) (string, error) {
 	if cluster.Spec.Cluster.Cluster.ID == "" {
 		return "", microerror.MaskAnyf(missingCloudConfigKeyError, "spec.cluster.cluster.id")
 	}
@@ -141,5 +141,9 @@ func launchConfigurationName(cluster awstpr.CustomObject, prefix string) (string
 		return "", microerror.MaskAnyf(missingCloudConfigKeyError, "launchConfiguration prefix")
 	}
 
-	return fmt.Sprintf("%s-%s", cluster.Spec.Cluster.Cluster.ID, prefix), nil
+	if securityGroupID == "" {
+		return "", microerror.MaskAnyf(missingCloudConfigKeyError, "launchConfiguration securityGroupID")
+	}
+
+	return fmt.Sprintf("%s-%s-%s", cluster.Spec.Cluster.Cluster.ID, prefix, securityGroupID), nil
 }

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -31,6 +31,7 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 		extension    cloudconfig.Extension
 		imageID      string
 		instanceType string
+		publicIP     bool
 	)
 
 	switch input.prefix {
@@ -47,6 +48,7 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 		// image ID and instance type is provided.
 		imageID = input.cluster.Spec.AWS.Workers[0].ImageID
 		instanceType = input.cluster.Spec.AWS.Workers[0].InstanceType
+		publicIP = true
 	default:
 		return false, microerror.MaskAnyf(invalidCloudconfigExtensionNameError, fmt.Sprintf("Invalid extension name '%s'", input.prefix))
 	}
@@ -99,13 +101,15 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 	launchConfig := &awsresources.LaunchConfiguration{
 		Client: input.clients.AutoScaling,
 		Name:   launchConfigName,
-		IamInstanceProfileName: input.instanceProfileName,
-		ImageID:                imageID,
-		InstanceType:           instanceType,
-		KeyName:                input.keypairName,
-		SecurityGroupID:        securityGroupID,
-		SmallCloudConfig:       smallCloudconfig,
+		IamInstanceProfileName:   input.instanceProfileName,
+		ImageID:                  imageID,
+		InstanceType:             instanceType,
+		KeyName:                  input.keypairName,
+		SecurityGroupID:          securityGroupID,
+		SmallCloudConfig:         smallCloudconfig,
+		AssociatePublicIpAddress: publicIP,
 	}
+
 	launchConfigCreated, err := launchConfig.CreateIfNotExists()
 	if err != nil {
 		return false, microerror.MaskAny(err)

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -14,16 +14,16 @@ import (
 )
 
 type launchConfigurationInput struct {
-	name                string
+	bucket              resources.Resource
 	clients             awsutil.Clients
 	cluster             awstpr.CustomObject
-	tlsAssets           *certificatetpr.CompactTLSAssets
-	bucket              resources.Resource
+	instanceProfileName string
+	keypairName         string
+	name                string
+	prefix              string
 	securityGroup       resources.ResourceWithID
 	subnet              *awsresources.Subnet
-	keypairName         string
-	instanceProfileName string
-	prefix              string
+	tlsAssets           *certificatetpr.CompactTLSAssets
 }
 
 func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (bool, error) {
@@ -132,6 +132,11 @@ func (s *Service) deleteLaunchConfiguration(input launchConfigurationInput) erro
 	return nil
 }
 
+// launchConfigurationName uses the cluster ID, a prefix and the security group
+// ID to produce a launch configuration name.  LC names are their unique
+// identifiers in AWS.  The reason we need the securityGroupID in the name is
+// that we can only reuse an LC if it has been created for the current SG.
+// Otherwise, the SG might not exist anymore.
 func launchConfigurationName(cluster awstpr.CustomObject, prefix, securityGroupID string) (string, error) {
 	if cluster.Spec.Cluster.Cluster.ID == "" {
 		return "", microerror.MaskAnyf(missingCloudConfigKeyError, "spec.cluster.cluster.id")

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -119,18 +119,19 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 }
 
 func (s *Service) deleteLaunchConfiguration(input launchConfigurationInput) error {
-	wSG := awsresources.SecurityGroup{
-		Description: securityGroupName(input.cluster.Name, prefixWorker),
-		GroupName:   securityGroupName(input.cluster.Name, prefixWorker),
+	groupName := securityGroupName(input.cluster.Name, input.prefix)
+	sg := awsresources.SecurityGroup{
+		Description: groupName,
+		GroupName:   groupName,
 		AWSEntity:   awsresources.AWSEntity{Clients: input.clients},
 	}
 
-	wSGID, err := wSG.GetID()
+	sgID, err := sg.GetID()
 	if err != nil {
 		return microerror.MaskAny(err)
 	}
 
-	workersLCName, err := launchConfigurationName(input.cluster, prefixWorker, wSGID)
+	workersLCName, err := launchConfigurationName(input.cluster, prefixWorker, sgID)
 	if err != nil {
 		return microerror.MaskAny(err)
 	}

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -120,7 +120,8 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 
 func (s *Service) deleteLaunchConfiguration(input launchConfigurationInput) error {
 	lc := awsresources.LaunchConfiguration{
-		Name: input.name,
+		Client: input.clients.AutoScaling,
+		Name:   input.name,
 	}
 
 	if err := lc.Delete(); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1038,6 +1038,7 @@ func (s *Service) onDelete(obj interface{}) {
 	lcInput := launchConfigurationInput{
 		clients: clients,
 		cluster: cluster,
+		prefix:  "worker",
 	}
 	if err := s.deleteLaunchConfiguration(lcInput); err != nil {
 		s.logger.Log("error", errgo.Details(err))

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -908,7 +908,7 @@ func (s *Service) onAdd(obj interface{}) {
 
 	asg := awsresources.AutoScalingGroup{
 		Client:                  clients.AutoScaling,
-		Name:                    cluster.Name,
+		Name:                    fmt.Sprintf("%s-%s", cluster.Name, prefixWorker),
 		MinSize:                 asgSize,
 		MaxSize:                 asgSize,
 		AvailabilityZone:        cluster.Spec.AWS.AZ,
@@ -1028,7 +1028,7 @@ func (s *Service) onDelete(obj interface{}) {
 	// Delete workers Auto Scaling Group.
 	asg := awsresources.AutoScalingGroup{
 		Client: clients.AutoScaling,
-		Name:   cluster.Name,
+		Name:   fmt.Sprintf("%s-%s", cluster.Name, prefixWorker),
 	}
 
 	if err := asg.Delete(); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1022,18 +1022,6 @@ func (s *Service) onDelete(obj interface{}) {
 		s.logger.Log("info", "deleted masters")
 	}
 
-	// Delete workers.
-	s.logger.Log("info", "deleting workers...")
-	if err := s.deleteMachines(deleteMachinesInput{
-		clients:     clients,
-		clusterName: cluster.Name,
-		prefix:      prefixWorker,
-	}); err != nil {
-		s.logger.Log("error", errgo.Details(err))
-	} else {
-		s.logger.Log("info", "deleted workers")
-	}
-
 	// Delete workers Auto Scaling Group.
 	asg := awsresources.AutoScalingGroup{
 		Client: clients.AutoScaling,

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -48,6 +48,9 @@ const (
 	// Number of retries of RunInstances to wait for Roles to propagate to
 	// Instance Profiles
 	runInstancesRetries = 10
+	// The number of seconds AWS will wait, before issuing a health check on
+	// instances in an Auto Scaling Group.
+	gracePeriodSeconds = 10
 )
 
 // Config represents the configuration used to create a version service.
@@ -912,7 +915,7 @@ func (s *Service) onAdd(obj interface{}) {
 		LaunchConfigurationName: workersLCName,
 		LoadBalancerName:        ingressLB.Name,
 		VPCZoneIdentifier:       publicSubnetID,
-		HealthCheckGracePeriod:  10,
+		HealthCheckGracePeriod:  gracePeriodSeconds,
 	}
 
 	if err := asg.CreateOrFail(); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -898,6 +898,11 @@ func (s *Service) onAdd(obj interface{}) {
 
 	// Create an Auto Scaling Group for the workers.
 	asgSize := len(cluster.Spec.AWS.Workers)
+	if asgSize == 0 {
+		s.logger.Log("error", fmt.Sprintf("%s: %s", missingCloudConfigKeyError.Error(), "spec.cluster.aws.workers"))
+		return
+	}
+
 	asg := awsresources.AutoScalingGroup{
 		Client:                  clients.AutoScaling,
 		Name:                    cluster.Name,

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -887,7 +887,7 @@ func (s *Service) onAdd(obj interface{}) {
 	if lcCreated {
 		s.logger.Log("info", fmt.Sprintf("created worker launch config"))
 	} else {
-		s.logger.Log("info", fmt.Sprintf("launch config already exists, reusing", cluster.Name))
+		s.logger.Log("info", fmt.Sprintf("launch config %s already exists, reusing", cluster.Name))
 	}
 
 	workersLCName, err := launchConfigurationName(cluster, "worker", workersSecurityGroupID)

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1047,28 +1047,14 @@ func (s *Service) onDelete(obj interface{}) {
 	}
 
 	// Delete workers launch configuration.
-	wSG := awsresources.SecurityGroup{
-		Description: securityGroupName(cluster.Name, prefixWorker),
-		GroupName:   securityGroupName(cluster.Name, prefixWorker),
-		AWSEntity:   awsresources.AWSEntity{Clients: clients},
+	lcInput := launchConfigurationInput{
+		clients: clients,
+		cluster: cluster,
 	}
-	wSGID, err := wSG.GetID()
-	if err != nil {
-		s.logger.Log("error", errgo.Details(err))
-	}
-
-	workersLCName, err := launchConfigurationName(cluster, prefixWorker, wSGID)
-	if err != nil {
+	if err := s.deleteLaunchConfiguration(lcInput); err != nil {
 		s.logger.Log("error", errgo.Details(err))
 	} else {
-		if err := s.deleteLaunchConfiguration(launchConfigurationInput{
-			clients: clients,
-			name:    workersLCName,
-		}); err != nil {
-			s.logger.Log("error", errgo.Details(err))
-		} else {
-			s.logger.Log("info", "deleted worker launch config")
-		}
+		s.logger.Log("info", "deleted worker launch config")
 	}
 
 	// Delete Record Sets.


### PR DESCRIPTION
### Changes

* We don't attach instances to the Ingress ELB anymore. Instead, we attach the ELB to the workers ASG.
* Instance creation/deletion is handled by the ASG, not the `runMachines`/`deleteMachines` methods anymore
* For now, only workers.

**NOTE**: AFAIK, there's no way to name instances created by an ASG, so we lose that kind of visual cue in the UI.

Closes #258.