### PR TITLE
Add cluster prefix to stack names

### DIFF
--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -108,19 +108,19 @@ func LoadBalancerName(domainName string, cluster v1alpha1.AWSConfig) (string, er
 func MainGuestStackName(customObject v1alpha1.AWSConfig) string {
 	clusterID := ClusterID(customObject)
 
-	return fmt.Sprintf("%s-guest-main", clusterID)
+	return fmt.Sprintf("cluster-%s-guest-main", clusterID)
 }
 
 func MainHostPreStackName(customObject v1alpha1.AWSConfig) string {
 	clusterID := ClusterID(customObject)
 
-	return fmt.Sprintf("%s-host-setup", clusterID)
+	return fmt.Sprintf("cluster-%s-host-setup", clusterID)
 }
 
 func MainHostPostStackName(customObject v1alpha1.AWSConfig) string {
 	clusterID := ClusterID(customObject)
 
-	return fmt.Sprintf("%s-host-main", clusterID)
+	return fmt.Sprintf("cluster-%s-host-main", clusterID)
 }
 
 func MasterImageID(customObject v1alpha1.AWSConfig) string {

--- a/service/keyv2/key_test.go
+++ b/service/keyv2/key_test.go
@@ -506,7 +506,7 @@ func Test_WorkerInstanceType(t *testing.T) {
 }
 
 func Test_MainGuestStackName(t *testing.T) {
-	expected := "xyz-guest-main"
+	expected := "cluster-xyz-guest-main"
 
 	cluster := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
@@ -523,7 +523,7 @@ func Test_MainGuestStackName(t *testing.T) {
 }
 
 func Test_MainHostPreStackName(t *testing.T) {
-	expected := "xyz-host-setup"
+	expected := "cluster-xyz-host-setup"
 
 	cluster := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
@@ -540,7 +540,7 @@ func Test_MainHostPreStackName(t *testing.T) {
 }
 
 func Test_MainHostPostStackName(t *testing.T) {
-	expected := "xyz-host-main"
+	expected := "cluster-xyz-host-main"
 
 	cluster := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{

--- a/service/resource/cloudformationv2/desired_test.go
+++ b/service/resource/cloudformationv2/desired_test.go
@@ -26,7 +26,7 @@ func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "5xchu-guest-main",
+			expectedName: "cluster-5xchu-guest-main",
 		},
 	}
 


### PR DESCRIPTION
Adds a prefix of `cluster` to all 3 stack names. This is needed because our cluster IDs can begin with a number but stack names cannot.