### PR TITLE
Correct bucket name format

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -32,7 +32,7 @@ func AvailabilityZone(customObject awstpr.CustomObject) string {
 }
 
 func BucketName(customObject awstpr.CustomObject, accountID string) string {
-	return fmt.Sprintf("%s-g8s-%s", ClusterID(customObject), accountID)
+	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(customObject))
 }
 
 func BucketObjectName(customObject awstpr.CustomObject, prefix string) string {

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -55,7 +55,7 @@ func Test_AvailabilityZone(t *testing.T) {
 
 func Test_BucketName(t *testing.T) {
 	accountID := "1234567890"
-	expectedName := "test-cluster-g8s-1234567890"
+	expectedName := "1234567890-g8s-test-cluster"
 
 	customObject := awstpr.CustomObject{
 		Spec: awstpr.Spec{

--- a/service/resource/s3bucketv1/desired_test.go
+++ b/service/resource/s3bucketv1/desired_test.go
@@ -29,7 +29,7 @@ func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "5xchu-g8s-000000000000",
+			expectedName: "000000000000-g8s-5xchu",
 		},
 	}
 

--- a/service/resource/s3objectv1/current_test.go
+++ b/service/resource/s3objectv1/current_test.go
@@ -35,7 +35,7 @@ func Test_CurrentState(t *testing.T) {
 			description:    "basic match",
 			obj:            clusterTpo,
 			expectedKey:    "cloudconfig/myversion/worker",
-			expectedBucket: "test-cluster-g8s-myaccountid",
+			expectedBucket: "myaccountid-g8s-test-cluster",
 			expectedBody:   "mybody",
 		},
 		{


### PR DESCRIPTION
Updates the BucketName helper to use the current format. I had the account ID and cluster ID the wrong way around.

