### PR TITLE
Cf implement get desired state

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0e05add1a117b58ead0a42b6355d62469160970f41467166eb20a9a32c3b3c21
-updated: 2017-11-07T12:27:40.479590438+01:00
+updated: 2017-11-07T17:53:27.065518281+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 8b344ddb7a49daf794928d1db484ad9a81499858
@@ -32,6 +32,7 @@ imports:
   - private/protocol/xml/xmlutil
   - service/autoscaling
   - service/cloudformation
+  - service/cloudformation/cloudformationiface
   - service/ec2
   - service/elb
   - service/iam
@@ -140,6 +141,7 @@ imports:
   - framework/resource/logresource
   - framework/resource/metricsresource
   - framework/resource/retryresource
+  - informer
   - tpr
 - name: github.com/giantswarm/randomkeytpr
   version: 9e1d78d125841c496889e8a54d49057212a2893e

--- a/service/key/error.go
+++ b/service/key/error.go
@@ -1,0 +1,10 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/awstpr"
 	cloudconfig "github.com/giantswarm/k8scloudconfig"
+	"github.com/giantswarm/microerror"
 )
 
 func AutoScalingGroupName(customObject awstpr.CustomObject, groupName string) string {
@@ -87,4 +88,24 @@ func WorkerInstanceType(customObject awstpr.CustomObject) string {
 	}
 
 	return instanceType
+}
+
+func ToCustomObject(v interface{}) (awstpr.CustomObject, error) {
+	if v == nil {
+		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
+	}
+
+	customObjectPointer, ok := v.(*awstpr.CustomObject)
+	if !ok {
+		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
+func MainStackName(customObject awstpr.CustomObject) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("%s-main", clusterID)
 }

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -33,6 +33,12 @@ func HasClusterVersion(customObject awstpr.CustomObject) bool {
 	}
 }
 
+func MainStackName(customObject awstpr.CustomObject) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("%s-main", clusterID)
+}
+
 func MasterImageID(customObject awstpr.CustomObject) string {
 	var imageID string
 
@@ -65,6 +71,20 @@ func SubnetName(customObject awstpr.CustomObject, suffix string) string {
 	return fmt.Sprintf("%s-%s", ClusterID(customObject), suffix)
 }
 
+func ToCustomObject(v interface{}) (awstpr.CustomObject, error) {
+	if v == nil {
+		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
+	}
+
+	customObjectPointer, ok := v.(*awstpr.CustomObject)
+	if !ok {
+		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
 func WorkerCount(customObject awstpr.CustomObject) int {
 	return len(customObject.Spec.AWS.Workers)
 }
@@ -88,24 +108,4 @@ func WorkerInstanceType(customObject awstpr.CustomObject) string {
 	}
 
 	return instanceType
-}
-
-func ToCustomObject(v interface{}) (awstpr.CustomObject, error) {
-	if v == nil {
-		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
-	}
-
-	customObjectPointer, ok := v.(*awstpr.CustomObject)
-	if !ok {
-		return awstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &awstpr.CustomObject{}, v)
-	}
-	customObject := *customObjectPointer
-
-	return customObject, nil
-}
-
-func MainStackName(customObject awstpr.CustomObject) string {
-	clusterID := ClusterID(customObject)
-
-	return fmt.Sprintf("%s-main", clusterID)
 }

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -383,3 +383,22 @@ func Test_WorkerInstanceType(t *testing.T) {
 		}
 	}
 }
+
+func Test_MainStackName(t *testing.T) {
+	expected := "xyz-main"
+
+	cluster := awstpr.CustomObject{
+		Spec: awstpr.Spec{
+			Cluster: clustertpr.Spec{
+				Cluster: spec.Cluster{
+					ID: "xyz",
+				},
+			},
+		},
+	}
+
+	actual := MainStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}

--- a/service/resource/cloudformation/create.go
+++ b/service/resource/cloudformation/create.go
@@ -1,0 +1,7 @@
+package cloudformation
+
+import "context"
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/service/resource/cloudformation/current.go
+++ b/service/resource/cloudformation/current.go
@@ -1,0 +1,7 @@
+package cloudformation
+
+import "context"
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/resource/cloudformation/delete.go
+++ b/service/resource/cloudformation/delete.go
@@ -1,0 +1,15 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	return nil, nil
+}

--- a/service/resource/cloudformation/desired.go
+++ b/service/resource/cloudformation/desired.go
@@ -1,0 +1,22 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	mainStack, err := newMainStack(customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return mainStack, nil
+}

--- a/service/resource/cloudformation/desired_test.go
+++ b/service/resource/cloudformation/desired_test.go
@@ -1,0 +1,66 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		obj          interface{}
+		expectedName string
+		description  string
+	}{
+		{
+			description: "CloudFormation gets name from custom object",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			expectedName: "5xchu-main",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		awsCfg := awsutil.Config{}
+		resourceConfig.Clients = awsutil.NewClients(awsCfg)
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Fatalf("expected '%v' got '%#v'", nil, err)
+			}
+
+			desiredStack, ok := result.(*awsCF.CreateStackInput)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredStack, result)
+			}
+
+			if tc.expectedName != *desiredStack.StackName {
+				t.Fatalf("expected cloudformation name '%s' got '%s'", tc.expectedName, *desiredStack.StackName)
+			}
+		})
+	}
+}

--- a/service/resource/cloudformation/desired_test.go
+++ b/service/resource/cloudformation/desired_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/awstpr"
 	"github.com/giantswarm/clustertpr"
@@ -53,13 +52,13 @@ func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
 				t.Fatalf("expected '%v' got '%#v'", nil, err)
 			}
 
-			desiredStack, ok := result.(*awsCF.CreateStackInput)
+			desiredStack, ok := result.(StackState)
 			if !ok {
 				t.Fatalf("case expected '%T', got '%T'", desiredStack, result)
 			}
 
-			if tc.expectedName != *desiredStack.StackName {
-				t.Fatalf("expected cloudformation name '%s' got '%s'", tc.expectedName, *desiredStack.StackName)
+			if tc.expectedName != desiredStack.Name {
+				t.Fatalf("expected cloudformation name '%s' got '%s'", tc.expectedName, desiredStack.Name)
 			}
 		})
 	}

--- a/service/resource/cloudformation/error.go
+++ b/service/resource/cloudformation/error.go
@@ -15,10 +15,3 @@ var notFoundError = microerror.New("not found")
 func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
-
-var wrongTypeError = microerror.New("wrong type")
-
-// IsWrongTypeError asserts wrongTypeError.
-func IsWrongTypeError(err error) bool {
-	return microerror.Cause(err) == wrongTypeError
-}

--- a/service/resource/cloudformation/main_stack.go
+++ b/service/resource/cloudformation/main_stack.go
@@ -1,0 +1,36 @@
+package cloudformation
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/awstpr"
+)
+
+func newMainStack(customObject awstpr.CustomObject) (*awsCF.CreateStackInput, error) {
+	stackName := key.MainStackName(customObject)
+
+	mainCF := &awsCF.CreateStackInput{
+		StackName:    aws.String(stackName),
+		TemplateBody: aws.String(MainTemplate),
+	}
+
+	return mainCF, nil
+}
+
+func getMainTemplateBody(customObject awstpr.CustomObject) (string, error) {
+	t, err := template.New("main").Parse(MainTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var tpl bytes.Buffer
+	if err := t.Execute(&tpl, customObject); err != nil {
+		return "", err
+	}
+
+	return tpl.String(), nil
+}

--- a/service/resource/cloudformation/main_stack.go
+++ b/service/resource/cloudformation/main_stack.go
@@ -4,18 +4,16 @@ import (
 	"bytes"
 	"text/template"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
 )
 
-func newMainStack(customObject awstpr.CustomObject) (*awsCF.CreateStackInput, error) {
+func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
 	stackName := key.MainStackName(customObject)
 
-	mainCF := &awsCF.CreateStackInput{
-		StackName:    aws.String(stackName),
-		TemplateBody: aws.String(MainTemplate),
+	mainCF := StackState{
+		Name:         stackName,
+		TemplateBody: MainTemplate,
 	}
 
 	return mainCF, nil

--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -1,6 +1,7 @@
 package cloudformation
 
 import (
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
@@ -43,6 +44,13 @@ type Resource struct {
 	// Dependencies.
 	awsClient cloudformationiface.CloudFormationAPI
 	logger    micrologger.Logger
+}
+
+// StackState is the state representation pn which the resource methods work
+type StackState struct {
+	Name         string
+	TemplateBody string
+	Parameters   []*awsCF.Parameter
 }
 
 // New creates a new configured cloudformation resource.

--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -1,7 +1,6 @@
 package cloudformation
 
 import (
-	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
@@ -44,13 +43,6 @@ type Resource struct {
 	// Dependencies.
 	awsClient cloudformationiface.CloudFormationAPI
 	logger    micrologger.Logger
-}
-
-// StackState is the state representation pn which the resource methods work
-type StackState struct {
-	Name         string
-	TemplateBody string
-	Parameters   []*awsCF.Parameter
 }
 
 // New creates a new configured cloudformation resource.

--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -1,14 +1,11 @@
 package cloudformation
 
 import (
-	"context"
-
-	"github.com/giantswarm/aws-operator/service/cloudconfig"
-	"github.com/giantswarm/certificatetpr"
+	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -16,57 +13,48 @@ const (
 	Name = "cloudformation"
 )
 
-// Config represents the configuration used to create a new config map resource.
-type Config struct {
-	// Dependencies.
-	CertWatcher certificatetpr.Searcher
-	CloudConfig *cloudconfig.CloudConfig
-	K8sClient   kubernetes.Interface
-	Logger      micrologger.Logger
+type AWSConfig struct {
+	AccessKeyID     string
+	AccessKeySecret string
+	SessionToken    string
+	Region          string
+	accountID       string
 }
 
-// DefaultConfig provides a default configuration to create a new config map
+// Config represents the configuration used to create a new cloudformation resource.
+type Config struct {
+	// Dependencies.
+	Clients awsutil.Clients
+	Logger  micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloudformation
 // resource by best effort.
 func DefaultConfig() Config {
 	return Config{
 		// Dependencies.
-		CertWatcher: nil,
-		CloudConfig: nil,
-		K8sClient:   nil,
-		Logger:      nil,
+		Clients: awsutil.Clients{},
+		Logger:  nil,
 	}
 }
 
-// Resource implements the config map resource.
+// Resource implements the cloudformation resource.
 type Resource struct {
 	// Dependencies.
-	certWatcher certificatetpr.Searcher
-	cloudConfig *cloudconfig.CloudConfig
-	k8sClient   kubernetes.Interface
-	logger      micrologger.Logger
+	awsClient cloudformationiface.CloudFormationAPI
+	logger    micrologger.Logger
 }
 
-// New creates a new configured config map resource.
+// New creates a new configured cloudformation resource.
 func New(config Config) (*Resource, error) {
 	// Dependencies.
-	if config.CertWatcher == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.CertWatcher must not be empty")
-	}
-	if config.CloudConfig == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.CloudConfig must not be empty")
-	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
 	newService := &Resource{
 		// Dependencies.
-		certWatcher: config.CertWatcher,
-		cloudConfig: config.CloudConfig,
-		k8sClient:   config.K8sClient,
+		awsClient: config.Clients.CloudFormation,
 		logger: config.Logger.With(
 			"resource", Name,
 		),
@@ -75,36 +63,8 @@ func New(config Config) (*Resource, error) {
 	return newService, nil
 }
 
-func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return nil, nil
-}
-
-func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return nil, nil
-}
-
-func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return &framework.Patch{}, nil
-}
-
-func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return &framework.Patch{}, nil
-}
-
 func (r *Resource) Name() string {
 	return Name
-}
-
-func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	return nil
-}
-
-func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
-	return nil
-}
-
-func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
-	return nil
 }
 
 func (r *Resource) Underlying() framework.Resource {

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -1,0 +1,7 @@
+package cloudformation
+
+// StackState is the state representation on which the resource methods work
+type StackState struct {
+	Name         string
+	TemplateBody string
+}

--- a/service/resource/cloudformation/template.go
+++ b/service/resource/cloudformation/template.go
@@ -1,0 +1,50 @@
+package cloudformation
+
+const (
+	MainTemplate = `AWSTemplateFormatVersion: 2010-09-09
+Description: {{ .ASGType }} autoscaling group
+Resources:
+  {{ .ASGType }}LaunchConfiguration:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Description: {{ .ASGType }} launch configuration
+    Properties:
+      ImageId: !Ref ImageID
+      SecurityGroups:
+      - !Ref SecurityGroupID
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref IAMInstanceProfileName
+      BlockDeviceMappings:
+      {{ range .BlockDeviceMappings }}
+      - DeviceName: "{{ .DeviceName }}"
+        Ebs:
+          DeleteOnTermination: {{ .DeleteOnTermination }}
+          VolumeSize: {{ .VolumeSize }}
+          VolumeType: {{ .VolumeType }}
+      {{ end }}
+      AssociatePublicIpAddress: !Ref AssociatePublicIPAddress
+      UserData: !Ref SmallCloudConfig
+      KeyName: !Ref KeyName
+  {{ .ASGType }}AutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      VPCZoneIdentifier:
+        - !Ref SubnetID
+      AvailabilityZones:
+        - !Ref AZ
+      MinSize: !Ref ASGMinSize
+      MaxSize: !Ref ASGMaxSize
+      LaunchConfigurationName: !Ref {{ .ASGType }}LaunchConfiguration
+      LoadBalancerNames:
+        - !Ref LoadBalancerName
+      HealthCheckGracePeriod: !Ref HealthCheckGracePeriod
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        # minimum amount of instances that must always be running during a rolling update
+        MinInstancesInService: 2
+        # only do a rolling update of this amount of instances max
+        MaxBatchSize: 2
+        # after creating a new instance, pause operations on the ASG for this amount of time
+        PauseTime: PT10S
+
+`
+)

--- a/service/resource/cloudformation/update.go
+++ b/service/resource/cloudformation/update.go
@@ -1,0 +1,15 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	return nil, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -191,9 +191,7 @@ func New(config Config) (*Service, error) {
 	{
 		cloudformationConfig := cloudformationresource.DefaultConfig()
 
-		cloudformationConfig.CertWatcher = certWatcher
-		cloudformationConfig.CloudConfig = ccService
-		cloudformationConfig.K8sClient = k8sClient
+		cloudformationConfig.Clients = awsclient.NewClients(awsConfig)
 		cloudformationConfig.Logger = config.Logger
 
 		cloudformationResource, err = cloudformationresource.New(cloudformationConfig)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

It also includes the separation of methods in files. The current ASG template is copied to a string variable in `service/resources/cloudformation/template.go`, still not used. I've removed the parameters from there but I'm afraid we are going to need them (plus outputs too) in order to be able to compare states. We can discuss this in the upcoming `GetCreateState` branch.
