### PR TITLE
e2e: wait also for nodes

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -153,8 +153,8 @@ func operatorSetup() error {
 		return microerror.Maskf(err, "unexpected error waiting for guest cluster installed: %v")
 	}
 
-	if err := f.WaitForAPIUp(); err != nil {
-		return microerror.Maskf(err, "unexpected error waiting for API up")
+	if err := f.WaitForGuestReady(); err != nil {
+		return microerror.Maskf(err, "unexpected error waiting for guest cluster ready")
 	}
 
 	return nil

--- a/integration/util.go
+++ b/integration/util.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultTimeout = 300
+	defaultTimeout = 400
 )
 
 func runCmd(cmdStr string) error {


### PR DESCRIPTION
Wait for nodes in `Ready` state ss part of the testing setup. The number of required ready nodes is defined as a constant. There's also some refactoring (wait functions used only once are defined locally) and increased wait timeout.