### PR TITLE
fix internet gateway depends on

### DIFF
--- a/service/templates/cloudformation/guest/internet_gateway.yaml
+++ b/service/templates/cloudformation/guest/internet_gateway.yaml
@@ -20,7 +20,7 @@
     Type: AWS::EC2::Route
     DependsOn:
       - PublicRouteTable
-      - PrivateRouteTable
+      - InternetGateway
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0


### PR DESCRIPTION
Aims to prevent dependency errors on `InternetGatewayRoute` creation.
```
route table rtb-0532436e and network gateway igw-5b54de33 belong to different networks
```