### PR TITLE
Add in-cluster test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,21 @@ jobs:
             ./architect deploy
           fi
 
+  e2eTestBuild:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: |
+        cp -ar vendor e2e
+        mkdir -p e2e/vendor/github.com/giantswarm/aws-operator/e2e
+        cp -ar e2e/tests e2e/vendor/github.com/giantswarm/aws-operator/e2e
+        cd e2e
+        ../architect build --project aws-operator-e2e
+
   e2eSetup:
     machine: true
     steps:
@@ -58,6 +73,9 @@ jobs:
 
     - run: ./e2e-harness test
 
+    - store_artifacts:
+        path: ./.e2e-harness/workdir/plugins/e2e/results.xml
+
     - run:
         name: Finish with cleanup, no matter if the test succeeded or not
         command: ./e2e-harness teardown
@@ -71,6 +89,10 @@ workflows:
       - e2eSetup:
           requires:
           - build
+      - e2eTestBuild:
+          requires:
+          - build
       - e2eTestExecution:
           requires:
           - e2eSetup
+          - e2eTestBuild

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.6
+
+ADD ./aws-operator-e2e /e2e
+
+ENTRYPOINT ["/e2e"]

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/giantswarm/aws-operator/e2e/tests"
+)
+
+func main() {
+	// architect requires this
+	if len(os.Args) > 1 {
+		return
+	}
+
+	if err := tests.Run(); err != nil {
+		log.Printf("error running tests: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/e2e/project.yaml
+++ b/e2e/project.yaml
@@ -6,7 +6,8 @@ setup:
       run: kubectl get namespace
       match: giantswarm\s*Active
 
-outOfClusterTest:
+  - run: helm delete aws-operator-chart --purge || true
+
   - run: |
       cat <<EOF > ./values.yaml
       Installation:
@@ -32,3 +33,6 @@ outOfClusterTest:
     waitFor:
       run: kubectl get pods -n giantswarm
       match: aws-operator-.*\s*1/1\s*Running
+
+inClusterTest:
+  enabled: true

--- a/e2e/tests/awstpr.go
+++ b/e2e/tests/awstpr.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"log"
+
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/client/k8sclient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	cs, err := k8sclient.New(k8sclient.DefaultConfig())
+	if err != nil {
+		log.Println("Could not create k8s client: ", err.Error())
+		return
+	}
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		log.Println("Could not create logger: ", err.Error())
+		return
+	}
+
+	ts := &TestSet{
+		clientset: cs,
+		logger:    logger,
+	}
+	Add(ts.TestCRExists)
+}
+
+func (ts *TestSet) TestCRExists() (string, error) {
+	desc := "aws TPR exists"
+
+	_, err := ts.clientset.ExtensionsV1beta1().ThirdPartyResources().Get(awstpr.Name, metav1.GetOptions{})
+	if err != nil {
+		ts.logger.Log("debug", "aws tpr not found, "+err.Error())
+		return desc, err
+	}
+	return desc, nil
+}

--- a/e2e/tests/runner.go
+++ b/e2e/tests/runner.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"github.com/giantswarm/e2e-harness/pkg/results"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Test is a generic type for all the test functions, it returns a
+// description of the tests and the eventually returned error
+type Test func() (string, error)
+
+type TestSet struct {
+	clientset kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+var (
+	// tests holds the array of functions to be executed
+	tests = []Test{}
+	// ts is the test suite that will keep the results
+	ts = &results.TestSuite{}
+)
+
+// Run executes all the tests and saves the results
+func Run() error {
+	for _, test := range tests {
+		ts.Tests++
+		desc, err := test()
+		tc := results.TestCase{
+			Name: desc,
+		}
+		if err != nil {
+			ts.Failures++
+			tc.Failure = &results.TestFailure{
+				Value: err.Error(),
+			}
+		}
+		ts.TestCases = append(ts.TestCases, tc)
+	}
+	fs := afero.NewOsFs()
+	return results.Write(fs, ts)
+}
+
+// Add appends the given test to the existing bundle
+func Add(t Test) {
+	tests = append(tests, t)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 14de7d102e3e38cbbaaf68f23e50a9228140467c7e3afc844615c240b60747b6
-updated: 2017-11-02T17:03:58.271840889+01:00
+hash: c98f890d6b2e4b61ed23bfe63b1248e4409c53e76a56848f9c461149c19665dc
+updated: 2017-11-02T17:32:35.316753398+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 8b344ddb7a49daf794928d1db484ad9a81499858
@@ -59,10 +59,11 @@ imports:
   - digest
   - reference
 - name: github.com/emicklei/go-restful
-  version: 09691a3b6378b740595c1002f40c34dd5f218a22
+  version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
   - log
-  - swagger
+- name: github.com/emicklei/go-restful-swagger12
+  version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/ghodss/yaml
@@ -147,10 +148,14 @@ imports:
   - transport/http
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
+- name: github.com/go-openapi/analysis
+  version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/loads
+  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38
 - name: github.com/go-openapi/spec
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
@@ -158,14 +163,14 @@ imports:
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/gogo/protobuf
-  version: e18d7aa8f8c624c915db340349aad4c49b10d173
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -174,6 +179,10 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/hcl
   version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
@@ -192,7 +201,7 @@ imports:
 - name: github.com/juju/errgo
   version: 08cceb5d0b5331634b9826762a8fd53b29b86ad8
 - name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/magiconair/properties
@@ -260,10 +269,9 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
-  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -292,7 +300,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 - name: k8s.io/apimachinery
-  version: 85ace5365f33b16fc735c866a12e3c765b9700f2
+  version: 8ab5f3d8a330c2e9baaf84e39042db8d49034ae2
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -303,8 +311,10 @@ imports:
   - pkg/apimachinery/registered
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
+  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/openapi
@@ -318,32 +328,31 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/cache
+  - pkg/util/clock
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
-  - pkg/util/httpstream
   - pkg/util/intstr
   - pkg/util/json
-  - pkg/util/mergepatch
   - pkg/util/net
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
-  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
-  - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 21300e3e11c918b8e6a70fb7293b310683d6c046
+  version: d92e8497f71b7b4e0494e5bd204b48d34bd6f254
   subpackages:
   - discovery
   - kubernetes
   - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
@@ -356,6 +365,7 @@ imports:
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/networking/v1
   - kubernetes/typed/policy/v1beta1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
@@ -363,45 +373,38 @@ imports:
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
   - pkg/api
-  - pkg/api/install
   - pkg/api/v1
+  - pkg/api/v1/ref
+  - pkg/apis/admissionregistration
+  - pkg/apis/admissionregistration/v1alpha1
   - pkg/apis/apps
-  - pkg/apis/apps/install
   - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
-  - pkg/apis/authentication/install
   - pkg/apis/authentication/v1
   - pkg/apis/authentication/v1beta1
   - pkg/apis/authorization
-  - pkg/apis/authorization/install
   - pkg/apis/authorization/v1
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
   - pkg/apis/autoscaling/v1
   - pkg/apis/autoscaling/v2alpha1
   - pkg/apis/batch
-  - pkg/apis/batch/install
   - pkg/apis/batch/v1
   - pkg/apis/batch/v2alpha1
   - pkg/apis/certificates
-  - pkg/apis/certificates/install
   - pkg/apis/certificates/v1beta1
   - pkg/apis/extensions
-  - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
+  - pkg/apis/networking
+  - pkg/apis/networking/v1
   - pkg/apis/policy
-  - pkg/apis/policy/install
   - pkg/apis/policy/v1beta1
   - pkg/apis/rbac
-  - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
   - pkg/apis/rbac/v1beta1
   - pkg/apis/settings
-  - pkg/apis/settings/install
   - pkg/apis/settings/v1alpha1
   - pkg/apis/storage
-  - pkg/apis/storage/install
   - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
   - pkg/util
@@ -414,7 +417,6 @@ imports:
   - tools/metrics
   - transport
   - util/cert
-  - util/clock
   - util/flowcontrol
   - util/integer
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4825e5e5dd4daf6c22025b330d50debf71d6e97d94b86452d3922296f39fbfcf
-updated: 2017-11-02T13:06:42.153099066+01:00
+hash: 14de7d102e3e38cbbaaf68f23e50a9228140467c7e3afc844615c240b60747b6
+updated: 2017-11-02T17:03:58.271840889+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 8b344ddb7a49daf794928d1db484ad9a81499858
@@ -59,11 +59,10 @@ imports:
   - digest
   - reference
 - name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
+  version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
   - log
-- name: github.com/emicklei/go-restful-swagger12
-  version: dcef7f55730566d41eae5db10e7d6981829720f6
+  - swagger
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/ghodss/yaml
@@ -87,8 +86,13 @@ imports:
   - spec/kubernetes/kubectl
   - spec/kubernetes/networksetup
   - spec/kubernetes/ssh
+- name: github.com/giantswarm/e2e-harness
+  version: 6fd13b9585c02e73def00ec7d22c22b4bd340838
+  subpackages:
+  - pkg/results
+  - pkg/runner
 - name: github.com/giantswarm/k8scloudconfig
-  version: 062d12fb69491f892fe3cb43524d16940ae50097
+  version: be9f399432713d5ec7223c3eca6fd9ecfb922456
   subpackages:
   - v_0_1_0
 - name: github.com/giantswarm/microendpoint
@@ -132,7 +136,7 @@ imports:
 - name: github.com/giantswarm/randomkeytpr
   version: 9e1d78d125841c496889e8a54d49057212a2893e
 - name: github.com/giantswarm/versionbundle
-  version: 74ece9fd181fc5ef2a8510cbeb408485f9a0b1a3
+  version: 4d1e771cce94902dc952eed5deef58ebbcbb973f
 - name: github.com/go-ini/ini
   version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
 - name: github.com/go-kit/kit
@@ -143,14 +147,10 @@ imports:
   - transport/http
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
-- name: github.com/go-openapi/analysis
-  version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/loads
-  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38
 - name: github.com/go-openapi/spec
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
@@ -158,14 +158,14 @@ imports:
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -174,10 +174,6 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
-- name: github.com/hashicorp/golang-lru
-  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
-  subpackages:
-  - simplelru
 - name: github.com/hashicorp/hcl
   version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
@@ -196,7 +192,7 @@ imports:
 - name: github.com/juju/errgo
   version: 08cceb5d0b5331634b9826762a8fd53b29b86ad8
 - name: github.com/juju/ratelimit
-  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/magiconair/properties
@@ -264,9 +260,10 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
+  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -295,7 +292,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 - name: k8s.io/apimachinery
-  version: 8ab5f3d8a330c2e9baaf84e39042db8d49034ae2
+  version: 85ace5365f33b16fc735c866a12e3c765b9700f2
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -306,10 +303,8 @@ imports:
   - pkg/apimachinery/registered
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
-  - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
-  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/openapi
@@ -323,31 +318,32 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
-  - pkg/util/cache
-  - pkg/util/clock
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
+  - pkg/util/httpstream
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/mergepatch
   - pkg/util/net
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: d92e8497f71b7b4e0494e5bd204b48d34bd6f254
+  version: 21300e3e11c918b8e6a70fb7293b310683d6c046
   subpackages:
   - discovery
   - kubernetes
   - kubernetes/scheme
-  - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1beta1
@@ -360,7 +356,6 @@ imports:
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
-  - kubernetes/typed/networking/v1
   - kubernetes/typed/policy/v1beta1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
@@ -368,38 +363,45 @@ imports:
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
   - pkg/api
+  - pkg/api/install
   - pkg/api/v1
-  - pkg/api/v1/ref
-  - pkg/apis/admissionregistration
-  - pkg/apis/admissionregistration/v1alpha1
   - pkg/apis/apps
+  - pkg/apis/apps/install
   - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
+  - pkg/apis/authentication/install
   - pkg/apis/authentication/v1
   - pkg/apis/authentication/v1beta1
   - pkg/apis/authorization
+  - pkg/apis/authorization/install
   - pkg/apis/authorization/v1
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
   - pkg/apis/autoscaling/v1
   - pkg/apis/autoscaling/v2alpha1
   - pkg/apis/batch
+  - pkg/apis/batch/install
   - pkg/apis/batch/v1
   - pkg/apis/batch/v2alpha1
   - pkg/apis/certificates
+  - pkg/apis/certificates/install
   - pkg/apis/certificates/v1beta1
   - pkg/apis/extensions
+  - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
-  - pkg/apis/networking
-  - pkg/apis/networking/v1
   - pkg/apis/policy
+  - pkg/apis/policy/install
   - pkg/apis/policy/v1beta1
   - pkg/apis/rbac
+  - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
   - pkg/apis/rbac/v1beta1
   - pkg/apis/settings
+  - pkg/apis/settings/install
   - pkg/apis/settings/v1alpha1
   - pkg/apis/storage
+  - pkg/apis/storage/install
   - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
   - pkg/util
@@ -412,6 +414,7 @@ imports:
   - tools/metrics
   - transport
   - util/cert
+  - util/clock
   - util/flowcontrol
   - util/integer
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,3 +27,7 @@ import:
   version: master
 - package: github.com/giantswarm/randomkeytpr
   version: master
+- package: github.com/giantswarm/e2e-harness
+  version: master
+- package: k8s.io/client-go
+  version: v3.0.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,5 +29,3 @@ import:
   version: master
 - package: github.com/giantswarm/e2e-harness
   version: master
-- package: k8s.io/client-go
-  version: v3.0.0

--- a/vendor/github.com/giantswarm/e2e-harness/.circleci/config.yml
+++ b/vendor/github.com/giantswarm/e2e-harness/.circleci/config.yml
@@ -1,0 +1,102 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+    - checkout
+
+    - run: |
+        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+        chmod +x ./architect
+        ./architect version
+
+    - run: ./architect build
+
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./e2e-harness
+        - ./architect
+
+    - deploy:
+        command: |
+          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            ./architect deploy
+          fi
+
+  e2eTestBuild:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: |
+        cp -ar vendor e2e
+
+        # the next commands are only needed for dog-fooding this repo
+        mkdir -p e2e/vendor/github.com/giantswarm/e2e-harness
+        cp -ar pkg e2e/vendor/github.com/giantswarm/e2e-harness
+
+        cd e2e
+        ../architect build --project e2e-harness-e2e
+
+  e2eSetup:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: ./e2e-harness setup --name=ci-e2e-harness-${CIRCLE_SHA1:0:7}
+
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./.e2e-harness
+
+  e2eTestExecution:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: ./e2e-harness test
+
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./.e2e-harness
+
+  e2eTeardown:
+    machine: true
+    steps:
+    - checkout
+
+    - attach_workspace:
+        at: .
+
+    - run: ./e2e-harness teardown
+
+workflows:
+  version: 2
+  build_e2e:
+    jobs:
+      - build
+      - e2eTestBuild:
+          requires:
+          - build
+      - e2eSetup:
+          requires:
+          - build
+      - e2eTestExecution:
+          requires:
+          - e2eSetup
+          - e2eTestBuild
+      - e2eTeardown:
+          requires:
+          - e2eTestExecution

--- a/vendor/github.com/giantswarm/e2e-harness/.gitignore
+++ b/vendor/github.com/giantswarm/e2e-harness/.gitignore
@@ -1,0 +1,2 @@
+.e2e-harness*
+e2e-harness

--- a/vendor/github.com/giantswarm/e2e-harness/CONTRIBUTING.md
+++ b/vendor/github.com/giantswarm/e2e-harness/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# How to contribute
+
+e2e-harness is Apache 2.0 licensed and accepts contributions via GitHub pull requests. This document outlines some of the conventions on commit message formatting, contact points for developers and other resources to make getting your contribution into e2e-harness easier.
+
+# Email and chat
+
+- Email: [giantswarm](https://groups.google.com/forum/#!forum/giantswarm)
+- IRC: #[giantswarm](irc://irc.freenode.org:6667/#giantswarm) IRC channel on freenode.org
+
+## Getting started
+
+- Fork the repository on GitHub
+- Read the [README](README.md) for build instructions
+
+## Reporting Bugs and Creating Issues
+
+Reporting bugs is one of the best ways to contribute. If you find bugs or documentation mistakes in the e2e-harness project, please let us know by [opening an issue](https://github.com/giantswarm/e2e-harness/issues/new). We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check there that one does not already exist.
+
+To make your bug report accurate and easy to understand, please try to create bug reports that are:
+
+- Specific. Include as much details as possible: which version, what environment, what configuration, etc. You can also attach logs.
+
+- Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please includes the steps that might lead to the problem. If applicable, you can also attach affected data dir(s) and a stack trace to the bug report.
+
+- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on e2e-harness is out of scope, but we are happy to point you in the right direction or help you interact with e2e-harness in the correct manner.
+
+- Unique. Do not duplicate existing bug reports.
+
+- Scoped. One bug per report. Do not follow up with another bug inside one report.
+
+You might also want to read [Elika Etemad’s article on filing good bug reports](http://fantasai.inkedblade.net/style/talks/filing-good-bugs/) before creating a bug report.
+
+We might ask you for further information to locate a bug. A duplicated bug report will be closed.
+
+## Contribution flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a feature branch from where you want to base your work. This is usually master.
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Submit a pull request to giantswarm/e2e-harness.
+- Adding unit tests will greatly improve the chance for getting a quick review and your PR accepted.
+- Your PR must receive a LGTM from one maintainer found in the MAINTAINERS file.
+- Before merging your PR be sure to squash all commits into one.
+
+Thanks for your contributions!
+
+### Code style
+
+The coding style suggested by the Golang community is used. See the [style doc](https://github.com/golang/go/wiki/CodeReviewComments) for details.
+
+Please follow this style to make the code easy to review, maintain, and develop.
+
+### Format of the Commit Message
+
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why. The subject line should feature the what and
+the body of the commit should describe the why.

--- a/vendor/github.com/giantswarm/e2e-harness/DCO
+++ b/vendor/github.com/giantswarm/e2e-harness/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/vendor/github.com/giantswarm/e2e-harness/Dockerfile
+++ b/vendor/github.com/giantswarm/e2e-harness/Dockerfile
@@ -1,0 +1,48 @@
+FROM alpine:3.6
+
+RUN adduser -D -u 1001 e2e-harness
+ENV HOME=/home/e2e-harness
+ENV WORKDIR=/workdir
+
+RUN mkdir -p ${HOME}/resources ${WORKDIR}
+ADD resources/ ${HOME}/resources
+
+RUN chown -R e2e-harness:e2e-harness ${WORKDIR} ${HOME}
+
+RUN apk -Uuv add --update --no-cache \
+      bash=4.3.48-r1 \
+      build-base=0.5-r0 \
+      git=2.13.5-r0 \
+      jq=1.5-r3 \
+      less=487-r0 \
+      libffi-dev=3.2.1-r3 \
+      openssh-client=7.5_p1-r1 \
+      openssl=1.0.2k-r0
+
+ENV KUBECTL_VERSION=v1.8.1
+ENV HELM_VERSION=v2.6.2
+ENV SHIPYARD_VERSION=v0.1.0
+
+RUN wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+  chmod a+x ./kubectl && \
+  mv ./kubectl /usr/local/bin
+
+RUN wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+  tar zxfv helm-${HELM_VERSION}-linux-amd64.tar.gz && \
+  chmod a+x ./linux-amd64/helm && \
+  mv ./linux-amd64/helm /usr/local/bin && \
+  rm -rf ./linux-amd64 helm-${HELM_VERSION}-linux-amd64.tar.gz
+
+RUN wget https://github.com/giantswarm/shipyard/releases/download/${SHIPYARD_VERSION}/shipyard && \
+  chmod a+x ./shipyard && \
+  mv ./shipyard /usr/local/bin
+
+USER e2e-harness
+
+RUN mkdir -p ${HOME}/.helm/plugins/ && \
+  git clone https://github.com/app-registry/appr-helm-plugin.git ${HOME}/.helm/plugins/registry && \
+  helm registry --help
+
+WORKDIR ${WORKDIR}
+
+ENTRYPOINT ["/bin/true"]

--- a/vendor/github.com/giantswarm/e2e-harness/LICENSE
+++ b/vendor/github.com/giantswarm/e2e-harness/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/giantswarm/e2e-harness/README.md
+++ b/vendor/github.com/giantswarm/e2e-harness/README.md
@@ -1,0 +1,27 @@
+# e2e-harness
+
+[![CircleCI](https://circleci.com/gh/giantswarm/e2e-harness.svg?style=shield)](https://circleci.com/gh/giantswarm/e2e-harness)
+
+Harness for custom kubernetes e2e testing.
+
+## Getting Project
+
+Clone the git repository: https://github.com/giantswarm/e2e-harness.git
+
+## Running e2e-harness
+
+TODO
+
+## Contact
+
+- Mailing list: [giantswarm](https://groups.google.com/forum/!forum/giantswarm)
+- IRC: #[giantswarm](irc://irc.freenode.org:6667/#giantswarm) on freenode.org
+- Bugs: [issues](https://github.com/giantswarm/e2e-harness/issues)
+
+## Contributing & Reporting Bugs
+
+See [CONTRIBUTING.md](/giantswarm/e2e-harness/blob/master/CONTRIBUTING.md) for details on submitting patches, the contribution workflow as well as reporting bugs.
+
+## License
+
+E2e-Harness is under the Apache 2.0 license. See the [LICENSE](/giantswarm/e2e-harness/blob/master/LICENSE) file for details.

--- a/vendor/github.com/giantswarm/e2e-harness/cmd/root.go
+++ b/vendor/github.com/giantswarm/e2e-harness/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	RootCmd = &cobra.Command{
+		Use:   "e2e-harness",
+		Short: "Harness for custom kubernetes e2e testing",
+	}
+
+	gitCommit   string
+	projectName string
+)
+
+func SetGitCommit(value string) {
+	gitCommit = value
+}
+
+func GetGitCommit() string {
+	return gitCommit
+}
+
+func SetProjectName(value string) {
+	projectName = value
+}
+
+func GetProjectName() string {
+	return projectName
+}

--- a/vendor/github.com/giantswarm/e2e-harness/cmd/setup.go
+++ b/vendor/github.com/giantswarm/e2e-harness/cmd/setup.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"github.com/giantswarm/e2e-harness/pkg/cluster"
+	"github.com/giantswarm/e2e-harness/pkg/docker"
+	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/e2e-harness/pkg/patterns"
+	"github.com/giantswarm/e2e-harness/pkg/project"
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+	"github.com/giantswarm/e2e-harness/pkg/wait"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	SetupCmd = &cobra.Command{
+		Use:   "setup",
+		Short: "setup e2e tests",
+		RunE:  runSetup,
+	}
+	remoteCluster bool
+	name          string
+)
+
+func init() {
+	RootCmd.AddCommand(SetupCmd)
+
+	SetupCmd.Flags().BoolVar(&remoteCluster, "remote-cluster", true, "use remote cluster")
+	SetupCmd.Flags().StringVar(&name, "name", "e2e-harness", "CI execution identifier")
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	gitCommit := GetGitCommit()
+	projectName := GetProjectName()
+
+	d := docker.New(logger, gitCommit)
+	pa := patterns.New(logger)
+	w := wait.New(logger, d, pa)
+	pCfg := &project.Config{
+		Name:      projectName,
+		GitCommit: gitCommit,
+	}
+	pDeps := &project.Dependencies{
+		Logger: logger,
+		Runner: d,
+		Wait:   w,
+	}
+	p := project.New(pDeps, pCfg)
+	hCfg := harness.Config{
+		RemoteCluster: remoteCluster,
+	}
+	h := harness.New(logger, hCfg)
+	c := cluster.New(logger, d, remoteCluster)
+
+	// tasks to run
+	bundle := []tasks.Task{
+		h.Init,
+		c.Create,
+		p.CommonSetupSteps,
+		p.SetupSteps,
+		h.WriteConfig,
+	}
+
+	return tasks.Run(bundle)
+}

--- a/vendor/github.com/giantswarm/e2e-harness/cmd/setup_test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/cmd/setup_test.go
@@ -1,0 +1,24 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/giantswarm/e2e-harness/cmd"
+)
+
+func TestSetupFlags(t *testing.T) {
+	remoteFlag := cmd.SetupCmd.Flags().Lookup("remote-cluster")
+
+	t.Run("flag exists", func(t *testing.T) {
+		if remoteFlag == nil {
+			t.Errorf("expected remoteFlag not nil")
+		}
+	})
+	t.Run("flag value", func(t *testing.T) {
+		actual := remoteFlag.Value.String()
+		expected := "true"
+		if actual != expected {
+			t.Errorf("expected %s, got %s", expected, actual)
+		}
+	})
+}

--- a/vendor/github.com/giantswarm/e2e-harness/cmd/teardown.go
+++ b/vendor/github.com/giantswarm/e2e-harness/cmd/teardown.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/giantswarm/e2e-harness/pkg/cluster"
+	"github.com/giantswarm/e2e-harness/pkg/docker"
+	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/e2e-harness/pkg/patterns"
+	"github.com/giantswarm/e2e-harness/pkg/project"
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+	"github.com/giantswarm/e2e-harness/pkg/wait"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	TeardownCmd = &cobra.Command{
+		Use:   "teardown",
+		Short: "teardown e2e tests",
+		RunE:  runTeardown,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(TeardownCmd)
+}
+
+func runTeardown(cmd *cobra.Command, args []string) error {
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		return err
+	}
+	h := harness.New(logger, harness.Config{})
+	cfg, err := h.ReadConfig()
+	if err != nil {
+		return err
+	}
+	imageTag := GetGitCommit()
+	projectName := GetProjectName()
+
+	d := docker.New(logger, imageTag)
+	pa := patterns.New(logger)
+	w := wait.New(logger, d, pa)
+	pCfg := &project.Config{
+		Name:      projectName,
+		GitCommit: gitCommit,
+	}
+	pDeps := &project.Dependencies{
+		Logger: logger,
+		Runner: d,
+		Wait:   w,
+	}
+	p := project.New(pDeps, pCfg)
+	c := cluster.New(logger, d, cfg.RemoteCluster)
+
+	bundle := []tasks.Task{
+		p.TeardownSteps,
+		c.Delete,
+	}
+
+	return tasks.Run(bundle)
+}

--- a/vendor/github.com/giantswarm/e2e-harness/cmd/test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/cmd/test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"github.com/giantswarm/e2e-harness/pkg/docker"
+	"github.com/giantswarm/e2e-harness/pkg/patterns"
+	"github.com/giantswarm/e2e-harness/pkg/project"
+	"github.com/giantswarm/e2e-harness/pkg/results"
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+	"github.com/giantswarm/e2e-harness/pkg/wait"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+var (
+	TestCmd = &cobra.Command{
+		Use:   "test",
+		Short: "execute e2e tests",
+		RunE:  runTest,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(TestCmd)
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	logger, err := micrologger.New(micrologger.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	gitCommit := GetGitCommit()
+	projectName := GetProjectName()
+
+	d := docker.New(logger, gitCommit)
+	pa := patterns.New(logger)
+	w := wait.New(logger, d, pa)
+	pCfg := &project.Config{
+		Name:      projectName,
+		GitCommit: gitCommit,
+	}
+	fs := afero.NewOsFs()
+	r := results.New(logger, fs, d)
+	pDeps := &project.Dependencies{
+		Logger:  logger,
+		Runner:  d,
+		Wait:    w,
+		Results: r,
+	}
+	p := project.New(pDeps, pCfg)
+
+	// tasks to run
+	bundle := []tasks.Task{
+		p.OutOfClusterTest,
+		p.InClusterTest,
+	}
+
+	return tasks.Run(bundle)
+}

--- a/vendor/github.com/giantswarm/e2e-harness/e2e/Dockerfile
+++ b/vendor/github.com/giantswarm/e2e-harness/e2e/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.6
+
+ADD e2e-harness-e2e /opt/e2e
+
+ENTRYPOINT ["/opt/e2e"]

--- a/vendor/github.com/giantswarm/e2e-harness/e2e/main.go
+++ b/vendor/github.com/giantswarm/e2e-harness/e2e/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/giantswarm/e2e-harness/pkg/results"
+	"github.com/spf13/afero"
+)
+
+func main() {
+	if len(os.Args) > 1 {
+		if os.Args[1] == "version" {
+			fmt.Println("0.1.0")
+			return
+		}
+
+		if os.Args[1] == "--help" {
+			fmt.Println("Yet another lookout")
+			return
+		}
+	}
+
+	ts := &results.TestSuite{
+		Tests:    1,
+		Failures: 0,
+		Errors:   0,
+	}
+	fs := afero.NewOsFs()
+	if err := results.Write(fs, ts); err != nil {
+		log.Fatalf("could not write results: %v", err)
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/e2e/project.yaml
+++ b/vendor/github.com/giantswarm/e2e-harness/e2e/project.yaml
@@ -1,0 +1,14 @@
+version: 1
+setup:
+  - run: helm registry install quay.io/giantswarm/cert-operator-lab-chart -- --set imageTag=latest --set clusterName=my-cluster --wait
+    waitFor:
+      run: kubectl get certificate
+      match: No resources found\.
+
+  - run: helm registry install quay.io/giantswarm/cert-resource-lab-chart -- --set clusterName=my-cluster
+    waitFor:
+      run: kubectl get secrets
+      match: my-cluster-api\s*Opaque
+
+inClusterTest:
+  enabled: true

--- a/vendor/github.com/giantswarm/e2e-harness/glide.lock
+++ b/vendor/github.com/giantswarm/e2e-harness/glide.lock
@@ -1,0 +1,37 @@
+hash: ac5dce2b3ae48948eb87c06bb716045dd011499f8cec1cb79cdb8c63dded463d
+updated: 2017-10-20T14:10:15.276450748+02:00
+imports:
+- name: github.com/giantswarm/microerror
+  version: 5ade94eb4ee35ef72eb9382228470caeddb29989
+- name: github.com/giantswarm/micrologger
+  version: 8a69b2ab80ba2d0bd40d609206518fefacfc8fdf
+- name: github.com/go-kit/kit
+  version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
+  subpackages:
+  - log
+- name: github.com/go-logfmt/logfmt
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
+- name: github.com/go-stack/stack
+  version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/juju/errgo
+  version: 08cceb5d0b5331634b9826762a8fd53b29b86ad8
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
+- name: github.com/spf13/afero
+  version: e67d870304c4bca21331b02f414f970df13aa694
+  subpackages:
+  - mem
+- name: github.com/spf13/cobra
+  version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
+- name: github.com/spf13/pflag
+  version: 97afa5e7ca8a08a383cb259e06636b5e2cc7897f
+- name: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+testImports:
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - transform
+  - unicode/norm

--- a/vendor/github.com/giantswarm/e2e-harness/glide.yaml
+++ b/vendor/github.com/giantswarm/e2e-harness/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/giantswarm/e2e-harness
+import:
+- package: github.com/giantswarm/micrologger
+  version: master
+- package: github.com/giantswarm/microerror
+  version: master
+- package: github.com/spf13/afero
+  version: master
+- package: gopkg.in/yaml.v2
+  version: master
+- package: github.com/spf13/cobra
+  version: master
+- package: github.com/spf13/pflag
+  version: master

--- a/vendor/github.com/giantswarm/e2e-harness/main.go
+++ b/vendor/github.com/giantswarm/e2e-harness/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/giantswarm/e2e-harness/cmd"
+)
+
+var (
+	gitCommit = "n/a"
+	name      = "e2e-harness"
+)
+
+func main() {
+	cmd.SetGitCommit(gitCommit)
+	cmd.SetProjectName(name)
+
+	if err := cmd.RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/cluster/cluster.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/cluster/cluster.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/giantswarm/e2e-harness/pkg/runner"
+	"github.com/giantswarm/micrologger"
+)
+
+type Cluster struct {
+	logger        micrologger.Logger
+	runner        runner.Runner
+	remoteCluster bool
+}
+
+func New(logger micrologger.Logger, runner runner.Runner, remoteCluster bool) *Cluster {
+	return &Cluster{
+		logger:        logger,
+		runner:        runner,
+		remoteCluster: remoteCluster,
+	}
+}
+
+// Create is a Task that creates a remote cluster.
+func (c *Cluster) Create() error {
+	return c.clusterAction("shipyard -action=start")
+}
+
+// Delete is a Task that gets rid of a remote cluster.
+func (c *Cluster) Delete() error {
+	return c.clusterAction("shipyard -action=stop")
+}
+
+func (c *Cluster) clusterAction(command string) error {
+	if !c.remoteCluster {
+		return nil
+	}
+	err := c.runner.Run(os.Stdout, command)
+
+	return err
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/docker/docker.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/docker/docker.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/micrologger"
+)
+
+type Docker struct {
+	logger   micrologger.Logger
+	imageTag string
+}
+
+func New(logger micrologger.Logger, imageTag string) *Docker {
+	return &Docker{
+		logger:   logger,
+		imageTag: imageTag,
+	}
+}
+
+// RunPortForward executes a command in the e2e-harness container after
+// setting up the port forwarding to the remote cluster, this command
+// is meant to be used after that cluster has been initialized
+func (d *Docker) RunPortForward(out io.Writer, command string) error {
+	args := append([]string{"quay.io/giantswarm/e2e-harness:" + d.imageTag}, "-c",
+		fmt.Sprintf("shipyard -action=forward-port && %s", command))
+
+	return d.baseRun(out, "/bin/bash", args)
+}
+
+// Run executes a command in the e2e-harness container.
+func (d *Docker) Run(out io.Writer, command string) error {
+	var args []string
+	fields := strings.Fields(command)
+	if len(fields) > 1 {
+		args = fields[1:]
+	}
+
+	args = append([]string{"quay.io/giantswarm/e2e-harness:" + d.imageTag}, args...)
+
+	return d.baseRun(out, fields[0], args)
+}
+
+func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string) error {
+	dir, err := harness.BaseDir()
+	if err != nil {
+		return err
+	}
+
+	baseArgs := []string{
+		"run",
+		"-v", fmt.Sprintf("%s:%s", filepath.Join(dir, "workdir"), "/workdir"),
+		"-e", fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", os.Getenv("AWS_ACCESS_KEY_ID")),
+		"-e", fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", os.Getenv("AWS_SECRET_ACCESS_KEY")),
+		"-e", "KUBECONFIG=/workdir/.shipyard/config",
+		"--entrypoint", entrypoint,
+	}
+	baseArgs = append(baseArgs, args...)
+
+	cmd := exec.Command("docker", baseArgs...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	return cmd.Run()
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/harness/harness.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/harness/harness.go
@@ -1,0 +1,86 @@
+package harness
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/giantswarm/micrologger"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	defaultConfigFile = "config.yaml"
+)
+
+type Harness struct {
+	logger micrologger.Logger
+	cfg    Config
+}
+
+type Config struct {
+	RemoteCluster bool `yaml:"remoteCluster"`
+}
+
+func New(logger micrologger.Logger, cfg Config) *Harness {
+	return &Harness{
+		logger: logger,
+		cfg:    cfg,
+	}
+}
+
+// Init initializes the harness.
+func (h *Harness) Init() error {
+	baseDir, err := BaseDir()
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(filepath.Join(baseDir, "workdir"), os.ModePerm)
+}
+
+// WriteConfig is a Task that persists the current config to a file.
+func (h *Harness) WriteConfig() error {
+	dir, err := BaseDir()
+	if err != nil {
+		return err
+	}
+
+	content, err := yaml.Marshal(&h.cfg)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(dir, defaultConfigFile), []byte(content), 0644)
+
+	return err
+}
+
+// ReadConfig is a Task that populates a Config struct data read
+// from a default file location.
+func (h *Harness) ReadConfig() (Config, error) {
+	dir, err := BaseDir()
+	if err != nil {
+		return Config{}, err
+	}
+
+	content, err := ioutil.ReadFile(filepath.Join(dir, defaultConfigFile))
+	if err != nil {
+		return Config{}, err
+	}
+
+	c := &Config{}
+
+	if err := yaml.Unmarshal(content, c); err != nil {
+		return Config{}, err
+	}
+
+	return *c, nil
+}
+
+func BaseDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".e2e-harness"), nil
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/patterns/patterns.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/patterns/patterns.go
@@ -1,0 +1,43 @@
+package patterns
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+
+	"github.com/giantswarm/micrologger"
+)
+
+type Matcher interface {
+	Find(input io.Reader, pattern string) (bool, error)
+}
+
+type Patterns struct {
+	logger micrologger.Logger
+}
+
+func New(logger micrologger.Logger) *Patterns {
+	return &Patterns{
+		logger: logger,
+	}
+}
+
+// Find returns true if the given pattern is found in the input pipe.
+func (pa *Patterns) Find(input io.Reader, pattern string) (bool, error) {
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, err
+	}
+
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		pa.logger.Log("debug", "line to match: "+scanner.Text())
+		if r.MatchString(scanner.Text()) {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/patterns/patterns_test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/patterns/patterns_test.go
@@ -1,0 +1,105 @@
+package patterns_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/e2e-harness/pkg/patterns"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func TestFindMatch(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		pattern     string
+		error       bool
+		expected    bool
+	}{
+		{
+			description: "basic match",
+			input:       "aabbaa",
+			pattern:     "bb",
+			error:       false,
+			expected:    true,
+		},
+		{
+			description: "multiline match",
+			input: `aa
+bb
+aa`,
+			pattern:  "bb",
+			error:    false,
+			expected: true,
+		},
+		{
+			description: "kubectl-like match",
+			input: `NAMESPACE     NAME                             READY     STATUS    RESTARTS   AGE
+kube-system   kube-addon-manager-minikube      1/1       Running   1          16h
+kube-system   kube-dns-1326421443-whr1s        3/3       Running   3          16h
+kube-system   kubernetes-dashboard-29pll       1/1       Running   1          16h
+kube-system   tiller-deploy-1046433508-ch23h   1/1       Running   1          16h
+`,
+			pattern:  `tiller-deploy.*1/1\s*Running`,
+			error:    false,
+			expected: true,
+		},
+		{
+			description: "basic unmatch",
+			input:       "aaccaa",
+			pattern:     "bb",
+			error:       false,
+			expected:    false,
+		},
+		{
+			description: "multiline unmatch",
+			input: `aa
+cc
+aa`,
+			pattern:  "bb",
+			error:    false,
+			expected: false,
+		},
+		{
+			description: "kubectl-like unmatch",
+			input: `NAMESPACE     NAME                             READY     STATUS    RESTARTS   AGE
+kube-system   kube-addon-manager-minikube      1/1       Running   1          16h
+kube-system   kube-dns-1326421443-whr1s        3/3       Running   3          16h
+kube-system   kubernetes-dashboard-29pll       1/1       Running   1          16h
+kube-system   tiller-deploy-1046433508-ch23h   1/1       Running   1          16h
+`,
+			pattern:  `mycustom-deploy.*1/1\s*Running`,
+			error:    false,
+			expected: false,
+		},
+		{
+			description: "pattern error",
+			input:       "aabbaa",
+			pattern:     "a([a-z",
+			error:       true,
+			expected:    false,
+		},
+	}
+	logger := microloggertest.New()
+	subject := patterns.New(logger)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			inputPipe := strings.NewReader(tc.input)
+			actual, err := subject.Find(inputPipe, tc.pattern)
+
+			if tc.error && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if !tc.error && err != nil {
+				t.Errorf("unexpected error %q", err)
+			}
+
+			if actual != tc.expected {
+				t.Errorf("match of %q with %q failed, expected %t and found %t",
+					tc.input, tc.pattern, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/project/project.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/project/project.go
@@ -1,0 +1,297 @@
+package project
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/e2e-harness/pkg/results"
+	"github.com/giantswarm/e2e-harness/pkg/runner"
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+	"github.com/giantswarm/e2e-harness/pkg/wait"
+	"github.com/giantswarm/micrologger"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	DefaultSonobuoyValuesFile = "/workdir/sonobuoy.yaml"
+)
+
+type E2e struct {
+	Version          string        `yaml:"version"`
+	Setup            []Step        `yaml:"setup"`
+	Teardown         []Step        `yaml:"teardown"`
+	OutOfClusterTest []Step        `yaml:"outOfClusterTest"`
+	InClusterTest    InClusterTest `yaml:"inClusterTest"`
+}
+
+type Step struct {
+	Run     string   `yaml:"run"`
+	WaitFor WaitStep `yaml:"waitFor"`
+}
+
+type WaitStep struct {
+	Run     string        `yaml:"run"`
+	Match   string        `yaml:"match"`
+	Timeout time.Duration `yaml:"timeout"`
+	Step    time.Duration `yaml:"step"`
+}
+
+type InClusterTest struct {
+	Enabled bool     `yaml:"enabled"`
+	Env     []EnvVar `yaml:"env"`
+}
+
+type EnvVar struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type Config struct {
+	Name      string
+	GitCommit string
+}
+
+type Dependencies struct {
+	Logger  micrologger.Logger
+	Runner  runner.Runner
+	Wait    *wait.Wait
+	Results *results.Results
+}
+
+type Project struct {
+	logger  micrologger.Logger
+	runner  runner.Runner
+	wait    *wait.Wait
+	results *results.Results
+	cfg     *Config
+}
+
+type SonoBuoyValues struct {
+	ImageName string   `yaml:"imageName"`
+	ImageTag  string   `yaml:"imageTag"`
+	Env       []EnvVar `yaml:"env"`
+}
+
+func New(deps *Dependencies, cfg *Config) *Project {
+	return &Project{
+		logger:  deps.Logger,
+		runner:  deps.Runner,
+		wait:    deps.Wait,
+		results: deps.Results,
+		cfg:     cfg,
+	}
+}
+
+func (p *Project) CommonSetupSteps() error {
+	p.logger.Log("info", "executing common setup steps")
+	steps := []Step{
+		Step{
+			Run: "kubectl create clusterrolebinding permissive-binding --clusterrole cluster-admin --group=system:serviceaccounts",
+		},
+		Step{
+			Run: "kubectl -n kube-system create sa tiller",
+		},
+		Step{
+			Run: "kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller",
+		},
+		Step{
+			Run: "helm init --service-account tiller",
+			WaitFor: WaitStep{
+				Run:   "kubectl get pod -n kube-system",
+				Match: `tiller-deploy.*1/1\s*Running`,
+			},
+		}}
+
+	for _, s := range steps {
+		if err := p.runStep(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Project) SetupSteps() error {
+	p.logger.Log("info", "executing setup steps")
+
+	e2e, err := p.readProjectFile()
+	if err != nil {
+		return err
+	}
+
+	for _, step := range e2e.Setup {
+		if err := p.runStep(step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Project) TeardownSteps() error {
+	p.logger.Log("info", "executing teardown steps")
+
+	e2e, err := p.readProjectFile()
+	if err != nil {
+		return err
+	}
+
+	for _, step := range e2e.Teardown {
+		if err := p.runStep(step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Project) OutOfClusterTest() error {
+	p.logger.Log("info", "executing out of cluster tests")
+
+	e2e, err := p.readProjectFile()
+	if err != nil {
+		return err
+	}
+
+	for _, step := range e2e.OutOfClusterTest {
+		if err := p.runStep(step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Project) InClusterTest() error {
+	p.logger.Log("info", "executing in-cluster tests")
+
+	e2e, err := p.readProjectFile()
+	if err != nil {
+		return err
+	}
+
+	if !e2e.InClusterTest.Enabled {
+		p.logger.Log("info", "in-cluster tests disabled")
+		return nil
+	}
+
+	bundle := []tasks.Task{
+		p.createSonobuoyValues,
+		p.installSonobuoyChart,
+		p.results.Unpack,
+		p.results.Interpret,
+	}
+	return tasks.Run(bundle)
+}
+
+func (p *Project) runStep(step Step) error {
+	p.logger.Log("info", fmt.Sprintf("executing step with command %q", step.Run))
+	// expand env vars
+	sEnv := os.ExpandEnv(step.Run)
+	if err := p.runner.RunPortForward(os.Stdout, sEnv); err != nil {
+		return err
+	}
+
+	md := &wait.MatchDef{
+		Run:      step.WaitFor.Run,
+		Match:    step.WaitFor.Match,
+		Deadline: step.WaitFor.Timeout,
+	}
+	if err := p.wait.For(md); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Project) readProjectFile() (*E2e, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	projectFile := filepath.Join(dir, "e2e", "project.yaml")
+	if _, err := os.Stat(projectFile); os.IsNotExist(err) {
+		return nil, err
+	}
+
+	content, err := ioutil.ReadFile(projectFile)
+	if err != nil {
+		return nil, err
+	}
+
+	e2e := &E2e{}
+
+	if err := yaml.Unmarshal(content, e2e); err != nil {
+		return nil, err
+	}
+	return e2e, nil
+}
+
+func (p *Project) createSonobuoyValues() error {
+	p.logger.Log("info", "creating sonobuoy values")
+
+	e2e, err := p.readProjectFile()
+	if err != nil {
+		return err
+	}
+
+	var name string
+	if os.Getenv("CIRCLE_PROJECT_REPONAME") != "" {
+		name = os.Getenv("CIRCLE_PROJECT_REPONAME")
+	} else {
+		name = p.cfg.Name
+	}
+	var tag string
+	if os.Getenv("CIRCLE_SHA1") != "" {
+		tag = os.Getenv("CIRCLE_SHA1")
+	} else {
+		tag = p.cfg.GitCommit
+	}
+
+	sonobuoyValues := &SonoBuoyValues{
+		ImageName: "quay.io/giantswarm/" + name + "-e2e",
+		ImageTag:  tag,
+		Env:       e2e.InClusterTest.Env,
+	}
+
+	content, err := yaml.Marshal(sonobuoyValues)
+	if err != nil {
+		return err
+	}
+
+	basedir, err := harness.BaseDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(basedir, DefaultSonobuoyValuesFile)
+	err = ioutil.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Project) installSonobuoyChart() error {
+	p.logger.Log("info", "cleaning up previous sonobuoy deployments")
+
+	p.runStep(Step{
+		Run: "helm delete --purge sonobuoy-chart",
+		WaitFor: WaitStep{
+			Run:   "kubectl get ns heptio-sonobuoy",
+			Match: `Error from server \(NotFound\): namespaces "heptio-sonobuoy" not found`,
+		},
+	})
+
+	p.logger.Log("info", "installing sonobuoy chart")
+	installSonobuoyChart := Step{
+		Run: "helm install /home/e2e-harness/resources/sonobuoy-chart --name sonobuoy-chart --values " + DefaultSonobuoyValuesFile,
+		WaitFor: WaitStep{
+			Run:   "kubectl logs sonobuoy --namespace=heptio-sonobuoy",
+			Match: "no-exit was specified, sonobuoy is now blocking",
+		},
+	}
+	if err := p.runStep(installSonobuoyChart); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/results/results.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/results/results.go
@@ -1,0 +1,133 @@
+package results
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/giantswarm/e2e-harness/pkg/runner"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+)
+
+const (
+	//DefaultResultsFilename    = "junit_01.xml"
+	DefaultResultsFilename    = "results.xml"
+	DefaultResultsPath        = "/workdir/plugins/e2e/" + DefaultResultsFilename
+	DefaultRemoteResultsPath  = "/tmp/results"
+	DefaultTarResultsFilename = "e2e.tar.gz"
+)
+
+type TestSuite struct {
+	Tests     int    `xml:"tests,attr,omitempty"`
+	Failures  int    `xml:"failures,attr,omitempty"`
+	Errors    int    `xml:"errors,attr,omitempty"`
+	Time      string `xml:"time,attr,omitempty"`
+	TestCases []TestCase
+}
+
+type TestCase struct {
+	Name    string       `xml:"name,attr"`
+	Error   *TestFailure `xml:"error,omitempty"`
+	Failure *TestFailure `xml:"failure,omitempty"`
+}
+
+// TestFailure contains data related to a failed test.
+type TestFailure struct {
+	Value   string `xml:",innerxml"`
+	Type    string `xml:"type,attr,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
+}
+
+type Results struct {
+	logger micrologger.Logger
+	fs     afero.Fs
+	runner runner.Runner
+}
+
+func New(logger micrologger.Logger, fs afero.Fs, r runner.Runner) *Results {
+	return &Results{
+		logger: logger,
+		fs:     fs,
+		runner: r,
+	}
+}
+
+func (r *Results) Read(path string) (*TestSuite, error) {
+	cmd := "cat " + path
+	b := new(bytes.Buffer)
+	if err := r.runner.RunPortForward(b, cmd); err != nil {
+		return nil, err
+	}
+
+	ts := &TestSuite{}
+
+	if err := xml.Unmarshal(b.Bytes(), ts); err != nil {
+		return nil, err
+	}
+	return ts, nil
+}
+
+func Write(fs afero.Fs, results *TestSuite) error {
+	if err := fs.MkdirAll(path.Dir(DefaultRemoteResultsPath), os.ModePerm); err != nil {
+		return err
+	}
+
+	content, err := xml.Marshal(results)
+	if err != nil {
+		return err
+	}
+
+	resultsFilename := filepath.Join(DefaultRemoteResultsPath, DefaultResultsFilename)
+	err = afero.WriteFile(fs, resultsFilename, []byte(content), 0644)
+	if err != nil {
+		return err
+	}
+
+	/*
+		cmd := exec.Command("/bin/busybox", "tar", "-czf", DefaultTarResultsFilename, "*")
+		cmd.Dir = DefaultRemoteResultsPath
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	*/
+	doneFilename := filepath.Join(DefaultRemoteResultsPath, "done")
+	//tarResultsFilename := filepath.Join(DefaultRemoteResultsPath, DefaultTarResultsFilename)
+	//err = afero.WriteFile(fs, doneFilename, []byte(tarResultsFilename), 0644)
+	err = afero.WriteFile(fs, doneFilename, []byte(resultsFilename), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Results) Unpack() error {
+	cmds := []string{
+		"kubectl cp heptio-sonobuoy/sonobuoy:/tmp/sonobuoy /workdir/results --namespace=heptio-sonobuoy",
+		"tar xzf /workdir/results/*.tar.gz",
+	}
+	for _, cmd := range cmds {
+		if err := r.runner.RunPortForward(os.Stdout, cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Interpret is a Task that knows how to grab test reesults and extract
+// results from them
+func (r *Results) Interpret() error {
+	ts, err := r.Read(DefaultResultsPath)
+	if err != nil {
+		return err
+	}
+
+	if ts.Failures == 0 && ts.Errors == 0 {
+		return nil
+	}
+	return fmt.Errorf("failures found")
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/results/results_test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/results/results_test.go
@@ -1,0 +1,136 @@
+package results_test
+
+import (
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/giantswarm/e2e-harness/pkg/results"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/afero"
+)
+
+type runnerMock struct {
+	currentOutput string
+}
+
+func (r *runnerMock) Run(out io.Writer, command string) error {
+	return nil
+}
+
+func (r *runnerMock) RunPortForward(out io.Writer, command string) error {
+	out.Write([]byte(r.currentOutput))
+
+	return nil
+}
+
+func TestInterpret(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	if err := fs.MkdirAll(path.Dir(results.DefaultResultsPath), os.ModePerm); err != nil {
+		t.Errorf("unexepcted error creating directory %v", err)
+	}
+
+	logger := microloggertest.New()
+	r := &runnerMock{}
+	subject := results.New(logger, fs, r)
+
+	testCases := []struct {
+		description string
+		content     string
+		success     bool
+	}{
+		{
+			description: "no failures, one test",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="1" failures="0" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+  </testsuite>
+`,
+			success: true,
+		},
+		{
+			description: "no failures, multiple test",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="3" failures="0" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+  </testsuite>
+`,
+			success: true,
+		},
+		{
+			description: "failure, one test",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="1" failures="1" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675">
+      <failure>
+      Failure message
+      </failure>
+    </testcase>
+  </testsuite>
+`,
+			success: false,
+		},
+		{
+			description: "failure, multiple tests",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="3" failures="1" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675">
+      <failure>
+      Failure message
+      </failure>
+    </testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+  </testsuite>
+`,
+			success: false,
+		},
+		{
+			description: "error, one test",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="1" errors="1" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675">
+      <error>
+      Failure message
+      </error>
+    </testcase>
+  </testsuite>
+`,
+			success: false,
+		},
+		{
+			description: "error, multiple tests",
+			content: `<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="3" errors="1" time="16.900219675">
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675">
+      <error>
+      Failure message
+      </error>
+    </testcase>
+    <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="16.900219675"></testcase>
+  </testsuite>
+`,
+			success: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			r.currentOutput = tc.content
+
+			actual := subject.Interpret()
+
+			if tc.success && actual != nil {
+				t.Errorf("unexpected result, expected success, got error %v", actual)
+			}
+
+			if !tc.success && actual == nil {
+				t.Errorf("expected error didn't happen")
+			}
+		})
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/runner/runner.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/runner/runner.go
@@ -1,0 +1,8 @@
+package runner
+
+import "io"
+
+type Runner interface {
+	Run(out io.Writer, command string) error
+	RunPortForward(out io.Writer, command string) error
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/tasks/tasks.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/tasks/tasks.go
@@ -1,0 +1,21 @@
+package tasks
+
+// Task represent a generic step in a pipeline.
+type Task func() error
+
+func Run(tasks []Task) error {
+	var err error
+	for _, task := range tasks {
+		err = task()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RunIgnoreError(tasks []Task) {
+	for _, task := range tasks {
+		task()
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/tasks/tasks_test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/tasks/tasks_test.go
@@ -1,0 +1,93 @@
+package tasks_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+	"github.com/spf13/afero"
+)
+
+var (
+	files   = []string{"/task1", "/task2"}
+	taskErr = func() error {
+		return fmt.Errorf("my-error")
+	}
+)
+
+func getTaskFunc(filename string, fs afero.Fs) tasks.Task {
+	return func() error {
+		if err := afero.WriteFile(fs, filename, []byte("test!"), 0644); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func TestRunNoError(t *testing.T) {
+	fs := new(afero.MemMapFs)
+
+	bundle := []tasks.Task{getTaskFunc(files[0], fs), getTaskFunc(files[1], fs)}
+
+	err := tasks.Run(bundle)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+
+	for _, file := range files {
+		e, err := afero.Exists(fs, file)
+		if err != nil {
+			t.Errorf("unexpected error %s", err)
+		}
+		if !e {
+			t.Errorf("expected file %s to exists", file)
+		}
+	}
+}
+
+func TestRunError(t *testing.T) {
+	fs := new(afero.MemMapFs)
+
+	var bundle []tasks.Task
+	bundle = append(bundle, getTaskFunc(files[0], fs))
+	bundle = append(bundle, taskErr)
+	bundle = append(bundle, getTaskFunc(files[1], fs))
+
+	err := tasks.Run(bundle)
+	if err == nil {
+		t.Error("expected error didn't happen")
+	}
+	if err.Error() != "my-error" {
+		t.Error("expected error didn't happen")
+	}
+
+	e, err := afero.Exists(fs, files[0])
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	if !e {
+		t.Errorf("expected file %s to exists", files[0])
+	}
+
+}
+
+func TestRunIgnoreError(t *testing.T) {
+	fs := new(afero.MemMapFs)
+
+	var bundle []tasks.Task
+	bundle = append(bundle, getTaskFunc(files[0], fs))
+	bundle = append(bundle, taskErr)
+	bundle = append(bundle, getTaskFunc(files[1], fs))
+
+	tasks.RunIgnoreError(bundle)
+
+	for _, file := range files {
+		e, err := afero.Exists(fs, file)
+		if err != nil {
+			t.Errorf("unexpected error %s", err)
+		}
+		if !e {
+			t.Errorf("expected file %s to exists", file)
+		}
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/wait/wait.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/wait/wait.go
@@ -1,0 +1,77 @@
+package wait
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/giantswarm/e2e-harness/pkg/patterns"
+	"github.com/giantswarm/e2e-harness/pkg/runner"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	defaultDeadline = 120000
+	defaultStep     = 500
+)
+
+type Wait struct {
+	logger  micrologger.Logger
+	matcher patterns.Matcher
+	runner  runner.Runner
+}
+
+type MatchDef struct {
+	Run   string
+	Match string
+	// total time to wait
+	Deadline time.Duration
+	// delay between checks
+	Step time.Duration
+}
+
+func New(logger micrologger.Logger, runner runner.Runner, matcher patterns.Matcher) *Wait {
+	return &Wait{
+		logger:  logger,
+		runner:  runner,
+		matcher: matcher,
+	}
+}
+
+func (w *Wait) For(md *MatchDef) error {
+	if md.Deadline == 0 {
+		md.Deadline = defaultDeadline
+	}
+	if md.Step == 0 {
+		md.Step = defaultStep
+	}
+
+	timeout := time.After(md.Deadline * time.Millisecond)
+	tick := time.Tick(md.Step * time.Millisecond)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout looking for pattern %q with command %q", md.Match, md.Run)
+		case <-tick:
+			// pipe the output of the docker command to the input of FindMatch,
+			// this way we can handle potentially long outputs without having
+			// to store them in a variable
+			re, wr := io.Pipe()
+			// writing without a reader will deadlock so write in a goroutine
+			go func() {
+				defer wr.Close()
+				w.runner.RunPortForward(wr, md.Run)
+			}()
+			w.logger.Log("debug", "checking pattern "+md.Match)
+			ok, err := w.matcher.Find(re, md.Match)
+			if err != nil {
+				return err
+			} else if ok {
+				w.logger.Log("debug", "match found")
+				return nil
+			}
+			w.logger.Log("debug", "match not found, retrying")
+		}
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/wait/wait_test.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/wait/wait_test.go
@@ -1,0 +1,95 @@
+package wait_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/e2e-harness/pkg/wait"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+type runnerMock struct{}
+
+func (r *runnerMock) Run(out io.Writer, command string) error {
+	return nil
+}
+
+func (r *runnerMock) RunPortForward(out io.Writer, command string) error {
+	return nil
+}
+
+type matcherMock struct {
+	untilMatch int
+	current    int
+	doError    bool
+}
+
+func (p *matcherMock) Find(input io.Reader, pattern string) (bool, error) {
+	if p.doError {
+		return false, fmt.Errorf("error from pattern matching!")
+	}
+	if p.current < p.untilMatch {
+		p.current++
+		return false, nil
+	}
+	return true, nil
+}
+
+func TestWait(t *testing.T) {
+	testCases := []struct {
+		description       string
+		deadline          time.Duration
+		step              time.Duration
+		untilMatch        int
+		success           bool
+		patternMatchError bool
+	}{
+		{
+			description: "Basic match",
+			deadline:    10,
+			step:        1,
+			untilMatch:  5,
+			success:     true,
+		},
+		{
+			description: "Basic unmatch, timeout",
+			deadline:    10,
+			step:        1,
+			untilMatch:  20,
+			success:     false,
+		},
+		{
+			description:       "Basic unmatch, pattern match error",
+			deadline:          10,
+			step:              1,
+			untilMatch:        5,
+			success:           false,
+			patternMatchError: true,
+		},
+	}
+
+	logger := microloggertest.New()
+	runner := &runnerMock{}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			matcher := &matcherMock{
+				untilMatch: tc.untilMatch,
+				doError:    tc.patternMatchError,
+			}
+			subject := wait.New(logger, runner, matcher)
+			md := &wait.MatchDef{
+				Deadline: tc.deadline,
+				Step:     tc.step,
+			}
+			actual := subject.For(md)
+			if tc.success && actual != nil {
+				t.Errorf("expected success, error returned %v", actual)
+			}
+			if !tc.success && actual == nil {
+				t.Errorf("expected error didn't happen")
+			}
+		})
+	}
+}

--- a/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/Chart.yaml
+++ b/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: sonobuoy-chart
+version: 0.1.0
+description: Installs sonobuoy infrastructure and a configurable plugin

--- a/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/templates/sonobuoy.yaml
+++ b/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/templates/sonobuoy.yaml
@@ -1,0 +1,227 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: heptio-sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: heptio-sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: heptio-sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: heptio-sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+data:
+  config.json: |
+    {
+        "Description": "EXAMPLE",
+        "Filters": {
+            "LabelSelector": "",
+            "Namespaces": ".*"
+        },
+        "PluginNamespace": "heptio-sonobuoy",
+        "Plugins": [
+            {
+                "name": "e2e"
+            }
+        ],
+        "Resources": [
+            "CertificateSigningRequests",
+            "ClusterRoleBindings",
+            "ClusterRoles",
+            "ComponentStatuses",
+            "CustomResourceDefinitions",
+            "Nodes",
+            "PersistentVolumes",
+            "PodSecurityPolicies",
+            "ServerVersion",
+            "StorageClasses",
+            "ConfigMaps",
+            "DaemonSets",
+            "Deployments",
+            "Endpoints",
+            "Events",
+            "HorizontalPodAutoscalers",
+            "Ingresses",
+            "Jobs",
+            "LimitRanges",
+            "PersistentVolumeClaims",
+            "Pods",
+            "PodDisruptionBudgets",
+            "PodTemplates",
+            "ReplicaSets",
+            "ReplicationControllers",
+            "ResourceQuotas",
+            "RoleBindings",
+            "Roles",
+            "ServerGroups",
+            "ServiceAccounts",
+            "Services",
+            "StatefulSets"
+        ],
+        "ResultsDir": "/tmp/sonobuoy",
+        "Server": {
+            "advertiseaddress": "sonobuoy-master:8080",
+            "bindaddress": "0.0.0.0",
+            "bindport": 8080,
+            "timeoutseconds": 5400
+        },
+        "Version": "v0.9.0"
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: heptio-sonobuoy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: heptio-sonobuoy
+data:
+  e2e.yaml: |
+    driver: Job
+    name: e2e
+    resultType: e2e
+    spec:
+      containers:
+      - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+        imagePullPolicy: Always
+        name: e2e
+        volumeMounts:
+        - mountPath: /tmp/results
+          name: results
+        env:
+        {{ range .Values.env }}
+        - name: {{ .name }}
+          value: {{ .value }}
+        {{ end }}
+      - command:
+        - sh
+        - -c
+        - /sonobuoy worker global -v 5 --logtostderr
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: RESULTS_DIR
+          value: /tmp/results
+        image: gcr.io/heptio-images/sonobuoy:master
+        imagePullPolicy: Always
+        name: sonobuoy-worker
+        volumeMounts:
+        - mountPath: /etc/sonobuoy
+          name: config
+        - mountPath: /tmp/results
+          name: results
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: results
+      - configMap:
+          name: __SONOBUOY_CONFIGMAP__
+        name: config
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: heptio-sonobuoy
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: gcr.io/heptio-images/sonobuoy:master
+    imagePullPolicy: Always
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: heptio-sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP

--- a/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/values.yaml
+++ b/vendor/github.com/giantswarm/e2e-harness/resources/sonobuoy-chart/values.yaml
@@ -1,0 +1,5 @@
+imageName: gcr.io/heptio-images/kube-conformance
+imageTag: v1.8
+env:
+  - name: E2E_FOCUS
+    value: Conformance

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
@@ -1942,7 +1942,7 @@ coreos:
       --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
-      --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:443 \
+      --etcd-servers=https://127.0.0.1:2379 \
       --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem \
       --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem \
       --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem \

--- a/vendor/github.com/giantswarm/versionbundle/bundles.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles.go
@@ -23,21 +23,6 @@ func (b Bundles) Contain(item Bundle) bool {
 	return false
 }
 
-func (b Bundles) Copy() Bundles {
-	raw, err := json.Marshal(b)
-	if err != nil {
-		panic(err)
-	}
-
-	var copy Bundles
-	err = json.Unmarshal(raw, &copy)
-	if err != nil {
-		panic(err)
-	}
-
-	return copy
-}
-
 func (b Bundles) Validate() error {
 	if len(b) == 0 {
 		return microerror.Maskf(invalidBundlesError, "version bundles must not be empty")
@@ -47,8 +32,8 @@ func (b Bundles) Validate() error {
 		return microerror.Maskf(invalidBundlesError, "version bundle versions must be unique")
 	}
 
-	b1 := b.Copy()
-	b2 := b.Copy()
+	b1 := CopyBundles(b)
+	b2 := CopyBundles(b)
 	sort.Sort(SortBundlesByTime(b1))
 	sort.Sort(SortBundlesByVersion(b2))
 	if !reflect.DeepEqual(b1, b2) {
@@ -70,6 +55,21 @@ func (b Bundles) Validate() error {
 	}
 
 	return nil
+}
+
+func CopyBundles(bundles []Bundle) []Bundle {
+	raw, err := json.Marshal(bundles)
+	if err != nil {
+		panic(err)
+	}
+
+	var copy []Bundle
+	err = json.Unmarshal(raw, &copy)
+	if err != nil {
+		panic(err)
+	}
+
+	return copy
 }
 
 func (b Bundles) hasDuplicatedVersions() bool {

--- a/vendor/github.com/giantswarm/versionbundle/bundles_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles_test.go
@@ -381,8 +381,8 @@ func Test_Bundles_Copy(t *testing.T) {
 		},
 	}
 
-	b1 := Bundles(bundles).Copy()
-	b2 := Bundles(bundles).Copy()
+	b1 := CopyBundles(bundles)
+	b2 := CopyBundles(bundles)
 
 	sort.Sort(SortBundlesByTime(b1))
 	sort.Sort(SortBundlesByVersion(b2))

--- a/vendor/github.com/giantswarm/versionbundle/distribution.go
+++ b/vendor/github.com/giantswarm/versionbundle/distribution.go
@@ -1,0 +1,70 @@
+package versionbundle
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/giantswarm/microerror"
+)
+
+type DistributionConfig struct {
+	Bundles []Bundle
+}
+
+func DefaultDistributionConfig() DistributionConfig {
+	return DistributionConfig{
+		Bundles: nil,
+	}
+}
+
+type Distribution struct {
+	bundles []Bundle
+	version string
+}
+
+func NewDistribution(config DistributionConfig) (Distribution, error) {
+	if len(config.Bundles) == 0 {
+		return Distribution{}, microerror.Maskf(invalidConfigError, "config.Bundles must not be empty")
+	}
+
+	version, err := aggregateDistributionVersion(config.Bundles)
+	if err != nil {
+		return Distribution{}, microerror.Maskf(invalidConfigError, err.Error())
+	}
+
+	d := Distribution{
+		bundles: config.Bundles,
+		version: version,
+	}
+
+	return d, nil
+}
+
+func (d Distribution) Bundles() []Bundle {
+	return CopyBundles(d.bundles)
+}
+
+func (d Distribution) Version() string {
+	return d.version
+}
+
+func aggregateDistributionVersion(bundles []Bundle) (string, error) {
+	var major int64
+	var minor int64
+	var patch int64
+
+	for _, b := range bundles {
+		v, err := semver.NewVersion(b.Version)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		major += v.Major
+		minor += v.Minor
+		patch += v.Patch
+	}
+
+	version := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+
+	return version, nil
+}

--- a/vendor/github.com/giantswarm/versionbundle/distribution_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/distribution_test.go
@@ -1,0 +1,261 @@
+package versionbundle
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_Distribution_Version(t *testing.T) {
+	testCases := []struct {
+		Bundles         []Bundle
+		ExpectedVersion string
+		ErrorMatcher    func(err error) bool
+	}{
+		// Test 0 ensures creating a distribution with a nil slice of bundles throws
+		// an error when creating a new distribution type.
+		{
+			Bundles:         nil,
+			ExpectedVersion: "",
+			ErrorMatcher:    IsInvalidConfig,
+		},
+
+		// Test 1 is the same as 0 but with an empty list of bundles.
+		{
+			Bundles:         []Bundle{},
+			ExpectedVersion: "",
+			ErrorMatcher:    IsInvalidConfig,
+		},
+
+		// Test 2 ensures computing the distribution version when having a list of
+		// one bundle given works as expected.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "0.0.1",
+					WIP:        false,
+				},
+			},
+			ExpectedVersion: "0.0.1",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 3 is the same as 2 but with a different version.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "11.4.1",
+					WIP:        false,
+				},
+			},
+			ExpectedVersion: "11.4.1",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 4 ensures computing the distribution version when having a list of
+		// two bundles given works as expected.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version requirements changed due to calico update.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "etcd",
+							Description: "Etcd version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "etcd",
+							Version: "3.2.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.1",
+						},
+					},
+					Dependencies: []Dependency{},
+					Name:         "cloud-config-operator",
+					Deprecated:   false,
+					Time:         time.Unix(20, 15),
+					Version:      "0.2.0",
+					WIP:          false,
+				},
+			},
+			ExpectedVersion: "0.3.0",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 5 is the same as 4 but with a different version.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version requirements changed due to calico update.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "5.0.1",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "etcd",
+							Description: "Etcd version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "etcd",
+							Version: "3.2.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.1",
+						},
+					},
+					Dependencies: []Dependency{},
+					Name:         "cloud-config-operator",
+					Deprecated:   false,
+					Time:         time.Unix(20, 15),
+					Version:      "12.2.77",
+					WIP:          false,
+				},
+			},
+			ExpectedVersion: "17.2.78",
+			ErrorMatcher:    nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		config := DefaultDistributionConfig()
+
+		config.Bundles = tc.Bundles
+
+		d, err := NewDistribution(config)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		}
+
+		v := d.Version()
+		if v != tc.ExpectedVersion {
+			t.Fatalf("test %d expected %s got %s", i, tc.ExpectedVersion, v)
+		}
+	}
+}

--- a/vendor/github.com/giantswarm/versionbundle/error.go
+++ b/vendor/github.com/giantswarm/versionbundle/error.go
@@ -46,6 +46,13 @@ func IsInvalidComponent(err error) bool {
 	return microerror.Cause(err) == invalidComponentError
 }
 
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
 var invalidDependencyError = microerror.New("invalid dependency")
 
 // IsInvalidDependency asserts invalidDependencyError.


### PR DESCRIPTION
First in-cluster e2e test, comes from #479 

The test just checks for the existence of the aws TPR in `e2e/tests/awstpr.go`. The file `e2e/tests/runner.go` probably belongs to e2e-harness project, will keep it here as we grow the e2e test suite to make development easier.

The sonobuoy results are saved as circleCI artifacts https://circleci.com/gh/giantswarm/aws-operator/1295#artifacts/containers/0, the string returned by the test is used as the testcase name.