### PR TITLE
Remove TPR to CRD migration code

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -2,19 +2,13 @@ package service
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/awstpr"
-	"github.com/giantswarm/awstpr/spec/aws"
 	"github.com/giantswarm/certificatetpr"
-	"github.com/giantswarm/clustertpr/spec"
-	"github.com/giantswarm/clustertpr/spec/kubernetes/ssh"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/client/k8sclient"
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/client/k8sextclient"
@@ -24,10 +18,8 @@ import (
 	"github.com/giantswarm/operatorkit/tpr"
 	"github.com/giantswarm/randomkeytpr"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -184,9 +176,6 @@ func newCRDFramework(config Config) (*framework.Framework, error) {
 			return nil, microerror.Mask(err)
 		}
 	}
-
-	// TODO remove after migration.
-	migrateTPRsToCRDs(config.Logger, clientSet)
 
 	var newWatcherFactory informer.WatcherFactory
 	{
@@ -786,242 +775,4 @@ func newCustomObjectFramework(config Config) (*framework.Framework, error) {
 	}
 
 	return customObjectFramework, nil
-}
-
-func migrateTPRsToCRDs(logger micrologger.Logger, clientSet *versioned.Clientset) {
-	logger.Log("debug", "start TPR migration")
-
-	var err error
-
-	// List all TPOs.
-	var b []byte
-	{
-		e := "/apis/cluster.giantswarm.io/v1/namespaces/default/awses"
-		b, err = clientSet.Discovery().RESTClient().Get().AbsPath(e).DoRaw()
-		if err != nil {
-			logger.Log("error", fmt.Sprintf("%#v", err))
-			return
-		}
-
-		fmt.Printf("\n")
-		fmt.Printf("b start\n")
-		fmt.Printf("%s\n", b)
-		fmt.Printf("b end\n")
-		fmt.Printf("\n")
-	}
-
-	// Convert bytes into structure.
-	var v *awstpr.List
-	{
-		v = &awstpr.List{}
-		if err := json.Unmarshal(b, v); err != nil {
-			logger.Log("error", fmt.Sprintf("%#v", err))
-			return
-		}
-
-		fmt.Printf("\n")
-		fmt.Printf("v start\n")
-		fmt.Printf("%#v\n", v)
-		fmt.Printf("v end\n")
-		fmt.Printf("\n")
-	}
-
-	// Iterate over all TPOs.
-	for _, tpo := range v.Items {
-		// Compute CRO using TPO.
-		var cro *v1alpha1.AWSConfig
-		{
-			cro = &v1alpha1.AWSConfig{}
-
-			cro.TypeMeta.APIVersion = "provider.giantswarm.io"
-			cro.TypeMeta.Kind = "AWSConfig"
-			cro.ObjectMeta.Name = tpo.Name
-			//cro.ObjectMeta.Finalizers = []string{
-			//	AWSConfigCleanupFinalizer,
-			//}
-			cro.Spec.AWS.API.ELB.IdleTimeoutSeconds = tpo.Spec.AWS.ELB.IdleTimeoutSeconds.API
-			cro.Spec.AWS.API.HostedZones = tpo.Spec.AWS.HostedZones.API
-			cro.Spec.AWS.AZ = tpo.Spec.AWS.AZ
-			cro.Spec.AWS.Etcd.ELB.IdleTimeoutSeconds = tpo.Spec.AWS.ELB.IdleTimeoutSeconds.Etcd
-			cro.Spec.AWS.Etcd.HostedZones = tpo.Spec.AWS.HostedZones.Etcd
-			cro.Spec.AWS.Ingress.ELB.IdleTimeoutSeconds = tpo.Spec.AWS.ELB.IdleTimeoutSeconds.Ingress
-			cro.Spec.AWS.Ingress.HostedZones = tpo.Spec.AWS.HostedZones.Ingress
-			cro.Spec.AWS.Masters = toAWSMasters(tpo.Spec.AWS.Masters)
-			cro.Spec.AWS.Region = tpo.Spec.AWS.Region
-			cro.Spec.AWS.VPC.CIDR = tpo.Spec.AWS.VPC.CIDR
-			cro.Spec.AWS.VPC.PeerID = tpo.Spec.AWS.VPC.PeerID
-			cro.Spec.AWS.VPC.PrivateSubnetCIDR = tpo.Spec.AWS.VPC.PrivateSubnetCIDR
-			cro.Spec.AWS.VPC.PublicSubnetCIDR = tpo.Spec.AWS.VPC.PublicSubnetCIDR
-			cro.Spec.AWS.VPC.RouteTableNames = tpo.Spec.AWS.VPC.RouteTableNames
-			cro.Spec.AWS.Workers = toAWSWorkers(tpo.Spec.AWS.Workers)
-			cro.Spec.Cluster.Calico.CIDR = tpo.Spec.Cluster.Calico.CIDR
-			cro.Spec.Cluster.Calico.Domain = tpo.Spec.Cluster.Calico.Domain
-			cro.Spec.Cluster.Calico.MTU = tpo.Spec.Cluster.Calico.MTU
-			cro.Spec.Cluster.Calico.Subnet = tpo.Spec.Cluster.Calico.Subnet
-			cro.Spec.Cluster.Customer.ID = tpo.Spec.Cluster.Customer.ID
-			cro.Spec.Cluster.Docker.Daemon.CIDR = tpo.Spec.Cluster.Docker.Daemon.CIDR
-			cro.Spec.Cluster.Docker.Daemon.ExtraArgs = tpo.Spec.Cluster.Docker.Daemon.ExtraArgs
-			cro.Spec.Cluster.Etcd.AltNames = tpo.Spec.Cluster.Etcd.AltNames
-			cro.Spec.Cluster.Etcd.Domain = tpo.Spec.Cluster.Etcd.Domain
-			cro.Spec.Cluster.Etcd.Port = tpo.Spec.Cluster.Etcd.Port
-			cro.Spec.Cluster.Etcd.Prefix = tpo.Spec.Cluster.Etcd.Prefix
-			cro.Spec.Cluster.ID = tpo.Spec.Cluster.Cluster.ID
-			cro.Spec.Cluster.Kubernetes.API.AltNames = tpo.Spec.Cluster.Kubernetes.API.AltNames
-			cro.Spec.Cluster.Kubernetes.API.ClusterIPRange = tpo.Spec.Cluster.Kubernetes.API.ClusterIPRange
-			cro.Spec.Cluster.Kubernetes.API.Domain = tpo.Spec.Cluster.Kubernetes.API.Domain
-			cro.Spec.Cluster.Kubernetes.API.InsecurePort = tpo.Spec.Cluster.Kubernetes.API.InsecurePort
-			cro.Spec.Cluster.Kubernetes.API.IP = tpo.Spec.Cluster.Kubernetes.API.IP
-			cro.Spec.Cluster.Kubernetes.API.SecurePort = tpo.Spec.Cluster.Kubernetes.API.SecurePort
-			cro.Spec.Cluster.Kubernetes.CloudProvider = tpo.Spec.Cluster.Kubernetes.CloudProvider
-			cro.Spec.Cluster.Kubernetes.DNS.IP = tpo.Spec.Cluster.Kubernetes.DNS.IP
-			cro.Spec.Cluster.Kubernetes.Domain = tpo.Spec.Cluster.Kubernetes.Domain
-			cro.Spec.Cluster.Kubernetes.Hyperkube.Docker.Image = tpo.Spec.Cluster.Kubernetes.Hyperkube.Docker.Image
-			cro.Spec.Cluster.Kubernetes.IngressController.Docker.Image = tpo.Spec.Cluster.Kubernetes.IngressController.Docker.Image
-			cro.Spec.Cluster.Kubernetes.IngressController.Domain = tpo.Spec.Cluster.Kubernetes.IngressController.Domain
-			cro.Spec.Cluster.Kubernetes.IngressController.InsecurePort = tpo.Spec.Cluster.Kubernetes.IngressController.InsecurePort
-			cro.Spec.Cluster.Kubernetes.IngressController.SecurePort = tpo.Spec.Cluster.Kubernetes.IngressController.SecurePort
-			cro.Spec.Cluster.Kubernetes.IngressController.WildcardDomain = tpo.Spec.Cluster.Kubernetes.IngressController.WildcardDomain
-			cro.Spec.Cluster.Kubernetes.Kubelet.AltNames = tpo.Spec.Cluster.Kubernetes.Kubelet.AltNames
-			cro.Spec.Cluster.Kubernetes.Kubelet.Domain = tpo.Spec.Cluster.Kubernetes.Kubelet.Domain
-			cro.Spec.Cluster.Kubernetes.Kubelet.Labels = tpo.Spec.Cluster.Kubernetes.Kubelet.Labels
-			cro.Spec.Cluster.Kubernetes.Kubelet.Port = tpo.Spec.Cluster.Kubernetes.Kubelet.Port
-			cro.Spec.Cluster.Kubernetes.NetworkSetup.Docker.Image = tpo.Spec.Cluster.Kubernetes.NetworkSetup.Docker.Image
-			cro.Spec.Cluster.Kubernetes.SSH.UserList = toUserList(tpo.Spec.Cluster.Kubernetes.SSH.UserList)
-			cro.Spec.Cluster.Masters = toClusterMasters(tpo.Spec.Cluster.Masters)
-			cro.Spec.Cluster.Vault.Address = tpo.Spec.Cluster.Vault.Address
-			cro.Spec.Cluster.Vault.Token = tpo.Spec.Cluster.Vault.Token
-			cro.Spec.Cluster.Version = tpo.Spec.Cluster.Version
-			cro.Spec.Cluster.Workers = toClusterWorkers(tpo.Spec.Cluster.Workers)
-			cro.Spec.VersionBundle.Version = tpo.Spec.VersionBundle.Version
-
-			fmt.Printf("\n")
-			fmt.Printf("cro start\n")
-			fmt.Printf("%#v\n", cro)
-			fmt.Printf("cro end\n")
-			fmt.Printf("\n")
-		}
-
-		// Create CRO in Kubernetes API.
-		{
-			_, err := clientSet.ProviderV1alpha1().AWSConfigs(tpo.Namespace).Get(cro.Name, apismetav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
-				_, err := clientSet.ProviderV1alpha1().AWSConfigs(tpo.Namespace).Create(cro)
-				if err != nil {
-					logger.Log("error", fmt.Sprintf("%#v", err))
-					return
-				}
-			} else if err != nil {
-				logger.Log("error", fmt.Sprintf("%#v", err))
-				return
-			}
-		}
-	}
-
-	// update existing CROs with empty cloud provider
-	cros, err := clientSet.
-		ProviderV1alpha1().
-		AWSConfigs("default").
-		List(apismetav1.ListOptions{})
-	if err != nil {
-		logger.Log("error", fmt.Sprintf("%#v", err))
-		return
-	}
-	for _, cro := range cros.Items {
-		if cro.Spec.Cluster.Kubernetes.CloudProvider != "" {
-			continue
-		}
-		// CRO existed with empty CloudProvider, refresh
-		type PatchSpec struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value string `json:"value"`
-		}
-		patch := make([]PatchSpec, 1)
-		patch[0].Op = "replace"
-		patch[0].Path = "/spec/cluster/kubernetes/cloudProvider"
-		patch[0].Value = awsCloudProvider
-		patchBytes, err := json.Marshal(patch)
-		if err != nil {
-			logger.Log("error", fmt.Sprintf("%#v", err))
-		}
-		_, err = clientSet.
-			ProviderV1alpha1().
-			AWSConfigs("default").
-			Patch(cro.Name, types.JSONPatchType, patchBytes)
-		if err != nil {
-			logger.Log("error", fmt.Sprintf("%#v", err))
-		}
-	}
-	logger.Log("debug", "end TPR migration")
-}
-
-func toClusterMasters(masters []spec.Node) []v1alpha1.ClusterNode {
-	var newList []v1alpha1.ClusterNode
-
-	for _, m := range masters {
-		n := v1alpha1.ClusterNode{
-			ID: m.ID,
-		}
-
-		newList = append(newList, n)
-	}
-
-	return newList
-}
-
-func toClusterWorkers(workers []spec.Node) []v1alpha1.ClusterNode {
-	var newList []v1alpha1.ClusterNode
-
-	for _, w := range workers {
-		n := v1alpha1.ClusterNode{
-			ID: w.ID,
-		}
-
-		newList = append(newList, n)
-	}
-
-	return newList
-}
-
-func toAWSMasters(masters []aws.Node) []v1alpha1.AWSConfigSpecAWSNode {
-	var newList []v1alpha1.AWSConfigSpecAWSNode
-
-	for _, m := range masters {
-		n := v1alpha1.AWSConfigSpecAWSNode{
-			ImageID:      m.ImageID,
-			InstanceType: m.InstanceType,
-		}
-		newList = append(newList, n)
-	}
-
-	return newList
-}
-
-func toAWSWorkers(workers []aws.Node) []v1alpha1.AWSConfigSpecAWSNode {
-	var newList []v1alpha1.AWSConfigSpecAWSNode
-
-	for _, w := range workers {
-		n := v1alpha1.AWSConfigSpecAWSNode{
-			ImageID:      w.ImageID,
-			InstanceType: w.InstanceType,
-		}
-		newList = append(newList, n)
-	}
-
-	return newList
-}
-
-func toUserList(userList []ssh.User) []v1alpha1.ClusterKubernetesSSHUser {
-	var newList []v1alpha1.ClusterKubernetesSSHUser
-
-	for _, user := range userList {
-		u := v1alpha1.ClusterKubernetesSSHUser{
-			Name:      user.Name,
-			PublicKey: user.PublicKey,
-		}
-
-		newList = append(newList, u)
-	}
-
-	return newList
 }


### PR DESCRIPTION
Towards #640 

Removes the migration code now that all AWS installs are migrated to CRDs.