### PR TITLE
revert small cloud config in legacy

### DIFF
--- a/service/resource/legacy/asg_stack.go
+++ b/service/resource/legacy/asg_stack.go
@@ -15,7 +15,6 @@ import (
 	"github.com/giantswarm/aws-operator/resources"
 	awsresources "github.com/giantswarm/aws-operator/resources/aws"
 	"github.com/giantswarm/aws-operator/service/key"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformation/adapter"
 )
 
 type asgStackInput struct {
@@ -163,7 +162,7 @@ func (s *Resource) createASGStack(input asgStackInput) (bool, error) {
 		}
 	}
 
-	cloudconfigConfig := adapter.SmallCloudconfigConfig{
+	cloudconfigConfig := SmallCloudconfigConfig{
 		MachineType: input.asgType,
 		Region:      input.cluster.Spec.AWS.Region,
 		S3URI:       s.bucketName(input.cluster),
@@ -179,7 +178,7 @@ func (s *Resource) createASGStack(input asgStackInput) (bool, error) {
 		return false, microerror.Mask(err)
 	}
 
-	smallCloudconfig, err := adapter.SmallCloudconfig(cloudconfigConfig)
+	smallCloudconfig, err := s.SmallCloudconfig(cloudconfigConfig)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}

--- a/service/resource/legacy/launch_configuration.go
+++ b/service/resource/legacy/launch_configuration.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/aws-operator/resources"
 	awsresources "github.com/giantswarm/aws-operator/resources/aws"
 	"github.com/giantswarm/aws-operator/service/key"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformation/adapter"
 )
 
 type launchConfigurationInput struct {
@@ -62,7 +61,7 @@ func (s *Resource) createLaunchConfiguration(input launchConfigurationInput) (bo
 	// cloudconfig" that just fetches the previously uploaded "final
 	// cloudconfig" and executes coreos-cloudinit with it as argument.
 	// We do this to circumvent the 16KB limit on user-data for EC2 instances.
-	cloudconfigConfig := adapter.SmallCloudconfigConfig{
+	cloudconfigConfig := SmallCloudconfigConfig{
 		MachineType: input.prefix,
 		Region:      input.cluster.Spec.AWS.Region,
 		S3URI:       s.bucketName(input.cluster),
@@ -78,7 +77,7 @@ func (s *Resource) createLaunchConfiguration(input launchConfigurationInput) (bo
 		return false, microerror.Mask(err)
 	}
 
-	smallCloudconfig, err := adapter.SmallCloudconfig(cloudconfigConfig)
+	smallCloudconfig, err := s.SmallCloudconfig(cloudconfigConfig)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}

--- a/service/resource/legacy/machine.go
+++ b/service/resource/legacy/machine.go
@@ -14,7 +14,6 @@ import (
 	awsutil "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/resources"
 	awsresources "github.com/giantswarm/aws-operator/resources/aws"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformation/adapter"
 )
 
 type instanceNameInput struct {
@@ -168,7 +167,7 @@ func (s *Resource) runMachine(input runMachineInput) (bool, string, error) {
 	// cloudconfig" that just fetches the previously uploaded "final
 	// cloudconfig" and executes coreos-cloudinit with it as argument.
 	// We do this to circumvent the 16KB limit on user-data for EC2 instances.
-	cloudconfigConfig := adapter.SmallCloudconfigConfig{
+	cloudconfigConfig := SmallCloudconfigConfig{
 		MachineType: input.prefix,
 		Region:      input.cluster.Spec.AWS.Region,
 		S3URI:       s.bucketName(input.cluster),
@@ -185,7 +184,7 @@ func (s *Resource) runMachine(input runMachineInput) (bool, string, error) {
 		return false, "", microerror.Mask(err)
 	}
 
-	smallCloudconfig, err := adapter.SmallCloudconfig(cloudconfigConfig)
+	smallCloudconfig, err := s.SmallCloudconfig(cloudconfigConfig)
 	if err != nil {
 		return false, "", microerror.Mask(err)
 	}

--- a/service/resource/legacy/small_cloudconfig.go
+++ b/service/resource/legacy/small_cloudconfig.go
@@ -1,0 +1,30 @@
+package legacy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"html/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+type SmallCloudconfigConfig struct {
+	MachineType string
+	Region      string
+	S3URI       string
+}
+
+func (s *Resource) SmallCloudconfig(config SmallCloudconfigConfig) (string, error) {
+	tmpl, err := template.New("smallCloudconfig").Parse(userDataScriptTemplate)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, config)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}


### PR DESCRIPTION
Fixes a problem with the small cloudconfig template location:
```
{/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/resource.go:749: could not start masters: '[{/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/machine.go:102: } {/go/src/github.com/giantswarm/aws-operator/service/resource/legacy/machine.go:190: } {/go/src/github.com/giantswarm/aws-operator/service/resource/cloudformation/adapter/small_cloudconfig.go:22: } {open /go/src/github.com/giantswarm/service/templates/cloudconfig/small_cloudconfig.yaml: no such file or directory}]'} {execution failed}]","event":"update","object":"/apis/cluster.giantswarm.io/v1/namespaces/default/awses/jttr0","time":"2017-11-28 15:37:36.838"}
```

Tested on gauss