### PR TITLE
Allow all traffic between masters and workers for Calico

### DIFF
--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -122,48 +122,6 @@ func (s *SecurityGroup) createRule(rule SecurityGroupRule) error {
 	return nil
 }
 
-// deleteRule creates a security group rule.
-// SourceCIDR always takes precedence over SecurityGroupID.
-func (s *SecurityGroup) deleteRule(rule SecurityGroupRule) error {
-	groupID, err := s.GetID()
-	if err != nil {
-		return microerror.MaskAny(err)
-	}
-
-	var params *ec2.RevokeSecurityGroupEgressInput
-	if rule.SourceCIDR != "" {
-		params = &ec2.RevokeSecurityGroupEgressInput{
-			CidrIp:     aws.String(rule.SourceCIDR),
-			GroupId:    aws.String(groupID),
-			IpProtocol: aws.String(rule.Protocol),
-			FromPort:   aws.Int64(int64(rule.Port)),
-			ToPort:     aws.Int64(int64(rule.Port)),
-		}
-	} else {
-		params = &ec2.RevokeSecurityGroupEgressInput{
-			GroupId: aws.String(groupID),
-			IpPermissions: []*ec2.IpPermission{
-				&ec2.IpPermission{
-					FromPort:   aws.Int64(int64(rule.Port)),
-					ToPort:     aws.Int64(int64(rule.Port)),
-					IpProtocol: aws.String(rule.Protocol),
-					UserIdGroupPairs: []*ec2.UserIdGroupPair{
-						{
-							GroupId: aws.String(rule.SecurityGroupID),
-						},
-					},
-				},
-			},
-		}
-	}
-
-	if _, err := s.Clients.EC2.RevokeSecurityGroupEgress(params); err != nil {
-		return microerror.MaskAny(err)
-	}
-
-	return nil
-}
-
 // CreateOrFail creates the security group or returns an error.
 func (s *SecurityGroup) CreateOrFail() error {
 	securityGroup, err := s.Clients.EC2.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
@@ -201,24 +159,6 @@ func (s *SecurityGroup) Delete() error {
 	if err != nil {
 		return microerror.MaskAny(err)
 	}
-
-	for _, ipPermission := range securityGroup.IpPermissions {
-		// Rule references a security group not a CIDR so it must be deleted.
-		if len(ipPermission.UserIdGroupPairs) > 0 {
-			for _, userIDGroupPair := range ipPermission.UserIdGroupPairs {
-				rule := SecurityGroupRule{
-					Port:            int(*ipPermission.FromPort),
-					Protocol:        *ipPermission.IpProtocol,
-					SecurityGroupID: *userIDGroupPair.GroupId,
-				}
-
-				if err := s.deleteRule(rule); err != nil {
-					return microerror.MaskAny(err)
-				}
-			}
-		}
-	}
-
 	if _, err := s.Clients.EC2.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 		GroupId: securityGroup.GroupId,
 	}); err != nil {

--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -9,6 +9,7 @@ import (
 	microerror "github.com/giantswarm/microkit/error"
 )
 
+// SecurityGroup is an AWS security group.
 type SecurityGroup struct {
 	Description string
 	GroupName   string
@@ -60,6 +61,7 @@ func (s SecurityGroup) findExisting() (*ec2.SecurityGroup, error) {
 	return securityGroups.SecurityGroups[0], nil
 }
 
+// CreateIfNotExists creates the security group if it does not exist.
 func (s *SecurityGroup) CreateIfNotExists() (bool, error) {
 	if err := s.CreateOrFail(); err != nil {
 		if strings.Contains(err.Error(), awsclient.SecurityGroupDuplicate) {
@@ -162,6 +164,7 @@ func (s *SecurityGroup) deleteRule(rule SecurityGroupRule) error {
 	return nil
 }
 
+// CreateOrFail creates the security group or returns an error.
 func (s *SecurityGroup) CreateOrFail() error {
 	securityGroup, err := s.Clients.EC2.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
 		Description: aws.String(s.Description),
@@ -179,6 +182,7 @@ func (s *SecurityGroup) CreateOrFail() error {
 	return nil
 }
 
+// ApplyRules creates the security group rules.
 func (s SecurityGroup) ApplyRules(rules []SecurityGroupRule) error {
 	for _, rule := range rules {
 		if err := s.createRule(rule); err != nil {
@@ -224,6 +228,7 @@ func (s *SecurityGroup) Delete() error {
 	return nil
 }
 
+// GetID gets the AWS security group ID.
 func (s SecurityGroup) GetID() (string, error) {
 	if s.id != "" {
 		return s.id, nil

--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -20,7 +20,10 @@ type SecurityGroup struct {
 
 // SecurityGroupRule is an AWS security group rule.
 type SecurityGroupRule struct {
+	// Port is the port to open.
 	Port int
+	// Protocol is the IP protocol.
+	Protocol string
 	// SourceCIDR is the CIDR of the source.
 	SourceCIDR string
 	// SecurityGroupID is the ID of the source Security Group.
@@ -88,7 +91,7 @@ func (s *SecurityGroup) createRule(rule SecurityGroupRule) error {
 		params = &ec2.AuthorizeSecurityGroupIngressInput{
 			CidrIp:     aws.String(rule.SourceCIDR),
 			GroupId:    aws.String(groupID),
-			IpProtocol: aws.String("tcp"),
+			IpProtocol: aws.String(rule.Protocol),
 			FromPort:   aws.Int64(int64(rule.Port)),
 			ToPort:     aws.Int64(int64(rule.Port)),
 		}
@@ -99,7 +102,7 @@ func (s *SecurityGroup) createRule(rule SecurityGroupRule) error {
 				{
 					FromPort:   aws.Int64(int64(rule.Port)),
 					ToPort:     aws.Int64(int64(rule.Port)),
-					IpProtocol: aws.String("tcp"),
+					IpProtocol: aws.String(rule.Protocol),
 					UserIdGroupPairs: []*ec2.UserIdGroupPair{
 						{
 							GroupId: aws.String(rule.SecurityGroupID),

--- a/resources/aws/security_group_rules.go
+++ b/resources/aws/security_group_rules.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+// SecurityGroupRules allows AWS security group rules to be deleted. Any rules
+// referencing other security groups must be deleted before the group can be
+// deleted.
+type SecurityGroupRules struct {
+	Description string
+	GroupName   string
+	AWSEntity
+}
+
+func (s SecurityGroupRules) findExisting() (*ec2.SecurityGroup, error) {
+	securityGroups, err := s.Clients.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String(subnetDescription),
+				Values: []*string{
+					aws.String(s.Description),
+				},
+			},
+			&ec2.Filter{
+				Name: aws.String(subnetGroupName),
+				Values: []*string{
+					aws.String(s.GroupName),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	if len(securityGroups.SecurityGroups) < 1 {
+		return nil, microerror.MaskAnyf(notFoundError, notFoundErrorFormat, SecurityGroupType, s.GroupName)
+	} else if len(securityGroups.SecurityGroups) > 1 {
+		return nil, microerror.MaskAny(tooManyResultsError)
+	}
+
+	return securityGroups.SecurityGroups[0], nil
+}
+
+// Delete deletes any security group rules that reference other groups.
+// This must happen before the security group can be deleted. Rules using a
+// CIDR do not need to be deleted.
+func (s SecurityGroupRules) Delete() error {
+	securityGroup, err := s.findExisting()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	var params *ec2.RevokeSecurityGroupIngressInput
+	params = &ec2.RevokeSecurityGroupIngressInput{
+		GroupId:       securityGroup.GroupId,
+		IpPermissions: securityGroup.IpPermissions,
+	}
+	if _, err := s.Clients.EC2.RevokeSecurityGroupIngress(params); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -32,3 +32,7 @@ type DNSNamedResource interface {
 	HostedZoneID() string
 	Resource
 }
+
+type DeletableResource interface {
+	Delete() error
+}

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -149,13 +149,13 @@ func (ri rulesInput) workerRules() []awsresources.SecurityGroupRule {
 		},
 		// Allow all traffic between the masters and worker nodes for Calico.
 		{
-			Port:            allowAllPorts,
-			Protocol:        allowAllProtocols,
+			Port:            allPorts,
+			Protocol:        allProtocols,
 			SecurityGroupID: ri.MastersSecurityGroupID,
 		},
 		{
-			Port:            allowAllPorts,
-			Protocol:        allowAllProtocols,
+			Port:            allPorts,
+			Protocol:        allProtocols,
 			SecurityGroupID: ri.WorkersSecurityGroupID,
 		},
 	}

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -26,7 +26,7 @@ type rulesInput struct {
 }
 
 const (
-	allowAllPorts        = -1
+	allPorts             = -1
 	calicoBGPNetworkPort = 179
 	httpPort             = 80
 	httpsPort            = 443
@@ -35,8 +35,8 @@ const (
 	readOnlyKubeletPort = 10255
 	sshPort             = 22
 
-	allowAllProtocols = "-1"
-	tcpProtocol       = "tcp"
+	allProtocols = "-1"
+	tcpProtocol  = "tcp"
 
 	defaultCIDR = "0.0.0.0/0"
 )
@@ -102,13 +102,13 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 		},
 		// Allow all traffic between the masters and worker nodes for Calico.
 		{
-			Port:            allowAllPorts,
-			Protocol:        allowAllProtocols,
+			Port:            allPorts,
+			Protocol:        allProtocols,
 			SecurityGroupID: ri.MastersSecurityGroupID,
 		},
 		{
-			Port:            allowAllPorts,
-			Protocol:        allowAllProtocols,
+			Port:            allPorts,
+			Protocol:        allProtocols,
 			SecurityGroupID: ri.WorkersSecurityGroupID,
 		},
 	}

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -26,6 +26,7 @@ type rulesInput struct {
 }
 
 const (
+	allowAllPorts        = -1
 	calicoBGPNetworkPort = 179
 	// This port is required in our current kubernetes/heapster setup, but will become unnecessary
 	// once we upgrade to kubernetes 1.6 and heapster 1.3 with apiserver deployment.
@@ -33,6 +34,9 @@ const (
 	httpPort            = 80
 	httpsPort           = 443
 	sshPort             = 22
+
+	allowAllProtocols = "-1"
+	tcpProtocol       = "tcp"
 
 	defaultCIDR = "0.0.0.0/0"
 )
@@ -78,19 +82,29 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 	return []awsresources.SecurityGroupRule{
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.API.SecurePort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       ri.Cluster.Spec.Cluster.Etcd.Port,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       sshPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       calicoBGPNetworkPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
+		},
+		// Allow all traffic from the worker nodes for Calico.
+		{
+			Port:            allowAllPorts,
+			Protocol:        allowAllProtocols,
+			SecurityGroupID: ri.WorkersSecurityGroupID,
 		},
 	}
 }
@@ -100,27 +114,39 @@ func (ri rulesInput) workerRules() []awsresources.SecurityGroupRule {
 	return []awsresources.SecurityGroupRule{
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.IngressController.SecurePort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.Kubelet.Port,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       readOnlyKubeletPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       sshPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       calicoBGPNetworkPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
+		},
+		// Allow all traffic from the master nodes for Calico.
+		{
+			Port:            allowAllPorts,
+			Protocol:        allowAllProtocols,
+			SecurityGroupID: ri.MastersSecurityGroupID,
 		},
 	}
 }
@@ -130,10 +156,12 @@ func (ri rulesInput) ingressRules() []awsresources.SecurityGroupRule {
 	return []awsresources.SecurityGroupRule{
 		{
 			Port:       httpPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 		{
 			Port:       httpsPort,
+			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
 	}

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -100,7 +100,12 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
-		// Allow all traffic from the worker nodes for Calico.
+		// Allow all traffic between the masters and worker nodes for Calico.
+		{
+			Port:            allowAllPorts,
+			Protocol:        allowAllProtocols,
+			SecurityGroupID: ri.MastersSecurityGroupID,
+		},
 		{
 			Port:            allowAllPorts,
 			Protocol:        allowAllProtocols,
@@ -142,11 +147,16 @@ func (ri rulesInput) workerRules() []awsresources.SecurityGroupRule {
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
-		// Allow all traffic from the master nodes for Calico.
+		// Allow all traffic between the masters and worker nodes for Calico.
 		{
 			Port:            allowAllPorts,
 			Protocol:        allowAllProtocols,
 			SecurityGroupID: ri.MastersSecurityGroupID,
+		},
+		{
+			Port:            allowAllPorts,
+			Protocol:        allowAllProtocols,
+			SecurityGroupID: ri.WorkersSecurityGroupID,
 		},
 	}
 }

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -28,11 +28,11 @@ type rulesInput struct {
 const (
 	allowAllPorts        = -1
 	calicoBGPNetworkPort = 179
+	httpPort             = 80
+	httpsPort            = 443
 	// This port is required in our current kubernetes/heapster setup, but will become unnecessary
 	// once we upgrade to kubernetes 1.6 and heapster 1.3 with apiserver deployment.
 	readOnlyKubeletPort = 10255
-	httpPort            = 80
-	httpsPort           = 443
 	sshPort             = 22
 
 	allowAllProtocols = "-1"

--- a/service/create/security_group_rules.go
+++ b/service/create/security_group_rules.go
@@ -1,0 +1,32 @@
+package create
+
+import (
+	"fmt"
+
+	microerror "github.com/giantswarm/microkit/error"
+
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/resources"
+	awsresources "github.com/giantswarm/aws-operator/resources/aws"
+)
+
+type securityGroupRulesInput struct {
+	Clients   awsutil.Clients
+	GroupName string
+}
+
+func (s *Service) deleteSecurityGroupRules(input securityGroupRulesInput) error {
+	var securityGroupRules resources.DeletableResource
+	securityGroupRules = awsresources.SecurityGroupRules{
+		Description: input.GroupName,
+		GroupName:   input.GroupName,
+		AWSEntity:   awsresources.AWSEntity{Clients: input.Clients},
+	}
+	if err := securityGroupRules.Delete(); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	s.logger.Log("info", fmt.Sprintf("deleted rules for security group '%s'", input.GroupName))
+
+	return nil
+}


### PR DESCRIPTION
Fixes #336 

This PR allows all traffic between the masters and workers security groups. This is needed so Calico can route traffic between the nodes. 

It also deletes any security group rules that reference other groups. This is needed because you can't delete a security group that is referenced in another security group.
 
