### PR TITLE
add template outputs

### DIFF
--- a/service/resource/cloudformationv1/adapter/adapter.go
+++ b/service/resource/cloudformationv1/adapter/adapter.go
@@ -37,6 +37,7 @@ type Adapter struct {
 
 	launchConfigAdapter
 	autoScalingGroupAdapter
+	outputsAdapter
 }
 
 func New(customObject awstpr.CustomObject, clients Clients) (Adapter, error) {
@@ -47,6 +48,7 @@ func New(customObject awstpr.CustomObject, clients Clients) (Adapter, error) {
 	hydraters := []hydrater{
 		a.getAutoScalingGroup,
 		a.getLaunchConfiguration,
+		a.getOutputs,
 	}
 
 	for _, h := range hydraters {

--- a/service/resource/cloudformationv1/adapter/outputs.go
+++ b/service/resource/cloudformationv1/adapter/outputs.go
@@ -1,0 +1,18 @@
+package adapter
+
+import (
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/awstpr"
+)
+
+// template related to this adapter: service/templates/cloudformation/outputs.yaml
+
+type outputsAdapter struct {
+	ClusterVersion string
+}
+
+func (o *outputsAdapter) getOutputs(customObject awstpr.CustomObject, clients Clients) error {
+	o.ClusterVersion = key.VersionBundleVersion(customObject)
+
+	return nil
+}

--- a/service/resource/cloudformationv1/adapter/outputs.go
+++ b/service/resource/cloudformationv1/adapter/outputs.go
@@ -12,7 +12,7 @@ type outputsAdapter struct {
 }
 
 func (o *outputsAdapter) getOutputs(customObject awstpr.CustomObject, clients Clients) error {
-	o.ClusterVersion = key.VersionBundleVersion(customObject)
+	o.ClusterVersion = key.ClusterVersion(customObject)
 
 	return nil
 }

--- a/service/resource/cloudformationv1/adapter/outputs_test.go
+++ b/service/resource/cloudformationv1/adapter/outputs_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/awstpr"
-	awstprspec "github.com/giantswarm/awstpr/spec"
+	"github.com/giantswarm/clustertpr"
 )
 
 func TestAdapterOutputsRegularFields(t *testing.T) {
@@ -22,7 +22,7 @@ func TestAdapterOutputsRegularFields(t *testing.T) {
 			description: "basic matching",
 			customObject: awstpr.CustomObject{
 				Spec: awstpr.Spec{
-					VersionBundle: awstprspec.VersionBundle{
+					Cluster: clustertpr.Spec{
 						Version: "myversion",
 					},
 				},

--- a/service/resource/cloudformationv1/adapter/outputs_test.go
+++ b/service/resource/cloudformationv1/adapter/outputs_test.go
@@ -1,0 +1,48 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/awstpr"
+	awstprspec "github.com/giantswarm/awstpr/spec"
+)
+
+func TestAdapterOutputsRegularFields(t *testing.T) {
+	testCases := []struct {
+		description            string
+		customObject           awstpr.CustomObject
+		expectedClusterVersion string
+	}{
+		{
+			description:            "empty custom object",
+			customObject:           awstpr.CustomObject{},
+			expectedClusterVersion: "",
+		},
+		{
+			description: "basic matching",
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					VersionBundle: awstprspec.VersionBundle{
+						Version: "myversion",
+					},
+				},
+			},
+			expectedClusterVersion: "myversion",
+		},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		clients := Clients{}
+		t.Run(tc.description, func(t *testing.T) {
+			err := a.getOutputs(tc.customObject, clients)
+
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.ClusterVersion != tc.expectedClusterVersion {
+				t.Errorf("unexpected ClusterVersion, got %q, want %q", a.ClusterVersion, tc.expectedClusterVersion)
+			}
+		})
+	}
+}

--- a/service/resource/cloudformationv1/main_stack_test.go
+++ b/service/resource/cloudformationv1/main_stack_test.go
@@ -97,4 +97,22 @@ func TestMainTemplateExistingFields(t *testing.T) {
 		fmt.Println(body)
 		t.Error("asg element not found")
 	}
+
+	if !strings.Contains(body, "Outputs:") {
+		fmt.Println(body)
+		t.Error("outputs header not found")
+	}
+
+	if !strings.Contains(body, "  WorkersOutput:") {
+		fmt.Println(body)
+		t.Error("workers output element not found")
+	}
+	if !strings.Contains(body, "  ImageIDOutput:") {
+		fmt.Println(body)
+		t.Error("imageID output element not found")
+	}
+	if !strings.Contains(body, "  ClusterVersionOutput:") {
+		fmt.Println(body)
+		t.Error("clusterVersion output element not found")
+	}
 }

--- a/service/resource/cloudformationv1/main_stack_test.go
+++ b/service/resource/cloudformationv1/main_stack_test.go
@@ -103,15 +103,15 @@ func TestMainTemplateExistingFields(t *testing.T) {
 		t.Error("outputs header not found")
 	}
 
-	if !strings.Contains(body, "  WorkersOutput:") {
+	if !strings.Contains(body, workersOutputKey+":") {
 		fmt.Println(body)
 		t.Error("workers output element not found")
 	}
-	if !strings.Contains(body, "  ImageIDOutput:") {
+	if !strings.Contains(body, imageIDOutputKey+":") {
 		fmt.Println(body)
 		t.Error("imageID output element not found")
 	}
-	if !strings.Contains(body, "  ClusterVersionOutput:") {
+	if !strings.Contains(body, clusterVersionOuputKey+":") {
 		fmt.Println(body)
 		t.Error("clusterVersion output element not found")
 	}

--- a/service/resource/cloudformationv1/spec.go
+++ b/service/resource/cloudformationv1/spec.go
@@ -8,6 +8,10 @@ const (
 	imageIDParameterKey        = "ImageIDParam"
 	clusterVersionParameterKey = "ClusterVersionParam"
 
+	workersOutputKey       = "WorkersOutput"
+	imageIDOutputKey       = "ImageIDOutput"
+	clusterVersionOuputKey = "ClusterVersionOutput"
+
 	cloudFormationTemplatesDirectory = "service/templates/cloudformation"
 )
 

--- a/service/resource/cloudformationv1/spec.go
+++ b/service/resource/cloudformationv1/spec.go
@@ -4,9 +4,9 @@ const (
 	// defaultCreationTimeout is the timeout in minutes for the creation of the stack.
 	defaultCreationTimeout = 10
 
-	workersParameterKey        = "workers"
-	imageIDParameterKey        = "imageID"
-	clusterVersionParameterKey = "clusterVersion"
+	workersParameterKey        = "WorkersParam"
+	imageIDParameterKey        = "ImageIDParam"
+	clusterVersionParameterKey = "ClusterVersionParam"
 
 	cloudFormationTemplatesDirectory = "service/templates/cloudformation"
 )

--- a/service/templates/cloudformation/main.yaml
+++ b/service/templates/cloudformation/main.yaml
@@ -3,4 +3,5 @@ Description: Main CloudFormation stack.
 Resources:
   {{template "launch_configuration" .}}
   {{template "autoscaling_group" .}}
+{{template "outputs"}}
 {{end}}

--- a/service/templates/cloudformation/outputs.yaml
+++ b/service/templates/cloudformation/outputs.yaml
@@ -1,0 +1,8 @@
+{{define "outputs"}}Outputs:
+  WorkersOutput:
+    Value: {{ .ASGMinSize }}
+  ImageIDOutput:
+    Value: {{ .ImageID }}
+  ClusterVersionOutput:
+    Value: {{ .ClusterVersion }}
+{{end}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

This PR adds outputs to the stack, those will be used in the reconciliation loop to determine if the stack needs to be changed.

Instead of getting values from the created resources we interpolate the values directly, this is due to limitations on the kind of values that we can get from those resources http://docs.aws.amazon.com/en_en/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html#intrinsic-function-reference-getatt-attrib for instance we can't get `ImageId` from a `LaunchConfiguration` resource.
