### PR TITLE
make VPCGatewayAttachment depend on route tables

### DIFF
--- a/service/templates/cloudformation/internet_gateway.yaml
+++ b/service/templates/cloudformation/internet_gateway.yaml
@@ -7,7 +7,10 @@
           Value: {{ .ClusterID }}
 
   VPCGatewayAttachment:
-    Type: AWS::EC2::VPCGatewayAttachment 
+    Type: AWS::EC2::VPCGatewayAttachment
+    DependsOn:
+      - PublicRouteTable
+      - PrivateRouteTable
     Properties:
       InternetGatewayId:
         Ref: InternetGateway


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

This prevents errors like:
```
15:38:04 UTC+0100    CREATE_FAILED    AWS::EC2::Route    InternetGatewayRoute    route table rtb-41e68a2a and network gateway igw-83d05feb belong to different networks
```
Tested with 0.2.0