### PR TITLE
support increasing workers ASG size

### DIFF
--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -88,3 +88,20 @@ func (asg *AutoScalingGroup) Delete() error {
 
 	return nil
 }
+
+func (asg *AutoScalingGroup) Update() error {
+	if asg.Client == nil {
+		return microerror.MaskAny(clientNotInitializedError)
+	}
+
+	params := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(asg.Name),
+		MinSize:              aws.Int64(int64(asg.MinSize)),
+		MaxSize:              aws.Int64(int64(asg.MaxSize)),
+	}
+
+	if _, err := asg.Client.UpdateAutoScalingGroup(params); err != nil {
+		return microerror.MaskAny(err)
+	}
+	return nil
+}


### PR DESCRIPTION
Allows setting Minimum, Maximum and Desired ASG sizes to a higher value.

This means that we can go from a fixed-size cluster, to a **bigger** fixed-size cluster. There's no elasticity in the size.

Closes https://github.com/giantswarm/giantswarm/issues/1507.