### PR TITLE
EBS for Docker images on workers

### DIFF
--- a/resources/aws/launch_configuration.go
+++ b/resources/aws/launch_configuration.go
@@ -10,6 +10,7 @@ import (
 // scaling group.
 type LaunchConfiguration struct {
 	AssociatePublicIpAddress bool
+	EBSStorage               bool
 	IamInstanceProfileName   string
 	ImageID                  string
 	InstanceType             string
@@ -21,6 +22,13 @@ type LaunchConfiguration struct {
 	// Dependencies
 	Client *autoscaling.AutoScaling
 }
+
+const (
+	defaultMountPoint = "/dev/xvdh"
+	// defaultVolumeSize is expressed in GB.
+	defaultVolumeSize = 50
+	defaultVolumeType = "gp2"
+)
 
 // CreateIfNotExists creates the launch config if it doesn't exist.
 func (lc *LaunchConfiguration) CreateIfNotExists() (bool, error) {
@@ -50,6 +58,18 @@ func (lc *LaunchConfiguration) CreateOrFail() error {
 		return microerror.MaskAny(clientNotInitializedError)
 	}
 
+	var ebsMount *autoscaling.BlockDeviceMapping
+	if lc.EBSStorage {
+		ebsMount = &autoscaling.BlockDeviceMapping{
+			DeviceName: aws.String(defaultMountPoint),
+			Ebs: &autoscaling.Ebs{
+				DeleteOnTermination: aws.Bool(true),
+				VolumeSize:          aws.Int64(defaultVolumeSize),
+				VolumeType:          aws.String(defaultVolumeType),
+			},
+		}
+	}
+
 	lcInput := &autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String(lc.Name),
 		IamInstanceProfile:      aws.String(lc.IamInstanceProfileName),
@@ -61,7 +81,9 @@ func (lc *LaunchConfiguration) CreateOrFail() error {
 		},
 		UserData:                 aws.String(lc.SmallCloudConfig),
 		AssociatePublicIpAddress: aws.Bool(lc.AssociatePublicIpAddress),
+		BlockDeviceMappings:      []*autoscaling.BlockDeviceMapping{ebsMount},
 	}
+
 	if _, err := lc.Client.CreateLaunchConfiguration(lcInput); err != nil {
 		return microerror.MaskAny(err)
 	}

--- a/resources/aws/launch_configuration.go
+++ b/resources/aws/launch_configuration.go
@@ -24,10 +24,10 @@ type LaunchConfiguration struct {
 }
 
 const (
-	defaultMountPoint = "/dev/xvdh"
-	// defaultVolumeSize is expressed in GB.
-	defaultVolumeSize = 50
-	defaultVolumeType = "gp2"
+	defaultEBSVolumeMountPoint = "/dev/xvdh"
+	// defaultEBSVolumeSize is expressed in GB.
+	defaultEBSVolumeSize = 50
+	defaultEBSVolumeType = "gp2"
 )
 
 // CreateIfNotExists creates the launch config if it doesn't exist.
@@ -61,11 +61,11 @@ func (lc *LaunchConfiguration) CreateOrFail() error {
 	var ebsMount *autoscaling.BlockDeviceMapping
 	if lc.EBSStorage {
 		ebsMount = &autoscaling.BlockDeviceMapping{
-			DeviceName: aws.String(defaultMountPoint),
+			DeviceName: aws.String(defaultEBSVolumeMountPoint),
 			Ebs: &autoscaling.Ebs{
 				DeleteOnTermination: aws.Bool(true),
-				VolumeSize:          aws.Int64(defaultVolumeSize),
-				VolumeType:          aws.String(defaultVolumeType),
+				VolumeSize:          aws.Int64(defaultEBSVolumeSize),
+				VolumeType:          aws.String(defaultEBSVolumeType),
 			},
 		}
 	}

--- a/service/create/cloud_config.go
+++ b/service/create/cloud_config.go
@@ -212,6 +212,12 @@ func (m *MasterCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
 			Command:      "start",
 		},
 		cloudconfig.UnitMetadata{
+			AssetContent: masterFormatVarLibDockerServiceTemplate,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		cloudconfig.UnitMetadata{
 			AssetContent: ephemeralVarLibDockerMountTemplate,
 			Name:         "var-lib-docker.mount",
 			Enable:       true,
@@ -336,7 +342,7 @@ func (w *WorkerCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
 			Command:      "start",
 		},
 		cloudconfig.UnitMetadata{
-			AssetContent: formatVarLibDockerServiceTemplate,
+			AssetContent: workerFormatVarLibDockerServiceTemplate,
 			Name:         "format-var-lib-docker.service",
 			Enable:       true,
 			Command:      "start",

--- a/service/create/cloud_config.go
+++ b/service/create/cloud_config.go
@@ -212,7 +212,7 @@ func (m *MasterCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
 			Command:      "start",
 		},
 		cloudconfig.UnitMetadata{
-			AssetContent: varLibDockerMountTemplate,
+			AssetContent: ephemeralVarLibDockerMountTemplate,
 			Name:         "var-lib-docker.mount",
 			Enable:       true,
 			Command:      "start",
@@ -342,7 +342,7 @@ func (w *WorkerCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
 			Command:      "start",
 		},
 		cloudconfig.UnitMetadata{
-			AssetContent: varLibDockerMountTemplate,
+			AssetContent: persistentVarLibDockerMountTemplate,
 			Name:         "var-lib-docker.mount",
 			Enable:       true,
 			Command:      "start",

--- a/service/create/cloud_config.go
+++ b/service/create/cloud_config.go
@@ -357,9 +357,7 @@ func (w *WorkerCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
 	return units, nil
 }
 
-// VerbatimSections is defined on CloudConfigExtension since there's no difference
-// between master and workers sections.
-func (c *CloudConfigExtension) VerbatimSections() []cloudconfig.VerbatimSection {
+func (m *MasterCloudConfigExtension) VerbatimSections() []cloudconfig.VerbatimSection {
 	sections := []cloudconfig.VerbatimSection{
 		{
 			Name:    "storage",
@@ -368,6 +366,10 @@ func (c *CloudConfigExtension) VerbatimSections() []cloudconfig.VerbatimSection 
 	}
 
 	return sections
+}
+
+func (w *WorkerCloudConfigExtension) VerbatimSections() []cloudconfig.VerbatimSection {
+	return nil
 }
 
 func (s *Service) cloudConfig(prefix string, params cloudconfig.Params, awsSpec awstpr.Spec, tlsAssets *certificatetpr.CompactTLSAssets) (string, error) {

--- a/service/create/cloud_config.go
+++ b/service/create/cloud_config.go
@@ -8,23 +8,6 @@ import (
 )
 
 var (
-	unitsMeta []cloudconfig.UnitMetadata = []cloudconfig.UnitMetadata{
-		cloudconfig.UnitMetadata{
-			AssetContent: decryptTLSAssetsServiceTemplate,
-			Name:         "decrypt-tls-assets.service",
-			Enable:       true,
-			Command:      "start",
-		},
-		cloudconfig.UnitMetadata{
-			AssetContent: varLibDockerMountTemplate,
-			Name:         "var-lib-docker.mount",
-			Enable:       true,
-			Command:      "start",
-		},
-	}
-)
-
-var (
 	assetTemplates = map[string]string{
 		prefixMaster: cloudconfig.MasterTemplate,
 		prefixWorker: cloudconfig.WorkerTemplate,
@@ -71,15 +54,6 @@ func (c *CloudConfigExtension) renderUnits(unitsMeta []cloudconfig.UnitMetadata)
 		}
 
 		units = append(units, unitAsset)
-	}
-
-	return units, nil
-}
-
-func (c *CloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
-	units, err := c.renderUnits(unitsMeta)
-	if err != nil {
-		return nil, microerror.MaskAny(err)
 	}
 
 	return units, nil
@@ -229,6 +203,30 @@ func (m *MasterCloudConfigExtension) Files() ([]cloudconfig.FileAsset, error) {
 	return files, nil
 }
 
+func (m *MasterCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
+	unitsMeta := []cloudconfig.UnitMetadata{
+		cloudconfig.UnitMetadata{
+			AssetContent: decryptTLSAssetsServiceTemplate,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		cloudconfig.UnitMetadata{
+			AssetContent: varLibDockerMountTemplate,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	units, err := m.renderUnits(unitsMeta)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	return units, nil
+}
+
 type WorkerCloudConfigExtension struct {
 	CloudConfigExtension
 }
@@ -327,6 +325,36 @@ func (w *WorkerCloudConfigExtension) Files() ([]cloudconfig.FileAsset, error) {
 	}
 
 	return files, nil
+}
+
+func (w *WorkerCloudConfigExtension) Units() ([]cloudconfig.UnitAsset, error) {
+	unitsMeta := []cloudconfig.UnitMetadata{
+		cloudconfig.UnitMetadata{
+			AssetContent: decryptTLSAssetsServiceTemplate,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		cloudconfig.UnitMetadata{
+			AssetContent: formatVarLibDockerServiceTemplate,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		cloudconfig.UnitMetadata{
+			AssetContent: varLibDockerMountTemplate,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	units, err := w.renderUnits(unitsMeta)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	return units, nil
 }
 
 // VerbatimSections is defined on CloudConfigExtension since there's no difference

--- a/service/create/launch_configuration.go
+++ b/service/create/launch_configuration.go
@@ -22,6 +22,7 @@ type launchConfigurationInput struct {
 	name                string
 	prefix              string
 	securityGroup       resources.ResourceWithID
+	ebsStorage          bool
 	subnet              *awsresources.Subnet
 	tlsAssets           *certificatetpr.CompactTLSAssets
 }
@@ -106,6 +107,7 @@ func (s *Service) createLaunchConfiguration(input launchConfigurationInput) (boo
 		SecurityGroupID:          securityGroupID,
 		SmallCloudConfig:         smallCloudconfig,
 		AssociatePublicIpAddress: publicIP,
+		EBSStorage:               input.ebsStorage,
 	}
 
 	launchConfigCreated, err := launchConfig.CreateIfNotExists()

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -884,6 +884,7 @@ func (s *Service) onAdd(obj interface{}) {
 		keypairName:         cluster.Name,
 		instanceProfileName: policy.GetName(),
 		prefix:              prefixWorker,
+		ebsStorage:          true,
 	}
 
 	lcCreated, err := s.createLaunchConfiguration(lcInput)

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -40,7 +40,22 @@ Type=oneshot
 ExecStart=/opt/bin/decrypt-tls-assets
 
 [Install]
-WantedBy=multi-user.target`
+WantedBy=multi-user.target
+`
+
+	formatVarLibDockerServiceTemplate = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/mkfs.xfs -f /dev/xvdh
+
+[Install]
+WantedBy=multi-user.target
+`
 
 	varLibDockerMountTemplate = `
 [Unit]

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -43,7 +43,21 @@ ExecStart=/opt/bin/decrypt-tls-assets
 WantedBy=multi-user.target
 `
 
-	formatVarLibDockerServiceTemplate = `
+	masterFormatVarLibDockerServiceTemplate = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/mkfs.xfs -f /dev/xvdb
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	workerFormatVarLibDockerServiceTemplate = `
 [Unit]
 Description=Format /var/lib/docker to XFS
 Before=docker.service var-lib-docker.mount
@@ -64,7 +78,7 @@ Description=Mount ephemeral volume on /var/lib/docker
 [Mount]
 What=/dev/xvdb
 Where=/var/lib/docker
-Type=ext3
+Type=xfs
 
 [Install]
 RequiredBy=local-fs.target

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -59,7 +59,7 @@ WantedBy=multi-user.target
 
 	ephemeralVarLibDockerMountTemplate = `
 [Unit]
-Description=Mount ephemeral to /var/lib/docker
+Description=Mount ephemeral volume on /var/lib/docker
 
 [Mount]
 What=/dev/xvdb
@@ -71,7 +71,7 @@ RequiredBy=local-fs.target
 `
 	persistentVarLibDockerMountTemplate = `
 [Unit]
-Description=Mount persistent /var/lib/docker
+Description=Mount persistent volume on /var/lib/docker
 
 [Mount]
 What=/dev/xvdh
@@ -85,7 +85,8 @@ RequiredBy=local-fs.target
 	waitDockerConfTemplate = `
 [Unit]
 After=var-lib-docker.mount
-Requires=var-lib-docker.mount`
+Requires=var-lib-docker.mount
+`
 
 	instanceStorageTemplate = `
 storage:
@@ -95,7 +96,8 @@ storage:
         device: /dev/xvdb
         format: ext3
         create:
-          force: true`
+          force: true
+`
 
 	userDataScriptTemplate = `#!/bin/bash
 

--- a/service/create/templates.go
+++ b/service/create/templates.go
@@ -57,7 +57,7 @@ ExecStart=/usr/sbin/mkfs.xfs -f /dev/xvdh
 WantedBy=multi-user.target
 `
 
-	varLibDockerMountTemplate = `
+	ephemeralVarLibDockerMountTemplate = `
 [Unit]
 Description=Mount ephemeral to /var/lib/docker
 
@@ -65,6 +65,18 @@ Description=Mount ephemeral to /var/lib/docker
 What=/dev/xvdb
 Where=/var/lib/docker
 Type=ext3
+
+[Install]
+RequiredBy=local-fs.target
+`
+	persistentVarLibDockerMountTemplate = `
+[Unit]
+Description=Mount persistent /var/lib/docker
+
+[Mount]
+What=/dev/xvdh
+Where=/var/lib/docker
+Type=xfs
 
 [Install]
 RequiredBy=local-fs.target


### PR DESCRIPTION
Workers will use a 50GB EBS volume for Docker images.

Masters use the SSD that comes with all m3 instances (32GB on the m3.large we use).

The 50GB, the mount path and the volume type are hard-coded. If we see we need to make it configurable, we can decide to move them to the TPO later on. 

Towards https://github.com/giantswarm/giantswarm/issues/1530