### PR TITLE
Don't add EC2 keypair for new clusters

### DIFF
--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -96,6 +96,8 @@ $ helm install -n aws-operator-lab --set idRsaPub="$(cat ~/.ssh/id_rsa.pub)" \
 `aws-resource-lab-chart` accepts the following configuration parameters:
 * `clusterName` - Cluster's name.
 * `commonDomain` - Cluster's etcd and API common domain.
+* `sshUser` - SSH user created via cloudconfig.
+* `sshPublicKey` - SSH public key added via cloudconfig.
 * `aws.region` - AWS region.
 * `aws.az` - AWS availability zone.
 * `aws.ami` - AWS image to be used on both master and worker machines.
@@ -106,6 +108,14 @@ $ helm install -n aws-operator-lab --set idRsaPub="$(cat ~/.ssh/id_rsa.pub)" \
 * `aws.routeTable0` - Existing route table of the cluster to use for VPC peering.
 * `aws.routeTable1` - Existing route table of the cluster to use for VPC peering.
 * `aws.vpcPeerId` - VPC ID of the host cluster to peer with.
+
+For instance, to create a SSH user with your current user and default public key.
+
+```bash
+$ helm install -n aws-resource-lab --set sshUser="$(whoami)" \
+                                  --set sshPublicKey="$(cat ~/.ssh/id_rsa.pub)" \
+                                   ./aws-resource-lab-chart/ --wait
+```
 
 ## Connecting to the new cluster
 

--- a/examples/local/aws-resource-lab-chart/templates/cluster.yaml
+++ b/examples/local/aws-resource-lab-chart/templates/cluster.yaml
@@ -53,7 +53,10 @@ spec:
       networkSetup:
         docker:
           image: "giantswarm/k8s-setup-network-environment:ba2b57155d859a1fc5d378c2a09a77d7c2c755ed"
-
+      ssh:
+        userList:
+        - name: "{{.Values.sshUser}}"
+          publicKey: "{{.Values.sshPublicKey}}"
     masters:
     - hostname: "master-1"
 

--- a/examples/local/aws-resource-lab-chart/values.yaml
+++ b/examples/local/aws-resource-lab-chart/values.yaml
@@ -1,5 +1,7 @@
 clusterName: "test-cluster"
 commonDomain: "aws.gigantic.io"
+sshUser: "test-user"
+sshPublicKey: ssh-rsa XXXXXXXXXXXXXXXXXXXXXXXXX"
 
 aws:
   region: "eu-central-1"

--- a/resources/aws/instance.go
+++ b/resources/aws/instance.go
@@ -142,10 +142,10 @@ func (i *Instance) CreateOrFail() error {
 	var reservation *ec2.Reservation
 	reserveOperation := func() error {
 		var err error
-		reservation, err = i.Clients.EC2.RunInstances(&ec2.RunInstancesInput{
+
+		instancesInput := &ec2.RunInstancesInput{
 			ImageId:      aws.String(i.ImageID),
 			InstanceType: aws.String(i.InstanceType),
-			KeyName:      aws.String(i.KeyName),
 			MinCount:     aws.Int64(int64(1)),
 			MaxCount:     aws.Int64(int64(1)),
 			UserData:     aws.String(i.SmallCloudconfig),
@@ -159,7 +159,12 @@ func (i *Instance) CreateOrFail() error {
 				aws.String(i.SecurityGroupID),
 			},
 			SubnetId: aws.String(i.SubnetID),
-		})
+		}
+		if i.KeyName != "" {
+			instancesInput.KeyName = aws.String(i.KeyName)
+		}
+
+		reservation, err = i.Clients.EC2.RunInstances(instancesInput)
 		if err != nil {
 
 			return microerror.Mask(err)

--- a/resources/aws/launch_configuration.go
+++ b/resources/aws/launch_configuration.go
@@ -77,13 +77,15 @@ func (lc *LaunchConfiguration) CreateOrFail() error {
 		IamInstanceProfile:      aws.String(lc.IamInstanceProfileName),
 		ImageId:                 aws.String(lc.ImageID),
 		InstanceType:            aws.String(lc.InstanceType),
-		KeyName:                 aws.String(lc.KeyName),
 		SecurityGroups: []*string{
 			aws.String(lc.SecurityGroupID),
 		},
 		UserData:                 aws.String(lc.SmallCloudConfig),
 		AssociatePublicIpAddress: aws.Bool(lc.AssociatePublicIpAddress),
 		BlockDeviceMappings:      []*autoscaling.BlockDeviceMapping{ebsMount},
+	}
+	if lc.KeyName != "" {
+		lcInput.KeyName = aws.String(lc.KeyName)
 	}
 
 	if _, err := lc.Client.CreateLaunchConfiguration(lcInput); err != nil {

--- a/service/cloudconfig/cloud_config.go
+++ b/service/cloudconfig/cloud_config.go
@@ -1,6 +1,7 @@
 package cloudconfig
 
 import (
+	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
 	"github.com/giantswarm/certificatetpr"
 	cloudconfig "github.com/giantswarm/k8scloudconfig"
@@ -55,13 +56,13 @@ func (c *CloudConfig) NewMasterTemplate(customObject awstpr.CustomObject, certs 
 	var err error
 
 	// TODO remove defaulting as soon as custom objects are configured.
-	if customObject.Spec.Cluster.Version == "" {
+	if key.ClusterVersion(customObject) == "" {
 		customObject.Spec.Cluster.Version = string(cloudconfig.V_0_1_0)
 	}
 
 	var template string
 
-	switch customObject.Spec.Cluster.Version {
+	switch key.ClusterVersion(customObject) {
 	case string(cloudconfig.V_0_1_0):
 		template, err = v_0_1_0MasterTemplate(customObject, certs)
 		if err != nil {

--- a/service/cloudconfig/cloud_config.go
+++ b/service/cloudconfig/cloud_config.go
@@ -56,7 +56,7 @@ func (c *CloudConfig) NewMasterTemplate(customObject awstpr.CustomObject, certs 
 	var err error
 
 	// TODO remove defaulting as soon as custom objects are configured.
-	if key.ClusterVersion(customObject) == "" {
+	if !key.HasClusterVersion(customObject) {
 		customObject.Spec.Cluster.Version = string(cloudconfig.V_0_1_0)
 	}
 

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -518,7 +518,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 
 	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
-	if !key.HasLatestVersion(cluster) {
+	if !key.HasClusterVersion(cluster) {
 		// Create keypair.
 		var keyPair resources.ReusableResource
 		var keyPairCreated bool
@@ -865,7 +865,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 
 	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
-	if !key.HasLatestVersion(cluster) {
+	if !key.HasClusterVersion(cluster) {
 		mastersInput.keyPairName = key.ClusterID(cluster)
 	}
 
@@ -978,7 +978,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 	}
 
 	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
-	if !key.HasLatestVersion(cluster) {
+	if !key.HasClusterVersion(cluster) {
 		lcInput.keypairName = key.ClusterID(cluster)
 	}
 

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -517,26 +517,29 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not retrieve host amazon account id: '%#v'", err))
 	}
 
-	// Create keypair.
-	var keyPair resources.ReusableResource
-	var keyPairCreated bool
-	{
-		var err error
-		keyPair = &awsresources.KeyPair{
-			ClusterName: key.ClusterID(cluster),
-			Provider:    awsresources.NewFSKeyPairProvider(s.pubKeyFile),
-			AWSEntity:   awsresources.AWSEntity{Clients: clients},
+	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
+	if !key.HasLatestVersion(cluster) {
+		// Create keypair.
+		var keyPair resources.ReusableResource
+		var keyPairCreated bool
+		{
+			var err error
+			keyPair = &awsresources.KeyPair{
+				ClusterName: key.ClusterID(cluster),
+				Provider:    awsresources.NewFSKeyPairProvider(s.pubKeyFile),
+				AWSEntity:   awsresources.AWSEntity{Clients: clients},
+			}
+			keyPairCreated, err = keyPair.CreateIfNotExists()
+			if err != nil {
+				return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create keypair: '%#v'", err))
+			}
 		}
-		keyPairCreated, err = keyPair.CreateIfNotExists()
-		if err != nil {
-			return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create keypair: '%#v'", err))
-		}
-	}
 
-	if keyPairCreated {
-		s.logger.Log("info", fmt.Sprintf("created keypair '%s'", key.ClusterID(cluster)))
-	} else {
-		s.logger.Log("info", fmt.Sprintf("keypair '%s' already exists, reusing", key.ClusterID(cluster)))
+		if keyPairCreated {
+			s.logger.Log("info", fmt.Sprintf("created keypair '%s'", key.ClusterID(cluster)))
+		} else {
+			s.logger.Log("info", fmt.Sprintf("keypair '%s' already exists, reusing", key.ClusterID(cluster)))
+		}
 	}
 
 	s.logger.Log("info", fmt.Sprintf("waiting for k8s secrets..."))
@@ -849,8 +852,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 
 	}
 
-	// Run masters.
-	anyMastersCreated, masterIDs, err := s.runMachines(runMachinesInput{
+	mastersInput := runMachinesInput{
 		clients:             clients,
 		cluster:             cluster,
 		tlsAssets:           tlsAssets,
@@ -858,10 +860,17 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		bucket:              bucket,
 		securityGroup:       mastersSecurityGroup,
 		subnet:              publicSubnet,
-		keyPairName:         key.ClusterID(cluster),
 		instanceProfileName: masterPolicy.GetName(),
 		prefix:              prefixMaster,
-	})
+	}
+
+	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
+	if !key.HasLatestVersion(cluster) {
+		mastersInput.keyPairName = key.ClusterID(cluster)
+	}
+
+	// Run masters.
+	anyMastersCreated, masterIDs, err := s.runMachines(mastersInput)
 	if err != nil {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not start masters: '%#v'", err))
 	}
@@ -963,10 +972,14 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		bucket:              bucket,
 		securityGroup:       workersSecurityGroup,
 		subnet:              publicSubnet,
-		keypairName:         key.ClusterID(cluster),
 		instanceProfileName: workerPolicy.GetName(),
 		prefix:              prefixWorker,
 		ebsStorage:          true,
+	}
+
+	// An EC2 Keypair is needed for legacy clusters. New clusters provide SSH keys via cloud config.
+	if !key.HasLatestVersion(cluster) {
+		lcInput.keypairName = key.ClusterID(cluster)
 	}
 
 	lcCreated, err := s.createLaunchConfiguration(lcInput)

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -18,6 +18,10 @@ func ClusterID(customObject awstpr.CustomObject) string {
 	return customObject.Spec.Cluster.Cluster.ID
 }
 
+func ClusterVersion(customObject awstpr.CustomObject) string {
+	return customObject.Spec.Cluster.Version
+}
+
 func MasterImageID(customObject awstpr.CustomObject) string {
 	var imageID string
 

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/awstpr"
+	cloudconfig "github.com/giantswarm/k8scloudconfig"
 )
 
 func AutoScalingGroupName(customObject awstpr.CustomObject, groupName string) string {
@@ -20,6 +21,14 @@ func ClusterID(customObject awstpr.CustomObject) string {
 
 func ClusterVersion(customObject awstpr.CustomObject) string {
 	return customObject.Spec.Cluster.Version
+}
+
+func HasLatestVersion(customObject awstpr.CustomObject) bool {
+	if ClusterVersion(customObject) == string(cloudconfig.V_0_1_0) {
+		return true
+	} else {
+		return false
+	}
 }
 
 func MasterImageID(customObject awstpr.CustomObject) string {

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -23,10 +23,11 @@ func ClusterVersion(customObject awstpr.CustomObject) string {
 	return customObject.Spec.Cluster.Version
 }
 
-func HasLatestVersion(customObject awstpr.CustomObject) bool {
-	if ClusterVersion(customObject) == string(cloudconfig.V_0_1_0) {
+func HasClusterVersion(customObject awstpr.CustomObject) bool {
+	switch ClusterVersion(customObject) {
+	case string(cloudconfig.V_0_1_0):
 		return true
-	} else {
+	default:
 		return false
 	}
 }

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -120,7 +120,7 @@ func Test_HasLatestVersion(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			customObject: awstpr.CustomObject{
@@ -130,7 +130,7 @@ func Test_HasLatestVersion(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 	}
 

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -91,7 +91,7 @@ func Test_ClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_HasLatestVersion(t *testing.T) {
+func Test_HasClusterVersion(t *testing.T) {
 	tests := []struct {
 		customObject   awstpr.CustomObject
 		expectedResult bool
@@ -135,8 +135,8 @@ func Test_HasLatestVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if HasLatestVersion(tc.customObject) != tc.expectedResult {
-			t.Fatalf("Expected has latest version to be %t but was %t", tc.expectedResult, HasLatestVersion(tc.customObject))
+		if HasClusterVersion(tc.customObject) != tc.expectedResult {
+			t.Fatalf("Expected has cluster version to be %t but was %t", tc.expectedResult, HasClusterVersion(tc.customObject))
 		}
 	}
 }

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -91,6 +91,56 @@ func Test_ClusterVersion(t *testing.T) {
 	}
 }
 
+func Test_HasLatestVersion(t *testing.T) {
+	tests := []struct {
+		customObject   awstpr.CustomObject
+		expectedResult bool
+	}{
+		{
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{},
+			},
+			expectedResult: false,
+		},
+		{
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Version: "",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Version: "v_0_1_0",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Version: "v_0_2_0",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range tests {
+		if HasLatestVersion(tc.customObject) != tc.expectedResult {
+			t.Fatalf("Expected has latest version to be %t but was %t", tc.expectedResult, HasLatestVersion(tc.customObject))
+		}
+	}
+}
+
 func Test_MasterImageID(t *testing.T) {
 	tests := []struct {
 		customObject    awstpr.CustomObject

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -73,6 +73,24 @@ func Test_ClusterID(t *testing.T) {
 	}
 }
 
+func Test_ClusterVersion(t *testing.T) {
+	expectedVersion := "v_0_1_0"
+
+	cluster := clustertpr.Spec{
+		Version: expectedVersion,
+	}
+
+	customObject := awstpr.CustomObject{
+		Spec: awstpr.Spec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterVersion(customObject) != expectedVersion {
+		t.Fatalf("Expected cluster version %s but was %s", expectedVersion, ClusterVersion(customObject))
+	}
+}
+
 func Test_MasterImageID(t *testing.T) {
 	tests := []struct {
 		customObject    awstpr.CustomObject


### PR DESCRIPTION
Towards giantswarm/giantswarm#1803

This PR doesn't create an EC2 keypair if the cluster version is set. SSH access will only be via the individual users added in the cluster custom object. 

For clusters without a version the original logic is used and a EC2 keypair is created.

This change also added key helpers for ClusterVersion and HasClusterVersion. HasClusterVersion is needed to distinguish between new locked down clusters and existing clusters.
