### PR TITLE
add e2e test for scaling workers

### DIFF
--- a/integration/framework.go
+++ b/integration/framework.go
@@ -357,14 +357,14 @@ func (f *framework) WaitForGuestReady() error {
 		return microerror.Mask(err)
 	}
 
-	if err := f.waitForNodesUp(minimunNodesReady); err != nil {
+	if err := f.WaitForNodesUp(minimunNodesReady); err != nil {
 		return microerror.Mask(err)
 	}
 	log.Println("Guest cluster ready")
 	return nil
 }
 
-func (f *framework) waitForNodesUp(numberOfNodes int) error {
+func (f *framework) WaitForNodesUp(numberOfNodes int) error {
 	nodesUp := func() error {
 		res, err := f.guestCS.
 			CoreV1().

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -34,9 +34,9 @@ type PatchSpec struct {
 }
 
 const (
-	// minimunNodesReady represents the minimun number of ready nodes in a guest
+	// minimumNodesReady represents the minimun number of ready nodes in a guest
 	// cluster to be considered healthy.
-	minimunNodesReady = 3
+	minimumNodesReady = 3
 
 	certOperatorValuesFile = "/tmp/cert-operator-values.yaml"
 	// certOperatorChartValues values required by cert-operator-chart, the environment
@@ -357,7 +357,7 @@ func (f *framework) WaitForGuestReady() error {
 		return microerror.Mask(err)
 	}
 
-	if err := f.WaitForNodesUp(minimunNodesReady); err != nil {
+	if err := f.WaitForNodesUp(minimumNodesReady); err != nil {
 		return microerror.Mask(err)
 	}
 	log.Println("Guest cluster ready")

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -169,6 +169,41 @@ func TestGuestReadyAfterMasterReboot(t *testing.T) {
 	}
 }
 
+func TestWorkersScaling(t *testing.T) {
+	currentWorkers, err := numberOfWorkers(os.Getenv("CLUSTER_NAME"))
+	if err != nil {
+		t.Fatalf("unexpected error getting number of workers %v", err)
+	}
+	currentMasters, err := numberOfMasters(os.Getenv("CLUSTER_NAME"))
+	if err != nil {
+		t.Fatalf("unexpected error getting number of masters %v", err)
+	}
+
+	// increase number of workers
+	expectedWorkers := currentWorkers + 1
+	log.Printf("Increasing the number of workers to %d", expectedWorkers)
+	err = addWorker(os.Getenv("CLUSTER_NAME"))
+	if err != nil {
+		t.Fatalf("unexpected error setting number of workers to %d, %v", expectedWorkers, err)
+	}
+
+	if err := f.WaitForNodesUp(currentMasters + expectedWorkers); err != nil {
+		t.Fatalf("unexpected error waiting for %d nodes up, %v", expectedWorkers, err)
+	}
+
+	// decrease number of workers
+	expectedWorkers--
+	log.Printf("Decreasing the number of workers to %d", expectedWorkers)
+	err = removeWorker(os.Getenv("CLUSTER_NAME"))
+	if err != nil {
+		t.Fatalf("unexpected error setting number of workers to %d, %v", expectedWorkers, err)
+	}
+
+	if err := f.WaitForNodesUp(currentMasters + expectedWorkers); err != nil {
+		t.Fatalf("unexpected error waiting for %d nodes up, %v", expectedWorkers, err)
+	}
+}
+
 func operatorSetup() error {
 	if err := f.InstallCertOperator(); err != nil {
 		return microerror.Mask(err)
@@ -243,4 +278,46 @@ func writeAWSResourceValues() error {
 	}
 
 	return nil
+}
+
+func numberOfWorkers(clusterName string) (int, error) {
+	cluster, err := f.AWSCluster(clusterName)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return len(cluster.Spec.AWS.Workers), nil
+}
+
+func numberOfMasters(clusterName string) (int, error) {
+	cluster, err := f.AWSCluster(clusterName)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	return len(cluster.Spec.AWS.Masters), nil
+}
+
+func addWorker(clusterName string) error {
+	cluster, err := f.AWSCluster(clusterName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	newWorker := cluster.Spec.AWS.Workers[0]
+
+	patch := make([]PatchSpec, 1)
+	patch[0].Op = "add"
+	patch[0].Path = "/spec/aws/workers/-"
+	patch[0].Value = newWorker
+
+	return f.ApplyAWSConfigPatch(patch, clusterName)
+}
+
+func removeWorker(clusterName string) error {
+	patch := make([]PatchSpec, 1)
+	patch[0].Op = "remove"
+	patch[0].Path = "/spec/aws/workers/1"
+
+	return f.ApplyAWSConfigPatch(patch, clusterName)
 }

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 	"github.com/giantswarm/microerror"
 )
 
@@ -190,6 +192,7 @@ func TestWorkersScaling(t *testing.T) {
 	if err := f.WaitForNodesUp(currentMasters + expectedWorkers); err != nil {
 		t.Fatalf("unexpected error waiting for %d nodes up, %v", expectedWorkers, err)
 	}
+	log.Printf("%d worker nodes ready", expectedWorkers)
 
 	// decrease number of workers
 	expectedWorkers--
@@ -202,6 +205,7 @@ func TestWorkersScaling(t *testing.T) {
 	if err := f.WaitForNodesUp(currentMasters + expectedWorkers); err != nil {
 		t.Fatalf("unexpected error waiting for %d nodes up, %v", expectedWorkers, err)
 	}
+	log.Printf("%d worker nodes ready", expectedWorkers)
 }
 
 func operatorSetup() error {
@@ -286,7 +290,7 @@ func numberOfWorkers(clusterName string) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	return len(cluster.Spec.AWS.Workers), nil
+	return keyv2.WorkerCount(cluster), nil
 }
 
 func numberOfMasters(clusterName string) (int, error) {
@@ -295,7 +299,7 @@ func numberOfMasters(clusterName string) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	return len(cluster.Spec.AWS.Masters), nil
+	return keyv2.MasterCount(cluster), nil
 }
 
 func addWorker(clusterName string) error {

--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -138,6 +138,10 @@ func MainHostPostStackName(customObject v1alpha1.AWSConfig) string {
 	return fmt.Sprintf("cluster-%s-host-main", clusterID)
 }
 
+func MasterCount(customObject v1alpha1.AWSConfig) int {
+	return len(customObject.Spec.AWS.Masters)
+}
+
 func MasterImageID(customObject v1alpha1.AWSConfig) string {
 	var imageID string
 

--- a/service/keyv2/key_test.go
+++ b/service/keyv2/key_test.go
@@ -894,3 +894,26 @@ func Test_PeerAccessRoleName(t *testing.T) {
 		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
 	}
 }
+
+func Test_MasterCount(t *testing.T) {
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					v1alpha1.AWSConfigSpecAWSNode{
+						InstanceType: "m3.medium",
+					},
+					v1alpha1.AWSConfigSpecAWSNode{
+						InstanceType: "m3.medium",
+					},
+				},
+			},
+		},
+	}
+
+	expected := 2
+	actual := MasterCount(customObject)
+	if actual != expected {
+		t.Fatalf("Expected master count %d but was %d", expected, actual)
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2023

Adds e2e test for scaling guest cluster up and down. The changes in the custom object are done through patching with JSON-patch.
