### PR TITLE
prevent ic schedule error (not enough cpu)

### DIFF
--- a/examples/aws-resource-lab-chart/values.yaml
+++ b/examples/aws-resource-lab-chart/values.yaml
@@ -9,8 +9,8 @@ aws:
   region: "eu-central-1"
   az: "eu-central-1a"
   ami: "ami-d60ad6b9"
-  instanceTypeMaster: "m3.medium"
-  instanceTypeWorker: "m3.medium"
+  instanceTypeMaster: "m3.large"
+  instanceTypeWorker: "m3.large"
 
   apiHostedZone: "Z*************"
   ingressHostedZone: "Z*************"


### PR DESCRIPTION
Without this change the ic pods in a guest created from local lab stay in `Pending` because any node fulfills the cpu requirements.