### PR TITLE
conditional creation of S3 resources

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -320,9 +320,9 @@ func newCRDFramework(config Config) (*framework.Framework, error) {
 		resources = []framework.Resource{
 			namespaceResource,
 			kmsKeyResource,
-			legacyResource,
 			s3BucketResource,
 			s3BucketObjectResource,
+			legacyResource,
 		}
 
 		// Disable retry wrapper due to problems with the legacy resource.

--- a/service/resource/s3bucketv2/delete.go
+++ b/service/resource/s3bucketv2/delete.go
@@ -18,7 +18,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if bucketInput.Name != "" {
 		r.logger.LogCtx(ctx, "debug", "deleting S3 bucket")
 
-		// make sure the bucket is empty.
+		// Make sure the bucket is empty.
 		input := &s3.ListObjectsV2Input{
 			Bucket: aws.String(bucketInput.Name),
 		}

--- a/service/resource/s3bucketv2/spec.go
+++ b/service/resource/s3bucketv2/spec.go
@@ -18,4 +18,7 @@ type S3Client interface {
 	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
 	DeleteBucket(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
 	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+	DeleteObjects(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
+	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 }

--- a/service/resource/s3objectv2/current.go
+++ b/service/resource/s3objectv2/current.go
@@ -30,6 +30,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		Bucket: aws.String(bucketName),
 	}
 	result, err := r.awsClients.S3.ListObjectsV2(input)
+	// the bucket can be already deleted with all the objects in it, it is ok if so.
+	if IsBucketNotFound(err) {
+		r.logger.LogCtx(ctx, "debug", "S3 object's bucket not found, no current objects present")
+		return output, nil
+	}
+	// we don't expect other errors.
 	if err != nil {
 		return output, microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

Before these changes, the S3 components were always created by the legacy resource, even though we had the S3 operatorkit resources in place. These changes enable tthe conditional creation of these components in legacy when we are not using cloudformation.

After enabling the proper usage of the operatorkit resources it looks like we hit again the same problem that we had with the fixed order of resource processing in operatorkit: we need s3bucketv2 before s3objectv2 on creation and s3objectv2 before s3bucketv2 on deletion. I've solved the problem by extending s3bucketv2 to be able to manage objects too, I don't quite like the approach (resources should be independent), but haven't found a better solution, other than merging the resources, let me know WDYT. Working for 0.1.0 and 0.2.0.