### PR TITLE
Fix gofmt error

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1007,11 +1007,11 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 
 	// Create apiserver load balancer.
 	lbInput := LoadBalancerInput{
-		Name:        cluster.Spec.Cluster.Kubernetes.API.Domain,
-		Clients:     clients,
-		Cluster:     cluster,
+		Name:               cluster.Spec.Cluster.Kubernetes.API.Domain,
+		Clients:            clients,
+		Cluster:            cluster,
 		IdleTimeoutSeconds: cluster.Spec.AWS.ELB.IdleTimeoutSeconds.API,
-		InstanceIDs: masterIDs,
+		InstanceIDs:        masterIDs,
 		PortsToOpen: awsresources.PortPairs{
 			{
 				PortELB:      cluster.Spec.Cluster.Kubernetes.API.SecurePort,
@@ -1034,11 +1034,11 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 
 	// Create etcd load balancer.
 	lbInput = LoadBalancerInput{
-		Name:        cluster.Spec.Cluster.Etcd.Domain,
-		Clients:     clients,
-		Cluster:     cluster,
+		Name:               cluster.Spec.Cluster.Etcd.Domain,
+		Clients:            clients,
+		Cluster:            cluster,
 		IdleTimeoutSeconds: cluster.Spec.AWS.ELB.IdleTimeoutSeconds.Etcd,
-		InstanceIDs: masterIDs,
+		InstanceIDs:        masterIDs,
 		PortsToOpen: awsresources.PortPairs{
 			{
 				PortELB:      httpsPort,
@@ -1067,9 +1067,9 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 
 	// Create Ingress load balancer.
 	lbInput = LoadBalancerInput{
-		Name:    cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
-		Clients: clients,
-		Cluster: cluster,
+		Name:               cluster.Spec.Cluster.Kubernetes.IngressController.Domain,
+		Clients:            clients,
+		Cluster:            cluster,
 		IdleTimeoutSeconds: cluster.Spec.AWS.ELB.IdleTimeoutSeconds.Ingress,
 		PortsToOpen: awsresources.PortPairs{
 			{

--- a/service/create/validation_test.go
+++ b/service/create/validation_test.go
@@ -268,19 +268,18 @@ func TestValidateELBSparseStruct(t *testing.T) {
 // Specific test with a missing IdleTimeoutSeconds struct
 func TestValidateELBMissingStruct(t *testing.T) {
 	tests := []struct {
-		name                   string
-		expectedError          error
+		name          string
+		expectedError error
 	}{
 		{
-			name: "Valid timeout missing value invokes default",
-			expectedError:          nil,
+			name:          "Valid timeout missing value invokes default",
+			expectedError: nil,
 		},
 	}
 
 	for _, tc := range tests {
-		elb := aws.ELB{
-			// Missing nested structs
-		}
+		// Missing nested structs
+		elb := aws.ELB{}
 
 		err := validateELB(elb)
 		assert.Equal(t, tc.expectedError, microerror.Cause(err), tc.name)


### PR DESCRIPTION
This PR fixes a couple of gofmt errors in Tim from IC Consult's PR to set ELB idle timeouts. These didn't get picked up because CI doesn't work for forked repos.