### PR TITLE
Retry logic for finding the VPC peering connection

### DIFF
--- a/service/resource/legacyv1/resource.go
+++ b/service/resource/legacyv1/resource.go
@@ -522,12 +522,6 @@ func (s *Resource) processCluster(cluster awstpr.CustomObject) error {
 		return microerror.Maskf(executionFailedError, fmt.Sprintf("could not get security group '%s' ID: '%#v'", ingressSGInput.GroupName, err))
 	}
 
-	// In rare cases the host cluster CIDR block can be nil. Return error rather
-	// than panic. TODO Fix issue #451 that tracks this.
-	if conn.AccepterVpcInfo.CidrBlock == nil {
-		return microerror.Maskf(executionFailedError, fmt.Sprintf("vpc peering connection cidr block is nil for cluster '%s'", key.ClusterID(cluster)))
-	}
-
 	// Create rules for the security groups.
 	rulesInput := rulesInput{
 		Cluster:                cluster,


### PR DESCRIPTION
Fixes #451 

This PR adds retry logic if the accepter and requester CIDR blocks in the VPC peering connection are nil.

This is necessary because the VPC resources are eventually consistent. In rare cases, the CIDRs are not populated even though the peering connection has been created.