### PR TITLE
Fix configmap not having correct extension and readme inconsistency

### DIFF
--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -21,7 +21,6 @@ guide, all placeholders must be replaced with sensible values.
 
 - *CLUSTER_NAME* - Cluster's name.
 - *COMMON_DOMAIN* - Cluster's etcd and API common domain.
-- *COMMON_DOMAIN_INTERNAL* - Ingress common domain.
 - *ID_RSA_PUB* - SSH public key to be installed on nodes.
 - *AWS_ACCESS_KEY_ID* - AWS access key.
 - *AWS_SECRET_ACCESS_KEY* - AWS secret.
@@ -39,7 +38,6 @@ This is a handy snippet that makes it painless - works in bash and zsh.
 ```bash
 export CLUSTER_NAME="example-cluster"
 export COMMON_DOMAIN="company.com"
-export COMMON_DOMAIN_INTERNAL="internal.company.com"
 export ID_RSA_PUB="$(cat ~/.ssh/id_rsa.pub)"
 export AWS_ACCESS_KEY_ID="AKIAIXXXXXXXXXXXXXXX"
 export AWS_SECRET_ACCESS_KEY="XXXXXXXXXXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXX"
@@ -56,7 +54,6 @@ for f in *.tmpl.yaml; do
     sed \
         -e 's|${CLUSTER_NAME}|'"${CLUSTER_NAME}"'|g' \
         -e 's|${COMMON_DOMAIN}|'"${COMMON_DOMAIN}"'|g' \
-        -e 's|${COMMON_DOMAIN_INTERNAL}|'"${COMMON_DOMAIN_INTERNAL}"'|g' \
         -e 's|${ID_RSA_PUB}|'"${ID_RSA_PUB}"'|g' \
         -e 's|${AWS_ACCESS_KEY_ID}|'"${AWS_ACCESS_KEY_ID}"'|g' \
         -e 's|${AWS_SECRET_ACCESS_KEY}|'"${AWS_SECRET_ACCESS_KEY}"'|g' \

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -21,7 +21,7 @@ guide, all placeholders must be replaced with sensible values.
 
 - *CLUSTER_NAME* - Cluster's name.
 - *COMMON_DOMAIN* - Cluster's etcd and API common domain.
-- *COMMON_DOMAIN_INGRESS* - Ingress common domain.
+- *COMMON_DOMAIN_INTERNAL* - Ingress common domain.
 - *ID_RSA_PUB* - SSH public key to be installed on nodes.
 - *AWS_ACCESS_KEY_ID* - AWS access key.
 - *AWS_SECRET_ACCESS_KEY* - AWS secret.
@@ -92,7 +92,7 @@ In that case the Docker image needs to be accessible from the K8s cluster
 running the operator. For Minikube run `eval $(minikube docker-env)` before
 `docker build`, see [reusing the Docker daemon] for details.
 
-[reusing the docker daemon]: https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md 
+[reusing the docker daemon]: https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md
 
 ```bash
 # Optional. Only when using Minikube.

--- a/examples/local/cluster.tmpl.yaml
+++ b/examples/local/cluster.tmpl.yaml
@@ -14,7 +14,7 @@ spec:
       imageNamespace: "giantswarm"
 
     etcd:
-      domain: "etcd.${CLUSTER_NAME}.${COMMON_DOMAIN_INTERNAL}"
+      domain: "etcd.${CLUSTER_NAME}.${COMMON_DOMAIN}"
       prefix: "${CLUSTER_NAME}"
       port: 2379
 
@@ -25,9 +25,9 @@ spec:
 
     kubernetes:
       api:
-        domain: "api.${CLUSTER_NAME}.${COMMON_DOMAIN_INTERNAL}"
+        domain: "api.${CLUSTER_NAME}.${COMMON_DOMAIN}"
         insecurePort: 8080
-        ip: "172.31.0.1" 
+        ip: "172.31.0.1"
         securePort: 443
         clusterIPRange: "172.31.0.0/24"
       cloudProvider: "aws"

--- a/examples/local/deployment.tmpl.yaml
+++ b/examples/local/deployment.tmpl.yaml
@@ -18,8 +18,8 @@ spec:
         configMap:
           name: aws-operator-configmap
           items:
-          - key: config.yml
-            path: config.yml
+          - key: config.yaml
+            path: config.yaml
       - name: ssh-key
         configMap:
           name: aws-operator-ssh-key-configmap


### PR DESCRIPTION
The configmap failed after yesterdays changes from `yml` to `yaml`.

Fixed readme referring to `COMMON_DOMAIN_INTERNAL` everywhere now.