### PR TITLE
Add AWS SessionToken support

### DIFF
--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -21,6 +21,7 @@ import (
 type Config struct {
 	AccessKeyID     string
 	AccessKeySecret string
+	SessionToken    string
 	Region          string
 	accountID       string
 }
@@ -43,7 +44,7 @@ const (
 
 func NewClients(config Config) Clients {
 	awsCfg := &aws.Config{
-		Credentials: credentials.NewStaticCredentials(config.AccessKeyID, config.AccessKeySecret, ""),
+		Credentials: credentials.NewStaticCredentials(config.AccessKeyID, config.AccessKeySecret, config.SessionToken),
 		Region:      aws.String(config.Region),
 	}
 	s := session.New(awsCfg)

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -24,6 +24,7 @@ guide, all placeholders must be replaced with sensible values.
 - *ID_RSA_PUB* - SSH public key to be installed on nodes.
 - *AWS_ACCESS_KEY_ID* - AWS access key.
 - *AWS_SECRET_ACCESS_KEY* - AWS secret.
+- *AWS_SESSION_TOKEN* - AWS session token for MFA accounts; can be left empty.
 - *AWS_REGION* - AWS region.
 - *AWS_AZ* - AWS availability zone.
 - *AWS_AMI* - AWS image to be used on both master and worker machines.
@@ -41,6 +42,7 @@ export COMMON_DOMAIN="company.com"
 export ID_RSA_PUB="$(cat ~/.ssh/id_rsa.pub)"
 export AWS_ACCESS_KEY_ID="AKIAIXXXXXXXXXXXXXXX"
 export AWS_SECRET_ACCESS_KEY="XXXXXXXXXXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXX"
+export AWS_SESSION_TOKEN="XXXXXXXXXXXXXXXXXXX"
 export AWS_REGION="eu-central-1"
 export AWS_AZ="eu-central-1a"
 export AWS_AMI="ami-d60ad6b9"
@@ -57,6 +59,7 @@ for f in *.tmpl.yaml; do
         -e 's|${ID_RSA_PUB}|'"${ID_RSA_PUB}"'|g' \
         -e 's|${AWS_ACCESS_KEY_ID}|'"${AWS_ACCESS_KEY_ID}"'|g' \
         -e 's|${AWS_SECRET_ACCESS_KEY}|'"${AWS_SECRET_ACCESS_KEY}"'|g' \
+        -e 's|${AWS_SESSION_TOKEN}|'"${AWS_SESSION_TOKEN}"'|g' \
         -e 's|${AWS_REGION}|'"${AWS_REGION}"'|g' \
         -e 's|${AWS_AZ}|'"${AWS_AZ}"'|g' \
         -e 's|${AWS_AMI}|'"${AWS_AMI}"'|g' \

--- a/examples/local/configmap.tmpl.yaml
+++ b/examples/local/configmap.tmpl.yaml
@@ -8,7 +8,8 @@ data:
       aws:
         accesskey:
           id: "${AWS_ACCESS_KEY_ID}"
-          secret: "${AWS_SECRET_ACCESS_KEY}" 
+          secret: "${AWS_SECRET_ACCESS_KEY}"
+          token: "${AWS_SESSION_TOKEN}"
       kubernetes:
         incluster: true
     server:

--- a/examples/local/configmap.tmpl.yaml
+++ b/examples/local/configmap.tmpl.yaml
@@ -9,7 +9,7 @@ data:
         accesskey:
           id: "${AWS_ACCESS_KEY_ID}"
           secret: "${AWS_SECRET_ACCESS_KEY}"
-          token: "${AWS_SESSION_TOKEN}"
+          session: "${AWS_SESSION_TOKEN}"
       kubernetes:
         incluster: true
     server:

--- a/flag/service/aws/accesskey/accesskey.go
+++ b/flag/service/aws/accesskey/accesskey.go
@@ -1,6 +1,7 @@
 package accesskey
 
 type AccessKey struct {
-	ID     string
-	Secret string
+	ID      string
+	Secret  string
+	Session string
 }

--- a/main.go
+++ b/main.go
@@ -126,8 +126,10 @@ func main() {
 
 	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.ID, "", "ID of the AWS access key for the account to create guest clusters in.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.Secret, "", "Secret of the AWS access key for the  account to create guest clusters in.")
+	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.Session, "", "Session token of the AWS access key for the  account to create guest clusters in. (Can be empty)")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.ID, "", "ID of the AWS access key for the host cluster account. If empty, guest cluster account is used.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.Secret, "", "Secret of the AWS access key for the host cluster account. If empty, guest cluster account is used.")
+	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.Session, "", "Session token of the AWS access key for the host cluster account. If empty, guest cluster token is used.")
 
 	// TODO(nhlfr): Deprecate these options when cert-operator will be implemented.
 	daemonCommand.PersistentFlags().String(f.Service.AWS.PubKeyFile, path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "Public key to be imported as a keypair in AWS.")

--- a/service/service.go
+++ b/service/service.go
@@ -110,7 +110,7 @@ func New(config Config) (*Service, error) {
 		accessKeySecret := config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Secret)
 		sessionToken := config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Session)
 
-		if accessKeyID == "" && accessKeySecret == "" && sessionToken == "" {
+		if accessKeyID == "" && accessKeySecret == "" {
 			config.Logger.Log("debug", "no host cluster account credentials supplied, assuming guest and host uses same account")
 			awsHostConfig = awsConfig
 		} else {

--- a/service/service.go
+++ b/service/service.go
@@ -100,6 +100,7 @@ func New(config Config) (*Service, error) {
 		awsConfig = awsclient.Config{
 			AccessKeyID:     config.Viper.GetString(config.Flag.Service.AWS.AccessKey.ID),
 			AccessKeySecret: config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Secret),
+			SessionToken:    config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Session),
 		}
 	}
 
@@ -107,8 +108,9 @@ func New(config Config) (*Service, error) {
 	{
 		accessKeyID := config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.ID)
 		accessKeySecret := config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Secret)
+		sessionToken := config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Session)
 
-		if accessKeyID == "" && accessKeySecret == "" {
+		if accessKeyID == "" && accessKeySecret == "" && sessionToken == "" {
 			config.Logger.Log("debug", "no host cluster account credentials supplied, assuming guest and host uses same account")
 			awsHostConfig = awsConfig
 		} else {
@@ -116,6 +118,7 @@ func New(config Config) (*Service, error) {
 			awsHostConfig = awsclient.Config{
 				AccessKeyID:     accessKeyID,
 				AccessKeySecret: accessKeySecret,
+				SessionToken:    sessionToken,
 			}
 		}
 	}


### PR DESCRIPTION
This is needed when we use a account with MFA to create a cluster (eg personal account for test purposes).