### PR TITLE
remove etcd sg rule

### DIFF
--- a/examples/local/aws-resource-lab-chart/templates/cluster.yaml
+++ b/examples/local/aws-resource-lab-chart/templates/cluster.yaml
@@ -85,7 +85,7 @@ spec:
       routeTableNames:
       - {{.Values.aws.routeTable0}}
       - {{.Values.aws.routeTable1}}
-      peerid: "{{.Values.aws.vpcPeerId}}"
+      peerId: "{{.Values.aws.vpcPeerId}}"
 
     masters:
     - imageid: "{{.Values.aws.ami}}"

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -67,9 +67,8 @@ func (s *Service) deleteSecurityGroup(input securityGroupInput) error {
 	}
 	if err := securityGroup.Delete(); err != nil {
 		return microerror.Mask(err)
-	} else {
-		s.logger.Log("info", fmt.Sprintf("deleted security group '%s'", input.GroupName))
 	}
+	s.logger.Log("info", fmt.Sprintf("deleted security group '%s'", input.GroupName))
 
 	return nil
 }
@@ -79,11 +78,6 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 	return []awsresources.SecurityGroupRule{
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.API.SecurePort,
-			Protocol:   tcpProtocol,
-			SourceCIDR: defaultCIDR,
-		},
-		{
-			Port:       ri.Cluster.Spec.Cluster.Etcd.Port,
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
 		},

--- a/service/create/security_group.go
+++ b/service/create/security_group.go
@@ -9,6 +9,7 @@ import (
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/resources"
 	awsresources "github.com/giantswarm/aws-operator/resources/aws"
+	"github.com/giantswarm/aws-operator/service/key"
 )
 
 type securityGroupInput struct {
@@ -75,7 +76,7 @@ func (s *Service) deleteSecurityGroup(input securityGroupInput) error {
 
 // masterRules returns the rules for the masters security group.
 func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
-	return []awsresources.SecurityGroupRule{
+	rules := []awsresources.SecurityGroupRule{
 		{
 			Port:       ri.Cluster.Spec.Cluster.Kubernetes.API.SecurePort,
 			Protocol:   tcpProtocol,
@@ -98,6 +99,15 @@ func (ri rulesInput) masterRules() []awsresources.SecurityGroupRule {
 			SecurityGroupID: ri.WorkersSecurityGroupID,
 		},
 	}
+	// we need to add an etcd rule for old clusters
+	if !key.HasClusterVersion(ri.Cluster) {
+		rules = append(rules, awsresources.SecurityGroupRule{
+			Port:       ri.Cluster.Spec.Cluster.Etcd.Port,
+			Protocol:   tcpProtocol,
+			SourceCIDR: defaultCIDR,
+		})
+	}
+	return rules
 }
 
 // workerRules returns the rules for the workers security group.


### PR DESCRIPTION
Towards giantswarm/giantswarm#1803

Tested with local example:
```
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl get cs
NAME                 STATUS    MESSAGE              ERROR
scheduler            Healthy   ok                   
controller-manager   Healthy   ok                   
etcd-0               Healthy   {"health": "true"}   
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl get nodes
NAME                                           STATUS    AGE       VERSION
ip-10-1-12-199.eu-central-1.compute.internal   Ready     2m        v1.7.5+coreos.0
ip-10-1-12-230.eu-central-1.compute.internal   Ready     3m        v1.7.5+coreos.0
ip-10-1-12-239.eu-central-1.compute.internal   Ready     2m        v1.7.5+coreos.0
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl get pods --all-namespaces 
NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE
kube-system   calico-node-1517s                          2/2       Running   0          3m
kube-system   calico-node-c8qp8                          2/2       Running   0          3m
kube-system   calico-node-q4p0f                          2/2       Running   0          3m
kube-system   calico-policy-controller-59090804-qgw01    1/1       Running   0          3m
kube-system   default-http-backend-2945164050-w51bz      1/1       Running   0          2m
kube-system   default-http-backend-2945164050-zqqhn      1/1       Running   0          2m
kube-system   kube-dns-4244741379-ffvks                  3/3       Running   0          3m
kube-system   kube-dns-4244741379-nqh9v                  3/3       Running   0          3m
kube-system   kube-dns-4244741379-t2k76                  3/3       Running   0          3m
kube-system   nginx-ingress-controller-327853665-6wvvs   1/1       Running   0          3m
kube-system   nginx-ingress-controller-327853665-ngpzb   1/1       Running   0          3m
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl run --rm -i -t busybox --image=busybox -- sh
If you don't see a command prompt, try pressing enter.
/ # nslookup google.com
Server:    172.31.0.10
Address 1: 172.31.0.10 kube-dns.kube-system.svc.cluster.local

Name:      google.com
Address 1: 2a00:1450:4001:80b::200e fra15s28-in-x0e.1e100.net
Address 2: 172.217.21.238 fra16s13-in-f14.1e100.net
/ # exit
Session ended, resume using 'kubectl attach busybox-4158955249-q4pc4 -c busybox -i -t' command when the pod is running
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ export DNS="nginx1.test-cluster.k8s.gauss.eu-central-1.aws.gigantic.io"
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ wget https://gist.githubusercontent.com/r7vme/bf7b9d8baf5e709f137a23ec6c105b05/raw/4f6811ffeb0c12e48663fb31de29790ced021295/gistfile1.txt -O ingress_test.yaml
--2017-10-16 16:27:54--  https://gist.githubusercontent.com/r7vme/bf7b9d8baf5e709f137a23ec6c105b05/raw/4f6811ffeb0c12e48663fb31de29790ced021295/gistfile1.txt
Resolving gist.githubusercontent.com (gist.githubusercontent.com)... 151.101.132.133
Connecting to gist.githubusercontent.com (gist.githubusercontent.com)|151.101.132.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 847 [text/plain]
Saving to: ‘ingress_test.yaml’

ingress_test.yaml                                                   100%[==================================================================================================================================================================>]     847  --.-KB/s    in 0s      

2017-10-16 16:27:55 (124 MB/s) - ‘ingress_test.yaml’ saved [847/847]

fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ sed -i "s/PUT_SITE_DNS_HERE/${DNS}/" ingress_test.yaml
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl apply -f ingress_test.yaml
deployment "nginx-for-ingress-deployment" created
service "nginx-for-ingress-service" created
ingress "nginx-for-ingress-ingress" created
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ curl ${DNS}
default backend - 404fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ 
fgimenez@dunwich:~/workspace/gocode/src/github.com/giantswarm/aws-operator$ kubectl delete -f ingress_test.yaml 
deployment "nginx-for-ingress-deployment" deleted
service "nginx-for-ingress-service" deleted
ingress "nginx-for-ingress-ingress" deleted
```