### PR TITLE
add current method to cloudformation resource

### DIFF
--- a/service/resource/cloudformation/current.go
+++ b/service/resource/cloudformation/current.go
@@ -1,7 +1,44 @@
 package cloudformation
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/microerror"
+)
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return nil, nil
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.Log("cluster", key.ClusterID(customObject), "debug", "looking for AWS stack")
+
+	stackName := key.MainStackName(customObject)
+
+	describeInput := &awsCF.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	}
+	describeOutput, err := r.awsClient.DescribeStacks(describeInput)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if len(describeOutput.Stacks) != 1 {
+		return nil, microerror.Mask(
+			fmt.Errorf("unexpected number of stacks with name %q found, %d",
+				stackName,
+				len(describeOutput.Stacks)))
+	}
+
+	outputStackState := StackState{
+		Name:    stackName,
+		Outputs: describeOutput.Stacks[0].Outputs,
+	}
+
+	return outputStackState, nil
 }

--- a/service/resource/cloudformation/error.go
+++ b/service/resource/cloudformation/error.go
@@ -29,5 +29,5 @@ func IsStackNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "does not exist")
+	return strings.Contains(microerror.Cause(err).Error(), "does not exist")
 }

--- a/service/resource/cloudformation/error.go
+++ b/service/resource/cloudformation/error.go
@@ -1,6 +1,10 @@
 package cloudformation
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var invalidConfigError = microerror.New("invalid config")
 
@@ -14,4 +18,16 @@ var notFoundError = microerror.New("not found")
 // IsNotFound asserts notFoundError.
 func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
+}
+
+// IsStackNotFound asserts stack not found error from upstream's API message
+//
+// FIXME: The validation error returned by the CloudFormation API doesn't make
+// things easy to check, other than looking for the returned string. There's no
+// constant in aws go sdk for defining this string, it comes from the service.
+func IsStackNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "does not exist")
 }

--- a/service/resource/cloudformation/main_stack.go
+++ b/service/resource/cloudformation/main_stack.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"text/template"
 
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
 )
@@ -12,8 +13,8 @@ func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
 	stackName := key.MainStackName(customObject)
 
 	mainCF := StackState{
-		Name:         stackName,
-		TemplateBody: MainTemplate,
+		Name:    stackName,
+		Outputs: []*awsCF.Output{},
 	}
 
 	return mainCF, nil

--- a/service/resource/cloudformation/main_stack.go
+++ b/service/resource/cloudformation/main_stack.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"text/template"
 
-	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
 )
@@ -14,7 +14,7 @@ func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
 
 	mainCF := StackState{
 		Name:    stackName,
-		Outputs: []*awsCF.Output{},
+		Outputs: []*awscloudformation.Output{},
 	}
 
 	return mainCF, nil

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -1,7 +1,9 @@
 package cloudformation
 
+import awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+
 // StackState is the state representation on which the resource methods work
 type StackState struct {
-	Name         string
-	TemplateBody string
+	Name    string
+	Outputs []*awsCF.Output
 }

--- a/service/resource/cloudformation/spec.go
+++ b/service/resource/cloudformation/spec.go
@@ -1,9 +1,9 @@
 package cloudformation
 
-import awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+import awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 
 // StackState is the state representation on which the resource methods work
 type StackState struct {
 	Name    string
-	Outputs []*awsCF.Output
+	Outputs []*awscloudformation.Output
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

Additionally to the method for getting the current state, the current outputs are added to the state and the template body is removed (it is only used when creating the stack and does not represent state).