### PR TITLE
Ensure inet gateway and public subnet are deleted correctly

### DIFF
--- a/service/resource/legacyv2/resource.go
+++ b/service/resource/legacyv2/resource.go
@@ -1304,7 +1304,9 @@ func (s *Resource) processDelete(cluster v1alpha1.AWSConfig) error {
 		} else {
 			s.logger.Log("info", "deleted private subnet")
 		}
+	}
 
+	if !keyv2.UseCloudFormation(cluster) {
 		// Delete internet gateway.
 		internetGateway := &awsresources.InternetGateway{
 			Name:  keyv2.ClusterID(cluster),
@@ -1320,7 +1322,7 @@ func (s *Resource) processDelete(cluster v1alpha1.AWSConfig) error {
 		}
 
 		// Delete public subnet.
-		subnetInput = SubnetInput{
+		subnetInput := SubnetInput{
 			Name:    keyv2.SubnetName(cluster, suffixPublic),
 			Clients: clients,
 		}


### PR DESCRIPTION
Investigating the CI error on master I found this bug in the deletion logic.

We use the presence of a version in custom object to identify newer clusters that should have the lockdown changes.

For the cloud formation migration the conditional is wrong. So if there is no version the internet gateway and public subnet are not deleted. This means the VPC will also not be deleted.

