### PR TITLE
add worker to local example

### DIFF
--- a/examples/local/cluster.tmpl.yaml
+++ b/examples/local/cluster.tmpl.yaml
@@ -58,6 +58,7 @@ spec:
 
     workers:
     - hostname: "worker-1"
+    - hostname: "worker-2"
 
   aws:
     region: "${AWS_REGION}"
@@ -77,5 +78,7 @@ spec:
       instancetype: "${AWS_INSTANCE_TYPE_MASTER}"
 
     workers:
+    - imageid: "${AWS_AMI}"
+      instancetype: "${AWS_INSTANCE_TYPE_WORKER}"
     - imageid: "${AWS_AMI}"
       instancetype: "${AWS_INSTANCE_TYPE_WORKER}"


### PR DESCRIPTION
This will prevent kube-dns pods in pending state