### PR TITLE
Split AWS/IAM policies for master and workers

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -474,7 +474,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	// Create AWS client
+	// Create AWS client.
 	s.awsConfig.Region = cluster.Spec.AWS.Region
 	clients := awsutil.NewClients(s.awsConfig)
 
@@ -484,7 +484,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	// Create keypair
+	// Create keypair.
 	var keyPair resources.ReusableResource
 	var keyPairCreated bool
 	{
@@ -515,7 +515,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	// Create KMS key
+	// Create KMS key.
 	kmsKey := &awsresources.KMSKey{
 		Name:      cluster.Name,
 		AWSEntity: awsresources.AWSEntity{Clients: clients},
@@ -533,7 +533,7 @@ func (s *Service) addFunc(obj interface{}) {
 		s.logger.Log("info", fmt.Sprintf("kms key '%s' already exists, reusing", kmsKey.Name))
 	}
 
-	// Encode TLS assets
+	// Encode TLS assets.
 	tlsAssets, err := s.encodeTLSAssets(certs, clients.KMS, kmsKey.Arn())
 	if err != nil {
 		s.logger.Log("error", fmt.Sprintf("could not encode TLS assets: '%#v'", err))
@@ -542,7 +542,7 @@ func (s *Service) addFunc(obj interface{}) {
 
 	bucketName := s.bucketName(cluster)
 
-	// Create master IAM policy
+	// Create master IAM policy.
 	var masterPolicy resources.NamedResource
 	var masterPolicyErr error
 	{
@@ -559,7 +559,7 @@ func (s *Service) addFunc(obj interface{}) {
 		s.logger.Log("error", fmt.Sprintf("could not create %s policy: '%#v'", prefixMaster, masterPolicyErr))
 	}
 
-	// Create worker IAM policy
+	// Create worker IAM policy.
 	var workerPolicy resources.NamedResource
 	var workerPolicyErr error
 	{
@@ -576,7 +576,7 @@ func (s *Service) addFunc(obj interface{}) {
 		s.logger.Log("error", fmt.Sprintf("could not create %s policy: '%#v'", prefixWorker, workerPolicyErr))
 	}
 
-	// Create S3 bucket
+	// Create S3 bucket.
 	var bucket resources.ReusableResource
 	var bucketCreated bool
 	{
@@ -598,7 +598,7 @@ func (s *Service) addFunc(obj interface{}) {
 		s.logger.Log("info", fmt.Sprintf("bucket '%s' already exists, reusing", bucketName))
 	}
 
-	// Create VPC
+	// Create VPC.
 	var vpc resources.ResourceWithID
 	vpc = &awsresources.VPC{
 		CidrBlock: cluster.Spec.AWS.VPC.CIDR,
@@ -620,7 +620,7 @@ func (s *Service) addFunc(obj interface{}) {
 		s.logger.Log("error", fmt.Sprintf("%#v", err))
 	}
 
-	// Create gateway
+	// Create gateway.
 	var gateway resources.ResourceWithID
 	gateway = &awsresources.Gateway{
 		Name:  cluster.Name,
@@ -736,7 +736,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	// Create public subnet for the masters
+	// Create public subnet for the masters.
 	publicSubnet := &awsresources.Subnet{
 		AvailabilityZone: cluster.Spec.AWS.AZ,
 		CidrBlock:        cluster.Spec.AWS.VPC.PublicSubnetCIDR,
@@ -767,7 +767,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	// Run masters
+	// Run masters.
 	anyMastersCreated, masterIDs, err := s.runMachines(runMachinesInput{
 		clients:             clients,
 		cluster:             cluster,
@@ -1170,7 +1170,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 		s.logger.Log("info", "deleted route table")
 	}
 
-	// Sync VPC
+	// Sync VPC.
 	var vpc resources.ResourceWithID
 	vpc = &awsresources.VPC{
 		Name:      cluster.Name,

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1283,17 +1283,32 @@ func (s *Service) deleteFunc(obj interface{}) {
 
 	s.logger.Log("info", "deleted bucket")
 
-	// Delete policy.
-	var policy resources.NamedResource
-	policy = &awsresources.Policy{
-		ClusterID: cluster.Spec.Cluster.Cluster.ID,
-		S3Bucket:  bucketName,
-		AWSEntity: awsresources.AWSEntity{Clients: clients},
+	// Delete master policy.
+	var masterPolicy resources.NamedResource
+	masterPolicy = &awsresources.Policy{
+		ClusterID:  cluster.Spec.Cluster.Cluster.ID,
+		PolicyType: prefixMaster,
+		S3Bucket:   bucketName,
+		AWSEntity:  awsresources.AWSEntity{Clients: clients},
 	}
-	if err := policy.Delete(); err != nil {
+	if err := masterPolicy.Delete(); err != nil {
 		s.logger.Log("error", fmt.Sprintf("%#v", err))
 	} else {
-		s.logger.Log("info", "deleted roles, policies, instance profiles")
+		s.logger.Log("info", fmt.Sprintf("deleted %s roles, policies, instance profiles", prefixMaster))
+	}
+
+	// Delete worker policy.
+	var workerPolicy resources.NamedResource
+	workerPolicy = &awsresources.Policy{
+		ClusterID:  cluster.Spec.Cluster.Cluster.ID,
+		PolicyType: prefixWorker,
+		S3Bucket:   bucketName,
+		AWSEntity:  awsresources.AWSEntity{Clients: clients},
+	}
+	if err := workerPolicy.Delete(); err != nil {
+		s.logger.Log("error", fmt.Sprintf("%#v", err))
+	} else {
+		s.logger.Log("info", fmt.Sprintf("deleted %s roles, policies, instance profiles", prefixWorker))
 	}
 
 	// Delete KMS key.


### PR DESCRIPTION
Fixes #330 

This PR splits the master and worker IAM policies and makes 2 permissions changes. These have been tested on a locally launched cluster.

- The worker policy has reduced EC2 permissions as per the docs to only support attaching and detaching volumes.

https://github.com/kubernetes/kubernetes/tree/release-1.5/cluster/aws/templates/iam

- ECR permissions are only applied to workers since the master cannot schedule pods.