### PR TITLE
Creating IAM policies should be idempotent

### DIFF
--- a/client/aws/errors.go
+++ b/client/aws/errors.go
@@ -5,6 +5,7 @@ import "github.com/giantswarm/microerror"
 const (
 	AlreadyAssociated        = "Resource.AlreadyAssociated"
 	InvalidSubnetConflict    = "InvalidSubnet.Conflict"
+	RoleDuplicate            = "EntityAlreadyExists: Role"
 	KeyPairDuplicate         = "InvalidKeyPair.Duplicate"
 	SecurityGroupDuplicate   = "InvalidGroup.Duplicate"
 	ELBAlreadyExists         = "DuplicateLoadBalancerName"

--- a/client/aws/errors.go
+++ b/client/aws/errors.go
@@ -1,6 +1,7 @@
 package aws
 
 import "github.com/giantswarm/microerror"
+import "strings"
 
 const (
 	AlreadyAssociated        = "Resource.AlreadyAssociated"
@@ -31,4 +32,9 @@ var emptyAmazonAccountIDError = microerror.New("empty amazon account ID")
 // IsEmptyAmazonAccountID asserts emptyAmazonAccountIDError.
 func IsEmptyAmazonAccountID(err error) bool {
 	return microerror.Cause(err) == emptyAmazonAccountIDError
+}
+
+// IsIAMRoleDuplicateError checks for duplicate IAM Role errors.
+func IsIAMRoleDuplicateError(err error) bool {
+	return strings.Contains(err.Error(), RoleDuplicate)
 }

--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -2,11 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
 )
 
@@ -144,11 +143,9 @@ func (p *Policy) clusterRoleName() string {
 
 func (p *Policy) CreateIfNotExists() (bool, error) {
 	err := p.CreateOrFail()
-	if err != nil {
-		if strings.Contains(err.Error(), awsclient.RoleDuplicate) {
-			return false, nil
-		}
-
+	if awsutil.IsIAMRoleDuplicateError(err) {
+		return false, nil
+	} else if err != nil {
 		return false, microerror.Mask(err)
 	}
 

--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
 )
 
@@ -141,7 +143,16 @@ func (p *Policy) clusterRoleName() string {
 }
 
 func (p *Policy) CreateIfNotExists() (bool, error) {
-	return false, fmt.Errorf("instance profiles cannot be reused")
+	err := p.CreateOrFail()
+	if err != nil {
+		if strings.Contains(err.Error(), awsclient.RoleDuplicate) {
+			return false, nil
+		}
+
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
 }
 
 func (p *Policy) createRole() error {


### PR DESCRIPTION
Fixes #378 

Now an error is only logged if creating the IAM policy failed.

IAM policies can't be reused for EC2 instances so we still check for if a master node was created but the IAM policy was from a previous execution. In this case the cluster can't be processed and needs to be deleted. 