### PR TITLE
Adds retries to VPC acceptance

### DIFF
--- a/service/create/service.go
+++ b/service/create/service.go
@@ -694,6 +694,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 			Clients:     clients,
 			HostClients: hostClients,
 		},
+		Logger: s.logger,
 	}
 	vpcPeeringConnectionCreated, err := vpcPeeringConection.CreateIfNotExists()
 	if err != nil {
@@ -1539,6 +1540,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 			Clients:     clients,
 			HostClients: hostClients,
 		},
+		Logger: s.logger,
 	}
 	conn, err := vpcPeeringConection.FindExisting()
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1943

We've had issues where the vpc was created, but acceptance did not
succeed. We think this is due to eventual consistency inside AWS
networking components, so some retrying should make it more reliable.