### PR TITLE
make igw route depend on the vpc gw attachment

### DIFF
--- a/service/templates/cloudformation/guest/internet_gateway.yaml
+++ b/service/templates/cloudformation/guest/internet_gateway.yaml
@@ -19,8 +19,7 @@
   InternetGatewayRoute:
     Type: AWS::EC2::Route
     DependsOn:
-      - PublicRouteTable
-      - InternetGateway
+      - VPCGatewayAttachment
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0


### PR DESCRIPTION
We are still getting errors like this when creating the gateway route:
```
route table rtb-0532436e and network gateway igw-5b54de33 belong to different networks
```
With these changes we make the gateway route depend on the VPC gateway attachment, when the latter resource is created we can be sure that the route table and the gateway belong to the same network. We don't need to refer to the rest of resources in the `DependsOn` field because their Ids are used in the route definition and their dependencies are implicitly created. 

Tested successfully on several executions.