### PR TITLE
prevent panic by moving error check

### DIFF
--- a/resources/aws/route.go
+++ b/resources/aws/route.go
@@ -14,15 +14,15 @@ type Route struct {
 
 func (r Route) findExisting() (*ec2.Route, error) {
 	awsRouteTable, err := r.RouteTable.findExisting()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
 	for _, route := range awsRouteTable.Routes {
 		if route.DestinationCidrBlock != nil && route.VpcPeeringConnectionId != nil &&
 			*route.VpcPeeringConnectionId == r.VpcID && *route.DestinationCidrBlock == r.DestinationCidrBlock {
 			return route, nil
 		}
-	}
-	if err != nil {
-		return nil, microerror.Mask(err)
 	}
 	return nil, microerror.Maskf(notFoundError, notFoundErrorFormat, RouteType)
 }


### PR DESCRIPTION
The error check was being done too late, `awsRouteTable` could be nil when trying to use it. This was causing a panic on the local example without `AWS_ROUTE_TABLE_0` and `AWS_ROUTE_TABLE_1` set.