### PR TITLE
add create methods to cloudformation resource

### DIFF
--- a/service/resource/cloudformation/create.go
+++ b/service/resource/cloudformation/create.go
@@ -27,16 +27,16 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
 	customObject, err := key.ToCustomObject(obj)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
 	}
 
 	currentStackState, ok := currentState.(StackState)
 	if !ok {
-		return nil, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", currentStackState, currentState))
+		return awscloudformation.CreateStackInput{}, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", currentStackState, currentState))
 	}
 	desiredStackState, ok := desiredState.(StackState)
 	if !ok {
-		return nil, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", desiredStackState, desiredState))
+		return awscloudformation.CreateStackInput{}, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", desiredStackState, desiredState))
 	}
 
 	r.logger.Log("cluster", key.ClusterID(customObject), "debug", "finding out if the main stack should be created")

--- a/service/resource/cloudformation/create.go
+++ b/service/resource/cloudformation/create.go
@@ -1,7 +1,67 @@
 package cloudformation
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/microerror"
+)
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	createChangeState, ok := createChange.(StackState)
+	if !ok {
+		return microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", createChangeState, createChange))
+	}
+
+	mainTemplate, err := getMainTemplateBody(customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	stackInput := &awsCF.CreateStackInput{
+		StackName:        aws.String(createChangeState.Name),
+		TemplateBody:     aws.String(mainTemplate),
+		TimeoutInMinutes: aws.Int64(30),
+	}
+
+	_, err = r.awsClient.CreateStack(stackInput)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	currentStackState, ok := currentState.(StackState)
+	if !ok {
+		return nil, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", currentStackState, currentState))
+	}
+	desiredStackState, ok := desiredState.(StackState)
+	if !ok {
+		return nil, microerror.Mask(fmt.Errorf("unexpected type, expecting %T, got %T", desiredStackState, desiredState))
+	}
+
+	r.logger.Log("cluster", key.ClusterID(customObject), "debug", "finding out if the main stack should be created")
+
+	var createState StackState
+
+	if currentStackState.Name != desiredStackState.Name {
+		createState = desiredStackState
+	}
+
+	return createState, nil
 }

--- a/service/resource/cloudformation/create.go
+++ b/service/resource/cloudformation/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/microerror"
 )
@@ -26,10 +26,10 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	stackInput := &awsCF.CreateStackInput{
+	stackInput := &awscloudformation.CreateStackInput{
 		StackName:        aws.String(createChangeState.Name),
 		TemplateBody:     aws.String(mainTemplate),
-		TimeoutInMinutes: aws.Int64(30),
+		TimeoutInMinutes: aws.Int64(defaultCreationTimeout),
 	}
 
 	_, err = r.awsClient.CreateStack(stackInput)

--- a/service/resource/cloudformation/create_test.go
+++ b/service/resource/cloudformation/create_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/awstpr"
 	"github.com/giantswarm/clustertpr"
@@ -13,11 +14,11 @@ import (
 
 func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 	testCases := []struct {
-		obj                  interface{}
-		currentState         interface{}
-		desiredState         interface{}
-		expectedCreateChange StackState
-		description          string
+		obj               interface{}
+		currentState      interface{}
+		desiredState      interface{}
+		expectedStackName string
+		description       string
 	}{
 		{
 			description: "current and desired state empty, expected empty",
@@ -30,9 +31,9 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 					},
 				},
 			},
-			currentState:         StackState{},
-			desiredState:         StackState{},
-			expectedCreateChange: StackState{},
+			currentState:      StackState{},
+			desiredState:      StackState{},
+			expectedStackName: "",
 		},
 		{
 			description: "current state empty, desired state not empty, expected desired state",
@@ -49,9 +50,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 			desiredState: StackState{
 				Name: "desired",
 			},
-			expectedCreateChange: StackState{
-				Name: "desired",
-			},
+			expectedStackName: "desired",
 		},
 		{
 			description: "current state not empty, desired state not empty but different, expected desired state",
@@ -70,9 +69,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 			desiredState: StackState{
 				Name: "desired",
 			},
-			expectedCreateChange: StackState{
-				Name: "desired",
-			},
+			expectedStackName: "desired",
 		},
 	}
 
@@ -95,14 +92,12 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)
 			}
-
-			createChange, ok := result.(StackState)
+			createChange, ok := result.(awscloudformation.CreateStackInput)
 			if !ok {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
-
-			if createChange.Name != tc.expectedCreateChange.Name {
-				t.Errorf("expected %s, got %s", tc.expectedCreateChange.Name, createChange.Name)
+			if *createChange.StackName != tc.expectedStackName {
+				t.Errorf("expected %s, got %s", tc.expectedStackName, createChange.StackName)
 			}
 		})
 	}

--- a/service/resource/cloudformation/create_test.go
+++ b/service/resource/cloudformation/create_test.go
@@ -1,0 +1,109 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Cloudformation_newCreate(t *testing.T) {
+	testCases := []struct {
+		obj                  interface{}
+		currentState         interface{}
+		desiredState         interface{}
+		expectedCreateChange StackState
+		description          string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState:         StackState{},
+			desiredState:         StackState{},
+			expectedCreateChange: StackState{},
+		},
+		{
+			description: "current state empty, desired state not empty, expected desired state",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedCreateChange: StackState{
+				Name: "desired",
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState: StackState{
+				Name: "current",
+			},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedCreateChange: StackState{
+				Name: "desired",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		awsCfg := awsutil.Config{}
+		resourceConfig.Clients = awsutil.NewClients(awsCfg)
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+
+			createChange, ok := result.(StackState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChange, result)
+			}
+
+			if createChange.Name != tc.expectedCreateChange.Name {
+				t.Errorf("expected %s, got %s", tc.expectedCreateChange.Name, createChange.Name)
+			}
+		})
+	}
+}

--- a/service/resource/cloudformation/error.go
+++ b/service/resource/cloudformation/error.go
@@ -31,3 +31,5 @@ func IsStackNotFound(err error) bool {
 	}
 	return strings.Contains(microerror.Cause(err).Error(), "does not exist")
 }
+
+var wrongTypeError = microerror.New("wrong type")

--- a/service/resource/cloudformation/error.go
+++ b/service/resource/cloudformation/error.go
@@ -33,3 +33,8 @@ func IsStackNotFound(err error) bool {
 }
 
 var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -1,6 +1,7 @@
 package cloudformation
 
 import (
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/microerror"
@@ -69,4 +70,30 @@ func (r *Resource) Name() string {
 
 func (r *Resource) Underlying() framework.Resource {
 	return r
+}
+
+func toStackState(v interface{}) (StackState, error) {
+	if v == nil {
+		return StackState{}, nil
+	}
+
+	stackState, ok := v.(StackState)
+	if !ok {
+		return StackState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", stackState, v)
+	}
+
+	return stackState, nil
+}
+
+func toCreateStackInput(v interface{}) (awscloudformation.CreateStackInput, error) {
+	if v == nil {
+		return awscloudformation.CreateStackInput{}, nil
+	}
+
+	createStackInput, ok := v.(awscloudformation.CreateStackInput)
+	if !ok {
+		return awscloudformation.CreateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", createStackInput, v)
+	}
+
+	return createStackInput, nil
 }

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -4,7 +4,7 @@ import awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 
 const (
 	// defaultCreationTimeout is the timeout in minutes for the creation of the stack.
-	defaultCreationTimeout = 30
+	defaultCreationTimeout = 10
 )
 
 // StackState is the state representation on which the resource methods work.

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -2,7 +2,12 @@ package cloudformation
 
 import awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 
-// StackState is the state representation on which the resource methods work
+const (
+	// defaultCreationTimeout is the timeout in minutes for the creation of the stack.
+	defaultCreationTimeout = 30
+)
+
+// StackState is the state representation on which the resource methods work.
 type StackState struct {
 	Name    string
 	Outputs []*awscloudformation.Output


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

When creating the create change the comparison is done only taking into account the stack name, not the parameters/outputs, AIUI this should be done in the Patch methods, let me know WDYT.