### PR TITLE
Use KMSKeyState when creating and deleting keys

### DIFF
--- a/service/resource/kmskeyv2/delete_test.go
+++ b/service/resource/kmskeyv2/delete_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 )
@@ -40,17 +38,7 @@ func Test_newDelete(t *testing.T) {
 			expectedAlias: "",
 		},
 		{
-			description: "current state not empty, desired state not empty but different, expected current state",
-			currentState: KMSKeyState{
-				KeyAlias: "current",
-			},
-			desiredState: KMSKeyState{
-				KeyAlias: "desired",
-			},
-			expectedAlias: "current",
-		},
-		{
-			description: "current state not empty, desired state not empty but equal, expected desired state",
+			description: "current state not empty, desired state not empty but equal, expected current state",
 			currentState: KMSKeyState{
 				KeyAlias: "current",
 			},
@@ -77,12 +65,12 @@ func Test_newDelete(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)
 			}
-			deleteChange, ok := result.(kms.DeleteAliasInput)
+			deleteChange, ok := result.(KMSKeyState)
 			if !ok {
 				t.Errorf("expected '%T', got '%T'", deleteChange, result)
 			}
-			if deleteChange.AliasName != nil && *deleteChange.AliasName != tc.expectedAlias {
-				t.Errorf("expected %s, got %s", tc.expectedAlias, *deleteChange.AliasName)
+			if deleteChange.KeyAlias != tc.expectedAlias {
+				t.Errorf("expected %s, got %s", tc.expectedAlias, deleteChange.KeyAlias)
 			}
 		})
 	}
@@ -98,18 +86,18 @@ func Test_ApplyDeleteChange(t *testing.T) {
 	}
 
 	testCases := []struct {
-		deleteChange kms.DeleteAliasInput
+		deleteChange KMSKeyState
 		description  string
 	}{
 		{
 			description: "basic case, create",
-			deleteChange: kms.DeleteAliasInput{
-				AliasName: aws.String("alias/test-cluster"),
+			deleteChange: KMSKeyState{
+				KeyAlias: "alias/test-cluster",
 			},
 		},
 		{
 			description:  "empty create change, not create",
-			deleteChange: kms.DeleteAliasInput{},
+			deleteChange: KMSKeyState{},
 		},
 	}
 

--- a/service/resource/kmskeyv2/resource.go
+++ b/service/resource/kmskeyv2/resource.go
@@ -3,7 +3,6 @@ package kmskeyv2
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
@@ -75,19 +74,6 @@ func toKMSKeyState(v interface{}) (KMSKeyState, error) {
 	}
 
 	return kmsKey, nil
-}
-
-func toDeleteAliasInput(v interface{}) (kms.DeleteAliasInput, error) {
-	if v == nil {
-		return kms.DeleteAliasInput{}, nil
-	}
-
-	deleteAliasInput, ok := v.(kms.DeleteAliasInput)
-	if !ok {
-		return kms.DeleteAliasInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", deleteAliasInput, v)
-	}
-
-	return deleteAliasInput, nil
 }
 
 func toAlias(keyID string) string {

--- a/service/resource/kmskeyv2/resource.go
+++ b/service/resource/kmskeyv2/resource.go
@@ -77,19 +77,6 @@ func toKMSKeyState(v interface{}) (KMSKeyState, error) {
 	return kmsKey, nil
 }
 
-func toCreateKeyInput(v interface{}) (*kms.CreateKeyInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-
-	createKeyInput, ok := v.(*kms.CreateKeyInput)
-	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", createKeyInput, v)
-	}
-
-	return createKeyInput, nil
-}
-
 func toDeleteAliasInput(v interface{}) (kms.DeleteAliasInput, error) {
 	if v == nil {
 		return kms.DeleteAliasInput{}, nil


### PR DESCRIPTION
Fixes problems with creating and deleting keys that I missed in my previous PR.

I've also changed the resource methods to use the KMSKeyState struct rather than the AWS SDK structs. I think this is simpler and matches what we do for the S3 bucket.