### PR TITLE
Fix error in reconciliation loop when service already exists

### DIFF
--- a/service/resource/legacy/master_service.go
+++ b/service/resource/legacy/master_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/aws-operator/resources/aws"
 	"github.com/giantswarm/aws-operator/service/key"
 	"github.com/giantswarm/awstpr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/pkg/api/v1"
@@ -93,11 +94,11 @@ func (s *Resource) createMasterService(input MasterServiceInput) error {
 		},
 	}
 
-	if _, err := s.k8sClient.Core().Services(service.ObjectMeta.Namespace).Create(&service); err != nil {
+	if _, err := s.k8sClient.Core().Services(service.ObjectMeta.Namespace).Create(&service); err != nil && !apierrors.IsAlreadyExists(err) {
 		return microerror.Mask(err)
 	}
 
-	if _, err := s.k8sClient.Core().Endpoints(endpoint.ObjectMeta.Namespace).Create(&endpoint); err != nil {
+	if _, err := s.k8sClient.Core().Endpoints(endpoint.ObjectMeta.Namespace).Create(&endpoint); err != nil && !apierrors.IsAlreadyExists(err) {
 		return microerror.Mask(err)
 	}
 


### PR DESCRIPTION
Will prevent errors like this on cluster reprocess:
```
{"action":"error","caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource/logresource/resource.go:96","component":"operatorkit","function":"NewUpdatePatch","time":"2017-11-14 13:08:21.077","underlyingResource":"legacy"}
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:215","error":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:412: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource/metricsresource/resource.go:109: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource/logresource/resource.go:97: } {/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/resource.go:204: } {/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/resource.go:974: } {/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/master_service.go:97: } {services \"master\" already exists}]","event":"update","time":"2017-11-14 13:08:21.077"}
```