### PR TITLE
Set the size of the workers ASG if it exists

### DIFF
--- a/service/resource/legacy/resource.go
+++ b/service/resource/legacy/resource.go
@@ -240,49 +240,6 @@ func (s *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 }
 
 func (s *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
-	// TODO The legacy resource needs to support scaling workers via NewUpdatePatch.
-	/*
-		oldCluster := *oldObj.(*awstpr.CustomObject)
-		cluster := *newObj.(*awstpr.CustomObject)
-
-		if err := validateCluster(cluster); err != nil {
-			s.logger.Log("error", "cluster spec is invalid: '%#v'", err)
-			return
-		}
-
-		oldSize := key.WorkerCount(oldCluster)
-		newSize := key.WorkerCount(cluster)
-
-		if oldSize == newSize {
-			// We get update events for all sorts of changes. We are currently only
-			// interested in changes to one property, so we ignore all the others.
-			return
-		}
-
-		s.awsConfig.Region = cluster.Spec.AWS.Region
-		clients := awsutil.NewClients(s.awsConfig)
-
-		err := s.awsConfig.SetAccountID(clients.IAM)
-		if err != nil {
-			s.logger.Log("error", fmt.Sprintf("could not retrieve amazon account id: '%#v'", err))
-			return
-		}
-
-		asg := awsresources.AutoScalingGroup{
-			Client:  clients.AutoScaling,
-			Name:    fmt.Sprintf("%s-%s", key.ClusterID(cluster), prefixWorker),
-			MinSize: newSize,
-			MaxSize: newSize,
-		}
-
-		if err := asg.Update(); err != nil {
-			s.logger.Log("error", fmt.Sprintf("%#v", err))
-			return
-		}
-
-		s.logger.Log("info", fmt.Sprintf("scaling workers auto scaling group from %d to %d", oldSize, newSize))
-	*/
-
 	return nil
 }
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

This PR sets the size of the worker autoscaling group if it already exists. This replaces the previous updateFunc logic and means we can still scale workers via the API.
