### PR TITLE
specify region when creating the S3 client

### DIFF
--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -41,6 +41,7 @@ type Clients struct {
 const (
 	accountIDPosition = 4
 	accountIDLength   = 12
+	defaultRegion     = "eu-central-1"
 )
 
 func NewClients(config Config) Clients {
@@ -57,7 +58,7 @@ func NewClients(config Config) Clients {
 		IAM:            iam.New(s),
 		KMS:            kms.New(s),
 		Route53:        route53.New(s),
-		S3:             s3.New(s),
+		S3:             s3.New(s, aws.NewConfig().WithRegion(defaultRegion)),
 	}
 
 	return clients

--- a/client/aws/aws.go
+++ b/client/aws/aws.go
@@ -41,7 +41,6 @@ type Clients struct {
 const (
 	accountIDPosition = 4
 	accountIDLength   = 12
-	defaultRegion     = "eu-central-1"
 )
 
 func NewClients(config Config) Clients {
@@ -58,7 +57,7 @@ func NewClients(config Config) Clients {
 		IAM:            iam.New(s),
 		KMS:            kms.New(s),
 		Route53:        route53.New(s),
-		S3:             s3.New(s, aws.NewConfig().WithRegion(defaultRegion)),
+		S3:             s3.New(s),
 	}
 
 	return clients

--- a/service/framework.go
+++ b/service/framework.go
@@ -84,6 +84,7 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 			AccessKeyID:     config.Viper.GetString(config.Flag.Service.AWS.AccessKey.ID),
 			AccessKeySecret: config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Secret),
 			SessionToken:    config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Session),
+			Region:          config.Viper.GetString(config.Flag.Service.AWS.Region),
 		}
 	}
 


### PR DESCRIPTION
It will prevent this kind of error at the first stages of the `s3bucketv1` resource handling:
```
2017/12/05 11:39:36 {"caller":"github.com/giantswarm/aws-operator/service/resource/s3bucketv1/current.go:18","debug":"looking for the S3 bucket","function":"GetCurrentState","object":"/apis/cluster.giantswarm.io/v1/namespaces/default/awses/fede-test","resource":"s3bucket","time":"2017-12-05 11:35:06.541"}
2017/12/05 11:39:36 {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:305","error":"[{/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:547: } {/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/framework/resource/metricsresource/resource.go:86: } {/home/fgimenez/workspace/gocode/src/github.com/giantswarm/aws-operator/service/resource/s3bucketv1/current.go:35: } {MissingRegion: could not find region configuration}]","event":"update","object":"/apis/cluster.giantswarm.io/v1/namespaces/default/awses/fede-test","time":"2017-12-05 11:35:06.768"}
```