### PR TITLE
Cloud provider tags

### DIFF
--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -15,6 +15,13 @@ const (
 	// TODO Remove once the migration is complete.
 	CloudFormationVersion = "0.2.0"
 
+	// CloudProviderTagName is used to add Cloud Provider tags to AWS resources.
+	CloudProviderTagName = "kubernetes.io/cluster/%s"
+
+	// CloudProviderTagOwnedValue is used to indicate an AWS resource is owned
+	// and managed by a cluster.
+	CloudProviderTagOwnedValue = "owned"
+
 	// LegacyVersion is the version in the version bundle for existing clusters.
 	LegacyVersion = "0.1.0"
 
@@ -52,6 +59,15 @@ func ClusterID(customObject v1alpha1.AWSConfig) string {
 
 func ClusterNamespace(customObject v1alpha1.AWSConfig) string {
 	return ClusterID(customObject)
+}
+
+func ClusterTags(customObject v1alpha1.AWSConfig) map[string]string {
+	cloudProviderTag := fmt.Sprintf(CloudProviderTagName, ClusterID(customObject))
+	tags := map[string]string{
+		cloudProviderTag: CloudProviderTagOwnedValue,
+	}
+
+	return tags
 }
 
 func CustomerID(customObject v1alpha1.AWSConfig) string {

--- a/service/keyv2/key_test.go
+++ b/service/keyv2/key_test.go
@@ -2,6 +2,7 @@ package keyv2
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -115,6 +116,25 @@ func Test_ClusterNamespace(t *testing.T) {
 
 	if ClusterNamespace(customObject) != expectedID {
 		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterNamespace(customObject))
+	}
+}
+
+func Test_ClusterTags(t *testing.T) {
+	expectedID := "test-cluster"
+	expectedTags := map[string]string{
+		"kubernetes.io/cluster/test-cluster": "owned",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject))
 	}
 }
 

--- a/service/resource/cloudformationv2/create.go
+++ b/service/resource/cloudformationv2/create.go
@@ -94,6 +94,8 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		createState.Capabilities = []*string{
 			aws.String(namedIAMCapability),
 		}
+
+		createState.SetTags(getCloudFormationTags(customObject))
 	}
 
 	return createState, nil
@@ -113,6 +115,7 @@ func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1
 			aws.String(namedIAMCapability),
 		},
 	}
+	createStack.SetTags(getCloudFormationTags(customObject))
 
 	r.logger.LogCtx(ctx, "debug", "creating AWS Host Pre-Guest cloudformation stack")
 	_, err = r.HostClients.CloudFormation.CreateStack(createStack)
@@ -140,6 +143,7 @@ func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha
 		StackName:    aws.String(stackName),
 		TemplateBody: aws.String(mainTemplate),
 	}
+	createStack.SetTags(getCloudFormationTags(customObject))
 
 	r.logger.LogCtx(ctx, "debug", "creating AWS Host Post-Guest cloudformation stack")
 	_, err = r.HostClients.CloudFormation.CreateStack(createStack)

--- a/service/resource/cloudformationv2/resource.go
+++ b/service/resource/cloudformationv2/resource.go
@@ -1,11 +1,14 @@
 package cloudformationv2
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
 
+	"github.com/giantswarm/aws-operator/service/keyv2"
 	"github.com/giantswarm/aws-operator/service/resource/cloudformationv2/adapter"
 )
 
@@ -140,4 +143,20 @@ func getStackOutputValue(outputs []*awscloudformation.Output, key string) (strin
 	}
 
 	return "", microerror.Mask(notFoundError)
+}
+
+func getCloudFormationTags(customObject v1alpha1.AWSConfig) []*awscloudformation.Tag {
+	clusterTags := keyv2.ClusterTags(customObject)
+	stackTags := []*awscloudformation.Tag{}
+
+	for k, v := range clusterTags {
+		tag := &awscloudformation.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		stackTags = append(stackTags, tag)
+	}
+
+	return stackTags
 }

--- a/service/resource/cloudformationv2/resource_test.go
+++ b/service/resource/cloudformationv2/resource_test.go
@@ -1,0 +1,45 @@
+package cloudformationv2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
+	testCases := []struct {
+		obj          v1alpha1.AWSConfig
+		expectedTags []*awscloudformation.Tag
+		description  string
+	}{
+		{
+			description: "basic match",
+			obj: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			expectedTags: []*awscloudformation.Tag{
+				&awscloudformation.Tag{
+					Key:   aws.String("kubernetes.io/cluster/5xchu"),
+					Value: aws.String("owned"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tags := getCloudFormationTags(tc.obj)
+
+			if !reflect.DeepEqual(tc.expectedTags, tags) {
+				t.Fatalf("Expected cloud formation tags %v but was %v", tc.expectedTags, tags)
+			}
+		})
+	}
+}

--- a/service/templates/cloudformation/guest/auto_scaling_group.yaml
+++ b/service/templates/cloudformation/guest/auto_scaling_group.yaml
@@ -17,9 +17,6 @@
         - Key: Name
           Value: {{ .ClusterID }}-{{ .ASGType }}
           PropagateAtLaunch: true
-        - Key: KubernetesCluster
-          Value: {{ .ClusterID }}
-          PropagateAtLaunch: true
     UpdatePolicy:
       AutoScalingRollingUpdate:
         # minimum amount of instances that must always be running during a rolling update

--- a/service/templates/cloudformation/guest/instance.yaml
+++ b/service/templates/cloudformation/guest/instance.yaml
@@ -14,8 +14,6 @@
       Tags:
       - Key: Name
         Value: {{ .ClusterID }}-master
-      - Key: KubernetesCluster
-        Value: {{ .ClusterID }}
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

This PR adds the new cloud provider tags to all 3 stacks and they propagate to the child resources. Tested scaling and creating LBs and PVCs and looks good.

I'd still like to tag the KMS key and S3 bucket as they aren't managed by Cloud Formation. But I'll do that as a later change.

![screen shot 2018-01-24 at 4 45 07 pm](https://user-images.githubusercontent.com/311527/35341458-0f6e0af8-0126-11e8-962d-3f3586e885b7.png)

![screen shot 2018-01-24 at 4 45 29 pm](https://user-images.githubusercontent.com/311527/35341485-19e42d1e-0126-11e8-9335-72916c30c0ab.png)




