### PR TITLE
Creating security group rules should be idempotent

### DIFF
--- a/resources/aws/consts.go
+++ b/resources/aws/consts.go
@@ -10,4 +10,10 @@ const (
 	subnetDescription      string = "description"
 	subnetGroupName        string = "group-name"
 	subnetVpcID            string = "vpc-id"
+	// Security Group IP Permission keys
+	ipPermissionCIDR     string = "ip-permission.cidr"
+	ipPermissionFromPort string = "ip-permission.from-port"
+	ipPermissionGroupID  string = "ip-permission.group-id"
+	ipPermissionProtocol string = "ip-permission.protocol"
+	ipPermissionToPort   string = "ip-permission.to-port"
 )


### PR DESCRIPTION
Fixes #323 

Currently when a cluster is processed multiple times the addFunc errors if a security group rule already exists.

This change checks if the rule exists before creating it. It does this by getting the security group and adding a filter for the rule config. I used this approach because you can't get an individual rule from the EC2 API.
