### PR TITLE
Don't use port filter for all ports rules

### DIFF
--- a/resources/aws/security_group.go
+++ b/resources/aws/security_group.go
@@ -32,6 +32,10 @@ type SecurityGroupRule struct {
 	SecurityGroupID string
 }
 
+const (
+	allPorts = -1
+)
+
 func (s SecurityGroup) findExisting() (*ec2.SecurityGroup, error) {
 	filters, err := s.getGroupFilters()
 	if err != nil {
@@ -100,17 +104,23 @@ func (s SecurityGroup) findGroupWithRule(rule SecurityGroupRule) (*ec2.SecurityG
 				},
 			},
 			{
-				Name: aws.String(ipPermissionFromPort),
-				Values: []*string{
-					aws.String(strconv.Itoa(rule.Port)),
-				},
-			},
-			{
 				Name: aws.String(ipPermissionProtocol),
 				Values: []*string{
 					aws.String(rule.Protocol),
 				},
 			},
+		}
+
+		// Needed as filters for all ports rules don't work.
+		if rule.Port != allPorts {
+			portFilter := &ec2.Filter{
+				Name: aws.String(ipPermissionFromPort),
+				Values: []*string{
+					aws.String(strconv.Itoa(rule.Port)),
+				},
+			}
+
+			ruleFilters = append(ruleFilters, portFilter)
 		}
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#1803

Adding a filter for port number was needed to created rules for both ingress controller ports. But it causes the error below when reprocessing clusters. This is because filters don't work for all ports rules :(

Cluster creation was unaffected but this change fixes the errors when reprocessing clusters.

```
{"caller":"github.com/giantswarm/aws-operator/service/create/service.go:493","error":"error processing cluster 'ross-cluster': '[{/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/create/service.go:753: could not create rules for security group 'ross-cluster-master': '[{/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/resources/aws/security_group.go:228: } {/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/resources/aws/security_group.go:200: } {InvalidPermission.Duplicate: the specified rule \"peer: sg-2e61b544, ALL, ALLOW\" already exists\n\tstatus code: 400, request id: 832cb23b-d46a-42a4-9c4e-d1fcb6f7f672}]} {execution failed}]'","time":"17-10-12 16:56:28.678"}
```

