### PR TITLE
Setting memory request equal to limit

### DIFF
--- a/helm/aws-operator-chart/templates/deployment.yaml
+++ b/helm/aws-operator-chart/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 250Mi
           limits:
             cpu: 250m
             memory: 250Mi


### PR DESCRIPTION
We want aws-operator scheduling to be guaranteed, right? So the memory request should be equal to limits.

For discussion: Should we increase the request and limit? We had a case of OOM killing here: https://github.com/giantswarm/giantswarm/issues/2364