### PR TITLE
Assign proxy policy to Ingress ELB and adapt ingress-controller ConfigMap

### DIFF
--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -201,6 +201,18 @@ func (lb *ELB) AssignProxyProtocolPolicy() error {
 		return microerror.Mask(err)
 	}
 
+	setPolicyInput := &elb.SetLoadBalancerPoliciesForBackendServerInput{
+		LoadBalancerName: aws.String(lb.Name),
+		PolicyNames:      []*string{aws.String(policyName)},
+	}
+	for _, portPair := range lb.PortsToOpen {
+		setPolicyInput.InstancePort = aws.Int64(int64(portPair.PortInstance))
+
+		if _, err := lb.Client.SetLoadBalancerPoliciesForBackendServer(setPolicyInput); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	return nil
 }
 

--- a/service/cloudconfig/templates.go
+++ b/service/cloudconfig/templates.go
@@ -171,6 +171,19 @@ write_files:
     provisioner: kubernetes.io/aws-ebs
     parameters:
       type: gp2
-      encrypted: "true" 
+      encrypted: "true"
+`
+
+	ingressControllerConfigMapTemplate = `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  server-name-hash-bucket-size: "1024"
+  server-name-hash-max-size: "1024"
+  use-proxy-protocol: "true"
 `
 )

--- a/service/cloudconfig/v_0_1_0_master_template.go
+++ b/service/cloudconfig/v_0_1_0_master_template.go
@@ -177,6 +177,14 @@ func (e *v_0_1_0MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			Encoding:     k8scloudconfig.GzipBase64,
 			Permissions:  0644,
 		},
+		// Add use-proxy-protocol to ingress-controller ConfigMap, this doesn't work
+		// on KVM because of dependencies on hardware LB configuration.
+		{
+			AssetContent: ingressControllerConfigMapTemplate,
+			Path:         "/srv/ingress-controller-cm.yml",
+			Owner:        FileOwner,
+			Permissions:  0644,
+		},
 	}
 
 	var newFiles []k8scloudconfig.FileAsset

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1027,11 +1027,6 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create apiserver load balancer: '%#v'", err))
 	}
 
-	// Assign the ProxyProtocol policy to the apiserver load balancer.
-	if err := apiLB.AssignProxyProtocolPolicy(); err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not assign proxy protocol policy: '%#v'", err))
-	}
-
 	// Create etcd load balancer.
 	lbInput = LoadBalancerInput{
 		Name:               cluster.Spec.Cluster.Etcd.Domain,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1952

The ELB proxy policy was being created for API and Ingress ELBs, but not assigned. These changes assign it to the ingress ELB (API was giving `Unable to connect to the server: remote error: tls: record overflow` error if applied).

This changeset also includes an aws-operator local extension to cloudconfig meanto to add to the ingress-controller ConfigMap. This change can't be added to k8scloudconfig because it breaks ingress on KVM guest clusters (details here https://github.com/giantswarm/k8scloudconfig/pull/226).