### PR TITLE
Set Peer VPC when deleting peering connections

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1280,6 +1280,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 	// Delete VPC peering connection.
 	vpcPeeringConection := &awsresources.VPCPeeringConnection{
 		VPCId:     vpcID,
+		PeerVPCId: cluster.Spec.AWS.VPC.PeerID,
 		AWSEntity: awsresources.AWSEntity{Clients: clients},
 	}
 	if err := vpcPeeringConection.Delete(); err != nil {


### PR DESCRIPTION
Fixes #401

Fixes problem deleting peering connections which also stops the VPC being deleted. Fix is to also provide the host cluster VPC when deleting.