### PR TITLE
allow getting objects from whole bucket

### DIFF
--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -48,7 +48,7 @@ const (
 			{
 				"Effect": "Allow",
 				"Action": "s3:GetObject",
-				"Resource": "arn:aws:s3:::%s/%s/*"
+				"Resource": "arn:aws:s3:::%s/*"
 			}
 		]
 	}`
@@ -80,7 +80,7 @@ func (p *Policy) CreateIfNotExists() (bool, error) {
 
 func (p *Policy) createRole() error {
 	// TODO switch to using a file and Go templates
-	policyDocument := fmt.Sprintf(PolicyDocumentTempl, p.KMSKeyArn, p.S3Bucket, p.S3Bucket, p.ClusterID)
+	policyDocument := fmt.Sprintf(PolicyDocumentTempl, p.KMSKeyArn, p.S3Bucket, p.S3Bucket)
 
 	clusterRoleName := fmt.Sprintf("%s-%s", p.ClusterID, RoleNameTemplate)
 


### PR DESCRIPTION
since we use a bucket per install, it doesn't make sense to add
additional restrictions based on sub-directories.

the instances in the cluster will be able to access all objects in the
cluster's bucket.