### PR TITLE
Restrict security group ports

### DIFF
--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -100,6 +100,12 @@ func (s SecurityGroup) findGroupWithRule(rule SecurityGroupRule) (*ec2.SecurityG
 				},
 			},
 			{
+				Name: aws.String(ipPermissionFromPort),
+				Values: []*string{
+					aws.String(strconv.Itoa(rule.Port)),
+				},
+			},
+			{
 				Name: aws.String(ipPermissionProtocol),
 				Values: []*string{
 					aws.String(rule.Protocol),

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -27,14 +27,10 @@ type rulesInput struct {
 }
 
 const (
-	allPorts             = -1
-	calicoBGPNetworkPort = 179
-	httpPort             = 80
-	httpsPort            = 443
-	// This port is required in our current kubernetes/heapster setup, but will become unnecessary
-	// once we upgrade to kubernetes 1.6 and heapster 1.3 with apiserver deployment.
-	readOnlyKubeletPort = 10255
-	sshPort             = 22
+	allPorts  = -1
+	httpPort  = 80
+	httpsPort = 443
+	sshPort   = 22
 
 	allProtocols = "-1"
 	tcpProtocol  = "tcp"
@@ -96,11 +92,6 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},
-		{
-			Port:       calicoBGPNetworkPort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
-		},
 		// Allow all traffic between the masters and worker nodes for Calico.
 		{
 			Port:            allPorts,
@@ -119,32 +110,17 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 func (ri rulesInput) workerRules() []awsresources.SecurityGroupRule {
 	return []awsresources.SecurityGroupRule{
 		{
-			Port:       ri.Cluster.Spec.Cluster.Kubernetes.IngressController.SecurePort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
+			Port:            ri.Cluster.Spec.Cluster.Kubernetes.IngressController.SecurePort,
+			Protocol:        tcpProtocol,
+			SecurityGroupID: ri.IngressSecurityGroupID,
 		},
 		{
-			Port:       ri.Cluster.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
-		},
-		{
-			Port:       ri.Cluster.Spec.Cluster.Kubernetes.Kubelet.Port,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
-		},
-		{
-			Port:       readOnlyKubeletPort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
+			Port:            ri.Cluster.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
+			Protocol:        tcpProtocol,
+			SecurityGroupID: ri.IngressSecurityGroupID,
 		},
 		{
 			Port:       sshPort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
-		},
-		{
-			Port:       calicoBGPNetworkPort,
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},


### PR DESCRIPTION
Towards giantswarm/giantswarm#1803

This PR locks down the ports on the master and worker security groups. This change is backwards compatible for existing clusters.

The services below still use the default CIDR of `0.0.0.0/0`. Changing these is not backwards compatible.

* k8s apiserver
* etcd 
* ssh