### PR TITLE
implement s3objectv1's GetCurrentState method

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -35,6 +35,10 @@ func BucketName(customObject awstpr.CustomObject, accountID string) string {
 	return fmt.Sprintf("%s-g8s-%s", ClusterID(customObject), accountID)
 }
 
+func BucketObjectName(customObject awstpr.CustomObject, prefix string) string {
+	return fmt.Sprintf("cloudconfig/%s/%s", ClusterVersion(customObject), prefix)
+}
+
 func ClusterCustomer(customObject awstpr.CustomObject) string {
 	return customObject.Spec.Cluster.Customer.ID
 }

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -725,3 +725,24 @@ func Test_VersionBundleVersion(t *testing.T) {
 		t.Fatalf("Expected version in version bundle to be %s but was %s", expectedVersion, VersionBundleVersion(customObject))
 	}
 }
+
+func Test_BucketObjectName(t *testing.T) {
+	version := "v_0_1_0"
+	suffix := "mysuffix"
+
+	cluster := clustertpr.Spec{
+		Version: version,
+	}
+
+	customObject := awstpr.CustomObject{
+		Spec: awstpr.Spec{
+			Cluster: cluster,
+		},
+	}
+
+	expectedBucketObjectName := "cloudconfig/v_0_1_0/mysuffix"
+	actualBucketObjectName := BucketObjectName(customObject, suffix)
+	if expectedBucketObjectName != actualBucketObjectName {
+		t.Fatalf("Expected bucket object name %q but was %q", expectedBucketObjectName, actualBucketObjectName)
+	}
+}

--- a/service/resource/s3objectv1/create.go
+++ b/service/resource/s3objectv1/create.go
@@ -30,7 +30,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 }
 
 func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	desiredObjectState, err := toBucketObject(desiredState)
+	desiredObjectState, err := toBucketObjectState(desiredState)
 	if err != nil {
 		return s3.PutObjectInput{}, microerror.Mask(err)
 	}
@@ -41,11 +41,11 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		Key: aws.String(""),
 	}
 
-	if desiredObjectState.Key != "" {
-		createState.Key = aws.String(desiredObjectState.Key)
-		createState.Body = strings.NewReader(desiredObjectState.Body)
-		createState.Bucket = aws.String(desiredObjectState.Bucket)
-		createState.ContentLength = aws.Int64(int64(len(desiredObjectState.Body)))
+	if desiredObjectState.WorkerCloudConfig.Key != "" {
+		createState.Key = aws.String(desiredObjectState.WorkerCloudConfig.Key)
+		createState.Body = strings.NewReader(desiredObjectState.WorkerCloudConfig.Body)
+		createState.Bucket = aws.String(desiredObjectState.WorkerCloudConfig.Bucket)
+		createState.ContentLength = aws.Int64(int64(len(desiredObjectState.WorkerCloudConfig.Body)))
 	}
 
 	return createState, nil

--- a/service/resource/s3objectv1/create_test.go
+++ b/service/resource/s3objectv1/create_test.go
@@ -26,8 +26,8 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 
 	testCases := []struct {
 		obj            awstpr.CustomObject
-		currentState   BucketObject
-		desiredState   BucketObject
+		currentState   BucketObjectState
+		desiredState   BucketObjectState
 		expectedBody   string
 		expectedBucket string
 		expectedKey    string
@@ -36,8 +36,8 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description:    "current state empty, desired state empty, empty create change",
 			obj:            clusterTpo,
-			currentState:   BucketObject{},
-			desiredState:   BucketObject{},
+			currentState:   BucketObjectState{},
+			desiredState:   BucketObjectState{},
 			expectedBody:   "",
 			expectedBucket: "",
 			expectedKey:    "",
@@ -45,11 +45,13 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description:  "current state empty, desired state not empty, create change == desired state",
 			obj:          clusterTpo,
-			currentState: BucketObject{},
-			desiredState: BucketObject{
-				Body:   "mybody",
-				Bucket: "mybucket",
-				Key:    "mykey",
+			currentState: BucketObjectState{},
+			desiredState: BucketObjectState{
+				WorkerCloudConfig: BucketObjectInstance{
+					Body:   "mybody",
+					Bucket: "mybucket",
+					Key:    "mykey",
+				},
 			},
 			expectedBody:   "mybody",
 			expectedBucket: "mybucket",
@@ -58,15 +60,19 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state not empty, desired state not empty, create change == desired state",
 			obj:         clusterTpo,
-			currentState: BucketObject{
-				Body:   "currentbody",
-				Bucket: "currentbucket",
-				Key:    "currentkey",
+			currentState: BucketObjectState{
+				WorkerCloudConfig: BucketObjectInstance{
+					Body:   "currentbody",
+					Bucket: "currentbucket",
+					Key:    "currentkey",
+				},
 			},
-			desiredState: BucketObject{
-				Body:   "mybody",
-				Bucket: "mybucket",
-				Key:    "mykey",
+			desiredState: BucketObjectState{
+				WorkerCloudConfig: BucketObjectInstance{
+					Body:   "mybody",
+					Bucket: "mybucket",
+					Key:    "mykey",
+				},
 			},
 			expectedBody:   "mybody",
 			expectedBucket: "mybucket",
@@ -76,16 +82,16 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 
 	var err error
 	var newResource *Resource
-	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.Clients = Clients{
-			S3: &S3ClientMock{},
-		}
-		resourceConfig.Logger = microloggertest.New()
-		newResource, err = New(resourceConfig)
-		if err != nil {
-			t.Error("expected", nil, "got", err)
-		}
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Clients = Clients{
+		S3: &S3ClientMock{},
+	}
+	resourceConfig.AwsService = AwsServiceMock{}
+	resourceConfig.Logger = microloggertest.New()
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Error("expected", nil, "got", err)
 	}
 
 	for _, tc := range testCases {

--- a/service/resource/s3objectv1/current.go
+++ b/service/resource/s3objectv1/current.go
@@ -1,9 +1,59 @@
 package s3objectv1
 
 import (
+	"bytes"
 	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/aws-operator/service/key"
+	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return BucketObject{}, nil
+	output := BucketObjectState{}
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for S3 objects")
+
+	workersObjectName := key.BucketObjectName(customObject, prefixWorker)
+
+	accountID, err := r.awsService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	bucketName := key.BucketName(customObject, accountID)
+
+	input := &s3.GetObjectInput{
+		Key:    aws.String(workersObjectName),
+		Bucket: aws.String(bucketName),
+	}
+	result, err := r.awsClients.S3.GetObject(input)
+
+	if IsNotFound(err) {
+		r.logger.LogCtx(ctx, "debug", "did not find the S3 objects")
+		// fall through
+
+	} else if err != nil {
+
+		return output, microerror.Mask(err)
+
+	} else {
+
+		r.logger.LogCtx(ctx, "debug", "found the S3 objects")
+		output.WorkerCloudConfig.Key = workersObjectName
+		output.WorkerCloudConfig.Bucket = bucketName
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(result.Body)
+		body := buf.String()
+
+		output.WorkerCloudConfig.Body = body
+	}
+
+	return output, nil
 }

--- a/service/resource/s3objectv1/current_test.go
+++ b/service/resource/s3objectv1/current_test.go
@@ -1,0 +1,105 @@
+package s3objectv1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_CurrentState(t *testing.T) {
+	clusterTpo := &awstpr.CustomObject{
+		Spec: awstpr.Spec{
+			Cluster: clustertpr.Spec{
+				Cluster: spec.Cluster{
+					ID: "test-cluster",
+				},
+				Version: "myversion",
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj              *awstpr.CustomObject
+		description      string
+		expectedIAMError bool
+		expectedS3Error  bool
+		expectedKey      string
+		expectedBucket   string
+		expectedBody     string
+	}{
+		{
+			description:    "basic match",
+			obj:            clusterTpo,
+			expectedKey:    "cloudconfig/myversion/worker",
+			expectedBucket: "test-cluster-g8s-myaccountid",
+			expectedBody:   "mybody",
+		},
+		{
+			description:      "IAM error",
+			obj:              clusterTpo,
+			expectedIAMError: true,
+		},
+
+		{
+			description:     "S3 error",
+			obj:             clusterTpo,
+			expectedS3Error: true,
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			resourceConfig.AwsService = AwsServiceMock{
+				accountID: "myaccountid",
+				isError:   tc.expectedIAMError,
+			}
+			resourceConfig.Clients = Clients{
+				S3: &S3ClientMock{
+					isError: tc.expectedS3Error,
+					body:    tc.expectedBody,
+				},
+			}
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			result, err := newResource.GetCurrentState(context.TODO(), tc.obj)
+			if err != nil && !tc.expectedIAMError && !tc.expectedS3Error {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if err == nil && tc.expectedIAMError {
+				t.Error("expected IAM error didn't happen")
+			}
+
+			if err == nil && tc.expectedS3Error {
+				t.Error("expected S3 error didn't happen")
+			}
+
+			if currentState.WorkerCloudConfig.Key != tc.expectedKey {
+				t.Errorf("expeccted key %q, got %q", tc.expectedKey, currentState.WorkerCloudConfig.Key)
+			}
+
+			if currentState.WorkerCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expeccted key %q, got %q", tc.expectedBucket, currentState.WorkerCloudConfig.Bucket)
+			}
+
+			if currentState.WorkerCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expeccted key %q, got %q", tc.expectedBody, currentState.WorkerCloudConfig.Body)
+			}
+		})
+	}
+}

--- a/service/resource/s3objectv1/desired.go
+++ b/service/resource/s3objectv1/desired.go
@@ -3,5 +3,5 @@ package s3objectv1
 import "context"
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return BucketObject{}, nil
+	return BucketObjectState{}, nil
 }

--- a/service/resource/s3objectv1/error.go
+++ b/service/resource/s3objectv1/error.go
@@ -1,6 +1,10 @@
 package s3objectv1
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var invalidConfigError = microerror.New("invalid config")
 
@@ -14,4 +18,12 @@ var wrongTypeError = microerror.New("wrong type")
 // IsWrongType asserts wrongTypeError.
 func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
+}
+
+// IsNotFound asserts object not found error from upstream's API message.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "An error occurred (404) when calling the HeadObject operation: Not Found")
 }

--- a/service/resource/s3objectv1/mock.go
+++ b/service/resource/s3objectv1/mock.go
@@ -1,8 +1,24 @@
 package s3objectv1
 
-import "github.com/aws/aws-sdk-go/service/s3"
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// nopCloser is required to implement the ReadCloser interface required by
+// the Body field in S3's GetObjectOutput
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
 
 type S3ClientMock struct {
+	isError bool
+	body    string
 }
 
 func (s *S3ClientMock) PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error) {
@@ -11,4 +27,29 @@ func (s *S3ClientMock) PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error
 
 func (s *S3ClientMock) DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	return nil, nil
+}
+
+func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.GetObjectOutput{
+		Body: nopCloser{strings.NewReader(s.body)},
+	}
+
+	return output, nil
+}
+
+type AwsServiceMock struct {
+	accountID string
+	isError   bool
+}
+
+func (a AwsServiceMock) GetAccountID() (string, error) {
+	if a.isError {
+		return "", fmt.Errorf("error!!")
+	}
+
+	return a.accountID, nil
 }

--- a/service/resource/s3objectv1/spec.go
+++ b/service/resource/s3objectv1/spec.go
@@ -2,7 +2,15 @@ package s3objectv1
 
 import "github.com/aws/aws-sdk-go/service/s3"
 
-type BucketObject struct {
+const (
+	prefixWorker = "worker"
+)
+
+type BucketObjectState struct {
+	WorkerCloudConfig BucketObjectInstance
+}
+
+type BucketObjectInstance struct {
 	Bucket string
 	Body   string
 	Key    string
@@ -13,6 +21,11 @@ type Clients struct {
 }
 
 type S3Client interface {
+	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+}
+
+type AwsService interface {
+	GetAccountID() (string, error)
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

Highlights from my side in this PR:
* I've added a new worker's member to the `BucketObjectState` struct so that we can use the same resource for other S3 objects.
* The versioning is implemented at the object key level (keys look like `cloudconfig/v_1_0_0/worker`), we could also use s3 versioning, let me know WDYT.
* Used AwsService (thanks for creating this! :)) and added mocking, maybe we could move the mock to the service for reusing.