### PR TITLE
fix-var-lib-mount

### DIFF
--- a/service/cloudconfig/templates.go
+++ b/service/cloudconfig/templates.go
@@ -148,7 +148,7 @@ storage:
     - name: ephemeral1
       mount:
         device: /dev/xvdb
-        format: ext3
+        format: xfs
         create:
           force: true
 `


### PR DESCRIPTION
fixing https://github.com/giantswarm/vodafone/issues/207
After reboot, disk is formatted with ext3 and the mount fails( because it's trying to mount xfs)

Also, a question for @jgsqware  why do we format the HDD with cloudconfig and then we have another service unit which does the format again? isn't it redundant?

Is it ok that we always reformat disk after each reboot?