### PR TITLE
Allow scaling down worker nodes

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1297,9 +1297,6 @@ func (s *Service) onUpdate(oldObj, newObj interface{}) {
 		// We get update events for all sorts of changes. We are currently only
 		// interested in changes to one property, so we ignore all the others.
 		return
-	} else if oldSize > newSize {
-		s.logger.Log("clusterID", cluster.Spec.Cluster.Cluster.ID, "info", "cluster size reduction not supported")
-		return
 	}
 
 	s.awsConfig.Region = cluster.Spec.AWS.Region
@@ -1323,5 +1320,5 @@ func (s *Service) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	s.logger.Log("info", fmt.Sprintf("increased size of workers auto scaling group to %d", newSize))
+	s.logger.Log("info", fmt.Sprintf("scaling workers auto scaling group from %d to %d", oldSize, newSize))
 }


### PR DESCRIPTION
Fixes #338 

Scale down worker nodes by updating the autoscaling group.