### PR TITLE
removed finalizer

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -765,9 +765,9 @@ func migrateTPRsToCRDs(logger micrologger.Logger, clientSet *versioned.Clientset
 			cro.TypeMeta.APIVersion = "provider.giantswarm.io"
 			cro.TypeMeta.Kind = "AWSConfig"
 			cro.ObjectMeta.Name = tpo.Name
-			cro.ObjectMeta.Finalizers = []string{
-				AWSConfigCleanupFinalizer,
-			}
+			//cro.ObjectMeta.Finalizers = []string{
+			//	AWSConfigCleanupFinalizer,
+			//}
 			cro.Spec.AWS.API.ELB.IdleTimeoutSeconds = tpo.Spec.AWS.ELB.IdleTimeoutSeconds.API
 			cro.Spec.AWS.API.HostedZones = tpo.Spec.AWS.HostedZones.API
 			cro.Spec.AWS.AZ = tpo.Spec.AWS.AZ


### PR DESCRIPTION
I noticed that finalizers in our installations behave differently than when I tested back then on my minikube. For now it is safer to just drop them and manage the finalizer logic separately in a unified way.