### PR TITLE
Enables asg metrics

### DIFF
--- a/resources/aws/auto_scaling_group.go
+++ b/resources/aws/auto_scaling_group.go
@@ -6,6 +6,10 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	ASGMetricsGranularity = "1Minute"
+)
+
 type AutoScalingGroup struct {
 	// AvailabilityZone is the AZ the instances will be placed in.
 	AvailabilityZone string
@@ -91,6 +95,13 @@ func (asg *AutoScalingGroup) CreateOrFail() error {
 	}
 
 	if _, err := asg.Client.CreateAutoScalingGroup(params); err != nil {
+		return microerror.Mask(err)
+	}
+
+	if _, err := asg.Client.EnableMetricsCollection(&autoscaling.EnableMetricsCollectionInput{
+		AutoScalingGroupName: aws.String(asg.Name),
+		Granularity:          aws.String(ASGMetricsGranularity),
+	}); err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/templates/cloudformation/auto_scaling_group.yaml
+++ b/service/templates/cloudformation/auto_scaling_group.yaml
@@ -10,6 +10,8 @@
       LoadBalancerNames:
         - {{ .LoadBalancerName }}
       HealthCheckGracePeriod: {{ .HealthCheckGracePeriod }}
+      MetricsCollection:
+        - Granularity: "1Minute"
     UpdatePolicy:
       AutoScalingRollingUpdate:
         # minimum amount of instances that must always be running during a rolling update


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2116

This enables ASG cloudwatch metrics for new ASGs.