### PR TITLE
Replace cluster version with cloudconfig version

### DIFF
--- a/service/cloudconfigv3/master_template.go
+++ b/service/cloudconfigv3/master_template.go
@@ -8,6 +8,12 @@ import (
 	"github.com/giantswarm/randomkeytpr"
 )
 
+const (
+	// MasterCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	MasterCloudConfigVersion = "v_3_0_0"
+)
+
 // NewMasterTemplate generates a new master cloud config template and returns it
 // as a base64 encoded string.
 func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.AWSConfig, certs certificatetpr.CompactTLSAssets, keys randomkeytpr.CompactRandomKeyAssets) (string, error) {

--- a/service/cloudconfigv3/worker_template.go
+++ b/service/cloudconfigv3/worker_template.go
@@ -7,6 +7,12 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+const (
+	// WorkerCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	WorkerCloudConfigVersion = "v_3_0_0"
+)
+
 // NewWorkerTemplate generates a new worker cloud config template and returns it
 // as a base64 encoded string.
 func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.AWSConfig, certs certificatetpr.CompactTLSAssets) (string, error) {

--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -39,8 +39,8 @@ func BucketName(customObject v1alpha1.AWSConfig, accountID string) string {
 	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(customObject))
 }
 
-func BucketObjectName(customObject v1alpha1.AWSConfig, prefix string) string {
-	return fmt.Sprintf("cloudconfig/%s/%s", ClusterVersion(customObject), prefix)
+func BucketObjectName(templateVersion string, prefix string) string {
+	return fmt.Sprintf("cloudconfig/%s/%s", templateVersion, prefix)
 }
 
 func ClusterCustomer(customObject v1alpha1.AWSConfig) string {

--- a/service/keyv2/key_test.go
+++ b/service/keyv2/key_test.go
@@ -809,18 +809,8 @@ func Test_BucketObjectName(t *testing.T) {
 	version := "v_0_1_0"
 	suffix := "mysuffix"
 
-	cluster := v1alpha1.Cluster{
-		Version: version,
-	}
-
-	customObject := v1alpha1.AWSConfig{
-		Spec: v1alpha1.AWSConfigSpec{
-			Cluster: cluster,
-		},
-	}
-
 	expectedBucketObjectName := "cloudconfig/v_0_1_0/mysuffix"
-	actualBucketObjectName := BucketObjectName(customObject, suffix)
+	actualBucketObjectName := BucketObjectName(version, suffix)
 	if expectedBucketObjectName != actualBucketObjectName {
 		t.Fatalf("Expected bucket object name %q but was %q", expectedBucketObjectName, actualBucketObjectName)
 	}

--- a/service/resource/cloudformationv2/adapter/adapter.go
+++ b/service/resource/cloudformationv2/adapter/adapter.go
@@ -27,8 +27,9 @@ package adapter
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/aws-operator/service/keyv2"
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 type hydrater func(Config) error

--- a/service/resource/cloudformationv2/adapter/instance.go
+++ b/service/resource/cloudformationv2/adapter/instance.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/cloudconfigv3"
 	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
@@ -36,10 +37,10 @@ func (i *instanceAdapter) getInstance(cfg Config) error {
 	s3URI := fmt.Sprintf("%s-g8s-%s", accountID, clusterID)
 
 	cloudConfigConfig := SmallCloudconfigConfig{
-		MachineType:    prefixMaster,
-		Region:         cfg.CustomObject.Spec.AWS.Region,
-		S3URI:          s3URI,
-		ClusterVersion: keyv2.ClusterVersion(cfg.CustomObject),
+		MachineType:        prefixMaster,
+		Region:             cfg.CustomObject.Spec.AWS.Region,
+		S3URI:              s3URI,
+		CloudConfigVersion: cloudconfigv3.MasterCloudConfigVersion,
 	}
 	smallCloudConfig, err := SmallCloudconfig(cloudConfigConfig)
 	if err != nil {

--- a/service/resource/cloudformationv2/adapter/instance_test.go
+++ b/service/resource/cloudformationv2/adapter/instance_test.go
@@ -1,6 +1,8 @@
 package adapter
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -77,6 +79,66 @@ func TestAdapterInstanceRegularFields(t *testing.T) {
 
 			if a.MasterInstanceType != tc.expectedInstanceType {
 				t.Errorf("unexpected MasterInstanceType, got %q, want %q", a.instanceAdapter.MasterInstanceType, tc.expectedInstanceType)
+			}
+		})
+	}
+}
+
+func TestAdapterInstanceSmallCloudConfig(t *testing.T) {
+	testCases := []struct {
+		description  string
+		expectedLine string
+	}{
+		{
+			description:  "userdata file",
+			expectedLine: "USERDATA_FILE=master",
+		},
+		{
+			description:  "s3 http uri",
+			expectedLine: `s3_http_uri="https://s3.myregion.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/v_3_0_0/$USERDATA_FILE"`,
+		},
+	}
+
+	a := Adapter{}
+	clients := Clients{
+		EC2: &EC2ClientMock{},
+		IAM: &IAMClientMock{accountID: "000000000000"},
+	}
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "myregion",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
+						ImageID:      "ami-test",
+						InstanceType: "m3.large",
+					},
+				},
+			},
+		},
+	}
+	cfg := Config{
+		CustomObject: customObject,
+		Clients:      clients,
+	}
+	err := a.getInstance(cfg)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(a.MasterSmallCloudConfig)
+	if err != nil {
+		t.Errorf("unexpected error decoding SmallCloudConfig %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if !strings.Contains(string(data), tc.expectedLine) {
+				t.Errorf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.expectedLine, string(data))
 			}
 		})
 	}

--- a/service/resource/cloudformationv2/adapter/launch_configuration.go
+++ b/service/resource/cloudformationv2/adapter/launch_configuration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/cloudconfigv3"
 	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
@@ -49,10 +50,10 @@ func (l *launchConfigAdapter) getLaunchConfiguration(cfg Config) error {
 	s3URI := fmt.Sprintf("%s-g8s-%s", accountID, clusterID)
 
 	cloudConfigConfig := SmallCloudconfigConfig{
-		MachineType:    prefixWorker,
-		Region:         cfg.CustomObject.Spec.AWS.Region,
-		S3URI:          s3URI,
-		ClusterVersion: keyv2.ClusterVersion(cfg.CustomObject),
+		MachineType:        prefixWorker,
+		Region:             cfg.CustomObject.Spec.AWS.Region,
+		S3URI:              s3URI,
+		CloudConfigVersion: cloudconfigv3.WorkerCloudConfigVersion,
 	}
 	smallCloudConfig, err := SmallCloudconfig(cloudConfigConfig)
 	if err != nil {

--- a/service/resource/cloudformationv2/adapter/launch_configuration_test.go
+++ b/service/resource/cloudformationv2/adapter/launch_configuration_test.go
@@ -97,7 +97,7 @@ func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
 		},
 		{
 			description:  "s3 http uri",
-			expectedLine: `s3_http_uri="https://s3.myregion.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/myversion/$USERDATA_FILE"`,
+			expectedLine: `s3_http_uri="https://s3.myregion.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/v_3_0_0/$USERDATA_FILE"`,
 		},
 	}
 
@@ -109,8 +109,7 @@ func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
 	customObject := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
 			Cluster: v1alpha1.Cluster{
-				ID:      "test-cluster",
-				Version: "myversion",
+				ID: "test-cluster",
 			},
 			AWS: v1alpha1.AWSConfigSpecAWS{
 				Region: "myregion",

--- a/service/resource/cloudformationv2/adapter/spec.go
+++ b/service/resource/cloudformationv2/adapter/spec.go
@@ -100,10 +100,10 @@ type KMSClient interface {
 // SmallCloudconfigConfig represents the data structure required for executing the
 // small cloudconfig template.
 type SmallCloudconfigConfig struct {
-	MachineType    string
-	Region         string
-	S3URI          string
-	ClusterVersion string
+	MachineType        string
+	Region             string
+	S3URI              string
+	CloudConfigVersion string
 }
 
 // ELBClient describes the methods required to be implemented by a ELB AWS client.

--- a/service/resource/cloudformationv2/main_stack.go
+++ b/service/resource/cloudformationv2/main_stack.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/cloudconfigv3"
 	"github.com/giantswarm/aws-operator/service/keyv2"
 	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
@@ -24,13 +25,13 @@ func newMainStack(customObject v1alpha1.AWSConfig) (StackState, error) {
 	if workers > 0 {
 		imageID = customObject.Spec.AWS.Workers[0].ImageID
 	}
-	clusterVersion := keyv2.ClusterVersion(customObject)
+	cloudConfigVersion := cloudconfigv3.MasterCloudConfigVersion
 
 	mainCF := StackState{
 		Name:           stackName,
 		Workers:        strconv.Itoa(workers),
 		ImageID:        imageID,
-		ClusterVersion: clusterVersion,
+		ClusterVersion: cloudConfigVersion,
 	}
 
 	return mainCF, nil

--- a/service/resource/s3objectv2/desired.go
+++ b/service/resource/s3objectv2/desired.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/cloudconfigv3"
 	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
@@ -55,7 +56,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return output, microerror.Mask(err)
 	}
 
-	masterObjectName := keyv2.BucketObjectName(customObject, prefixMaster)
+	masterObjectName := keyv2.BucketObjectName(cloudconfigv3.MasterCloudConfigVersion, prefixMaster)
 	masterCloudConfig := BucketObjectState{
 		Bucket: keyv2.BucketName(customObject, accountID),
 		Body:   masterBody,
@@ -68,7 +69,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return output, microerror.Mask(err)
 	}
 
-	workerObjectName := keyv2.BucketObjectName(customObject, prefixWorker)
+	workerObjectName := keyv2.BucketObjectName(cloudconfigv3.WorkerCloudConfigVersion, prefixWorker)
 	workerCloudConfig := BucketObjectState{
 		Bucket: keyv2.BucketName(customObject, accountID),
 		Body:   workerBody,

--- a/service/resource/s3objectv2/desired_test.go
+++ b/service/resource/s3objectv2/desired_test.go
@@ -16,8 +16,7 @@ func Test_DesiredState(t *testing.T) {
 	clusterTpo := &v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
 			Cluster: v1alpha1.Cluster{
-				ID:      "test-cluster",
-				Version: "myversion",
+				ID: "test-cluster",
 			},
 		},
 	}
@@ -35,8 +34,8 @@ func Test_DesiredState(t *testing.T) {
 			obj:               clusterTpo,
 			expectedBody:      "mybody-",
 			expectedBucket:    "myaccountid-g8s-test-cluster",
-			expectedMasterKey: "cloudconfig/myversion/master",
-			expectedWorkerKey: "cloudconfig/myversion/worker",
+			expectedMasterKey: "cloudconfig/v_3_0_0/master",
+			expectedWorkerKey: "cloudconfig/v_3_0_0/worker",
 		},
 	}
 	var err error

--- a/service/templates/cloudconfig/small_cloudconfig.yaml
+++ b/service/templates/cloudconfig/small_cloudconfig.yaml
@@ -18,7 +18,7 @@
 USERDATA_FILE={{.MachineType}}
 
 # Wait for S3 bucket to be available.
-s3_http_uri="https://s3.{{.Region}}.amazonaws.com/{{.S3URI}}/cloudconfig/{{.ClusterVersion}}/$USERDATA_FILE"
+s3_http_uri="https://s3.{{.Region}}.amazonaws.com/{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE"
 retry=30
 
 until [ $(curl --output /dev/null --silent --head --fail -w "%{http_code}" $s3_http_uri) -eq "403" ]; do
@@ -37,6 +37,6 @@ done
     --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf  \
     --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
     --trust-keys-from-https \
-    quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 -- aws s3 --region {{.Region}} cp s3://{{.S3URI}}/cloudconfig/{{.ClusterVersion}}/$USERDATA_FILE /var/run/coreos/temp.txt
+    quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 -- aws s3 --region {{.Region}} cp s3://{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE /var/run/coreos/temp.txt
 base64 -d /var/run/coreos/temp.txt | gunzip > /var/run/coreos/$USERDATA_FILE
 exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

Changes the operator to specify the k8scloudconfig version in the cloudconfigv3 service. This replaces the current approach of using the version in the custom object.

We need to specify the version in the operator so we can expose new versions of k8scloudconfig as version bundles.
