### PR TITLE
remove useless logs

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -3,7 +3,6 @@
 package service
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/giantswarm/certificatetpr"
@@ -63,7 +62,6 @@ func New(config Config) (*Service, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
 	}
-	config.Logger.Log("debug", fmt.Sprintf("creating aws-operator service with config: %s", config))
 
 	var err error
 


### PR DESCRIPTION
This PR removes logging the provided configuration. Currently the log is not properly formatted but even passwords and secrets are logged. This should not happen. Removing the logs should be good enough since it is not that useful in general. It started out to be logged for debugging reasons and got used permanently. Lets get rid of it and add dedicated, safe and useful logging when necessary. 