### PR TITLE
Don't delete kms key when using cloud formation

### DIFF
--- a/service/resource/legacyv2/resource.go
+++ b/service/resource/legacyv2/resource.go
@@ -1497,18 +1497,18 @@ func (s *Resource) processDelete(cluster v1alpha1.AWSConfig) error {
 		} else {
 			s.logger.Log("info", fmt.Sprintf("deleted %s roles, policies, instance profiles", prefixWorker))
 		}
-	}
 
-	// Delete KMS key.
-	var kmsKey resources.ArnResource
-	kmsKey = &awsresources.KMSKey{
-		Name:      keyv2.ClusterID(cluster),
-		AWSEntity: awsresources.AWSEntity{Clients: clients},
-	}
-	if err := kmsKey.Delete(); err != nil {
-		s.logger.Log("error", fmt.Sprintf("%#v", err))
-	} else {
-		s.logger.Log("info", "deleted KMS key")
+		// Delete KMS key.
+		var kmsKey resources.ArnResource
+		kmsKey = &awsresources.KMSKey{
+			Name:      keyv2.ClusterID(cluster),
+			AWSEntity: awsresources.AWSEntity{Clients: clients},
+		}
+		if err := kmsKey.Delete(); err != nil {
+			s.logger.Log("error", fmt.Sprintf("%#v", err))
+		} else {
+			s.logger.Log("info", "deleted KMS key")
+		}
 	}
 
 	// Delete keypair.


### PR DESCRIPTION
Investigating the internet gateway problem I found this minor issue with KMS key deletion.

Now we only delete if we're not using cloud formation since the KMS key has been migrated.