### PR TITLE
Extract addFunc logic to processCluster

### DIFF
--- a/resources/aws/asg_stack_test.go
+++ b/resources/aws/asg_stack_test.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+func TestHasStackChanged(t *testing.T) {
+	tests := []struct {
+		params         map[string]string
+		updatedParams  map[string]string
+		expectedResult bool
+	}{
+		// Case 1. Updated parameters are the same.
+		{
+			params: map[string]string{
+				"AZ":            "eu-central-1a",
+				asgMaxSizeParam: "2",
+				asgMinSizeParam: "2",
+				imageIDParam:    "ami-test",
+			},
+			updatedParams: map[string]string{
+				asgMaxSizeParam: "2",
+				asgMinSizeParam: "2",
+				imageIDParam:    "ami-test",
+			},
+			expectedResult: false,
+		},
+		// Case 2. ASG size parameters are different.
+		{
+			params: map[string]string{
+				"AZ":            "eu-central-1a",
+				asgMaxSizeParam: "2",
+				asgMinSizeParam: "2",
+				imageIDParam:    "ami-test",
+			},
+			updatedParams: map[string]string{
+				asgMaxSizeParam: "3",
+				asgMinSizeParam: "3",
+				imageIDParam:    "ami-test",
+			},
+			expectedResult: true,
+		},
+		// Case 3. Image ID parameter is different.
+		{
+			params: map[string]string{
+				"AZ":            "eu-central-1a",
+				asgMaxSizeParam: "2",
+				asgMinSizeParam: "2",
+				imageIDParam:    "ami-test",
+			},
+			updatedParams: map[string]string{
+				asgMaxSizeParam: "2",
+				asgMinSizeParam: "2",
+				imageIDParam:    "ami-new",
+			},
+			expectedResult: true,
+		},
+	}
+
+	for i, tc := range tests {
+		params := []*cloudformation.Parameter{}
+
+		for k, v := range tc.params {
+			param := &cloudformation.Parameter{}
+			param.SetParameterKey(k)
+			param.SetParameterValue(v)
+
+			params = append(params, param)
+		}
+
+		result := hasStackChanged(params, tc.updatedParams)
+		if result != tc.expectedResult {
+			t.Fatalf("case %d expected hasStackChanged was '%t' but was '%t'", i, tc.expectedResult, result)
+		}
+	}
+}

--- a/service/create/error.go
+++ b/service/create/error.go
@@ -75,3 +75,10 @@ var invalidWorkerNodeCountError = microerror.New("invalid worker node count")
 func IsInvalidWorkerNodeCount(err error) bool {
 	return microerror.Cause(err) == invalidWorkerNodeCountError
 }
+
+var executionFailedError = microerror.New("execution failed")
+
+// IsExecutionFailedError asserts isExecutionFailedError.
+func IsExecutionFailedError(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -479,6 +479,7 @@ func (s *Service) addFunc(obj interface{}) {
 	err := s.processCluster(cluster)
 	if err != nil {
 		s.logger.Log("error", fmt.Sprintf("error processing cluster '%s': '%#v'", key.ClusterID(cluster), err))
+		return
 	}
 
 	s.logger.Log("info", fmt.Sprintf("cluster '%s' processed", key.ClusterID(cluster)))

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -462,7 +462,13 @@ func validateIDs(ids []string) bool {
 }
 
 func (s *Service) addFunc(obj interface{}) {
-	cluster := *obj.(*awstpr.CustomObject)
+	customObject, ok := obj.(*awstpr.CustomObject)
+	if !ok {
+		s.logger.Log("error", "could not convert to awstpr.CustomObject")
+		return
+	}
+	cluster := *customObject
+
 	s.logger.Log("info", fmt.Sprintf("creating cluster '%s'", key.ClusterID(cluster)))
 
 	if err := validateCluster(cluster); err != nil {


### PR DESCRIPTION
This is some boyscouting to tidy up the addFunc which is currently huge. The logic is extracted to a new method called processCluster.

In a later PR I want to fix the updateFunc so it also just calls processCluster. This refactoring also should make it easier to move aws-operator to the reconciler framework.
