### PR TITLE
Don't create workers ASG if the cluster version is cloud formation

### DIFF
--- a/service/cloudconfig/cloud_config.go
+++ b/service/cloudconfig/cloud_config.go
@@ -56,8 +56,9 @@ func New(config Config) (*CloudConfig, error) {
 func (c *CloudConfig) NewMasterTemplate(customObject awstpr.CustomObject, certs certificatetpr.CompactTLSAssets, keys randomkeytpr.CompactRandomKeyAssets) (string, error) {
 	var err error
 
-	// TODO remove defaulting as soon as custom objects are configured.
-	if !key.HasClusterVersion(customObject) {
+	// Default the version if it is not configured or we are using Cloud Formation.
+	// TODO Remove once Cloud Formation migration is complete.
+	if !key.HasClusterVersion(customObject) || key.UseCloudFormation(customObject) {
 		customObject.Spec.Cluster.Version = string(cloudconfig.V_0_1_0)
 	}
 
@@ -82,8 +83,9 @@ func (c *CloudConfig) NewMasterTemplate(customObject awstpr.CustomObject, certs 
 func (c *CloudConfig) NewWorkerTemplate(customObject awstpr.CustomObject, certs certificatetpr.CompactTLSAssets) (string, error) {
 	var err error
 
-	// TODO remove defaulting as soon as custom objects are configured.
-	if customObject.Spec.Cluster.Version == "" {
+	// Default the version if it is not configured or we are using Cloud Formation.
+	// TODO Remove once Cloud Formation migration is complete.
+	if !key.HasClusterVersion(customObject) || key.UseCloudFormation(customObject) {
 		customObject.Spec.Cluster.Version = string(cloudconfig.V_0_1_0)
 	}
 

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -8,6 +8,13 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	// cloudFormationVersion is set during the migration so resources are
+	// managed by the cloudformation resource.
+	// TODO Remove once the migration is complete.
+	cloudFormationVersion = "cloud-formation"
+)
+
 func AutoScalingGroupName(customObject awstpr.CustomObject, groupName string) string {
 	return fmt.Sprintf("%s-%s", ClusterID(customObject), groupName)
 }
@@ -83,6 +90,16 @@ func ToCustomObject(v interface{}) (awstpr.CustomObject, error) {
 	customObject := *customObjectPointer
 
 	return customObject, nil
+}
+
+// UseCloudFormation returns true if the cluster version is "cloud-formation".
+// This will be used while we migrate to Cloud Formation and then removed.
+func UseCloudFormation(customObject awstpr.CustomObject) bool {
+	if ClusterVersion(customObject) == cloudFormationVersion {
+		return true
+	}
+
+	return false
 }
 
 func WorkerCount(customObject awstpr.CustomObject) int {

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -402,3 +402,37 @@ func Test_MainStackName(t *testing.T) {
 		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
 	}
 }
+
+func Test_UseCloudFormation(t *testing.T) {
+	tests := []struct {
+		clusterVersion string
+		expectedResult bool
+	}{
+		{
+			clusterVersion: "cloud-formation",
+			expectedResult: true,
+		},
+		{
+			clusterVersion: "v_0_1_0",
+			expectedResult: false,
+		},
+		{
+			clusterVersion: "",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range tests {
+		cluster := awstpr.CustomObject{
+			Spec: awstpr.Spec{
+				Cluster: clustertpr.Spec{
+					Version: tc.clusterVersion,
+				},
+			},
+		}
+
+		if UseCloudFormation(cluster) != tc.expectedResult {
+			t.Fatalf("Expected use cloud formation to be %t but was %t", tc.expectedResult, UseCloudFormation(cluster))
+		}
+	}
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

This PR adds a UseCloudFormation key helper we'll use to enable / disable logic while we migrate to CF. It returns true when the cluster version is set to "cloud-formation" which we can do via the helm local chart.

The workers ASG is disabled in the legacy resource if the CF version is set. We will expand this as more resources are migrated to the CF templates.

@xh3b4sd This is just an FYI on the approach.

