### PR TITLE
Set ELB healthy threshold to 2 seconds

### DIFF
--- a/resources/aws/elb.go
+++ b/resources/aws/elb.go
@@ -43,7 +43,7 @@ const (
 	// proxyProtocolAttributeName is the name of the ProxyProtocol attribute we set on the policy.
 	proxyProtocolAttributeName = "ProxyProtocol"
 	// Default values for health checks.
-	healthCheckHealthyThreshold   = 10
+	healthCheckHealthyThreshold   = 2
 	healthCheckInterval           = 5
 	healthCheckTimeout            = 3
 	healthCheckUnhealthyThreshold = 2

--- a/service/resource/legacyv2/adapter/load_balancers.go
+++ b/service/resource/legacyv2/adapter/load_balancers.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Default values for health checks.
-	healthCheckHealthyThreshold   = 10
+	healthCheckHealthyThreshold   = 2
 	healthCheckInterval           = 5
 	healthCheckTimeout            = 3
 	healthCheckUnhealthyThreshold = 2

--- a/service/resource/legacyv2/adapter/load_balancers_test.go
+++ b/service/resource/legacyv2/adapter/load_balancers_test.go
@@ -78,7 +78,7 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 			},
 			expectedAPIElbScheme:                     "internet-facing",
 			expectedELBAZ:                            "eu-central-1a",
-			expectedELBHealthCheckHealthyThreshold:   10,
+			expectedELBHealthCheckHealthyThreshold:   2,
 			expectedELBHealthCheckInterval:           5,
 			expectedELBHealthCheckTimeout:            3,
 			expectedELBHealthCheckUnhealthyThreshold: 2,


### PR DESCRIPTION
Right now restart of kubernetes api causes 50 seconds
downtime. Because 10 tries x 5sec = 50 sec.

This change reduces number of tries to 2 before marking backend
as healthy.

I tested 2 tries threshold manually in ginger.