### PR TITLE
Add a new release for 1.8.4, deprecate previous releases

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -268,9 +268,9 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 	// We provide a map of resource lists keyed by the version bundle version
 	// to the resource router.
 	versionedResources := map[string][]framework.Resource{
-		key.LegacyVersion:         legacyResources,
-		key.CloudFormationVersion: resources,
-		"1.0.0":                   legacyResources,
+		keyv1.LegacyVersion:         legacyResources,
+		keyv1.CloudFormationVersion: resources,
+		"1.0.0":                     legacyResources,
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {

--- a/service/framework.go
+++ b/service/framework.go
@@ -270,7 +270,7 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 	versionedResources := map[string][]framework.Resource{
 		key.LegacyVersion:         legacyResources,
 		key.CloudFormationVersion: resources,
-		"1.0.0":                   resources,
+		"1.0.0":                   legacyResources,
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {

--- a/service/framework.go
+++ b/service/framework.go
@@ -268,8 +268,9 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 	// We provide a map of resource lists keyed by the version bundle version
 	// to the resource router.
 	versionedResources := map[string][]framework.Resource{
-		keyv1.LegacyVersion:         legacyResources,
-		keyv1.CloudFormationVersion: resources,
+		key.LegacyVersion:         legacyResources,
+		key.CloudFormationVersion: resources,
+		"1.0.0":                   resources,
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {

--- a/service/resource_router.go
+++ b/service/resource_router.go
@@ -31,6 +31,9 @@ func NewResourceRouter(resources map[string][]framework.Resource) func(ctx conte
 		case keyv1.CloudFormationVersion:
 			// Cloud Formation transitional version so enable all resources.
 			enabledResources = resources[keyv1.CloudFormationVersion]
+		case "1.0.0":
+			// Kubernetes update to 1.8.4.
+			enabledResources = resources["1.0.0"]
 		case "":
 			// Default to the legacy resource for custom objects without a version
 			// bundle.

--- a/service/resource_router_test.go
+++ b/service/resource_router_test.go
@@ -117,7 +117,7 @@ func Test_Service_NewResourceRouter(t *testing.T) {
 	versionedResources := make(map[string][]framework.Resource)
 	versionedResources["0.1.0"] = legacyResources
 	versionedResources["0.2.0"] = allResources
-	versionedResources["1.0.0"] = allResources
+	versionedResources["1.0.0"] = legacyResources
 
 	testCases := []struct {
 		customObject      awstpr.CustomObject
@@ -173,7 +173,7 @@ func Test_Service_NewResourceRouter(t *testing.T) {
 					},
 				},
 			},
-			expectedResources: allResources,
+			expectedResources: legacyResources,
 			errorMatcher:      nil,
 			resourceRouter:    NewResourceRouter(versionedResources),
 		},

--- a/service/resource_router_test.go
+++ b/service/resource_router_test.go
@@ -117,6 +117,7 @@ func Test_Service_NewResourceRouter(t *testing.T) {
 	versionedResources := make(map[string][]framework.Resource)
 	versionedResources["0.1.0"] = legacyResources
 	versionedResources["0.2.0"] = allResources
+	versionedResources["1.0.0"] = allResources
 
 	testCases := []struct {
 		customObject      awstpr.CustomObject
@@ -163,7 +164,20 @@ func Test_Service_NewResourceRouter(t *testing.T) {
 			errorMatcher:      nil,
 			resourceRouter:    NewResourceRouter(versionedResources),
 		},
-		// Case 3. Invalid version returns an error.
+		// Case 3. Kubernetes update to 1.8.4.
+		{
+			customObject: awstpr.CustomObject{
+				Spec: awstpr.Spec{
+					VersionBundle: spec.VersionBundle{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expectedResources: allResources,
+			errorMatcher:      nil,
+			resourceRouter:    NewResourceRouter(versionedResources),
+		},
+		// Case 4. Invalid version returns an error.
 		{
 			customObject: awstpr.CustomObject{
 				Spec: awstpr.Spec{

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -72,7 +72,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Name:         "aws-operator",
 			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
 			Version:      "0.1.0",
-			WIP:          true,
+			WIP:          false,
 		},
 		{
 			Changelogs: []versionbundle.Changelog{
@@ -113,7 +113,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Name:         "aws-operator",
 			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
 			Version:      "0.2.0",
-			WIP:          true,
+			WIP:          false,
 		},
 		{
 			Changelogs: []versionbundle.Changelog{

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -109,11 +109,11 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 			},
 			Dependencies: []versionbundle.Dependency{},
-			Deprecated:   true,
+			Deprecated:   false,
 			Name:         "aws-operator",
 			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
 			Version:      "0.2.0",
-			WIP:          false,
+			WIP:          true,
 		},
 		{
 			Changelogs: []versionbundle.Changelog{

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -152,7 +152,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Dependencies: []versionbundle.Dependency{},
 			Deprecated:   false,
 			Name:         "aws-operator",
-			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
+			Time:         time.Date(2017, time.December, 5, 13, 00, 0, 0, time.UTC),
 			Version:      "1.0.0",
 			WIP:          false,
 		},

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -68,7 +68,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 			},
 			Dependencies: []versionbundle.Dependency{},
-			Deprecated:   false,
+			Deprecated:   true,
 			Name:         "aws-operator",
 			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
 			Version:      "0.1.0",
@@ -109,11 +109,52 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 			},
 			Dependencies: []versionbundle.Dependency{},
-			Deprecated:   false,
+			Deprecated:   true,
 			Name:         "aws-operator",
 			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
 			Version:      "0.2.0",
 			WIP:          true,
+		},
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "kubernetes",
+					Description: "Updated to kubernetes 1.8.4. Fixes a goroutine leak in the k8s api.",
+					Kind:        "changed",
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "calico",
+					Version: "2.6.2",
+				},
+				{
+					Name:    "docker",
+					Version: "1.12.6",
+				},
+				{
+					Name:    "etcd",
+					Version: "3.2.7",
+				},
+				{
+					Name:    "kubedns",
+					Version: "1.14.5",
+				},
+				{
+					Name:    "kubernetes",
+					Version: "1.8.4",
+				},
+				{
+					Name:    "nginx-ingress-controller",
+					Version: "0.9.0",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{},
+			Deprecated:   false,
+			Name:         "aws-operator",
+			Time:         time.Date(2017, time.November, 29, 16, 16, 0, 0, time.UTC),
+			Version:      "1.0.0",
+			WIP:          false,
 		},
 	}
 }


### PR DESCRIPTION
I think this does what I'd want. It makes it clear that it is impossible to select 1.8.1 clusters now (by making them deprecated)
And makes a 1.0.0 release so that we communicate confidence.

This makes me think that we should have validation somewhere that stops people from selecting invalid or deprecated versions. Do we already have that @xh3b4sd?