### PR TITLE
implement cloudformation resource update methods

### DIFF
--- a/service/resource/cloudformation/current.go
+++ b/service/resource/cloudformation/current.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/resource/cloudformation/main_stack.go
+++ b/service/resource/cloudformation/main_stack.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 	"text/template"
 
-	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
+
+	"github.com/giantswarm/aws-operator/service/key"
 )
 
 func newMainStack(customObject awstpr.CustomObject) (StackState, error) {

--- a/service/resource/cloudformation/resource.go
+++ b/service/resource/cloudformation/resource.go
@@ -120,3 +120,16 @@ func getStackOutputValue(outputs []*awscloudformation.Output, key string) (strin
 
 	return "", microerror.Mask(notFoundError)
 }
+
+func toUpdateStackInput(v interface{}) (awscloudformation.UpdateStackInput, error) {
+	if v == nil {
+		return awscloudformation.UpdateStackInput{}, nil
+	}
+
+	updateStackInput, ok := v.(awscloudformation.UpdateStackInput)
+	if !ok {
+		return awscloudformation.UpdateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", updateStackInput, v)
+	}
+
+	return updateStackInput, nil
+}

--- a/service/resource/cloudformation/update.go
+++ b/service/resource/cloudformation/update.go
@@ -90,15 +90,15 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		updateState.TemplateBody = aws.String(mainTemplate)
 		updateState.Parameters = []*awscloudformation.Parameter{
 			{
-				ParameterKey:   aws.String("workers"),
+				ParameterKey:   aws.String(workersParameterKey),
 				ParameterValue: aws.String(desiredStackState.Workers),
 			},
 			{
-				ParameterKey:   aws.String("imageID"),
+				ParameterKey:   aws.String(imageIDParameterKey),
 				ParameterValue: aws.String(desiredStackState.ImageID),
 			},
 			{
-				ParameterKey:   aws.String("clusterVersion"),
+				ParameterKey:   aws.String(clusterVersionParameterKey),
 				ParameterValue: aws.String(desiredStackState.ClusterVersion),
 			},
 		}

--- a/service/resource/cloudformation/update.go
+++ b/service/resource/cloudformation/update.go
@@ -2,15 +2,107 @@ package cloudformation
 
 import (
 	"context"
+	"reflect"
 
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/aws-operator/service/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	updateStackInput, err := toUpdateStackInput(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	stackName := updateStackInput.StackName
+	if *stackName != "" {
+		_, err := r.awsClient.UpdateStack(&updateStackInput)
+		if err != nil {
+			return microerror.Maskf(err, "updating AWS cloudformation stack")
+		}
+
+		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "updating AWS cloudformation stack: updated")
+	} else {
+		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "updating AWS cloudformation stack: no need to update")
+	}
+
 	return nil
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
 	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+
+	r.logger.Log("cluster", key.ClusterID(customObject), "debug", "finding out if the main stack should be updated")
+
+	updateState := awscloudformation.UpdateStackInput{
+		StackName: aws.String(""),
+	}
+
+	if !reflect.DeepEqual(desiredStackState, currentStackState) {
+		var mainTemplate string
+		/*
+			      commented out until we assing proper values to the template
+						mainTemplate, err := getMainTemplateBody(customObject)
+						if err != nil {
+							return nil, microerror.Mask(err)
+						}
+		*/
+		updateState.StackName = aws.String(desiredStackState.Name)
+		updateState.TemplateBody = aws.String(mainTemplate)
+		updateState.Parameters = []*awscloudformation.Parameter{
+			{
+				ParameterKey:   aws.String("workers"),
+				ParameterValue: aws.String(desiredStackState.Workers),
+			},
+			{
+				ParameterKey:   aws.String("imageID"),
+				ParameterValue: aws.String(desiredStackState.ImageID),
+			},
+			{
+				ParameterKey:   aws.String("clusterVersion"),
+				ParameterValue: aws.String(desiredStackState.ClusterVersion),
+			},
+		}
+	}
+
+	return updateState, nil
 }

--- a/service/resource/cloudformation/update_test.go
+++ b/service/resource/cloudformation/update_test.go
@@ -63,15 +63,15 @@ func Test_Resource_Cloudformation_newUpdateChange(t *testing.T) {
 				TemplateBody: aws.String(""),
 				Parameters: []*awscloudformation.Parameter{
 					{
-						ParameterKey:   aws.String("workers"),
+						ParameterKey:   aws.String(workersParameterKey),
 						ParameterValue: aws.String("4"),
 					},
 					{
-						ParameterKey:   aws.String("imageID"),
+						ParameterKey:   aws.String(imageIDParameterKey),
 						ParameterValue: aws.String("ami-1234"),
 					},
 					{
-						ParameterKey:   aws.String("clusterVersion"),
+						ParameterKey:   aws.String(clusterVersionParameterKey),
 						ParameterValue: aws.String("myclusterversion"),
 					},
 				},
@@ -105,15 +105,15 @@ func Test_Resource_Cloudformation_newUpdateChange(t *testing.T) {
 				TemplateBody: aws.String(""),
 				Parameters: []*awscloudformation.Parameter{
 					{
-						ParameterKey:   aws.String("workers"),
+						ParameterKey:   aws.String(workersParameterKey),
 						ParameterValue: aws.String("4"),
 					},
 					{
-						ParameterKey:   aws.String("imageID"),
+						ParameterKey:   aws.String(imageIDParameterKey),
 						ParameterValue: aws.String("ami-1234"),
 					},
 					{
-						ParameterKey:   aws.String("clusterVersion"),
+						ParameterKey:   aws.String(clusterVersionParameterKey),
 						ParameterValue: aws.String("myclusterversion"),
 					},
 				},

--- a/service/resource/cloudformation/update_test.go
+++ b/service/resource/cloudformation/update_test.go
@@ -1,0 +1,152 @@
+package cloudformation
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsutil "github.com/giantswarm/aws-operator/client/aws"
+)
+
+func Test_Resource_Cloudformation_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		obj            interface{}
+		currentState   interface{}
+		desiredState   interface{}
+		expectedChange interface{}
+		description    string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState: StackState{},
+			desiredState: StackState{},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "current state empty, desired state not empty, expected desired state",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState: StackState{},
+			desiredState: StackState{
+				Name:           "desired",
+				Workers:        "4",
+				ImageID:        "ami-1234",
+				ClusterVersion: "myclusterversion",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName:    aws.String("desired"),
+				TemplateBody: aws.String(""),
+				Parameters: []*awscloudformation.Parameter{
+					{
+						ParameterKey:   aws.String("workers"),
+						ParameterValue: aws.String("4"),
+					},
+					{
+						ParameterKey:   aws.String("imageID"),
+						ParameterValue: aws.String("ami-1234"),
+					},
+					{
+						ParameterKey:   aws.String("clusterVersion"),
+						ParameterValue: aws.String("myclusterversion"),
+					},
+				},
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: spec.Cluster{
+							ID: "5xchu",
+						},
+					},
+				},
+			},
+			currentState: StackState{
+				Name:           "current",
+				Workers:        "3",
+				ImageID:        "ami-6789",
+				ClusterVersion: "oldclusterversion",
+			},
+			desiredState: StackState{
+				Name:           "desired",
+				Workers:        "4",
+				ImageID:        "ami-1234",
+				ClusterVersion: "myclusterversion",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName:    aws.String("desired"),
+				TemplateBody: aws.String(""),
+				Parameters: []*awscloudformation.Parameter{
+					{
+						ParameterKey:   aws.String("workers"),
+						ParameterValue: aws.String("4"),
+					},
+					{
+						ParameterKey:   aws.String("imageID"),
+						ParameterValue: aws.String("ami-1234"),
+					},
+					{
+						ParameterKey:   aws.String("clusterVersion"),
+						ParameterValue: aws.String("myclusterversion"),
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		awsCfg := awsutil.Config{}
+		resourceConfig.Clients = awsutil.NewClients(awsCfg)
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newUpdateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			updateChange, ok := result.(awscloudformation.UpdateStackInput)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", updateChange, result)
+			}
+			if !reflect.DeepEqual(updateChange, tc.expectedChange) {
+				t.Errorf("expected %v, got %v", tc.expectedChange, updateChange)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

These changes add more fields to the `StackState` type in order to describe a stack, instead of using foreign types. Currently we take into account the number of workers, their AMI and the cluster version, changes on any of them would trigger an update.