### PR TITLE
Set DNS record types when deleting Route 53 records

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1091,11 +1091,12 @@ func (s *Service) deleteFunc(obj interface{}) {
 					Type:         route53.RRTypeA,
 				},
 				recordSetInput{
-					Cluster: cluster,
-					Client:  clients.Route53,
-					Value:   cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
-					Domain:  cluster.Spec.Cluster.Kubernetes.IngressController.WildcardDomain,
-					Type:    route53.RRTypeCname,
+					Cluster:      cluster,
+					Client:       clients.Route53,
+					Value:        cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
+					Domain:       cluster.Spec.Cluster.Kubernetes.IngressController.WildcardDomain,
+					HostedZoneID: cluster.Spec.AWS.HostedZones.Ingress,
+					Type:         route53.RRTypeCname,
 				},
 			}
 

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1072,6 +1072,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 					Resource:     apiLB,
 					Domain:       cluster.Spec.Cluster.Kubernetes.API.Domain,
 					HostedZoneID: cluster.Spec.AWS.HostedZones.API,
+					Type:         route53.RRTypeA,
 				},
 				recordSetInput{
 					Cluster:      cluster,
@@ -1079,6 +1080,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 					Resource:     etcdLB,
 					Domain:       cluster.Spec.Cluster.Etcd.Domain,
 					HostedZoneID: cluster.Spec.AWS.HostedZones.Etcd,
+					Type:         route53.RRTypeA,
 				},
 				recordSetInput{
 					Cluster:      cluster,
@@ -1086,12 +1088,14 @@ func (s *Service) deleteFunc(obj interface{}) {
 					Resource:     ingressLB,
 					Domain:       cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
 					HostedZoneID: cluster.Spec.AWS.HostedZones.Ingress,
+					Type:         route53.RRTypeA,
 				},
 				recordSetInput{
 					Cluster: cluster,
 					Client:  clients.Route53,
 					Value:   cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
 					Domain:  cluster.Spec.Cluster.Kubernetes.IngressController.WildcardDomain,
+					Type:    route53.RRTypeCname,
 				},
 			}
 


### PR DESCRIPTION
Fixes #360 

Fixes an error when deleting Route 53 records.

```
/.gvm/pkgsets/go1.8/giantswarm/src/github.com/giantswarm/aws-operator/resources/aws/record_set.go:43: } {/Users/ross/.gvm/pkgsets/go1.8/giantswarm/src/github.com/giantswarm/aws-operator/resources/aws/record_set.go:57: } {InvalidInput: Invalid XML ; cvc-enumeration-valid: Value '' is not facet-valid with respect to enumeration '[SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA, CAA]'. It must be a value from the enumeration.\n\tstatus code: 400, request id: 609fb88c-7211-11e7-9d3b-997b1216adfb}]","time":"17-07-26 14:47:43.853"}
```