### PR TITLE
e2e: increase default timeout to wait for the API

### DIFF
--- a/integration/util.go
+++ b/integration/util.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultTimeout = 400
+	defaultTimeout = 500
 )
 
 func runCmd(cmdStr string) error {


### PR DESCRIPTION
We need more time to allow the API to come up before failing:
```
2018/01/08 10:26:44 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:45 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:45 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:46 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:48 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:51 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:26:54 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:27:00 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:27:11 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:27:30 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: server misbehaving
2018/01/08 10:27:52 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:28:16 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:29:03 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:29:39 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: EOF
2018/01/08 10:30:38 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: EOF
2018/01/08 10:31:11 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:31:52 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: EOF
2018/01/08 10:32:45 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: EOF
2018/01/08 10:33:24 unexpected error: unexpected error waiting for guest cluster ready: waitTimeout
```
With the increased timeout:
```
2018/01/08 10:39:41 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:41 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:42 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:43 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:46 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:39:49 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:52 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:39:56 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:40:05 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:40:19 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: x509: certificate is valid for ingress.local, not api.fede-test.gauss.eu-central-1.aws.gigantic.io
2018/01/08 10:40:43 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: server misbehaving
2018/01/08 10:41:07 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:41:37 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:42:14 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:43:09 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: EOF
2018/01/08 10:44:35 waiting for k8s API up: Get https://api.fede-test.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.fede-test.gauss.eu-central-1.aws.gigantic.io on 8.8.8.8:53: no such host
2018/01/08 10:45:47 k8s API up
// here the timeout resets
2018/01/08 10:45:47 worker nodes not found
2018/01/08 10:45:48 worker nodes not found
2018/01/08 10:45:48 worker nodes not found
2018/01/08 10:45:49 worker nodes not found
2018/01/08 10:45:50 worker nodes not found
2018/01/08 10:45:52 worker nodes not found
2018/01/08 10:45:56 worker nodes not found
2018/01/08 10:46:01 worker nodes not found
2018/01/08 10:46:06 worker nodes not found
2018/01/08 10:46:18 worker nodes not found
2018/01/08 10:46:39 worker nodes not found
2018/01/08 10:46:55 worker nodes not found
PASS
```