### PR TITLE
Support creating k8s namespaces

### DIFF
--- a/service/resource/legacy/resource.go
+++ b/service/resource/legacy/resource.go
@@ -251,9 +251,13 @@ func (s *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 }
 
 func (s *Resource) processCluster(cluster awstpr.CustomObject) error {
-	// Create cluster namespace in k8s.
-	if err := s.createClusterNamespace(cluster.Spec.Cluster); err != nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create cluster namespace: '%#v'", err))
+	// For new clusters using Cloud Formation there is an OperatorKit resource
+	// for the k8s namespace.
+	if !key.UseCloudFormation(cluster) {
+		// Create cluster namespace in k8s.
+		if err := s.createClusterNamespace(cluster.Spec.Cluster); err != nil {
+			return microerror.Maskf(executionFailedError, fmt.Sprintf("could not create cluster namespace: '%#v'", err))
+		}
 	}
 
 	// Create AWS guest cluster client.

--- a/service/resource/namespace/create.go
+++ b/service/resource/namespace/create.go
@@ -2,8 +2,62 @@ package namespace
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/aws-operator/service/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// No-op if we are not using cloudformation.
+	if !key.UseCloudFormation(customObject) {
+		r.logger.LogCtx(ctx, "debug", "not processing Kubernetes namespace")
+		return nil
+	}
+
+	namespaceToCreate, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToCreate != nil {
+		r.logger.LogCtx(ctx, "debug", "creating Kubernetes namespace")
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", "creating Kubernetes namespace: created")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "creating Kubernetes namespace: already created")
+	}
+
 	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var namespaceToCreate *apiv1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	return namespaceToCreate, nil
 }

--- a/service/resource/namespace/create_test.go
+++ b/service/resource/namespace/create_test.go
@@ -1,0 +1,130 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	clustertprspec "github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+func Test_Resource_Namespace_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: clustertprspec.Cluster{
+							ID: "foobar",
+						},
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+
+		{
+			Obj: &awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					Cluster: clustertpr.Spec{
+						Cluster: clustertprspec.Cluster{
+							ID: "foobar",
+						},
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/resource/namespace/current.go
+++ b/service/resource/namespace/current.go
@@ -17,6 +17,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
+	// No-op if we are not using cloudformation.
+	if !key.UseCloudFormation(customObject) {
+		r.logger.LogCtx(ctx, "debug", "not processing Kubernetes namespace")
+		return nil, nil
+	}
+
 	r.logger.LogCtx(ctx, "debug", "looking for the namespace in the Kubernetes API")
 
 	// Lookup the current state of the namespace.

--- a/service/resource/namespace/current_test.go
+++ b/service/resource/namespace/current_test.go
@@ -25,6 +25,7 @@ func Test_Resource_Namespace_GetCurrentState(t *testing.T) {
 						Cluster: clustertprspec.Cluster{
 							ID: "al9qy",
 						},
+						Version: "cloud-formation",
 					},
 				},
 			},

--- a/service/resource/namespace/resource.go
+++ b/service/resource/namespace/resource.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
 	"k8s.io/client-go/kubernetes"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -63,4 +64,17 @@ func (r *Resource) Name() string {
 
 func (r *Resource) Underlying() framework.Resource {
 	return r
+}
+
+func toNamespace(v interface{}) (*apiv1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*apiv1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Namespace{}, v)
+	}
+
+	return namespace, nil
 }

--- a/service/resource/namespace/update.go
+++ b/service/resource/namespace/update.go
@@ -3,6 +3,7 @@ package namespace
 import (
 	"context"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )
 
@@ -11,5 +12,24 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 }
 
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return framework.NewPatch(), nil
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because Kubernetes namespaces are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

In this PR creating the k8s namespace is implemented as well as updating namespaces which is a no-op. Delete will follow in the final PR.