### PR TITLE
Add IAM policy allowing authenticated pull from ECR

### DIFF
--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -54,6 +54,19 @@ const (
 				"Effect": "Allow",
 				"Action": "s3:GetObject",
 				"Resource": "arn:aws:s3:::%s/*"
+			},
+			{
+				"Effect": "Allow",
+				"Action": [
+					"ecr:GetAuthorizationToken",
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:GetDownloadUrlForLayer",
+					"ecr:GetRepositoryPolicy",
+					"ecr:DescribeRepositories",
+					"ecr:ListImages",
+					"ecr:BatchGetImage"
+				],
+				"Resource": "*"
 			}
 		]
 	}`


### PR DESCRIPTION
Add an IAM policy on the master and workers to allow image pulling from ECR as implemented in https://github.com/kubernetes/kubernetes/pull/19447 and https://github.com/kubernetes/kubernetes/pull/24369

As noted in https://github.com/kubernetes/kubernetes/pull/19447#issuecomment-174026000 it might be possible to reduce the permission set, but this is the policy implemented upstream.