### PR TITLE
Specify Container Linux AMI in the operator

### DIFF
--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -172,6 +172,10 @@ func PolicyName(customObject v1alpha1.AWSConfig, profileType string) string {
 	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, PolicyNameTemplate)
 }
 
+func Region(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.Region
+}
+
 func RoleName(customObject v1alpha1.AWSConfig, profileType string) string {
 	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, RoleNameTemplate)
 }

--- a/service/keyv2/key_test.go
+++ b/service/keyv2/key_test.go
@@ -363,6 +363,22 @@ func Test_MasterInstanceType(t *testing.T) {
 	}
 }
 
+func Test_Region(t *testing.T) {
+	expectedRegion := "eu-central-1"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "eu-central-1",
+			},
+		},
+	}
+
+	if Region(customObject) != expectedRegion {
+		t.Fatalf("Expected region %s but was %s", expectedRegion, Region(customObject))
+	}
+}
+
 func Test_RouteTableName(t *testing.T) {
 	expectedName := "test-cluster-private"
 	suffix := "private"

--- a/service/resource/cloudformationv2/adapter/adapter.go
+++ b/service/resource/cloudformationv2/adapter/adapter.go
@@ -139,8 +139,15 @@ func NewHostPost(cfg Config) (Adapter, error) {
 func getImageID(customObject v1alpha1.AWSConfig) (string, error) {
 	region := keyv2.Region(customObject)
 
-	// Container Linux AMIs for each active region.
-	// NOTE: AMIs should always be for HVM virtualisation and not PV.
+	/*
+		Container Linux AMIs for each active AWS region.
+		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
+
+		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
+		NOTE 2: You also need to update adapter_test.go.
+
+		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
+	*/
 	imageIDs := map[string]string{
 		"eu-central-1": "ami-90c152ff",
 		"eu-west-1":    "ami-32d1474b",

--- a/service/resource/cloudformationv2/adapter/adapter.go
+++ b/service/resource/cloudformationv2/adapter/adapter.go
@@ -70,8 +70,15 @@ func NewGuest(cfg Config) (Adapter, error) {
 
 	a.ASGType = prefixWorker
 	a.ClusterID = keyv2.ClusterID(cfg.CustomObject)
-	a.MasterImageID = keyv2.MasterImageID(cfg.CustomObject)
-	a.WorkerImageID = keyv2.WorkerImageID(cfg.CustomObject)
+
+	// Get the EC2 AMI for the configured region.
+	imageID, err := getImageID(cfg.CustomObject)
+	if err != nil {
+		return Adapter{}, microerror.Mask(err)
+	}
+
+	a.MasterImageID = imageID
+	a.WorkerImageID = imageID
 
 	hydraters := []hydrater{
 		a.getAutoScalingGroup,
@@ -126,4 +133,24 @@ func NewHostPost(cfg Config) (Adapter, error) {
 	}
 
 	return a, nil
+}
+
+// getImageID returns the EC2 AMI for the configured region.
+func getImageID(customObject v1alpha1.AWSConfig) (string, error) {
+	region := keyv2.Region(customObject)
+
+	// Container Linux AMIs for each active region.
+	// NOTE: AMIs should always be for HVM virtualisation and not PV.
+	imageIDs := map[string]string{
+		"eu-central-1": "ami-90c152ff",
+		"eu-west-1":    "ami-32d1474b",
+		"us-west-2":    "ami-dc4ce6a4",
+	}
+
+	imageID, ok := imageIDs[region]
+	if !ok {
+		return "", microerror.Maskf(invalidConfigError, "no image id for region '%s'", region)
+	}
+
+	return imageID, nil
 }

--- a/service/resource/cloudformationv2/create_test.go
+++ b/service/resource/cloudformationv2/create_test.go
@@ -26,12 +26,13 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 				},
 			},
 			AWS: v1alpha1.AWSConfigSpecAWS{
-				AZ: "myaz",
+				AZ: "eu-central-1a",
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
 					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID: "myimageid",
 					},
 				},
+				Region: "eu-central-1",
 				Workers: []v1alpha1.AWSConfigSpecAWSNode{
 					v1alpha1.AWSConfigSpecAWSNode{
 						ImageID: "myimageid",

--- a/service/resource/cloudformationv2/main_stack_test.go
+++ b/service/resource/cloudformationv2/main_stack_test.go
@@ -72,15 +72,16 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 						IdleTimeoutSeconds: 3600,
 					},
 				},
-				AZ: "myaz",
+				Region: "eu-central-1",
+				AZ:     "eu-central-1a",
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
 					v1alpha1.AWSConfigSpecAWSNode{
-						ImageID: "myimageid",
+						InstanceType: "m3.large",
 					},
 				},
 				Workers: []v1alpha1.AWSConfigSpecAWSNode{
 					v1alpha1.AWSConfigSpecAWSNode{
-						ImageID: "myimageid",
+						InstanceType: "m3.large",
 					},
 				},
 				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
@@ -131,11 +132,11 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 		t.Error("asg header not found")
 	}
 
-	if !strings.Contains(body, "ImageId: myimageid") {
+	if !strings.Contains(body, "InstanceType: m3.large") {
 		t.Error("launch configuration element not found")
 	}
 
-	if !strings.Contains(body, "AvailabilityZones: [myaz]") {
+	if !strings.Contains(body, "AvailabilityZones: [eu-central-1a]") {
 		fmt.Println(body)
 		t.Error("asg element not found")
 	}

--- a/service/resource/cloudformationv2/update_test.go
+++ b/service/resource/cloudformationv2/update_test.go
@@ -27,16 +27,13 @@ func Test_Resource_Cloudformation_newUpdateChange(t *testing.T) {
 				},
 			},
 			AWS: v1alpha1.AWSConfigSpecAWS{
-				AZ: "myaz",
+				AZ: "eu-central-1a",
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
-					v1alpha1.AWSConfigSpecAWSNode{
-						ImageID: "myimageid",
-					},
+					v1alpha1.AWSConfigSpecAWSNode{},
 				},
+				Region: "eu-central-1",
 				Workers: []v1alpha1.AWSConfigSpecAWSNode{
-					v1alpha1.AWSConfigSpecAWSNode{
-						ImageID: "myimageid",
-					},
+					v1alpha1.AWSConfigSpecAWSNode{},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #642 

This change specifies the Container Linux AMI in the operator rather than it coming from `installations`. This is because we want to.

- Control upgrades via version bundles.
- Include the Docker Engine version in our releases which comes from the Container Linux version.
- Include the Container Linux version in our release changelogs.


