### PR TITLE
Namespace resource should be before legacy resource

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -288,10 +288,10 @@ func New(config Config) (*Service, error) {
 	var resources []framework.Resource
 	{
 		resources = []framework.Resource{
+			namespaceResource,
 			legacyResource,
 			s3BucketResource,
 			cloudformationResource,
-			namespaceResource,
 		}
 
 		// Disable retry wrapper due to problems with the legacy resource.


### PR DESCRIPTION
Fixes a resource ordering problem. The namespace resource should be before the legacy resource so the k8s service is created correctly in the legacy resource.