### PR TITLE
add first cloudformation resource implementation

### DIFF
--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -75,22 +75,35 @@ func New(config Config) (*Resource, error) {
 }
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	// TODO fetch a comparable current state of the cloudformation associated with
+	// the processed custom object.
 	return nil, nil
 }
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	// TODO compute a comparable desired state of the cloudformation associated
+	// with the processed custom object.
 	return nil, nil
 }
 
 func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	// TODO compute a comparable create state of the cloudformation associated
+	// with the processed custom object. This can be derived by comparing the
+	// current and the desired state.
 	return nil, nil
 }
 
 func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	// TODO compute a comparable delete state of the cloudformation associated
+	// with the processed custom object. This can be derived by comparing the
+	// current and the desired state.
 	return nil, nil
 }
 
 func (r *Resource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
+	// TODO compute a comparable create, delete and update state of the
+	// cloudformation associated with the processed custom object. This can be
+	// derived by comparing the current and the desired state.
 	return nil, nil, nil, nil
 }
 
@@ -99,14 +112,23 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+	// TODO process a comparable create state of the cloudformation associated
+	// with the processed custom object. This can be done by creating the given
+	// create state in some remote API via some configured client.
 	return nil
 }
 
 func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+	// TODO process a comparable delete state of the cloudformation associated
+	// with the processed custom object. This can be done by deleting the given
+	// delete state in some remote API via some configured client.
 	return nil
 }
 
 func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+	// TODO process a comparable update state of the cloudformation associated
+	// with the processed custom object. This can be done by updating the given
+	// update state in some remote API via some configured client.
 	return nil
 }
 

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -1,0 +1,7 @@
+package cloudformation
+
+// Cloudformation is the comparable state of a AWS cloudformation associated
+// with a processed custom object.
+type Cloudformation struct {
+	// TODO add necessary properties.
+}


### PR DESCRIPTION
Note this PR is based on https://github.com/giantswarm/aws-operator/pull/417. Here we have to implement the cloudformation resource. For references of how this is done in other projects see for instance the KVM operator's resources: https://github.com/giantswarm/kvm-operator/tree/bf49015a93ecd9f793e45ac9297304992521df5e/service/resource.