### PR TITLE
Vendor: remove kubeproxy unit

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0e05add1a117b58ead0a42b6355d62469160970f41467166eb20a9a32c3b3c21
-updated: 2017-11-22T12:34:49.907568247+01:00
+hash: 8b167e061d4f6de83b2b505cf12a80c895abeb46d96ba8b63832c251badd2810
+updated: 2017-11-22T18:12:54.03010575+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 8b344ddb7a49daf794928d1db484ad9a81499858
@@ -95,7 +95,7 @@ imports:
 - name: github.com/giantswarm/e2e-harness
   version: 59cf7b74ca2c0149f9e18e337c9ea9ed3f025099
 - name: github.com/giantswarm/k8scloudconfig
-  version: af226a776a758ffa33eb715daa7a04a3906dde13
+  version: 96e3658464a136d8700c27f9ba9f44942dad3ff1
   subpackages:
   - v_0_1_0
 - name: github.com/giantswarm/microendpoint
@@ -124,15 +124,16 @@ imports:
   - transaction/context/id
   - transaction/context/tracked
 - name: github.com/giantswarm/micrologger
-  version: 954d1261928bbb50dc917c629edf0b71db6a1527
+  version: c2ffba36495025eff48982e6543397dbc4da0ac6
   subpackages:
+  - loggercontext
   - microloggertest
 - name: github.com/giantswarm/microstorage
   version: 99418478ec8f5c68f9b5fc5e6be7e0474948f80d
   subpackages:
   - memory
 - name: github.com/giantswarm/operatorkit
-  version: 0bd1c4365f66a52c233957c38367ca3a3c2a81e9
+  version: 443b5fd52645b29e15f23dedf63865fba4a23564
   subpackages:
   - client/k8sclient
   - framework

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
 - package: github.com/giantswarm/awstpr
   version: master
 - package: github.com/giantswarm/k8scloudconfig
-  version: master
+  version: remove-kubeproxy-unit
 - package: github.com/stretchr/testify
   version: v1.1.4
   repo: git://github.com/stretchr/testify.git

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/worker_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/worker_template.go
@@ -295,53 +295,6 @@ coreos:
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
-  - name: k8s-proxy.service
-    enable: false
-    command: stop
-    content: |
-      [Unit]
-      Description=k8s-proxy
-      StartLimitIntervalSec=0
-
-      [Service]
-      Restart=always
-      RestartSec=0
-      TimeoutStopSec=10
-      EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
-      Environment="NAME=%p.service"
-      Environment="NETWORK_CONFIG_CONTAINER="
-      ExecStartPre=/usr/bin/docker pull $IMAGE
-      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
-      ExecStartPre=-/usr/bin/docker rm -f $NAME      
-      ExecStart=/bin/sh -c "/usr/bin/docker run --rm --net=host --privileged=true \
-      --name $NAME \
-      -v /usr/share/ca-certificates:/etc/ssl/certs \
-      -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
-      -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
-      $IMAGE \
-      /hyperkube proxy \
-      --proxy-mode=iptables \
-      --logtostderr=true \
-      --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
-      --conntrack-max-per-core 131072 \
-      --v=2"
-      ExecStop=-/usr/bin/docker stop -t 10 $NAME
-      ExecStopPost=-/usr/bin/docker rm -f $NAME
-  - name: k8s-proxy-watcher.service
-    enable: true
-    command: start
-    content: |
-      [Unit]
-      Description=k8s-proxy-watcher
-      Wants=k8s-kubelet.service
-      After=k8s-kubelet.service
-      
-      [Service]
-      Type=oneshot
-      ExecStartPre=/bin/sh -c "sleep 2m"
-      ExecStart=/bin/sh -c "proxyCount=$(docker ps | grep 'kube-proxy' | wc -l);if [ "$proxyCount" == "0" ]; then sudo systemctl start k8s-proxy; fi;"
-      RemainAfterExit=yes
 
   update:
     reboot-strategy: off

--- a/vendor/github.com/giantswarm/micrologger/loggercontext/logger_context.go
+++ b/vendor/github.com/giantswarm/micrologger/loggercontext/logger_context.go
@@ -1,0 +1,47 @@
+// Package loggercontext stores and accesses the container struct in
+// context.Context.
+package loggercontext
+
+import (
+	"context"
+)
+
+// key is an unexported type for keys defined in this package. This prevents
+// collisions with keys defined in other packages.
+type key string
+
+// loggerKey is the key for logger struct values in context.Context. Clients use
+// loggercontext.NewContext and loggercontext.FromContext instead of using this
+// key directly.
+var loggerKey key = "logger"
+
+// Container is a communication structure used to transport information in order
+// for a micro logger to use it when issuing logs.
+type Container struct {
+	// KeyVals is a mapping of key-value pairs a micro logger adds to the log
+	// message issuance.
+	KeyVals map[string]string
+}
+
+// NewContainer returns a new communication structure used to apply to a
+// context.
+func NewContainer() *Container {
+	return &Container{
+		KeyVals: map[string]string{},
+	}
+}
+
+// NewContext returns a new context.Context that carries value v.
+func NewContext(ctx context.Context, v *Container) context.Context {
+	if v == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, loggerKey, v)
+}
+
+// FromContext returns the logger struct, if any.
+func FromContext(ctx context.Context) (*Container, bool) {
+	v, ok := ctx.Value(loggerKey).(*Container)
+	return v, ok
+}

--- a/vendor/github.com/giantswarm/micrologger/loggercontext/logger_context_test.go
+++ b/vendor/github.com/giantswarm/micrologger/loggercontext/logger_context_test.go
@@ -1,0 +1,44 @@
+package loggercontext
+
+import (
+	"context"
+	"testing"
+)
+
+func Test_LoggerContext_NewContainer(t *testing.T) {
+	ctx := context.Background()
+
+	_, ok := FromContext(ctx)
+	if ok {
+		t.Fatalf("expected %#v got %#v", false, true)
+	}
+
+	ctx = NewContext(ctx, NewContainer())
+
+	c1, ok := FromContext(ctx)
+	if !ok {
+		t.Fatalf("expected %#v got %#v", true, false)
+	}
+	l1 := len(c1.KeyVals)
+	if l1 != 0 {
+		t.Fatalf("expected %#v got %#v", 0, l1)
+	}
+
+	c1.KeyVals["foo"] = "bar"
+
+	c2, ok := FromContext(ctx)
+	if !ok {
+		t.Fatalf("expected %#v got %#v", true, false)
+	}
+	l2 := len(c2.KeyVals)
+	if l2 != 1 {
+		t.Fatalf("expected %#v got %#v", 1, l2)
+	}
+	v2, ok := c2.KeyVals["foo"]
+	if !ok {
+		t.Fatalf("expected %#v got %#v", true, false)
+	}
+	if v2 != "bar" {
+		t.Fatalf("expected %#v got %#v", "bar", v2)
+	}
+}

--- a/vendor/github.com/giantswarm/micrologger/spec.go
+++ b/vendor/github.com/giantswarm/micrologger/spec.go
@@ -1,14 +1,19 @@
 package micrologger
 
+import "context"
+
 // Logger is a simple interface describing services that emit messages to gather
 // certain runtime information.
 type Logger interface {
 	// Log takes a sequence of alternating key/value pairs which are used to
 	// create the log message structure.
-	Log(v ...interface{}) error
-
-	// With returns a new contextual logger with keyvals appended to those
+	Log(keyVals ...interface{}) error
+	// LogWithCtx is the same as Log but additionally taking a context which may
+	// contain additional key-value pairs that are added to the log issuance, if
+	// any.
+	LogWithCtx(ctx context.Context, keyVals ...interface{}) error
+	// With returns a new contextual logger with keyVals appended to those
 	// passed to calls to Log. If logger is also a contextual logger
-	// created by With, keyvals is appended to the existing context.
-	With(keyvals ...interface{}) Logger
+	// created by With, keyVals is appended to the existing context.
+	With(keyVals ...interface{}) Logger
 }

--- a/vendor/github.com/giantswarm/operatorkit/framework/framework.go
+++ b/vendor/github.com/giantswarm/operatorkit/framework/framework.go
@@ -126,32 +126,34 @@ func (f *Framework) AddFunc(obj interface{}) {
 		var err error
 		ctx, err = f.initCtxFunc(ctx, obj)
 		if err != nil {
-			f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "create")
+			f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "create")
 			return
 		}
 	}
 
 	rs, err := f.resourceRouter(ctx, obj)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "create")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "create")
 		return
 	}
 
-	f.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessCreate")
+	f.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ProcessCreate")
 
 	err = ProcessCreate(ctx, obj, rs)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "create")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "create")
 		return
 	}
 
-	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessCreate")
+	f.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ProcessCreate")
 }
 
 func (f *Framework) Boot() {
+	ctx := context.TODO()
+
 	f.bootOnce.Do(func() {
 		operation := func() error {
-			err := f.bootWithError()
+			err := f.bootWithError(ctx)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -160,12 +162,12 @@ func (f *Framework) Boot() {
 		}
 
 		notifier := func(err error, d time.Duration) {
-			f.logger.Log("warning", fmt.Sprintf("retrying operator boot due to error: %#v", microerror.Mask(err)))
+			f.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying operator boot due to error: %#v", microerror.Mask(err)))
 		}
 
 		err := backoff.RetryNotify(operation, f.backOffFactory(), notifier)
 		if err != nil {
-			f.logger.Log("error", fmt.Sprintf("stop operator boot retries due to too many errors: %#v", microerror.Mask(err)))
+			f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("stop operator boot retries due to too many errors: %#v", microerror.Mask(err)))
 			os.Exit(1)
 		}
 	})
@@ -188,26 +190,26 @@ func (f *Framework) DeleteFunc(obj interface{}) {
 		var err error
 		ctx, err = f.initCtxFunc(ctx, obj)
 		if err != nil {
-			f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "delete")
+			f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "delete")
 			return
 		}
 	}
 
 	rs, err := f.resourceRouter(ctx, obj)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "delete")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "delete")
 		return
 	}
 
-	f.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessDelete")
+	f.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ProcessDelete")
 
 	err = ProcessDelete(ctx, obj, rs)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "delete")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "delete")
 		return
 	}
 
-	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessDelete")
+	f.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ProcessDelete")
 }
 
 // NewCacheResourceEventHandler returns the framework's event handler for the
@@ -242,26 +244,26 @@ func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
 		var err error
 		ctx, err = f.initCtxFunc(ctx, obj)
 		if err != nil {
-			f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "update")
+			f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "update")
 			return
 		}
 	}
 
 	rs, err := f.resourceRouter(ctx, obj)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "update")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "update")
 		return
 	}
 
-	f.logger.Log("action", "start", "component", "operatorkit", "function", "ProcessUpdate")
+	f.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ProcessUpdate")
 
 	err = ProcessUpdate(ctx, obj, rs)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("%#v", err), "event", "update")
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("%#v", err), "event", "update")
 		return
 	}
 
-	f.logger.Log("action", "end", "component", "operatorkit", "function", "ProcessUpdate")
+	f.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ProcessUpdate")
 }
 
 // ProcessCreate is a drop-in for an informer's AddFunc. It receives the custom
@@ -403,12 +405,12 @@ func (f *Framework) ProcessEvents(ctx context.Context, deleteChan chan watch.Eve
 	}
 
 	notifier := func(err error, d time.Duration) {
-		f.logger.Log("warning", fmt.Sprintf("retrying operator event processing due to error: %#v", microerror.Mask(err)))
+		f.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying operator event processing due to error: %#v", microerror.Mask(err)))
 	}
 
 	err := backoff.RetryNotify(operation, f.backOffFactory(), notifier)
 	if err != nil {
-		f.logger.Log("error", fmt.Sprintf("stop operator event processing retries due to too many errors: %#v", microerror.Mask(err)))
+		f.logger.LogWithCtx(ctx, "error", fmt.Sprintf("stop operator event processing retries due to too many errors: %#v", microerror.Mask(err)))
 		os.Exit(1)
 	}
 }
@@ -504,23 +506,23 @@ func ProcessUpdate(ctx context.Context, obj interface{}, resources []Resource) e
 	return nil
 }
 
-func (f *Framework) bootWithError() error {
+func (f *Framework) bootWithError(ctx context.Context) error {
 	if f.tpr != nil {
-		f.logger.Log("debug", "ensuring third party resource exists")
+		f.logger.LogWithCtx(ctx, "debug", "ensuring third party resource exists")
 
 		err := f.tpr.CreateAndWait()
 		if tpr.IsAlreadyExists(err) {
-			f.logger.Log("debug", "third party resource already exists")
+			f.logger.LogWithCtx(ctx, "debug", "third party resource already exists")
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			f.logger.Log("debug", "created third party resource")
+			f.logger.LogWithCtx(ctx, "debug", "created third party resource")
 		}
 
 		f.tpr.CollectMetrics(context.TODO())
 	}
 
-	f.logger.Log("debug", "starting list/watch")
+	f.logger.LogWithCtx(ctx, "debug", "starting list/watch")
 
 	deleteChan, updateChan, errChan := f.informer.Watch(context.TODO())
 	f.ProcessEvents(context.TODO(), deleteChan, updateChan, errChan)

--- a/vendor/github.com/giantswarm/operatorkit/framework/resource/logresource/resource.go
+++ b/vendor/github.com/giantswarm/operatorkit/framework/resource/logresource/resource.go
@@ -61,57 +61,57 @@ func New(config Config) (*Resource, error) {
 }
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetCurrentState")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "GetCurrentState")
 
 	v, err := r.resource.GetCurrentState(ctx, obj)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "GetCurrentState")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "GetCurrentState")
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "GetCurrentState")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "GetCurrentState")
 
 	return v, nil
 }
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "GetDesiredState")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "GetDesiredState")
 
 	v, err := r.resource.GetDesiredState(ctx, obj)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "GetDesiredState")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "GetDesiredState")
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "GetDesiredState")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "GetDesiredState")
 
 	return v, nil
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewUpdatePatch")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "NewUpdatePatch")
 
 	v, err := r.resource.NewUpdatePatch(ctx, obj, cur, des)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "NewUpdatePatch")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "NewUpdatePatch")
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewUpdatePatch")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "NewUpdatePatch")
 
 	return v, nil
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, cur, des interface{}) (*framework.Patch, error) {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "NewDeletePatch")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "NewDeletePatch")
 
 	v, err := r.resource.NewDeletePatch(ctx, obj, cur, des)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "NewDeletePatch")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "NewDeletePatch")
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "NewDeletePatch")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "NewDeletePatch")
 
 	return v, nil
 }
@@ -121,43 +121,43 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, cre interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyCreatePatch")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ApplyCreatePatch")
 
 	err := r.resource.ApplyCreateChange(ctx, obj, cre)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "ApplyCreatePatch")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "ApplyCreatePatch")
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyCreatePatch")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ApplyCreatePatch")
 
 	return nil
 }
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, del interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyDeletePatch")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ApplyDeletePatch")
 
 	err := r.resource.ApplyDeleteChange(ctx, obj, del)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "ApplyDeletePatch")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "ApplyDeletePatch")
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyDeletePatch")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ApplyDeletePatch")
 
 	return nil
 }
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, upd interface{}) error {
-	r.logger.Log("action", "start", "component", "operatorkit", "function", "ApplyUpdatePatch")
+	r.logger.LogWithCtx(ctx, "action", "start", "component", "operatorkit", "function", "ApplyUpdatePatch")
 
 	err := r.resource.ApplyUpdateChange(ctx, obj, upd)
 	if err != nil {
-		r.logger.Log("action", "error", "component", "operatorkit", "function", "ApplyUpdatePatch")
+		r.logger.LogWithCtx(ctx, "action", "error", "component", "operatorkit", "function", "ApplyUpdatePatch")
 		return microerror.Mask(err)
 	}
 
-	r.logger.Log("action", "end", "component", "operatorkit", "function", "ApplyUpdatePatch")
+	r.logger.LogWithCtx(ctx, "action", "end", "component", "operatorkit", "function", "ApplyUpdatePatch")
 
 	return nil
 }

--- a/vendor/github.com/giantswarm/operatorkit/framework/resource/retryresource/resource.go
+++ b/vendor/github.com/giantswarm/operatorkit/framework/resource/retryresource/resource.go
@@ -93,7 +93,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'GetCurrentState' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'GetCurrentState' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -118,7 +118,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'GetDesiredState' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'GetDesiredState' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -143,7 +143,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'NewUpdatePatch' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'NewUpdatePatch' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -168,7 +168,7 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'NewDeletePatch' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'NewDeletePatch' due to error (%s)", err.Error()))
 	}
 
 	err = backoff.RetryNotify(o, r.backOff, n)
@@ -194,7 +194,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState inter
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyCreatePatch' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'ApplyCreatePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -216,7 +216,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState inter
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyDeletePatch' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'ApplyDeletePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)
@@ -238,7 +238,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState inter
 	}
 
 	n := func(err error, dur time.Duration) {
-		r.logger.Log("warning", fmt.Sprintf("retrying 'ApplyUpdatePatch' due to error (%s)", err.Error()))
+		r.logger.LogWithCtx(ctx, "warning", fmt.Sprintf("retrying 'ApplyUpdatePatch' due to error (%s)", err.Error()))
 	}
 
 	err := backoff.RetryNotify(o, r.backOff, n)

--- a/vendor/github.com/giantswarm/operatorkit/glide.lock
+++ b/vendor/github.com/giantswarm/operatorkit/glide.lock
@@ -1,5 +1,5 @@
 hash: 14f39052e4af8f278465730a1f238e28dfb8dfd3644a46de0ba256d4ac4438fc
-updated: 2017-11-17T11:53:50.684956762+01:00
+updated: 2017-11-22T17:08:04.416950417+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
@@ -27,10 +27,11 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/giantswarm/microerror
-  version: 5ade94eb4ee35ef72eb9382228470caeddb29989
+  version: ec5f66bb657662031c0d651504fee6908cdf28d9
 - name: github.com/giantswarm/micrologger
-  version: 954d1261928bbb50dc917c629edf0b71db6a1527
+  version: c2ffba36495025eff48982e6543397dbc4da0ac6
   subpackages:
+  - loggercontext
   - microloggertest
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
@@ -86,7 +87,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/prometheus/client_golang
-  version: 5cec1d0429b02e4323e042eb04dafdb079ddf568
+  version: 1cdba8fdde81f444626530cce66e138d2f68ae1c
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model


### PR DESCRIPTION
Removes kube-proxy systemd unit and timer which causes problems on AWS. It takes over 2 minutes for the apiserver to start due to the delay from the etcd and apiserver ELBs.

If this change is KVM specific it should be embedded by kvm-operator.

