### PR TITLE
Reuse existing ELBs and their DNS resource records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,20 +23,6 @@ jobs:
             ./architect deploy
           fi
 
-  e2eTestBuild:
-    machine: true
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
-
-    - run: |
-        cp -ar vendor e2e
-
-        cd e2e
-        ../architect build --project aws-operator-e2e
-
   e2eSetup:
     machine: true
     steps:
@@ -82,13 +68,9 @@ workflows:
   build_e2e:
     jobs:
       - build
-      - e2eTestBuild:
-          requires:
-          - build
       - e2eSetup:
           requires:
           - build
       - e2eTestExecution:
           requires:
           - e2eSetup
-          - e2eTestBuild

--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -56,16 +56,19 @@ func (lb *ELB) CreateIfNotExists() (bool, error) {
 		return false, microerror.Mask(clientNotInitializedError)
 	}
 
-	_, err := lb.findExisting()
-	if err == nil {
-		return false, nil
-	}
-
+	lbDescription, err := lb.findExisting()
 	if !strings.Contains(err.Error(), notFoundError.Error()) {
-
+		// error looking for elb
 		return false, err
 	}
 
+	if err == nil {
+		// elb found, initialize dns and hoested zone id
+		lb.setDNSFields(*lbDescription)
+		return false, nil
+	}
+
+	// elb not found, create
 	if err := lb.CreateOrFail(); err != nil {
 		return false, microerror.Mask(err)
 	}

--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -57,8 +57,13 @@ func (lb *ELB) CreateIfNotExists() (bool, error) {
 	}
 
 	_, err := lb.findExisting()
-	if err != nil && strings.Contains(err.Error(), notFoundError.Error()) {
+	if err == nil {
 		return false, nil
+	}
+
+	if !strings.Contains(err.Error(), notFoundError.Error()) {
+
+		return false, err
 	}
 
 	if err := lb.CreateOrFail(); err != nil {

--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -57,15 +57,16 @@ func (lb *ELB) CreateIfNotExists() (bool, error) {
 	}
 
 	lbDescription, err := lb.findExisting()
-	if !strings.Contains(err.Error(), notFoundError.Error()) {
-		// error looking for elb
-		return false, err
-	}
 
 	if err == nil {
 		// elb found, initialize dns and hoested zone id
 		lb.setDNSFields(*lbDescription)
 		return false, nil
+	}
+
+	if !strings.Contains(err.Error(), notFoundError.Error()) {
+		// error looking for elb
+		return false, err
 	}
 
 	// elb not found, create

--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -56,15 +56,15 @@ func (lb *ELB) CreateIfNotExists() (bool, error) {
 		return false, microerror.Mask(clientNotInitializedError)
 	}
 
-	lbDescription, err := lb.findExisting()
+	existingElb, err := lb.findExisting()
 
 	if err == nil {
-		// elb found, initialize dns and hoested zone id
-		lb.setDNSFields(*lbDescription)
+		// elb found, initialize dns and hosted zone id
+		lb.setDNSFields(*existingElb)
 		return false, nil
 	}
 
-	if !strings.Contains(err.Error(), notFoundError.Error()) {
+	if !strings.Contains(err.Error(), elb.ErrCodeAccessPointNotFoundException) {
 		// error looking for elb
 		return false, err
 	}

--- a/service/create/load_balancer.go
+++ b/service/create/load_balancer.go
@@ -66,7 +66,22 @@ func (s *Service) createLoadBalancer(input LoadBalancerInput) (*awsresources.ELB
 			return nil, microerror.Mask(err)
 		}
 	}
+
 	return lb, nil
+}
+
+func (s *Service) createIngressLoadBalancer(input LoadBalancerInput) (*awsresources.ELB, error) {
+	elb, err := s.createLoadBalancer(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// Assign the ProxyProtocol policy
+	if err := elb.AssignProxyProtocolPolicy(); err != nil {
+		return nil, microerror.Maskf(executionFailedError, fmt.Sprintf("could not assign proxy protocol policy: '%#v'", err))
+	}
+
+	return elb, nil
 }
 
 func (s *Service) deleteLoadBalancer(input LoadBalancerInput) error {

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1081,7 +1081,7 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		SubnetID:        publicSubnetID,
 	}
 
-	ingressLB, err := s.createIngressLoadBalancer(lbInput)
+	ingressLB, err := s.createLoadBalancer(lbInput)
 	if err != nil {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create ingress load balancer: '%#v'", err))
 	}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1081,17 +1081,10 @@ func (s *Service) processCluster(cluster awstpr.CustomObject) error {
 		SubnetID:        publicSubnetID,
 	}
 
-	ingressLB, err := s.createLoadBalancer(lbInput)
+	ingressLB, err := s.createIngressLoadBalancer(lbInput)
 	if err != nil {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create ingress load balancer: '%#v'", err))
 	}
-
-	// Assign the ProxyProtocol policy to the Ingress load balancer.
-	if err := ingressLB.AssignProxyProtocolPolicy(); err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not assign proxy protocol policy: '%#v'", err))
-	}
-
-	s.logger.Log("info", fmt.Sprintf("created ingress load balancer"))
 
 	// Create a launch configuration for the worker nodes.
 	lcInput := launchConfigurationInput{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2063

These changes will prevent the creation of a new ELB when a cluster is reprocessed, we were always creating new ones and updating the DNS entries even when they were already in place. Also, the proxy protocol is only assigned after creating a new ingress ELB, so that old clusters will keep the old configuration (the old ELBs will be reused and, because the ingress controller is not being created, the proxy policy will not be applied).

I've also included changes to the circleci pipeline, recent changes to architect make an empty project fail to build, and currently the in-cluster tests for this repo are empty, this build step will be readded when we have ready the first in-cluster test.