### PR TITLE
Support multiple S3 objects

### DIFF
--- a/service/resource/s3objectv2/create.go
+++ b/service/resource/s3objectv2/create.go
@@ -2,50 +2,60 @@ package s3objectv2
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	s3PutInput, err := toPutObjectInput(createChange)
+	createBucketState, err := toBucketObjectState(createChange)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	if s3PutInput.Key != nil {
-		_, err = r.awsClients.S3.PutObject(&s3PutInput)
-		if err != nil {
-			return microerror.Mask(err)
-		}
+	for key, bucketObject := range createBucketState {
+		if bucketObject.Key != "" {
+			s3PutInput, err := toPutObjectInput(bucketObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 
-		r.logger.LogCtx(ctx, "debug", "creating S3 worker's cloudconfig: created")
-	} else {
-		r.logger.LogCtx(ctx, "debug", "creating S3 worker's cloudconfig: already created")
+			_, err = r.awsClients.S3.PutObject(&s3PutInput)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "debug", fmt.Sprintf("creating S3 object '%s': created", key))
+		} else {
+			r.logger.LogCtx(ctx, "debug", fmt.Sprintf("creating S3 object '%s': already created", key))
+		}
 	}
 
 	return nil
 }
 
 func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	desiredObjectState, err := toBucketObjectState(desiredState)
+	currentBucketState, err := toBucketObjectState(currentState)
 	if err != nil {
 		return s3.PutObjectInput{}, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "debug", "finding out if worker's cloudconfig object should be created")
-
-	createState := s3.PutObjectInput{
-		Key: aws.String(""),
+	desiredBucketState, err := toBucketObjectState(desiredState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
 	}
 
-	if desiredObjectState.WorkerCloudConfig.Key != "" {
-		createState.Key = aws.String(desiredObjectState.WorkerCloudConfig.Key)
-		createState.Body = strings.NewReader(desiredObjectState.WorkerCloudConfig.Body)
-		createState.Bucket = aws.String(desiredObjectState.WorkerCloudConfig.Bucket)
-		createState.ContentLength = aws.Int64(int64(len(desiredObjectState.WorkerCloudConfig.Body)))
+	r.logger.LogCtx(ctx, "debug", "finding out if the s3 objects should be created")
+
+	createState := map[string]BucketObjectState{}
+
+	for key, bucketObject := range desiredBucketState {
+		if _, ok := currentBucketState[key]; !ok {
+			createState[key] = bucketObject
+		} else {
+			createState[key] = BucketObjectState{}
+		}
 	}
 
 	return createState, nil

--- a/service/resource/s3objectv2/create_test.go
+++ b/service/resource/s3objectv2/create_test.go
@@ -1,12 +1,10 @@
 package s3objectv2
 
 import (
-	"bufio"
 	"context"
-	"strings"
+	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certificatetpr/certificatetprtest"
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -25,58 +23,125 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 	}
 
 	testCases := []struct {
-		obj            v1alpha1.AWSConfig
-		currentState   BucketObjectState
-		desiredState   BucketObjectState
-		expectedBody   string
-		expectedBucket string
-		expectedKey    string
-		description    string
+		description   string
+		obj           v1alpha1.AWSConfig
+		currentState  map[string]BucketObjectState
+		desiredState  map[string]BucketObjectState
+		expectedState map[string]BucketObjectState
 	}{
 		{
-			description:    "current state empty, desired state empty, empty create change",
-			obj:            clusterTpo,
-			currentState:   BucketObjectState{},
-			desiredState:   BucketObjectState{},
-			expectedBody:   "",
-			expectedBucket: "",
-			expectedKey:    "",
+			description:   "current state empty, desired state empty, empty create change",
+			obj:           clusterTpo,
+			currentState:  map[string]BucketObjectState{},
+			desiredState:  map[string]BucketObjectState{},
+			expectedState: map[string]BucketObjectState{},
 		},
 		{
 			description:  "current state empty, desired state not empty, create change == desired state",
 			obj:          clusterTpo,
-			currentState: BucketObjectState{},
-			desiredState: BucketObjectState{
-				WorkerCloudConfig: BucketObjectInstance{
-					Body:   "mybody",
+			currentState: map[string]BucketObjectState{},
+			desiredState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
 					Bucket: "mybucket",
-					Key:    "mykey",
+					Key:    "master",
 				},
 			},
-			expectedBody:   "mybody",
-			expectedBucket: "mybucket",
-			expectedKey:    "mykey",
+			expectedState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
 		},
 		{
 			description: "current state not empty, desired state not empty, create change == desired state",
 			obj:         clusterTpo,
-			currentState: BucketObjectState{
-				WorkerCloudConfig: BucketObjectInstance{
-					Body:   "currentbody",
-					Bucket: "currentbucket",
-					Key:    "currentkey",
-				},
-			},
-			desiredState: BucketObjectState{
-				WorkerCloudConfig: BucketObjectInstance{
-					Body:   "mybody",
+			currentState: map[string]BucketObjectState{
+				"mykey": BucketObjectState{
+					Body:   "mykey",
 					Bucket: "mybucket",
-					Key:    "mykey",
+					Key:    "master",
 				},
 			},
-			expectedBody:   "mybody",
-			expectedBucket: "mybucket",
-			expectedKey:    "mykey",
+			desiredState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state has 1 object, desired state has 2 objects, create change == missing object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": BucketObjectState{
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": BucketObjectState{},
+				"worker": BucketObjectState{
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, empty create change",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": BucketObjectState{
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": BucketObjectState{
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": BucketObjectState{
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": BucketObjectState{},
+				"worker": BucketObjectState{},
+			},
 		},
 	}
 
@@ -103,27 +168,13 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)
 			}
-			createChange, ok := result.(s3.PutObjectInput)
+			createChange, ok := result.(map[string]BucketObjectState)
 			if !ok {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
-			if createChange.Key != nil && *createChange.Key != tc.expectedKey {
-				t.Errorf("expected key %s, got %s", tc.expectedKey, createChange.Key)
-			}
-			if createChange.Bucket != nil && *createChange.Bucket != tc.expectedBucket {
-				t.Errorf("expected bucket %s, got %s", tc.expectedBucket, createChange.Bucket)
-			}
 
-			if createChange.Body != nil {
-				var actualBodyItems []string
-				scanner := bufio.NewScanner(createChange.Body)
-				for scanner.Scan() {
-					actualBodyItems = append(actualBodyItems, scanner.Text())
-				}
-				actualBody := strings.Join(actualBodyItems, "\n")
-				if actualBody != tc.expectedBody {
-					t.Errorf("expected body %s, got %s", tc.expectedBody, actualBody)
-				}
+			if !reflect.DeepEqual(tc.expectedState, createChange) {
+				t.Error("expected", tc.expectedState, "got", createChange)
 			}
 		})
 	}

--- a/service/resource/s3objectv2/current.go
+++ b/service/resource/s3objectv2/current.go
@@ -61,7 +61,7 @@ func (r *Resource) getBucketObjectBody(bucketName string, keyName string) (strin
 	}
 	result, err := r.awsClients.S3.GetObject(input)
 	if IsObjectNotFound(err) || IsBucketNotFound(err) {
-		r.logger.Log("debug", fmt.Sprintf("did not find S3 object '%s'", keyName))
+		r.logger.Log("info", fmt.Sprintf("did not find S3 object '%s'", keyName))
 
 		// fall through
 		return body, nil

--- a/service/resource/s3objectv2/current.go
+++ b/service/resource/s3objectv2/current.go
@@ -3,6 +3,7 @@ package s3objectv2
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -11,7 +12,7 @@ import (
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	output := BucketObjectState{}
+	output := map[string]BucketObjectState{}
 	customObject, err := keyv2.ToCustomObject(obj)
 	if err != nil {
 		return output, microerror.Mask(err)
@@ -19,41 +20,59 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "debug", "looking for S3 objects")
 
-	workersObjectName := keyv2.BucketObjectName(customObject, prefixWorker)
-
 	accountID, err := r.awsService.GetAccountID()
 	if err != nil {
 		return output, microerror.Mask(err)
 	}
 
 	bucketName := keyv2.BucketName(customObject, accountID)
-
-	input := &s3.GetObjectInput{
-		Key:    aws.String(workersObjectName),
+	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucketName),
 	}
-	result, err := r.awsClients.S3.GetObject(input)
-
-	if IsObjectNotFound(err) || IsBucketNotFound(err) {
-		r.logger.LogCtx(ctx, "debug", "did not find the S3 objects")
-		// fall through
-
-	} else if err != nil {
-
+	result, err := r.awsClients.S3.ListObjectsV2(input)
+	if err != nil {
 		return output, microerror.Mask(err)
+	}
 
-	} else {
+	r.logger.LogCtx(ctx, "debug", "found the S3 objects")
 
-		r.logger.LogCtx(ctx, "debug", "found the S3 objects")
-		output.WorkerCloudConfig.Key = workersObjectName
-		output.WorkerCloudConfig.Bucket = bucketName
+	for _, object := range result.Contents {
+		body, err := r.getBucketObjectBody(bucketName, *object.Key)
+		if err != nil {
+			return output, microerror.Mask(err)
+		}
 
-		buf := new(bytes.Buffer)
-		buf.ReadFrom(result.Body)
-		body := buf.String()
-
-		output.WorkerCloudConfig.Body = body
+		output[*object.Key] = BucketObjectState{
+			Body:   body,
+			Bucket: bucketName,
+			Key:    *object.Key,
+		}
 	}
 
 	return output, nil
+}
+
+func (r *Resource) getBucketObjectBody(bucketName string, keyName string) (string, error) {
+	var body string
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(keyName),
+	}
+	result, err := r.awsClients.S3.GetObject(input)
+	if IsObjectNotFound(err) || IsBucketNotFound(err) {
+		r.logger.Log("debug", fmt.Sprintf("did not find S3 object '%s'", keyName))
+
+		// fall through
+		return body, nil
+	}
+	if err != nil {
+		return body, microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(result.Body)
+	body = buf.String()
+
+	return body, nil
 }

--- a/service/resource/s3objectv2/current_test.go
+++ b/service/resource/s3objectv2/current_test.go
@@ -80,7 +80,7 @@ func Test_CurrentState(t *testing.T) {
 			if err != nil && !tc.expectedIAMError && !tc.expectedS3Error {
 				t.Errorf("unexpected error %v", err)
 			}
-			currentState, ok := result.(BucketObjectState)
+			currentState, ok := result.(map[string]BucketObjectState)
 			if !ok {
 				t.Errorf("expected '%T', got '%T'", currentState, result)
 			}
@@ -93,16 +93,24 @@ func Test_CurrentState(t *testing.T) {
 				t.Error("expected S3 error didn't happen")
 			}
 
-			if currentState.WorkerCloudConfig.Key != tc.expectedKey {
-				t.Errorf("expeccted key %q, got %q", tc.expectedKey, currentState.WorkerCloudConfig.Key)
-			}
+			if !tc.expectedIAMError && !tc.expectedS3Error {
+				var bucketObject BucketObjectState
 
-			if currentState.WorkerCloudConfig.Bucket != tc.expectedBucket {
-				t.Errorf("expeccted key %q, got %q", tc.expectedBucket, currentState.WorkerCloudConfig.Bucket)
-			}
+				if bucketObject, ok = currentState[tc.expectedKey]; !ok {
+					t.Errorf("expected S3 key %q not found", tc.expectedKey)
+				}
 
-			if currentState.WorkerCloudConfig.Body != tc.expectedBody {
-				t.Errorf("expeccted key %q, got %q", tc.expectedBody, currentState.WorkerCloudConfig.Body)
+				if bucketObject.Body != tc.expectedBody {
+					t.Errorf("expected body %q, got %q", tc.expectedBody, bucketObject.Body)
+				}
+
+				if bucketObject.Bucket != tc.expectedBucket {
+					t.Errorf("expected bucket %q, got %q", tc.expectedBucket, bucketObject.Bucket)
+				}
+
+				if bucketObject.Key != tc.expectedKey {
+					t.Errorf("expected key %q, got %q", tc.expectedKey, bucketObject.Key)
+				}
 			}
 		})
 	}

--- a/service/resource/s3objectv2/desired.go
+++ b/service/resource/s3objectv2/desired.go
@@ -10,7 +10,7 @@ import (
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 	customObject, err := keyv2.ToCustomObject(obj)
-	output := BucketObjectState{}
+	output := map[string]BucketObjectState{}
 	if err != nil {
 		return output, microerror.Mask(err)
 	}
@@ -55,22 +55,26 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return output, microerror.Mask(err)
 	}
 
-	output.MasterCloudConfig = BucketObjectInstance{
+	masterObjectName := keyv2.BucketObjectName(customObject, prefixMaster)
+	masterCloudConfig := BucketObjectState{
 		Bucket: keyv2.BucketName(customObject, accountID),
 		Body:   masterBody,
-		Key:    keyv2.BucketObjectName(customObject, prefixMaster),
+		Key:    masterObjectName,
 	}
+	output[masterObjectName] = masterCloudConfig
 
 	workerBody, err := r.cloudConfig.NewWorkerTemplate(customObject, *tlsAssets)
 	if err != nil {
 		return output, microerror.Mask(err)
 	}
 
-	output.WorkerCloudConfig = BucketObjectInstance{
+	workerObjectName := keyv2.BucketObjectName(customObject, prefixWorker)
+	workerCloudConfig := BucketObjectState{
 		Bucket: keyv2.BucketName(customObject, accountID),
 		Body:   workerBody,
-		Key:    keyv2.BucketObjectName(customObject, prefixWorker),
+		Key:    workerObjectName,
 	}
+	output[workerObjectName] = workerCloudConfig
 
 	return output, nil
 }

--- a/service/resource/s3objectv2/desired_test.go
+++ b/service/resource/s3objectv2/desired_test.go
@@ -41,6 +41,8 @@ func Test_DesiredState(t *testing.T) {
 	}
 	var err error
 	var newResource *Resource
+	var masterCloudConfig BucketObjectState
+	var workerCloudConfig BucketObjectState
 
 	resourceConfig := DefaultConfig()
 	resourceConfig.Logger = microloggertest.New()
@@ -69,33 +71,45 @@ func Test_DesiredState(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			desiredState, ok := result.(BucketObjectState)
+			desiredState, ok := result.(map[string]BucketObjectState)
 			if !ok {
 				t.Errorf("expected '%T', got '%T'", desiredState, result)
 			}
 
-			if desiredState.MasterCloudConfig.Bucket != tc.expectedBucket {
-				t.Errorf("expected key %q, got %q", tc.expectedBucket, desiredState.MasterCloudConfig.Bucket)
+			if len(desiredState) != 2 {
+				t.Errorf("expected 2 objects, got %d", len(desiredState))
 			}
 
-			if desiredState.MasterCloudConfig.Key != tc.expectedMasterKey {
-				t.Errorf("expected key %q, got %q", tc.expectedMasterKey, desiredState.MasterCloudConfig.Key)
+			if masterCloudConfig, ok = desiredState[tc.expectedMasterKey]; !ok {
+				t.Errorf("expected key %q, not found", tc.expectedMasterKey)
 			}
 
-			if desiredState.WorkerCloudConfig.Body != tc.expectedBody {
-				t.Errorf("expected key %q, got %q", tc.expectedBody, desiredState.MasterCloudConfig.Body)
+			if masterCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expected bucket %q, got %q", tc.expectedBucket, masterCloudConfig.Bucket)
 			}
 
-			if desiredState.WorkerCloudConfig.Bucket != tc.expectedBucket {
-				t.Errorf("expected key %q, got %q", tc.expectedBucket, desiredState.WorkerCloudConfig.Bucket)
+			if masterCloudConfig.Key != tc.expectedMasterKey {
+				t.Errorf("expected key %q, got %q", tc.expectedMasterKey, masterCloudConfig.Key)
 			}
 
-			if desiredState.WorkerCloudConfig.Key != tc.expectedWorkerKey {
-				t.Errorf("expected key %q, got %q", tc.expectedWorkerKey, desiredState.WorkerCloudConfig.Key)
+			if masterCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expected key %q, got %q", tc.expectedBody, masterCloudConfig.Body)
 			}
 
-			if desiredState.WorkerCloudConfig.Body != tc.expectedBody {
-				t.Errorf("expected key %q, got %q", tc.expectedBody, desiredState.WorkerCloudConfig.Body)
+			if workerCloudConfig, ok = desiredState[tc.expectedWorkerKey]; !ok {
+				t.Errorf("expected key %q, not found", tc.expectedWorkerKey)
+			}
+
+			if workerCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expected bucket %q, got %q", tc.expectedBucket, workerCloudConfig.Bucket)
+			}
+
+			if workerCloudConfig.Key != tc.expectedWorkerKey {
+				t.Errorf("expected key %q, got %q", tc.expectedWorkerKey, workerCloudConfig.Key)
+			}
+
+			if workerCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expected key %q, got %q", tc.expectedBody, workerCloudConfig.Body)
 			}
 		})
 	}

--- a/service/resource/s3objectv2/mock.go
+++ b/service/resource/s3objectv2/mock.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/randomkeytpr"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -41,6 +42,22 @@ func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error
 
 	output := &s3.GetObjectOutput{
 		Body: nopCloser{strings.NewReader(s.body)},
+	}
+
+	return output, nil
+}
+
+func (s *S3ClientMock) ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.ListObjectsV2Output{
+		Contents: []*s3.Object{
+			&s3.Object{
+				Key: aws.String("cloudconfig/myversion/worker"),
+			},
+		},
 	}
 
 	return output, nil

--- a/service/resource/s3objectv2/resource.go
+++ b/service/resource/s3objectv2/resource.go
@@ -97,7 +97,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
-	return &framework.Patch{}, nil
+	return framework.NewPatch(), nil
 }
 
 func toBucketObjectState(v interface{}) (BucketObjectState, error) {
@@ -125,17 +125,4 @@ func toPutObjectInput(v interface{}) (s3.PutObjectInput, error) {
 	}
 
 	return putObjectInput, nil
-}
-
-func toDeleteObjectInput(v interface{}) (s3.DeleteObjectInput, error) {
-	if v == nil {
-		return s3.DeleteObjectInput{}, nil
-	}
-
-	deleteObjectInput, ok := v.(s3.DeleteObjectInput)
-	if !ok {
-		return s3.DeleteObjectInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", deleteObjectInput, v)
-	}
-
-	return deleteObjectInput, nil
 }

--- a/service/resource/s3objectv2/resource.go
+++ b/service/resource/s3objectv2/resource.go
@@ -2,7 +2,9 @@ package s3objectv2
 
 import (
 	"context"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -100,18 +102,17 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 	return framework.NewPatch(), nil
 }
 
-func toBucketObjectState(v interface{}) (BucketObjectState, error) {
+func toBucketObjectState(v interface{}) (map[string]BucketObjectState, error) {
 	if v == nil {
-		return BucketObjectState{}, nil
+		return map[string]BucketObjectState{}, nil
 	}
 
-	bucketObject, ok := v.(BucketObjectState)
+	bucketObjectState, ok := v.(map[string]BucketObjectState)
 	if !ok {
-		return BucketObjectState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObject, v)
+		return map[string]BucketObjectState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObjectState, v)
 	}
 
-	return bucketObject, nil
-
+	return bucketObjectState, nil
 }
 
 func toPutObjectInput(v interface{}) (s3.PutObjectInput, error) {
@@ -119,9 +120,16 @@ func toPutObjectInput(v interface{}) (s3.PutObjectInput, error) {
 		return s3.PutObjectInput{}, nil
 	}
 
-	putObjectInput, ok := v.(s3.PutObjectInput)
+	bucketObject, ok := v.(BucketObjectState)
 	if !ok {
-		return s3.PutObjectInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", putObjectInput, v)
+		return s3.PutObjectInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObject, v)
+	}
+
+	putObjectInput := s3.PutObjectInput{
+		Key:           aws.String(bucketObject.Key),
+		Body:          strings.NewReader(bucketObject.Body),
+		Bucket:        aws.String(bucketObject.Bucket),
+		ContentLength: aws.Int64(int64(len(bucketObject.Body))),
 	}
 
 	return putObjectInput, nil

--- a/service/resource/s3objectv2/spec.go
+++ b/service/resource/s3objectv2/spec.go
@@ -28,11 +28,6 @@ resources:
 )
 
 type BucketObjectState struct {
-	MasterCloudConfig BucketObjectInstance
-	WorkerCloudConfig BucketObjectInstance
-}
-
-type BucketObjectInstance struct {
 	Bucket string
 	Body   string
 	Key    string
@@ -47,6 +42,7 @@ type S3Client interface {
 	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
 }
 
 type KMSClient interface {


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

This PR ensures both the master and worker cloudconfigs are uploaded to the S3 bucket. At the moment only the worker cloudconfig is supported.

Changes the s3object resource to process a map of bucket objects. This also allows us to upload more objects to S3 if needed.

