### PR TITLE
prevent panic on nil error

### DIFF
--- a/resources/aws/policy.go
+++ b/resources/aws/policy.go
@@ -143,13 +143,13 @@ func (p *Policy) clusterRoleName() string {
 
 func (p *Policy) CreateIfNotExists() (bool, error) {
 	err := p.CreateOrFail()
+	if err == nil {
+		return true, nil
+	}
 	if awsutil.IsIAMRoleDuplicateError(err) {
 		return false, nil
-	} else if err != nil {
-		return false, microerror.Mask(err)
 	}
-
-	return true, nil
+	return false, microerror.Mask(err)
 }
 
 func (p *Policy) createRole() error {


### PR DESCRIPTION
This will prevent a panic on error checking when the returned error from creating a policy is nil:
```
{"caller":"github.com/giantswarm/aws-operator/service/create/service.go:495","info":"creating cluster 'test-cluster'","time":"17-10-16 10:00:23.235"}
{"caller":"github.com/giantswarm/aws-operator/service/create/service.go:556","info":"waiting for k8s secrets...","time":"17-10-16 10:00:24.517"}
{"caller":"github.com/giantswarm/aws-operator/service/create/service.go:564","info":"waiting for k8s keys...","time":"17-10-16 10:00:24.538"}
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/randomkeytpr/service.go:90","debug":"searching secret: clusterKey=encryption, clusterID=test-cluster","time":"17-10-16 10:00:24.538"}
{"caller":"github.com/giantswarm/aws-operator/service/create/service.go:584","info":"kms key 'test-cluster' already exists, reusing","time":"17-10-16 10:00:24.788"}
E1016 10:00:26.518493       1 runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/home/fgimenez/src/go/src/runtime/asm_amd64.s:509
/home/fgimenez/src/go/src/runtime/panic.go:491
/home/fgimenez/src/go/src/runtime/panic.go:63
/home/fgimenez/src/go/src/runtime/signal_unix.go:367
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/client/aws/errors.go:39
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/resources/aws/policy.go:146
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:613
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:502
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:192
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:192
<autogenerated>:1
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:311
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:451
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:147
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:97
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:98
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:52
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:201
/home/fgimenez/src/go/src/sync/once.go:44
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:180
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:219
/home/fgimenez/src/go/src/sync/once.go:44
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:218
/home/fgimenez/src/go/src/runtime/asm_amd64.s:2337
E1016 10:00:26.519930       1 runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/home/fgimenez/src/go/src/runtime/asm_amd64.s:509
/home/fgimenez/src/go/src/runtime/panic.go:491
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58
/home/fgimenez/src/go/src/runtime/asm_amd64.s:509
/home/fgimenez/src/go/src/runtime/panic.go:491
/home/fgimenez/src/go/src/runtime/panic.go:63
/home/fgimenez/src/go/src/runtime/signal_unix.go:367
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/client/aws/errors.go:39
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/resources/aws/policy.go:146
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:613
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:502
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:192
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:192
<autogenerated>:1
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:311
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:451
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:147
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:97
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:98
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:52
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:201
/home/fgimenez/src/go/src/sync/once.go:44
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:180
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:219
/home/fgimenez/src/go/src/sync/once.go:44
/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:218
/home/fgimenez/src/go/src/runtime/asm_amd64.s:2337
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1673b72]

goroutine 22 [running]:
github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x111
panic(0x1949740, 0x2b40f60)
	/home/fgimenez/src/go/src/runtime/panic.go:491 +0x283
github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x111
panic(0x1949740, 0x2b40f60)
	/home/fgimenez/src/go/src/runtime/panic.go:491 +0x283
github.com/giantswarm/aws-operator/client/aws.IsIAMRoleDuplicateError(0x0, 0x0, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/client/aws/errors.go:39 +0x22
github.com/giantswarm/aws-operator/resources/aws.(*Policy).CreateIfNotExists(0xc4202855f0, 0xc4202855f0, 0x3, 0xc420314020)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/resources/aws/policy.go:146 +0x51
github.com/giantswarm/aws-operator/service/create.(*Service).processCluster(0xc420160200, 0xc4204461c8, 0x3, 0xc420314020, 0x18, 0xc420446210, 0xc, 0x0, 0x0, 0xc420446220, ...)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:613 +0x11f8
github.com/giantswarm/aws-operator/service/create.(*Service).addFunc(0xc420160200, 0x1b9d580, 0xc4201c3b00)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:502 +0x3ec
github.com/giantswarm/aws-operator/service/create.(*Service).(github.com/giantswarm/aws-operator/service/create.addFunc)-fm(0x1b9d580, 0xc4201c3b00)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:192 +0x3e
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(0xc42035bf20, 0xc42035bf40, 0xc42035bf30, 0x1b9d580, 0xc4201c3b00)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:192 +0x49
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd(0xc420145600, 0x1b9d580, 0xc4201c3b00)
	<autogenerated>:1 +0x62
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.NewInformer.func1(0x1976e40, 0xc4202179c0, 0x1976e40, 0xc4202179c0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:311 +0x1a8
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc4201bf380, 0xc420290cf0, 0x0, 0x0, 0x0, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:451 +0x268
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc420348a80)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:147 +0x40
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.(*controller).(github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.processLoop)-fm()
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121 +0x2a
github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc420411e00)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:97 +0x5e
github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc420583e00, 0x3b9aca00, 0x0, 0x180b601, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:98 +0xbd
github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0xc420411e00, 0x3b9aca00, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:52 +0x4d
github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc420348a80, 0x0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/k8s.io/client-go/tools/cache/controller.go:121 +0x22e
github.com/giantswarm/aws-operator/service/create.(*Service).Boot.func1()
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:201 +0x436
sync.(*Once).Do(0xc420160238, 0xc420020738)
	/home/fgimenez/src/go/src/sync/once.go:44 +0xbe
github.com/giantswarm/aws-operator/service/create.(*Service).Boot(0xc420160200)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/create/service.go:180 +0x4c
github.com/giantswarm/aws-operator/service.(*Service).Boot.func1()
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:219 +0x2d
sync.(*Once).Do(0xc4204b2eb8, 0xc4200207b8)
	/home/fgimenez/src/go/src/sync/once.go:44 +0xbe
github.com/giantswarm/aws-operator/service.(*Service).Boot(0xc4204b2ea0)
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/service.go:218 +0x4c
created by main.main.func1
	/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/main.go:63 +0x1f0
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl logs -f aws-operator-local-315647449-n2mmf
```
The panic comes from here https://github.com/giantswarm/aws-operator/blob/master/client/aws/errors.go#L39 if err is nil it blows up :)