### PR TITLE
Return empty patch struct to avoid panic from framework

### DIFF
--- a/service/resource/cloudformation/delete.go
+++ b/service/resource/cloudformation/delete.go
@@ -11,5 +11,5 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return nil, nil
+	return &framework.Patch{}, nil
 }

--- a/service/resource/cloudformation/update.go
+++ b/service/resource/cloudformation/update.go
@@ -11,5 +11,5 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return nil, nil
+	return &framework.Patch{}, nil
 }


### PR DESCRIPTION
I hit a problem with the operator crash looping because the Patch was nil. I'll propose a fix in operatorkit but I think its good to also return the empty struct here.

```
{"action":"end","caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource/logresource/resource.go:100","component":"operatorkit","function":"NewUpdatePatch","time":"2017-11-08 15:45:53.675","underlyingResource":"cloudformation"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12b2a74]

goroutine 27 [running]:
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework.(*Patch).getCreateChange(...)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/patch.go:28
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework.ProcessUpdate(0x2b6bbe0, 0xc420332450, 0x1be0280, 0xc4201cf200, 0xc42030a1a0, 0x2, 0x2, 0x0, 0xc4202cbb30)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:392 +0x2c4
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework.(*Framework).UpdateFunc(0xc420385db0, 0x0, 0x0, 0x1be0280, 0xc4201cf200)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:189 +0x24f
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework.(*Framework).ProcessEvents.func1(0xc420050720, 0xc420050720)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:319 +0x298
github.com/giantswarm/aws-operator/vendor/github.com/cenk/backoff.RetryNotify(0xc4203bcec0, 0x2b5eea0, 0xc420050720, 0xc420589ca0, 0x1cc5bb8, 0x2b6bb60)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/cenk/backoff/retry.go:37 +0x88
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework.(*Framework).ProcessEvents(0xc420385db0, 0x2b6bb60, 0xc420068048, 0xc4201a6a20, 0xc4201a6a80, 0xc4201a6ae0)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:332 +0x102
github.com/giantswarm/aws-operator/service/operator.(*Operator).bootWithError(0xc420385e00, 0xbe78e7896c0a266c, 0x171f16b8)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/operator/operator.go:124 +0x154
github.com/giantswarm/aws-operator/service/operator.(*Operator).Boot.func1.1(0xc420050840, 0xc420050840)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/operator/operator.go:93 +0x2a
github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc4202c2000, 0x2b5eee0, 0xc420050840, 0xc420589ed0, 0x4, 0xc420072be0)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0x88
github.com/giantswarm/aws-operator/service/operator.(*Operator).Boot.func1()
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/operator/operator.go:105 +0xa9
sync.(*Once).Do(0xc420385e38, 0xc420029738)
	/Users/ross/.gvm/gos/go1.9.1/src/sync/once.go:44 +0xbe
github.com/giantswarm/aws-operator/service/operator.(*Operator).Boot(0xc420385e00)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/operator/operator.go:91 +0x4c
github.com/giantswarm/aws-operator/service.(*Service).Boot.func1()
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/service.go:371 +0x2e
sync.(*Once).Do(0xc4203e51e8, 0xc4200297b8)
	/Users/ross/.gvm/gos/go1.9.1/src/sync/once.go:44 +0xbe
github.com/giantswarm/aws-operator/service.(*Service).Boot(0xc4203e51d0)
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/service/service.go:370 +0x4c
created by main.main.func1
	/Users/ross/.gvm/pkgsets/go1.9.1/giantswarm/src/github.com/giantswarm/aws-operator/main.go:63 +0x1f0
```
