### PR TITLE
Validate AZ

### DIFF
--- a/service/create/error.go
+++ b/service/create/error.go
@@ -41,6 +41,13 @@ func IsSecretsRetrievalFailed(err error) bool {
 
 // Validation errors
 
+var invalidAvailabilityZoneError = microerror.New("invalid availability zone")
+
+// IsInvalidAvailabilityZone asserts invalidAvailabilityZoneError.
+func IsInvalidAvailabilityZone(err error) bool {
+	return microerror.Cause(err) == invalidAvailabilityZoneError
+}
+
 var workersListEmptyError = microerror.New("workers list empty")
 
 // IsWorkersListEmpty asserts workersListEmptyError.

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	ClusterListAPIEndpoint  string = "/apis/cluster.giantswarm.io/v1/awses"
-	ClusterWatchAPIEndpoint string = "/apis/cluster.giantswarm.io/v1/watch/awses"
 	// The format of instance's name is "[name of cluster]-[prefix ('master' or 'worker')]-[number]".
 	instanceNameFormat string = "%s-%s-%d"
 	// The format of prefix inside a cluster "[name of cluster]-[prefix ('master' or 'worker')]".


### PR DESCRIPTION
Fixes #76 

Validates the Availability Zone in cluster custom object matches the Region. The cluster is validated before the cluster is launched so we catch this before any resources are created.