### PR TITLE
Check for KMS key before searching for certs

### DIFF
--- a/service/resource/s3objectv2/desired.go
+++ b/service/resource/s3objectv2/desired.go
@@ -21,21 +21,21 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	clusterID := keyv2.ClusterID(customObject)
+	kmsArn, err := r.awsService.GetKeyArn(clusterID)
+	if IsKeyNotFound(err) {
+		// we can get here during deletion, if the key is already deleted we can safely exit.
+		return output, nil
+	}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
 	certs, err := r.certWatcher.SearchCerts(clusterID)
 	if err != nil {
 		return output, microerror.Mask(err)
 	}
 
 	randomKeys, err := r.randomKeyWatcher.SearchKeys(clusterID)
-	if err != nil {
-		return output, microerror.Mask(err)
-	}
-
-	kmsArn, err := r.awsService.GetKeyArn(clusterID)
-	if IsKeyNotFound(err) {
-		// we can get here during deletion, if the key is already deleted we can safely exit.
-		return output, nil
-	}
 	if err != nil {
 		return output, microerror.Mask(err)
 	}


### PR DESCRIPTION
Checks for the KMS key before searching for the certs so we can detect if it's already been deleted.