### PR TITLE
KubernetesCluster tag should just contain the cluster ID

### DIFF
--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -9,6 +9,8 @@ import (
 type AutoScalingGroup struct {
 	// AvailabilityZone is the AZ the instances will be placed in.
 	AvailabilityZone string
+	// ClusterID is the ID of the cluster.
+	ClusterID string
 	// HealthCheckGracePeriod is the time, in seconds, that the instances are
 	// given after boot before the healthchecks start.
 	HealthCheckGracePeriod int
@@ -59,7 +61,7 @@ func (asg *AutoScalingGroup) CreateOrFail() error {
 			{
 				Key:               aws.String(tagKeyCluster),
 				PropagateAtLaunch: aws.Bool(true),
-				Value:             aws.String(asg.Name),
+				Value:             aws.String(asg.ClusterID),
 			},
 		},
 	}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -912,6 +912,7 @@ func (s *Service) onAdd(obj interface{}) {
 	asg := awsresources.AutoScalingGroup{
 		Client:                  clients.AutoScaling,
 		Name:                    fmt.Sprintf("%s-%s", cluster.Name, prefixWorker),
+		ClusterID:               cluster.Name,
 		MinSize:                 asgSize,
 		MaxSize:                 asgSize,
 		AvailabilityZone:        cluster.Spec.AWS.AZ,


### PR DESCRIPTION
The KubernetesCluster should just contain the clusterID. Previously it used the ASG name which is [clusterID]-worker.