### PR TITLE
Fix confusing naming of subnetName

### DIFF
--- a/service/create/subnet_names.go
+++ b/service/create/subnet_names.go
@@ -6,6 +6,6 @@ import (
 	"github.com/giantswarm/awstpr"
 )
 
-func subnetName(cluster awstpr.CustomObject, prefix string) string {
-	return fmt.Sprintf("%s-%s", cluster.Name, prefix)
+func subnetName(cluster awstpr.CustomObject, suffix string) string {
+	return fmt.Sprintf("%s-%s", cluster.Name, suffix)
 }


### PR DESCRIPTION
The function named a string prefix when it was actually the suffix. Got me confused when trying to build subnet names.