### PR TITLE
implement s3objectv1's GetDesiredState

### DIFF
--- a/service/aws/mocks.go
+++ b/service/aws/mocks.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
@@ -32,4 +34,26 @@ func (i *IAMClientMock) GetUser(input *iam.GetUserInput) (*iam.GetUserOutput, er
 	}
 
 	return output, nil
+}
+
+type AwsServiceMock struct {
+	AccountID string
+	KeyArn    string
+	IsError   bool
+}
+
+func (a AwsServiceMock) GetAccountID() (string, error) {
+	if a.IsError {
+		return "", fmt.Errorf("error!!")
+	}
+
+	return a.AccountID, nil
+}
+
+func (a AwsServiceMock) GetKeyArn(cllustterID string) (string, error) {
+	if a.IsError {
+		return "", fmt.Errorf("error!!")
+	}
+
+	return a.KeyArn, nil
 }

--- a/service/aws/mocks.go
+++ b/service/aws/mocks.go
@@ -50,7 +50,7 @@ func (a AwsServiceMock) GetAccountID() (string, error) {
 	return a.AccountID, nil
 }
 
-func (a AwsServiceMock) GetKeyArn(cllustterID string) (string, error) {
+func (a AwsServiceMock) GetKeyArn(clusterID string) (string, error) {
 	if a.IsError {
 		return "", fmt.Errorf("error!!")
 	}

--- a/service/aws/service.go
+++ b/service/aws/service.go
@@ -1,10 +1,13 @@
 package aws
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
@@ -78,4 +81,21 @@ func ValidateAccountID(accountID string) error {
 	}
 
 	return nil
+}
+
+// GetKeyArn returns the key ARN associated with the given cluster ID.
+func (s *Service) GetKeyArn(clusterID string) (string, error) {
+	keyAlias := fmt.Sprintf("alias/%s", clusterID)
+	input := &kms.DescribeKeyInput{
+		KeyId: aws.String(keyAlias),
+	}
+
+	output, err := s.clients.KMS.DescribeKey(input)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	keyArn := *output.KeyMetadata.Arn
+
+	return keyArn, nil
 }

--- a/service/aws/spec.go
+++ b/service/aws/spec.go
@@ -2,13 +2,20 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/kms"
 )
 
 type Clients struct {
 	IAM IAMClient
+	KMS KMSClient
 }
 
 // IAMClient describes the methods required to be implemented by a IAM AWS client.
 type IAMClient interface {
 	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
+}
+
+// KMSClient describes the methods required to be implemented by a KMS AWS client.
+type KMSClient interface {
+	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
 }

--- a/service/resource/s3objectv1/assets.go
+++ b/service/resource/s3objectv1/assets.go
@@ -1,0 +1,75 @@
+package s3objectv1
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/certificatetpr"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeytpr"
+)
+
+func (s *Resource) encodeTLSAssets(assets certificatetpr.AssetsBundle, kmsKeyArn string) (*certificatetpr.CompactTLSAssets, error) {
+	rawTLS := createRawTLSAssets(assets)
+
+	encTLS, err := rawTLS.encrypt(s.awsClients.KMS, kmsKeyArn)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	compTLS, err := encTLS.compact()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return compTLS, nil
+}
+
+func (s *Resource) encodeKeyAssets(assets map[randomkeytpr.Key][]byte, svc *kms.KMS, kmsKeyArn string) (*randomkeytpr.CompactRandomKeyAssets, error) {
+
+	encryptionKey, ok := assets[randomkeytpr.EncryptionKey]
+	if !ok {
+		return nil, microerror.Mask(invalidConfigError)
+	}
+
+	encryptionConfig, err := s.EncryptionConfig(string(encryptionKey))
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	rawKeys := make(rawKeyAssets)
+	rawKeys[randomkeytpr.EncryptionKey] = []byte(encryptionConfig)
+
+	encKeys, err := rawKeys.encrypt(svc, kmsKeyArn)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	compKeys, err := encKeys.compact()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return compKeys, nil
+}
+
+func (s *Resource) EncryptionConfig(encryptionKey string) (string, error) {
+	tmpl, err := template.New("encryptionConfig").Parse(encryptionConfigTemplate)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, struct {
+		EncryptionKey string
+	}{
+		EncryptionKey: encryptionKey,
+	})
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(buf.Bytes()), nil
+}

--- a/service/resource/s3objectv1/create_test.go
+++ b/service/resource/s3objectv1/create_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/certificatetpr/certificatetprtest"
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -90,7 +91,7 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		S3: &S3ClientMock{},
 	}
 	resourceConfig.AwsService = awsservice.AwsServiceMock{}
-	resourceConfig.CertWatcher = &CertWatcherMock{}
+	resourceConfig.CertWatcher = &certificatetprtest.Service{}
 	resourceConfig.CloudConfig = &CloudConfigMock{}
 	resourceConfig.Logger = microloggertest.New()
 	newResource, err = New(resourceConfig)

--- a/service/resource/s3objectv1/create_test.go
+++ b/service/resource/s3objectv1/create_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
 )
 
 func Test_Resource_S3Object_newCreate(t *testing.T) {
@@ -87,11 +89,13 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 	resourceConfig.Clients = Clients{
 		S3: &S3ClientMock{},
 	}
-	resourceConfig.AwsService = AwsServiceMock{}
+	resourceConfig.AwsService = awsservice.AwsServiceMock{}
+	resourceConfig.CertWatcher = &CertWatcherMock{}
+	resourceConfig.CloudConfig = &CloudConfigMock{}
 	resourceConfig.Logger = microloggertest.New()
 	newResource, err = New(resourceConfig)
 	if err != nil {
-		t.Error("expected", nil, "got", err)
+		t.Fatal("expected", nil, "got", err)
 	}
 
 	for _, tc := range testCases {

--- a/service/resource/s3objectv1/current_test.go
+++ b/service/resource/s3objectv1/current_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
 )
 
 func Test_CurrentState(t *testing.T) {
@@ -54,12 +56,14 @@ func Test_CurrentState(t *testing.T) {
 	var newResource *Resource
 
 	resourceConfig := DefaultConfig()
+	resourceConfig.CertWatcher = &CertWatcherMock{}
+	resourceConfig.CloudConfig = &CloudConfigMock{}
 	resourceConfig.Logger = microloggertest.New()
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			resourceConfig.AwsService = AwsServiceMock{
-				accountID: "myaccountid",
-				isError:   tc.expectedIAMError,
+			resourceConfig.AwsService = awsservice.AwsServiceMock{
+				AccountID: "myaccountid",
+				IsError:   tc.expectedIAMError,
 			}
 			resourceConfig.Clients = Clients{
 				S3: &S3ClientMock{

--- a/service/resource/s3objectv1/current_test.go
+++ b/service/resource/s3objectv1/current_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/certificatetpr/certificatetprtest"
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -56,7 +57,7 @@ func Test_CurrentState(t *testing.T) {
 	var newResource *Resource
 
 	resourceConfig := DefaultConfig()
-	resourceConfig.CertWatcher = &CertWatcherMock{}
+	resourceConfig.CertWatcher = &certificatetprtest.Service{}
 	resourceConfig.CloudConfig = &CloudConfigMock{}
 	resourceConfig.Logger = microloggertest.New()
 	for _, tc := range testCases {

--- a/service/resource/s3objectv1/desired.go
+++ b/service/resource/s3objectv1/desired.go
@@ -1,7 +1,51 @@
 package s3objectv1
 
-import "context"
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/key"
+)
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return BucketObjectState{}, nil
+	customObject, err := key.ToCustomObject(obj)
+	output := BucketObjectState{}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	accountID, err := r.awsService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+	certs, err := r.certWatcher.SearchCerts(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	kmsArn, err := r.awsService.GetKeyArn(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	tlsAssets, err := r.encodeTLSAssets(certs, kmsArn)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	body, err := r.cloudConfig.NewWorkerTemplate(customObject, *tlsAssets)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	output.WorkerCloudConfig = BucketObjectInstance{
+		Bucket: key.BucketName(customObject, accountID),
+		Body:   body,
+		Key:    key.BucketObjectName(customObject, prefixWorker),
+	}
+
+	return output, nil
 }

--- a/service/resource/s3objectv1/desired_test.go
+++ b/service/resource/s3objectv1/desired_test.go
@@ -36,7 +36,7 @@ func Test_DesiredState(t *testing.T) {
 			description:    "basic match",
 			obj:            clusterTpo,
 			expectedKey:    "cloudconfig/myversion/worker",
-			expectedBucket: "test-cluster-g8s-myaccountid",
+			expectedBucket: "myaccountid-g8s-test-cluster",
 			expectedBody:   "mybody-",
 		},
 	}
@@ -77,15 +77,15 @@ func Test_DesiredState(t *testing.T) {
 			}
 
 			if desiredState.WorkerCloudConfig.Key != tc.expectedKey {
-				t.Errorf("expeccted key %q, got %q", tc.expectedKey, desiredState.WorkerCloudConfig.Key)
+				t.Errorf("expected key %q, got %q", tc.expectedKey, desiredState.WorkerCloudConfig.Key)
 			}
 
 			if desiredState.WorkerCloudConfig.Bucket != tc.expectedBucket {
-				t.Errorf("expeccted key %q, got %q", tc.expectedBucket, desiredState.WorkerCloudConfig.Bucket)
+				t.Errorf("expected key %q, got %q", tc.expectedBucket, desiredState.WorkerCloudConfig.Bucket)
 			}
 
 			if desiredState.WorkerCloudConfig.Body != tc.expectedBody {
-				t.Errorf("expeccted key %q, got %q", tc.expectedBody, desiredState.WorkerCloudConfig.Body)
+				t.Errorf("expected key %q, got %q", tc.expectedBody, desiredState.WorkerCloudConfig.Body)
 			}
 		})
 	}

--- a/service/resource/s3objectv1/desired_test.go
+++ b/service/resource/s3objectv1/desired_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/awstpr"
-	"github.com/giantswarm/certificatetpr"
+	"github.com/giantswarm/certificatetpr/certificatetprtest"
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -52,12 +52,9 @@ func Test_DesiredState(t *testing.T) {
 	resourceConfig.Clients = Clients{
 		KMS: &KMSClientMock{},
 	}
-	defaultAssetsBundle := make(map[certificatetpr.AssetsBundleKey][]byte)
+	resourceConfig.CertWatcher = &certificatetprtest.Service{}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			resourceConfig.CertWatcher = &CertWatcherMock{
-				certs: defaultAssetsBundle,
-			}
 			resourceConfig.CloudConfig = &CloudConfigMock{
 				template: tc.expectedBody,
 			}

--- a/service/resource/s3objectv1/desired_test.go
+++ b/service/resource/s3objectv1/desired_test.go
@@ -1,1 +1,92 @@
 package s3objectv1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/certificatetpr"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+)
+
+func Test_DesiredState(t *testing.T) {
+	clusterTpo := &awstpr.CustomObject{
+		Spec: awstpr.Spec{
+			Cluster: clustertpr.Spec{
+				Cluster: spec.Cluster{
+					ID: "test-cluster",
+				},
+				Version: "myversion",
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj            *awstpr.CustomObject
+		description    string
+		expectedKey    string
+		expectedBucket string
+		expectedBody   string
+	}{
+		{
+			description:    "basic match",
+			obj:            clusterTpo,
+			expectedKey:    "cloudconfig/myversion/worker",
+			expectedBucket: "test-cluster-g8s-myaccountid",
+			expectedBody:   "mybody-",
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.AwsService = awsservice.AwsServiceMock{
+		AccountID: "myaccountid",
+		KeyArn:    "mykeyarn",
+	}
+	resourceConfig.Clients = Clients{
+		KMS: &KMSClientMock{},
+	}
+	defaultAssetsBundle := make(map[certificatetpr.AssetsBundleKey][]byte)
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			resourceConfig.CertWatcher = &CertWatcherMock{
+				certs: defaultAssetsBundle,
+			}
+			resourceConfig.CloudConfig = &CloudConfigMock{
+				template: tc.expectedBody,
+			}
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			desiredState, ok := result.(BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", desiredState, result)
+			}
+
+			if desiredState.WorkerCloudConfig.Key != tc.expectedKey {
+				t.Errorf("expeccted key %q, got %q", tc.expectedKey, desiredState.WorkerCloudConfig.Key)
+			}
+
+			if desiredState.WorkerCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expeccted key %q, got %q", tc.expectedBucket, desiredState.WorkerCloudConfig.Bucket)
+			}
+
+			if desiredState.WorkerCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expeccted key %q, got %q", tc.expectedBody, desiredState.WorkerCloudConfig.Body)
+			}
+		})
+	}
+}

--- a/service/resource/s3objectv1/encrypt.go
+++ b/service/resource/s3objectv1/encrypt.go
@@ -1,0 +1,203 @@
+package s3objectv1
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+
+	"github.com/giantswarm/randomkeytpr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/certificatetpr"
+	"github.com/giantswarm/microerror"
+)
+
+type TLSassets struct {
+	APIServerCA       []byte
+	APIServerKey      []byte
+	APIServerCrt      []byte
+	WorkerCA          []byte
+	WorkerKey         []byte
+	WorkerCrt         []byte
+	ServiceAccountCA  []byte
+	ServiceAccountKey []byte
+	ServiceAccountCrt []byte
+	CalicoClientCA    []byte
+	CalicoClientKey   []byte
+	CalicoClientCrt   []byte
+	EtcdServerCA      []byte
+	EtcdServerKey     []byte
+	EtcdServerCrt     []byte
+}
+
+// PEM encoded TLS assets.
+type rawTLSAssets TLSassets
+
+// Encrypted PEM encoded TLS assets
+type encryptedTLSAssets TLSassets
+
+func createRawTLSAssets(assets certificatetpr.AssetsBundle) *rawTLSAssets {
+	// TODO refactor this with a for loop iterating over components and asset types
+	return &rawTLSAssets{
+		APIServerCA:       assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.CA}],
+		APIServerCrt:      assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Crt}],
+		APIServerKey:      assets[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Key}],
+		WorkerCA:          assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.CA}],
+		WorkerCrt:         assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Crt}],
+		WorkerKey:         assets[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Key}],
+		ServiceAccountCA:  assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.CA}],
+		ServiceAccountCrt: assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Crt}],
+		ServiceAccountKey: assets[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Key}],
+		EtcdServerCA:      assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}],
+		EtcdServerCrt:     assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}],
+		EtcdServerKey:     assets[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}],
+		CalicoClientCA:    assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}],
+		CalicoClientCrt:   assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}],
+		CalicoClientKey:   assets[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}],
+	}
+}
+
+type rawKeyAssets map[randomkeytpr.Key][]byte
+type encryptedKeyAssets map[randomkeytpr.Key][]byte
+
+func (r rawKeyAssets) encrypt(svc *kms.KMS, kmsKeyARN string) (*encryptedKeyAssets, error) {
+
+	encryptedAssets := make(encryptedKeyAssets)
+	for k, v := range r {
+		b, err := encryptor(svc, kmsKeyARN, v)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		encryptedAssets[k] = b
+	}
+
+	return &encryptedAssets, nil
+}
+
+func (r encryptedKeyAssets) compact() (*randomkeytpr.CompactRandomKeyAssets, error) {
+	var err error
+	compact := func(data []byte) (r string) {
+		if err != nil {
+			return ""
+		}
+
+		r, err = compactor(data)
+		if err != nil {
+			return ""
+		}
+
+		return r
+	}
+
+	compactAssets := randomkeytpr.CompactRandomKeyAssets{
+		APIServerEncryptionKey: compact(r[randomkeytpr.EncryptionKey]),
+	}
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &compactAssets, nil
+}
+
+func (r *rawTLSAssets) encrypt(svc KMSClient, kmsKeyARN string) (*encryptedTLSAssets, error) {
+	var err error
+	encrypt := func(data []byte) (b []byte) {
+		if err != nil {
+			return []byte{}
+		}
+
+		b, err = encryptor(svc, kmsKeyARN, data)
+
+		if err != nil {
+			return []byte{}
+		}
+		return b
+	}
+	encryptedAssets := encryptedTLSAssets{
+		APIServerCA:       encrypt(r.APIServerCA),
+		APIServerKey:      encrypt(r.APIServerKey),
+		APIServerCrt:      encrypt(r.APIServerCrt),
+		WorkerCA:          encrypt(r.WorkerCA),
+		WorkerCrt:         encrypt(r.WorkerCrt),
+		WorkerKey:         encrypt(r.WorkerKey),
+		ServiceAccountCA:  encrypt(r.ServiceAccountCA),
+		ServiceAccountCrt: encrypt(r.ServiceAccountCrt),
+		ServiceAccountKey: encrypt(r.ServiceAccountKey),
+		CalicoClientCA:    encrypt(r.CalicoClientCA),
+		CalicoClientKey:   encrypt(r.CalicoClientKey),
+		CalicoClientCrt:   encrypt(r.CalicoClientCrt),
+		EtcdServerCA:      encrypt(r.EtcdServerCA),
+		EtcdServerKey:     encrypt(r.EtcdServerKey),
+		EtcdServerCrt:     encrypt(r.EtcdServerCrt),
+	}
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &encryptedAssets, nil
+}
+
+func (r *encryptedTLSAssets) compact() (*certificatetpr.CompactTLSAssets, error) {
+	var err error
+	compact := func(data []byte) (r string) {
+		if err != nil {
+			return ""
+		}
+
+		r, err = compactor(data)
+		if err != nil {
+			return ""
+		}
+
+		return r
+	}
+
+	compactAssets := certificatetpr.CompactTLSAssets{
+		APIServerCA:       compact(r.APIServerCA),
+		APIServerKey:      compact(r.APIServerKey),
+		APIServerCrt:      compact(r.APIServerCrt),
+		WorkerCA:          compact(r.WorkerCA),
+		WorkerKey:         compact(r.WorkerKey),
+		WorkerCrt:         compact(r.WorkerCrt),
+		ServiceAccountCA:  compact(r.ServiceAccountCA),
+		ServiceAccountKey: compact(r.ServiceAccountKey),
+		ServiceAccountCrt: compact(r.ServiceAccountCrt),
+		CalicoClientCA:    compact(r.CalicoClientCA),
+		CalicoClientKey:   compact(r.CalicoClientKey),
+		CalicoClientCrt:   compact(r.CalicoClientCrt),
+		EtcdServerCA:      compact(r.EtcdServerCA),
+		EtcdServerKey:     compact(r.EtcdServerKey),
+		EtcdServerCrt:     compact(r.EtcdServerCrt),
+	}
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &compactAssets, nil
+}
+
+func compactor(data []byte) (string, error) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if _, err := gzw.Write(data); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func encryptor(svc KMSClient, kmsKeyARN string, data []byte) ([]byte, error) {
+	encryptInput := kms.EncryptInput{
+		KeyId:     aws.String(kmsKeyARN),
+		Plaintext: data,
+	}
+
+	var encryptOutput *kms.EncryptOutput
+	var err error
+	if encryptOutput, err = svc.Encrypt(&encryptInput); err != nil {
+		return []byte{}, err
+	}
+	return encryptOutput.CiphertextBlob, nil
+}

--- a/service/resource/s3objectv1/mock.go
+++ b/service/resource/s3objectv1/mock.go
@@ -44,14 +44,6 @@ func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error
 	return output, nil
 }
 
-type CertWatcherMock struct {
-	certs certificatetpr.AssetsBundle
-}
-
-func (c *CertWatcherMock) SearchCerts(string) (certificatetpr.AssetsBundle, error) {
-	return c.certs, nil
-}
-
 type CloudConfigMock struct {
 	template string
 }

--- a/service/resource/s3objectv1/mock.go
+++ b/service/resource/s3objectv1/mock.go
@@ -5,7 +5,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/certificatetpr"
 )
 
 // nopCloser is required to implement the ReadCloser interface required by
@@ -41,15 +44,24 @@ func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error
 	return output, nil
 }
 
-type AwsServiceMock struct {
-	accountID string
-	isError   bool
+type CertWatcherMock struct {
+	certs certificatetpr.AssetsBundle
 }
 
-func (a AwsServiceMock) GetAccountID() (string, error) {
-	if a.isError {
-		return "", fmt.Errorf("error!!")
-	}
+func (c *CertWatcherMock) SearchCerts(string) (certificatetpr.AssetsBundle, error) {
+	return c.certs, nil
+}
 
-	return a.accountID, nil
+type CloudConfigMock struct {
+	template string
+}
+
+func (c *CloudConfigMock) NewWorkerTemplate(customObject awstpr.CustomObject, certs certificatetpr.CompactTLSAssets) (string, error) {
+	return c.template, nil
+}
+
+type KMSClientMock struct{}
+
+func (k *KMSClientMock) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutput, error) {
+	return &kms.EncryptOutput{}, nil
 }

--- a/service/resource/s3objectv1/resource.go
+++ b/service/resource/s3objectv1/resource.go
@@ -17,9 +17,11 @@ const (
 // Config represents the configuration used to create a new cloudformation resource.
 type Config struct {
 	// Dependencies.
-	AwsService AwsService
-	Clients    Clients
-	Logger     micrologger.Logger
+	AwsService  AwsService
+	CertWatcher CertWatcher
+	Clients     Clients
+	CloudConfig CloudConfigService
+	Logger      micrologger.Logger
 }
 
 // DefaultConfig provides a default configuration to create a new cloudformation
@@ -27,18 +29,22 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		// Dependencies.
-		AwsService: nil,
-		Clients:    Clients{},
-		Logger:     nil,
+		AwsService:  nil,
+		CertWatcher: nil,
+		Clients:     Clients{},
+		CloudConfig: nil,
+		Logger:      nil,
 	}
 }
 
 // Resource implements the cloudformation resource.
 type Resource struct {
 	// Dependencies.
-	awsService AwsService
-	awsClients Clients
-	logger     micrologger.Logger
+	awsService  AwsService
+	awsClients  Clients
+	certWatcher CertWatcher
+	cloudConfig CloudConfigService
+	logger      micrologger.Logger
 }
 
 // New creates a new configured cloudformation resource.
@@ -50,11 +56,19 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
+	if config.CloudConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CloudConfig must not be empty")
+	}
+	if config.CertWatcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertWatcher must not be empty")
+	}
 
 	newService := &Resource{
 		// Dependencies.
-		awsService: config.AwsService,
-		awsClients: config.Clients,
+		awsService:  config.AwsService,
+		awsClients:  config.Clients,
+		certWatcher: config.CertWatcher,
+		cloudConfig: config.CloudConfig,
 		logger: config.Logger.With(
 			"resource", Name,
 		),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

Implementation of the `GetDesiredState` method, it duplicates part of the TLS assets handling from the legacy resource. The resource needs more dependencies now, CertWatcher and CloudConfig, and we need also an additional KMS client for encryption.

The KMS creation is still done in legacy, here we just query the key, this is done in `service/aws`. Also `AwsServiceMock` is moved to that package so that we can reuse.