### PR TITLE
Remove cloud formation logic from legacy

### DIFF
--- a/service/resource/legacyv2/resource.go
+++ b/service/resource/legacyv2/resource.go
@@ -450,7 +450,7 @@ func (s *Resource) processCluster(cluster v1alpha1.AWSConfig) error {
 	var mastersSecurityGroupID string
 	var workersSecurityGroupID string
 	var ingressSecurityGroupID string
-	var err error
+
 	if !keyv2.UseCloudFormation(cluster) {
 		// Create masters security group.
 		mastersSGInput := securityGroupInput{


### PR DESCRIPTION
Removes the cloud formation switching logic now the resources are split. I want to do this so we can put legacy in "maintenance mode". I'll split it over a few PRs as processCluster is huge.