### PR TITLE
Set route table when creating public subnet

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -822,6 +822,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		Clients:    clients,
 		Cluster:    cluster,
 		MakePublic: true,
+		RouteTable: routeTable,
 		VpcID:      vpcID,
 	}
 	publicSubnet, err := s.createSubnet(subnetInput)


### PR DESCRIPTION
Set route table when creating public subnet so it's made public.