### PR TITLE
Disable cloudformation resource before starting the transition

### DIFF
--- a/service/resource/cloudformation/create.go
+++ b/service/resource/cloudformation/create.go
@@ -10,6 +10,16 @@ import (
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// no-op if we are not using cloudformation
+	if !key.UseCloudFormation(customObject) {
+		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "not processing cloudformation stack")
+		return nil
+	}
+
 	stackInput, err := toCreateStackInput(createChange)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/resource/cloudformation/delete.go
+++ b/service/resource/cloudformation/delete.go
@@ -16,6 +16,12 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	// no-op if we are not using cloudformation
+	if !key.UseCloudFormation(customObject) {
+		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "not processing cloudformation stack")
+		return nil
+	}
+
 	deleteStackInput, err := toDeleteStackInput(deleteChange)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/resource/cloudformation/update.go
+++ b/service/resource/cloudformation/update.go
@@ -17,6 +17,12 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	// no-op if we are not using cloudformation
+	if !key.UseCloudFormation(customObject) {
+		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "not processing cloudformation stack")
+		return nil
+	}
+
 	updateStackInput, err := toUpdateStackInput(updateChange)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

During the first stages of the transition, we don't want to affect existing clusters, nor new ones created in production, only the ones in which we set explicitly the cluster version for testing purposes. We have a helper method `UseCloudFormation` that checks the cluster version for a specific value which should enable the resource.

The current approach does the cluster version check at the resource methods level, not sure if we could check somehow if cloudformation could be removed from the resources array https://github.com/giantswarm/aws-operator/blob/operatorkit/service/service.go#L214 before instantiating the framework.