### PR TITLE
Add CRD resource router

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -691,7 +691,7 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 
 		frameworkConfig.InitCtxFunc = initCtxFunc
 		frameworkConfig.Logger = config.Logger
-		frameworkConfig.ResourceRouter = NewResourceRouter(versionedResources)
+		frameworkConfig.ResourceRouter = NewTPRResourceRouter(versionedResources)
 		frameworkConfig.Informer = newInformer
 		frameworkConfig.TPR = newTPR
 

--- a/service/resource_router.go
+++ b/service/resource_router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 
 	"github.com/giantswarm/aws-operator/service/keyv1"
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 const (
@@ -16,6 +17,39 @@ const (
 // NewResourceRouter determines which resources are enabled based upon the
 // version in the version bundle.
 func NewResourceRouter(resources map[string][]framework.Resource) func(ctx context.Context, obj interface{}) ([]framework.Resource, error) {
+	return func(ctx context.Context, obj interface{}) ([]framework.Resource, error) {
+		var enabledResources []framework.Resource
+
+		customObject, err := keyv2.ToCustomObject(obj)
+		if err != nil {
+			return enabledResources, microerror.Mask(err)
+		}
+
+		switch keyv2.VersionBundleVersion(customObject) {
+		case keyv2.LegacyVersion:
+			// Legacy version so only enable the legacy resource.
+			enabledResources = resources[keyv2.LegacyVersion]
+		case keyv2.CloudFormationVersion:
+			// Cloud Formation transitional version so enable all resources.
+			enabledResources = resources[keyv2.CloudFormationVersion]
+		case "1.0.0":
+			// Kubernetes update to 1.8.4.
+			enabledResources = resources["1.0.0"]
+		case "":
+			// Default to the legacy resource for custom objects without a version
+			// bundle.
+			enabledResources = resources[keyv2.LegacyVersion]
+		default:
+			return enabledResources, microerror.Maskf(invalidVersionError, "version '%s' in version bundle is invalid", keyv2.VersionBundleVersion(customObject))
+		}
+
+		return enabledResources, nil
+	}
+}
+
+// NewTPRResourceRouter determines which resources are enabled based upon the
+// version in the version bundle. It will be removed when we remove TPR support.
+func NewTPRResourceRouter(resources map[string][]framework.Resource) func(ctx context.Context, obj interface{}) ([]framework.Resource, error) {
 	return func(ctx context.Context, obj interface{}) ([]framework.Resource, error) {
 		var enabledResources []framework.Resource
 


### PR DESCRIPTION
In local testing I found a problem with the resource router and CRDs.

It needs to use the keyv2 package. So I've renamed the old router function to `NewTPRResourceRouter`. I haven't had a chance to improve the tests yet so they just duplicate the current tests.

I wanted to push this just in case anyone is testing with CRDs before I'm back on Tuesday.