### PR TITLE
service: Validate workers definition

### DIFF
--- a/service/create/error.go
+++ b/service/create/error.go
@@ -38,3 +38,26 @@ var secretsRetrievalFailedError = errgo.New("secrets retrieval failed")
 func IsSecretsRetrievalFailed(err error) bool {
 	return errgo.Cause(err) == secretsRetrievalFailedError
 }
+
+// Validation errors
+
+var workersListEmptyError = errgo.New("workers list empty")
+
+// IsWorkersListEmpty asserts workersListEmptyError.
+func IsWorkersListEmpty(err error) bool {
+	return errgo.Cause(err) == workersListEmptyError
+}
+
+var differentImageIDsError = errgo.New("different image IDs")
+
+// IsDifferentImageIDs assert differentImageIDsError.
+func IsDifferentImageIDs(err error) bool {
+	return errgo.Cause(err) == differentImageIDsError
+}
+
+var differentInstanceTypesError = errgo.New("different instance types")
+
+// IsDifferentInstanceTypes asserts differentInstanceTypesError.
+func IsDifferentInstanceTypes(err error) bool {
+	return errgo.Cause(err) == differentInstanceTypesError
+}

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -44,8 +44,6 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 	case prefixWorker:
 		extension = NewWorkerCloudConfigExtension(input.cluster.Spec, input.tlsAssets)
 
-		// TODO Until multiple worker instance types supported check only a single
-		// image ID and instance type is provided.
 		imageID = input.cluster.Spec.AWS.Workers[0].ImageID
 		instanceType = input.cluster.Spec.AWS.Workers[0].InstanceType
 		publicIP = true

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -475,6 +475,11 @@ func (s *Service) onAdd(obj interface{}) {
 	cluster := *obj.(*awstpr.CustomObject)
 	s.logger.Log("info", fmt.Sprintf("creating cluster '%s'", cluster.Name))
 
+	if err := validateCluster(cluster); err != nil {
+		s.logger.Log("error", "cluster spec is invalid: %s", errgo.Details(err))
+		return
+	}
+
 	if err := s.createClusterNamespace(cluster.Spec.Cluster); err != nil {
 		s.logger.Log("error", fmt.Sprintf("could not create cluster namespace: %s", errgo.Details(err)))
 		return
@@ -999,6 +1004,11 @@ func (s *Service) onDelete(obj interface{}) {
 			return
 		}
 		cluster = *clusterPtr
+	}
+
+	if err := validateCluster(cluster); err != nil {
+		s.logger.Log("error", "cluster spec is invalid: %s", errgo.Details(err))
+		return
 	}
 
 	if err := s.deleteClusterNamespace(cluster.Spec.Cluster); err != nil {

--- a/service/create/validation.go
+++ b/service/create/validation.go
@@ -1,0 +1,34 @@
+package create
+
+import (
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/awstpr/aws"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+func validateWorkers(workers []aws.Node) error {
+	if len(workers) < 1 {
+		return microerror.MaskAny(workersListEmptyError)
+	}
+
+	firstImageID := workers[0].ImageID
+	firstInstanceType := workers[0].InstanceType
+	for _, worker := range workers {
+		if worker.ImageID != firstImageID {
+			return microerror.MaskAny(differentImageIDsError)
+		}
+		if worker.InstanceType != firstInstanceType {
+			return microerror.MaskAny(differentInstanceTypesError)
+		}
+	}
+
+	return nil
+}
+
+func validateCluster(cluster awstpr.CustomObject) error {
+	if err := validateWorkers(cluster.Spec.AWS.Workers); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/service/create/validation_test.go
+++ b/service/create/validation_test.go
@@ -1,0 +1,70 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/giantswarm/awstpr/aws"
+	"github.com/juju/errgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateWorkers(t *testing.T) {
+	tests := []struct {
+		name          string
+		workers       []aws.Node
+		expectedError error
+	}{
+		{
+			name: "Valid workers - image IDs and instance types are the same",
+			workers: []aws.Node{
+				aws.Node{
+					ImageID:      "example-image-id",
+					InstanceType: "example-instance-type",
+				},
+				aws.Node{
+					ImageID:      "example-image-id",
+					InstanceType: "example-instance-type",
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:          "Invalid workers - list is empty",
+			workers:       []aws.Node{},
+			expectedError: workersListEmptyError,
+		},
+		{
+			name: "Invalid workers - image IDs are different",
+			workers: []aws.Node{
+				aws.Node{
+					ImageID:      "example-image-id",
+					InstanceType: "example-instance-type",
+				},
+				aws.Node{
+					ImageID:      "another-image-id",
+					InstanceType: "example-instance-type",
+				},
+			},
+			expectedError: differentImageIDsError,
+		},
+		{
+			name: "Invalid workers - instance types are different",
+			workers: []aws.Node{
+				aws.Node{
+					ImageID:      "example-image-id",
+					InstanceType: "example-instance-type",
+				},
+				aws.Node{
+					ImageID:      "example-image-id",
+					InstanceType: "another-instance-type",
+				},
+			},
+			expectedError: differentInstanceTypesError,
+		},
+	}
+
+	for _, tc := range tests {
+		err := validateWorkers(tc.workers)
+		assert.Equal(t, tc.expectedError, errgo.Cause(err), tc.name)
+	}
+}


### PR DESCRIPTION
We need to check whether all the workers have the same image ID and instance type, until we switch to using multiple auto-scaling group which will make that kind of mixing mixing possible.

Fixes #304