### PR TITLE
Migrate legacy ASG workers to CF stack-managed ASG

### DIFF
--- a/resources/aws/auto_scaling_group_test.go
+++ b/resources/aws/auto_scaling_group_test.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+)
+
+func TestIsLegacyASG(t *testing.T) {
+	nameOk := "my-asg"
+	clusterOk := "my-cluster"
+	tagNameOK := tagKeyName
+	tagClusterOK := tagKeyCluster
+	tagCF := "aws:cloudformation:stack-id"
+
+	t.Run("name and cluster match, no CF tag", func(t *testing.T) {
+		tags := []*autoscaling.TagDescription{
+			{Key: &tagNameOK, Value: &nameOk},
+			{Key: &tagClusterOK, Value: &clusterOk},
+		}
+
+		if !isLegacyASG(nameOk, clusterOk, tags) {
+			t.Errorf("not legacy for tags %v, name %s and clusterID %s",
+				tags, nameOk, clusterOk)
+		}
+	})
+
+	t.Run("name and cluster match, CF tag", func(t *testing.T) {
+		tags := []*autoscaling.TagDescription{
+			{Key: &tagNameOK, Value: &nameOk},
+			{Key: &tagClusterOK, Value: &clusterOk},
+			{Key: &tagCF, Value: &clusterOk},
+		}
+
+		if isLegacyASG(nameOk, clusterOk, tags) {
+			t.Errorf("legacy for tags %v, name %s and clusterID %s",
+				tags, nameOk, clusterOk)
+		}
+	})
+
+	t.Run("name no match, cluster match, no CF tag", func(t *testing.T) {
+		tags := []*autoscaling.TagDescription{
+			{Key: &tagNameOK, Value: &nameOk},
+			{Key: &tagClusterOK, Value: &clusterOk},
+		}
+
+		nameBad := "my-other-asg"
+
+		if isLegacyASG(nameBad, clusterOk, tags) {
+			t.Errorf("legacy for tags %v, name %s and clusterID %s",
+				tags, nameBad, clusterOk)
+		}
+	})
+
+	t.Run("name match, cluster no match, no CF tag", func(t *testing.T) {
+		tags := []*autoscaling.TagDescription{
+			{Key: &tagNameOK, Value: &nameOk},
+			{Key: &tagClusterOK, Value: &clusterOk},
+		}
+
+		clusterBad := "my-other-cluster"
+
+		if isLegacyASG(nameOk, clusterBad, tags) {
+			t.Errorf("legacy for tags %v, name %s and clusterID %s",
+				tags, clusterBad, clusterBad)
+		}
+	})
+
+}

--- a/resources/aws/auto_scaling_group_test.go
+++ b/resources/aws/auto_scaling_group_test.go
@@ -42,7 +42,7 @@ func TestIsLegacyASG(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run("name and cluster match, no CF tag", func(t *testing.T) {
+		t.Run(tc.description, func(t *testing.T) {
 			actual := isLegacyASG(tc.name, tc.clusterID, tc.tags)
 
 			if actual != tc.expected {

--- a/resources/aws/auto_scaling_group_test.go
+++ b/resources/aws/auto_scaling_group_test.go
@@ -22,23 +22,42 @@ func TestIsLegacyASG(t *testing.T) {
 		tags        []*autoscaling.TagDescription
 		expected    bool
 	}{
-		{"name and cluster match, no CF tag", nameOk, clusterOk, []*autoscaling.TagDescription{
-			{Key: &tagNameOK, Value: &nameOk},
-			{Key: &tagClusterOK, Value: &clusterOk},
-		}, true},
-		{"name and cluster match, CF tag", nameOk, clusterOk, []*autoscaling.TagDescription{
-			{Key: &tagNameOK, Value: &nameOk},
-			{Key: &tagClusterOK, Value: &clusterOk},
-			{Key: &tagCF, Value: &clusterOk},
-		}, false},
-		{"name no match, cluster match, no CF tag", nameBad, clusterOk, []*autoscaling.TagDescription{
-			{Key: &tagNameOK, Value: &nameOk},
-			{Key: &tagClusterOK, Value: &clusterOk},
-		}, false},
-		{"name match, cluster no match, no CF tag", nameOk, clusterBad, []*autoscaling.TagDescription{
-			{Key: &tagNameOK, Value: &nameOk},
-			{Key: &tagClusterOK, Value: &clusterOk},
-		}, false},
+		{
+			description: "name and cluster match, no CF tag",
+			name:        nameOk,
+			clusterID:   clusterOk,
+			tags: []*autoscaling.TagDescription{
+				{Key: &tagNameOK, Value: &nameOk},
+				{Key: &tagClusterOK, Value: &clusterOk},
+			},
+			expected: true},
+		{
+			description: "name and cluster match, CF tag",
+			name:        nameOk,
+			clusterID:   clusterOk,
+			tags: []*autoscaling.TagDescription{
+				{Key: &tagNameOK, Value: &nameOk},
+				{Key: &tagClusterOK, Value: &clusterOk},
+				{Key: &tagCF, Value: &clusterOk},
+			},
+			expected: false},
+		{
+			description: "name no match, cluster match, no CF tag",
+			name:        nameBad,
+			clusterID:   clusterOk,
+			tags: []*autoscaling.TagDescription{
+				{Key: &tagNameOK, Value: &nameOk},
+				{Key: &tagClusterOK, Value: &clusterOk},
+			},
+			expected: false},
+		{
+			description: "name match, cluster no match, no CF tag",
+			name:        nameOk,
+			clusterID:   clusterBad,
+			tags: []*autoscaling.TagDescription{
+				{Key: &tagNameOK, Value: &nameOk},
+				{Key: &tagClusterOK, Value: &clusterOk},
+			}, expected: false},
 	}
 
 	for _, tc := range testCases {

--- a/resources/aws/consts.go
+++ b/resources/aws/consts.go
@@ -16,4 +16,7 @@ const (
 	ipPermissionGroupID  string = "ip-permission.group-id"
 	ipPermissionProtocol string = "ip-permission.protocol"
 	ipPermissionToPort   string = "ip-permission.to-port"
+	// newestFirstTerminationPolicy is the ASG termination policy used to prevent
+	// old instances to be terminated during migration
+	newestFirstTerminationPolicy string = "NewestInstance"
 )

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -969,7 +969,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	if legacyASG {
 		cfAsg, err := s.findCFASG(clients.AutoScaling, key.AutoScalingGroupName(cluster, prefixWorker), key.ClusterID(cluster))
 		if err != nil {
-			return microerror.Maskf(executionFailedError, "could find CF ASG: '#%v'", err)
+			return microerror.Maskf(executionFailedError, "could not find CF ASG: '#%v'", err)
 		}
 
 		if err := cfAsg.AttachInstances(instances); err != nil {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -927,7 +927,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	var instances []*autoscaling.Instance
 	if legacyASG {
 		// detach instances and delete legacy ASG to prevent name clash
-		instances, err = asg.DetachInstances()
+		instances, err = asg.DetachInstances(s.logger)
 		if err != nil {
 			return microerror.Maskf(executionFailedError, "detaching legacy worker from ASG failed: '%#v'", err)
 		}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -921,7 +921,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 	legacyASG, err := asg.FindLegacy()
 	if err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("search for legacy worker ASG failed: '%#v'", err))
+		return microerror.Maskf(executionFailedError, "search for legacy worker ASG failed: '%#v'", err)
 	}
 
 	var instances []*autoscaling.Instance
@@ -929,10 +929,10 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		// detach instances and delete legacy ASG to prevent name clash
 		instances, err = asg.DetachInstances()
 		if err != nil {
-			return microerror.Maskf(executionFailedError, fmt.Sprintf("detaching legacy worker from ASG failed: '%#v'", err))
+			return microerror.Maskf(executionFailedError, "detaching legacy worker from ASG failed: '%#v'", err)
 		}
 		if err := asg.Delete(); err != nil {
-			return microerror.Maskf(executionFailedError, fmt.Sprintf("deletingg legacy ASG failed: '%#v'", err))
+			return microerror.Maskf(executionFailedError, "deleting legacy ASG failed: '%#v'", err)
 		}
 	}
 
@@ -969,11 +969,11 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	if legacyASG {
 		cfAsg, err := s.findCFASG(clients.AutoScaling, key.AutoScalingGroupName(cluster, prefixWorker), key.ClusterID(cluster))
 		if err != nil {
-			return microerror.Maskf(executionFailedError, fmt.Sprintf("could find CF ASG: '#%v'", err))
+			return microerror.Maskf(executionFailedError, "could find CF ASG: '#%v'", err)
 		}
 
 		if err := cfAsg.AttachInstances(instances); err != nil {
-			return microerror.Maskf(executionFailedError, fmt.Sprintf("could not process legacy ASG: '#%v'", err))
+			return microerror.Maskf(executionFailedError, "could not process legacy ASG: '#%v'", err)
 		}
 	}
 

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1,11 +1,13 @@
 package create
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -912,6 +914,28 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 
 	// Create an Auto Scaling Group for the workers.
+	asg := awsresources.AutoScalingGroup{
+		Client:    clients.AutoScaling,
+		Name:      key.AutoScalingGroupName(cluster, prefixWorker),
+		ClusterID: key.ClusterID(cluster),
+	}
+	legacyASG, err := asg.FindLegacy()
+	if err != nil {
+		return microerror.Maskf(executionFailedError, fmt.Sprintf("search for legacy worker ASG failed: '%#v'", err))
+	}
+
+	var instances []*autoscaling.Instance
+	if legacyASG {
+		// detach instances and delete legacy ASG to prevent name clash
+		instances, err = asg.DetachInstances()
+		if err != nil {
+			return microerror.Maskf(executionFailedError, fmt.Sprintf("detaching legacy worker from ASG failed: '%#v'", err))
+		}
+		if err := asg.Delete(); err != nil {
+			return microerror.Maskf(executionFailedError, fmt.Sprintf("deletingg legacy ASG failed: '%#v'", err))
+		}
+	}
+
 	asgStackInput := asgStackInput{
 		// Dependencies.
 		clients: clients,
@@ -941,6 +965,17 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 
 	s.logger.Log("info", fmt.Sprintf("processed autoscaling group stack '%s'", key.AutoScalingGroupName(cluster, prefixWorker)))
+
+	if legacyASG {
+		cfAsg, err := s.findCFASG(clients.AutoScaling, key.AutoScalingGroupName(cluster, prefixWorker), key.ClusterID(cluster))
+		if err != nil {
+			return microerror.Maskf(executionFailedError, fmt.Sprintf("could find CF ASG: '#%v'", err))
+		}
+
+		if err := cfAsg.AttachInstances(instances); err != nil {
+			return microerror.Maskf(executionFailedError, fmt.Sprintf("could not process legacy ASG: '#%v'", err))
+		}
+	}
 
 	// Create Record Sets for the Load Balancers.
 	recordSetInputs := []recordSetInput{
@@ -1382,4 +1417,25 @@ func (s *Service) updateFunc(oldObj, newObj interface{}) {
 	}
 
 	s.logger.Log("info", fmt.Sprintf("processed autoscaling group stack '%s'", key.AutoScalingGroupName(cluster, prefixWorker)))
+}
+
+func (s *Service) findCFASG(client *autoscaling.AutoScaling, name string, clusterID string) (awsresources.AutoScalingGroup, error) {
+	autoScalingGroups, err := client.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	if err != nil {
+		return awsresources.AutoScalingGroup{}, microerror.Mask(err)
+	}
+
+	for _, asg := range autoScalingGroups.AutoScalingGroups {
+		for _, tag := range asg.Tags {
+			if *tag.Key == "aws:cloudformation:stack-name" && *tag.Value == name {
+				return awsresources.AutoScalingGroup{
+					Client:    client,
+					Name:      *asg.AutoScalingGroupName,
+					ClusterID: clusterID,
+				}, nil
+			}
+		}
+	}
+
+	return awsresources.AutoScalingGroup{}, microerror.Mask(errors.New("not found"))
 }


### PR DESCRIPTION
Targeted to #379, builds on top of it and tries to address the shortcomings of that approach when dealing with legacy clusters. The old workers' ASG is detected, the workers are detached from it and attached to the new ASG.