### PR TITLE
Migrate cloudformationv2 package

### DIFF
--- a/service/resource/cloudformationv2/adapter/adapter.go
+++ b/service/resource/cloudformationv2/adapter/adapter.go
@@ -26,11 +26,11 @@
 package adapter
 
 import (
-	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
 
-type hydrater func(awstpr.CustomObject, Clients) error
+type hydrater func(v1alpha1.AWSConfig, Clients) error
 
 type Adapter struct {
 	ASGType string
@@ -40,7 +40,7 @@ type Adapter struct {
 	outputsAdapter
 }
 
-func New(customObject awstpr.CustomObject, clients Clients) (Adapter, error) {
+func New(customObject v1alpha1.AWSConfig, clients Clients) (Adapter, error) {
 	a := Adapter{}
 
 	a.ASGType = prefixWorker

--- a/service/resource/cloudformationv2/adapter/adapter_test.go
+++ b/service/resource/cloudformationv2/adapter/adapter_test.go
@@ -3,21 +3,14 @@ package adapter
 import (
 	"testing"
 
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
-	"github.com/giantswarm/clustertpr/spec/kubernetes"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 )
 
 var (
-	defaultCluster = clustertpr.Spec{
-		Cluster: spec.Cluster{
-			ID: "test-cluster",
-		},
-		Kubernetes: spec.Kubernetes{
-			IngressController: kubernetes.IngressController{
+	defaultCluster = v1alpha1.Cluster{
+		ID: "test-cluster",
+		Kubernetes: v1alpha1.ClusterKubernetes{
+			IngressController: v1alpha1.ClusterKubernetesIngressController{
 				Domain: "mysubdomain.mydomain.com",
 			},
 		},
@@ -25,12 +18,12 @@ var (
 )
 
 func TestAdapterMain(t *testing.T) {
-	customObject := awstpr.CustomObject{
-		Spec: awstpr.Spec{
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
 			Cluster: defaultCluster,
-			AWS: awsspec.AWS{
-				Workers: []awsspecaws.Node{
-					awsspecaws.Node{},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{},
 				},
 			},
 		},

--- a/service/resource/cloudformationv2/adapter/auto_scaling_group.go
+++ b/service/resource/cloudformationv2/adapter/auto_scaling_group.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/giantswarm/aws-operator/service/keyv1"
-	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 // template related to this adapter: service/templates/cloudformation/auto_scaling_group.go
@@ -26,9 +27,9 @@ type autoScalingGroupAdapter struct {
 	ClusterID              string
 }
 
-func (a *autoScalingGroupAdapter) getAutoScalingGroup(customObject awstpr.CustomObject, clients Clients) error {
+func (a *autoScalingGroupAdapter) getAutoScalingGroup(customObject v1alpha1.AWSConfig, clients Clients) error {
 	a.AZ = customObject.Spec.AWS.AZ
-	workers := keyv1.WorkerCount(customObject)
+	workers := keyv2.WorkerCount(customObject)
 	a.ASGMaxSize = workers
 	a.ASGMinSize = workers
 	a.MaxBatchSize = strconv.FormatFloat(asgMaxBatchSizeRatio, 'f', -1, 32)
@@ -39,7 +40,7 @@ func (a *autoScalingGroupAdapter) getAutoScalingGroup(customObject awstpr.Custom
 	// load balancer name
 	// TODO: remove this code once the ingress load balancer is created by cloudformation
 	// and add a reference in the template
-	lbName, err := keyv1.LoadBalancerName(customObject.Spec.Cluster.Kubernetes.IngressController.Domain, customObject)
+	lbName, err := keyv2.LoadBalancerName(customObject.Spec.Cluster.Kubernetes.IngressController.Domain, customObject)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -48,7 +49,7 @@ func (a *autoScalingGroupAdapter) getAutoScalingGroup(customObject awstpr.Custom
 	// subnet ID
 	// TODO: remove this code once the subnet is created by cloudformation and add a
 	// reference in the template
-	subnetName := keyv1.SubnetName(customObject, suffixPrivate)
+	subnetName := keyv2.SubnetName(customObject, suffixPrivate)
 	describeSubnetInput := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -69,7 +70,7 @@ func (a *autoScalingGroupAdapter) getAutoScalingGroup(customObject awstpr.Custom
 
 	a.SubnetID = *output.Subnets[0].SubnetId
 
-	a.ClusterID = keyv1.ClusterID(customObject)
+	a.ClusterID = keyv2.ClusterID(customObject)
 
 	return nil
 }

--- a/service/resource/cloudformationv2/adapter/auto_scaling_group_test.go
+++ b/service/resource/cloudformationv2/adapter/auto_scaling_group_test.go
@@ -4,17 +4,13 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 )
 
 func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 	testCases := []struct {
 		description                    string
-		customObject                   awstpr.CustomObject
+		customObject                   v1alpha1.AWSConfig
 		expectedError                  bool
 		expectedAZ                     string
 		expectedASGMaxSize             int
@@ -27,20 +23,20 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 	}{
 		{
 			description:   "empty custom object",
-			customObject:  awstpr.CustomObject{},
+			customObject:  v1alpha1.AWSConfig{},
 			expectedError: true,
 		},
 		{
 			description: "basic matching, all fields present",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
 					Cluster: defaultCluster,
-					AWS: awsspec.AWS{
+					AWS: v1alpha1.AWSConfigSpecAWS{
 						AZ: "myaz",
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{},
-							awsspecaws.Node{},
-							awsspecaws.Node{},
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{},
+							v1alpha1.AWSConfigSpecAWSNode{},
+							v1alpha1.AWSConfigSpecAWSNode{},
 						},
 					},
 				},
@@ -110,13 +106,13 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 func TestAdapterAutoScalingGroupLoadBalancerName(t *testing.T) {
 	testCases := []struct {
 		description              string
-		customObject             awstpr.CustomObject
+		customObject             v1alpha1.AWSConfig
 		expectedLoadBalancerName string
 	}{
 		{
 			description: "basic matching, all fields present",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
 					Cluster: defaultCluster,
 				},
 			},
@@ -145,19 +141,19 @@ func TestAdapterAutoScalingGroupLoadBalancerName(t *testing.T) {
 func TestAdapterAutoScalingGroupSubnetID(t *testing.T) {
 	testCases := []struct {
 		description                string
-		customObject               awstpr.CustomObject
+		customObject               v1alpha1.AWSConfig
 		expectedReceivedSubnetName string
 		expectedError              bool
 		unexistentSubnet           bool
 	}{
 		{
 			description: "existent subnet",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
 					Cluster: defaultCluster,
-					AWS: awsspec.AWS{
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{
 								ImageID:      "myimageid",
 								InstanceType: "myinstancetype",
 							},
@@ -169,16 +165,14 @@ func TestAdapterAutoScalingGroupSubnetID(t *testing.T) {
 		},
 		{
 			description: "unexistent subnet",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "test-cluster",
-						},
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
 					},
-					AWS: awsspec.AWS{
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{
 								ImageID:      "myimageid",
 								InstanceType: "myinstancetype",
 							},

--- a/service/resource/cloudformationv2/adapter/launch_configuration.go
+++ b/service/resource/cloudformationv2/adapter/launch_configuration.go
@@ -7,9 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/giantswarm/aws-operator/service/keyv1"
-	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 // template related to this adapter: service/templates/cloudformation/launch_configuration.go
@@ -31,14 +32,14 @@ type BlockDeviceMapping struct {
 	VolumeType          string
 }
 
-func (l *launchConfigAdapter) getLaunchConfiguration(customObject awstpr.CustomObject, clients Clients) error {
+func (l *launchConfigAdapter) getLaunchConfiguration(customObject v1alpha1.AWSConfig, clients Clients) error {
 	if len(customObject.Spec.AWS.Workers) == 0 {
 		return microerror.Mask(invalidConfigError)
 	}
 
-	l.ImageID = customObject.Spec.AWS.Workers[0].ImageID
-	l.InstanceType = customObject.Spec.AWS.Workers[0].InstanceType
-	l.IAMInstanceProfileName = keyv1.InstanceProfileName(customObject, prefixWorker)
+	l.ImageID = keyv2.WorkerImageID(customObject)
+	l.InstanceType = keyv2.WorkerInstanceType(customObject)
+	l.IAMInstanceProfileName = keyv2.InstanceProfileName(customObject, prefixWorker)
 	l.AssociatePublicIPAddress = false
 
 	l.BlockDeviceMappings = []BlockDeviceMapping{
@@ -53,7 +54,7 @@ func (l *launchConfigAdapter) getLaunchConfiguration(customObject awstpr.CustomO
 	// security group
 	// TODO: remove this code once the security group is created by cloudformation
 	// and add a reference in the template
-	groupName := keyv1.SecurityGroupName(customObject, prefixWorker)
+	groupName := keyv2.SecurityGroupName(customObject, prefixWorker)
 	describeSgInput := &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -90,14 +91,14 @@ func (l *launchConfigAdapter) getLaunchConfiguration(customObject awstpr.CustomO
 		return microerror.Mask(err)
 	}
 
-	clusterID := keyv1.ClusterID(customObject)
+	clusterID := keyv2.ClusterID(customObject)
 	s3URI := fmt.Sprintf("%s-g8s-%s", accountID, clusterID)
 
 	cloudConfigConfig := SmallCloudconfigConfig{
 		MachineType:    prefixWorker,
 		Region:         customObject.Spec.AWS.Region,
 		S3URI:          s3URI,
-		ClusterVersion: keyv1.ClusterVersion(customObject),
+		ClusterVersion: keyv2.ClusterVersion(customObject),
 	}
 	smallCloudConfig, err := SmallCloudconfig(cloudConfigConfig)
 	if err != nil {

--- a/service/resource/cloudformationv2/adapter/launch_configuration_test.go
+++ b/service/resource/cloudformationv2/adapter/launch_configuration_test.go
@@ -6,17 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 )
 
 func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
 	testCases := []struct {
 		description                      string
-		customObject                     awstpr.CustomObject
+		customObject                     v1alpha1.AWSConfig
 		expectedError                    bool
 		expectedImageID                  string
 		expectedInstanceType             string
@@ -26,21 +22,19 @@ func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
 	}{
 		{
 			description:   "empty custom object",
-			customObject:  awstpr.CustomObject{},
+			customObject:  v1alpha1.AWSConfig{},
 			expectedError: true,
 		},
 		{
 			description: "basic matching, all fields present",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "test-cluster",
-						},
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
 					},
-					AWS: awsspec.AWS{
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{
 								ImageID:      "myimageid",
 								InstanceType: "myinstancetype",
 							},
@@ -101,23 +95,21 @@ func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
 func TestAdapterLaunchConfigurationSecurityGroupID(t *testing.T) {
 	testCases := []struct {
 		description             string
-		customObject            awstpr.CustomObject
+		customObject            v1alpha1.AWSConfig
 		expectedSecurityGroupID string
 		expectedError           bool
 		unexistingSG            bool
 	}{
 		{
 			description: "existent security group",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "test-cluster",
-						},
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
 					},
-					AWS: awsspec.AWS{
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{
 								ImageID:      "myimageid",
 								InstanceType: "myinstancetype",
 							},
@@ -129,16 +121,14 @@ func TestAdapterLaunchConfigurationSecurityGroupID(t *testing.T) {
 		},
 		{
 			description: "unexistent security group",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "test-cluster",
-						},
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
 					},
-					AWS: awsspec.AWS{
-						Workers: []awsspecaws.Node{
-							awsspecaws.Node{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							v1alpha1.AWSConfigSpecAWSNode{
 								ImageID:      "myimageid",
 								InstanceType: "myinstancetype",
 							},
@@ -199,18 +189,16 @@ func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
 		EC2: &EC2ClientMock{},
 		IAM: &IAMClientMock{accountID: "000000000000"},
 	}
-	customObject := awstpr.CustomObject{
-		Spec: awstpr.Spec{
-			Cluster: clustertpr.Spec{
-				Cluster: spec.Cluster{
-					ID: "test-cluster",
-				},
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
 				Version: "myversion",
 			},
-			AWS: awsspec.AWS{
+			AWS: v1alpha1.AWSConfigSpecAWS{
 				Region: "myregion",
-				Workers: []awsspecaws.Node{
-					awsspecaws.Node{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID:      "myimageid",
 						InstanceType: "myinstancetype",
 					},

--- a/service/resource/cloudformationv2/adapter/outputs.go
+++ b/service/resource/cloudformationv2/adapter/outputs.go
@@ -1,8 +1,9 @@
 package adapter
 
 import (
-	"github.com/giantswarm/aws-operator/service/keyv1"
-	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 // template related to this adapter: service/templates/cloudformation/outputs.yaml
@@ -11,8 +12,8 @@ type outputsAdapter struct {
 	ClusterVersion string
 }
 
-func (o *outputsAdapter) getOutputs(customObject awstpr.CustomObject, clients Clients) error {
-	o.ClusterVersion = keyv1.ClusterVersion(customObject)
+func (o *outputsAdapter) getOutputs(customObject v1alpha1.AWSConfig, clients Clients) error {
+	o.ClusterVersion = keyv2.ClusterVersion(customObject)
 
 	return nil
 }

--- a/service/resource/cloudformationv2/adapter/outputs_test.go
+++ b/service/resource/cloudformationv2/adapter/outputs_test.go
@@ -3,26 +3,25 @@ package adapter
 import (
 	"testing"
 
-	"github.com/giantswarm/awstpr"
-	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 )
 
 func TestAdapterOutputsRegularFields(t *testing.T) {
 	testCases := []struct {
 		description            string
-		customObject           awstpr.CustomObject
+		customObject           v1alpha1.AWSConfig
 		expectedClusterVersion string
 	}{
 		{
 			description:            "empty custom object",
-			customObject:           awstpr.CustomObject{},
+			customObject:           v1alpha1.AWSConfig{},
 			expectedClusterVersion: "",
 		},
 		{
 			description: "basic matching",
-			customObject: awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
 						Version: "myversion",
 					},
 				},

--- a/service/resource/cloudformationv2/adapter/small_cloudconfig.go
+++ b/service/resource/cloudformationv2/adapter/small_cloudconfig.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/giantswarm/aws-operator/service/keyv1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 func SmallCloudconfig(config SmallCloudconfigConfig) (string, error) {
@@ -16,7 +17,7 @@ func SmallCloudconfig(config SmallCloudconfigConfig) (string, error) {
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
-	rootDir, err := keyv1.RootDir(baseDir, RootDirElement)
+	rootDir, err := keyv2.RootDir(baseDir, RootDirElement)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/resource/cloudformationv2/create.go
+++ b/service/resource/cloudformationv2/create.go
@@ -1,12 +1,13 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/keyv1"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
@@ -26,7 +27,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 }
 
 func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	customObject, err := keyv1.ToCustomObject(obj)
+	customObject, err := keyv2.ToCustomObject(obj)
 	if err != nil {
 		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
 	}

--- a/service/resource/cloudformationv2/create_test.go
+++ b/service/resource/cloudformationv2/create_test.go
@@ -1,37 +1,31 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
 	"testing"
 
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
-	"github.com/giantswarm/clustertpr/spec/kubernetes"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 func Test_Resource_Cloudformation_newCreate(t *testing.T) {
-	clusterTpo := &awstpr.CustomObject{
-		Spec: awstpr.Spec{
-			Cluster: clustertpr.Spec{
-				Cluster: spec.Cluster{
-					ID: "test-cluster",
-				},
-				Kubernetes: spec.Kubernetes{
-					IngressController: kubernetes.IngressController{
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
 						Domain: "mysubdomain.mydomain.com",
 					},
 				},
 			},
-			AWS: awsspec.AWS{
+			AWS: v1alpha1.AWSConfigSpecAWS{
 				AZ: "myaz",
-				Workers: []awsspecaws.Node{
-					awsspecaws.Node{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID: "myimageid",
 					},
 				},

--- a/service/resource/cloudformationv2/current.go
+++ b/service/resource/cloudformationv2/current.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
@@ -7,18 +7,18 @@ import (
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/keyv1"
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	customObject, err := keyv1.ToCustomObject(obj)
+	customObject, err := keyv2.ToCustomObject(obj)
 	if err != nil {
 		return StackState{}, microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "debug", "looking for AWS stack")
 
-	stackName := keyv1.MainStackName(customObject)
+	stackName := keyv2.MainStackName(customObject)
 
 	describeInput := &awscloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),

--- a/service/resource/cloudformationv2/delete.go
+++ b/service/resource/cloudformationv2/delete.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"

--- a/service/resource/cloudformationv2/delete_test.go
+++ b/service/resource/cloudformationv2/delete_test.go
@@ -1,15 +1,14 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
 	"testing"
 
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
-	"github.com/giantswarm/awstpr"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 func Test_Resource_Cloudformation_newDelete(t *testing.T) {
@@ -22,12 +21,10 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 	}{
 		{
 			description: "current and desired state empty, expected empty",
-			obj: &awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "5xchu",
-						},
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
 					},
 				},
 			},
@@ -37,12 +34,10 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 		},
 		{
 			description: "current state empty, desired state not empty, expected empty",
-			obj: &awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "5xchu",
-						},
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
 					},
 				},
 			},
@@ -54,12 +49,10 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 		},
 		{
 			description: "current state not empty, desired state not empty but different, expected current state",
-			obj: &awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "5xchu",
-						},
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
 					},
 				},
 			},
@@ -73,12 +66,10 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 		},
 		{
 			description: "current state not empty, desired state not empty but equal, expected desired state",
-			obj: &awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
-						Cluster: spec.Cluster{
-							ID: "5xchu",
-						},
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
 					},
 				},
 			},

--- a/service/resource/cloudformationv2/desired.go
+++ b/service/resource/cloudformationv2/desired.go
@@ -1,15 +1,15 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/keyv1"
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	customObject, err := keyv1.ToCustomObject(obj)
+	customObject, err := keyv2.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/resource/cloudformationv2/desired_test.go
+++ b/service/resource/cloudformationv2/desired_test.go
@@ -1,14 +1,13 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
 	"testing"
 
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
-	"github.com/giantswarm/awstpr"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
@@ -19,13 +18,11 @@ func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
 	}{
 		{
 			description: "CloudFormation gets name from custom object",
-			obj: &awstpr.CustomObject{
-				Spec: awstpr.Spec{
-					Cluster: clustertpr.Spec{
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID:      "5xchu",
 						Version: "cloud-formation",
-						Cluster: spec.Cluster{
-							ID: "5xchu",
-						},
 					},
 				},
 			},

--- a/service/resource/cloudformationv2/error.go
+++ b/service/resource/cloudformationv2/error.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"strings"

--- a/service/resource/cloudformationv2/main_stack.go
+++ b/service/resource/cloudformationv2/main_stack.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"bytes"
@@ -8,15 +8,15 @@ import (
 	"strconv"
 	"text/template"
 
-	"github.com/giantswarm/awstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/keyv1"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
+	"github.com/giantswarm/aws-operator/service/keyv2"
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
-func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
-	stackName := keyv1.MainStackName(customObject)
+func newMainStack(customObject v1alpha1.AWSConfig) (StackState, error) {
+	stackName := keyv2.MainStackName(customObject)
 	workers := len(customObject.Spec.AWS.Workers)
 	var imageID string
 	// FIXME: the imageID should not depend on the number of workers.
@@ -24,7 +24,7 @@ func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
 	if workers > 0 {
 		imageID = customObject.Spec.AWS.Workers[0].ImageID
 	}
-	clusterVersion := keyv1.ClusterVersion(customObject)
+	clusterVersion := keyv2.ClusterVersion(customObject)
 
 	mainCF := StackState{
 		Name:           stackName,
@@ -36,7 +36,7 @@ func newMainStack(customObject awstpr.CustomObject) (StackState, error) {
 	return mainCF, nil
 }
 
-func (r *Resource) getMainTemplateBody(customObject awstpr.CustomObject) (string, error) {
+func (r *Resource) getMainTemplateBody(customObject v1alpha1.AWSConfig) (string, error) {
 	main := template.New("")
 
 	var t *template.Template
@@ -48,7 +48,7 @@ func (r *Resource) getMainTemplateBody(customObject awstpr.CustomObject) (string
 		return "", microerror.Mask(err)
 	}
 
-	rootDir, err := keyv1.RootDir(baseDir, adapter.RootDirElement)
+	rootDir, err := keyv2.RootDir(baseDir, adapter.RootDirElement)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/resource/cloudformationv2/main_stack_test.go
+++ b/service/resource/cloudformationv2/main_stack_test.go
@@ -1,23 +1,18 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
-	"github.com/giantswarm/clustertpr/spec/kubernetes"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 func TestMainTemplateGetEmptyBody(t *testing.T) {
-	customObject := awstpr.CustomObject{}
+	customObject := v1alpha1.AWSConfig{}
 
 	resourceConfig := DefaultConfig()
 	resourceConfig.Clients = adapter.Clients{}
@@ -36,23 +31,21 @@ func TestMainTemplateGetEmptyBody(t *testing.T) {
 
 func TestMainTemplateExistingFields(t *testing.T) {
 	// customObject with example fields for both asg and launch config
-	customObject := awstpr.CustomObject{
-		Spec: awstpr.Spec{
-			Cluster: clustertpr.Spec{
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
 				Version: "myversion",
-				Cluster: spec.Cluster{
-					ID: "test-cluster",
-				},
-				Kubernetes: spec.Kubernetes{
-					IngressController: kubernetes.IngressController{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
 						Domain: "mysubdomain.mydomain.com",
 					},
 				},
 			},
-			AWS: awsspec.AWS{
+			AWS: v1alpha1.AWSConfigSpecAWS{
 				AZ: "myaz",
-				Workers: []awsspecaws.Node{
-					awsspecaws.Node{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID: "myimageid",
 					},
 				},

--- a/service/resource/cloudformationv2/resource.go
+++ b/service/resource/cloudformationv2/resource.go
@@ -1,11 +1,12 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 const (

--- a/service/resource/cloudformationv2/spec.go
+++ b/service/resource/cloudformationv2/spec.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 const (
 	// defaultCreationTimeout is the timeout in minutes for the creation of the stack.

--- a/service/resource/cloudformationv2/update.go
+++ b/service/resource/cloudformationv2/update.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
@@ -6,9 +6,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/keyv1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -51,7 +52,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 }
 
 func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	customObject, err := keyv1.ToCustomObject(obj)
+	customObject, err := keyv2.ToCustomObject(obj)
 	if err != nil {
 		return awscloudformation.CreateStackInput{}, microerror.Mask(err)
 	}

--- a/service/resource/cloudformationv2/update_test.go
+++ b/service/resource/cloudformationv2/update_test.go
@@ -1,4 +1,4 @@
-package cloudformationv1
+package cloudformationv2
 
 import (
 	"context"
@@ -6,34 +6,27 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/awstpr"
-	awsspec "github.com/giantswarm/awstpr/spec"
-	awsspecaws "github.com/giantswarm/awstpr/spec/aws"
-	"github.com/giantswarm/clustertpr"
-	"github.com/giantswarm/clustertpr/spec"
-	"github.com/giantswarm/clustertpr/spec/kubernetes"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/resource/cloudformationv1/adapter"
+	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
 func Test_Resource_Cloudformation_newUpdateChange(t *testing.T) {
-	clusterTpo := &awstpr.CustomObject{
-		Spec: awstpr.Spec{
-			Cluster: clustertpr.Spec{
-				Cluster: spec.Cluster{
-					ID: "test-cluster",
-				},
-				Kubernetes: spec.Kubernetes{
-					IngressController: kubernetes.IngressController{
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
 						Domain: "mysubdomain.mydomain.com",
 					},
 				},
 			},
-			AWS: awsspec.AWS{
+			AWS: v1alpha1.AWSConfigSpecAWS{
 				AZ: "myaz",
-				Workers: []awsspecaws.Node{
-					awsspecaws.Node{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID: "myimageid",
 					},
 				},


### PR DESCRIPTION
Updates the cloudformationv2 package to use `apiextensions`.  Just legacyv2 to go now.