### PR TITLE
Always use keyv2.ImageID when getting the CoreOS AMI

### DIFF
--- a/service/keyv2/error.go
+++ b/service/keyv2/error.go
@@ -29,3 +29,10 @@ var notFoundError = microerror.New("not found")
 func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -272,3 +272,30 @@ func componentName(domainName string) (string, error) {
 
 	return splits[0], nil
 }
+
+// ImageID returns the EC2 AMI for the configured region.
+func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
+	region := Region(customObject)
+
+	/*
+		Container Linux AMIs for each active AWS region.
+		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
+
+		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
+		NOTE 2: You also need to update service/resource/cloudformationv2/adapter/adapter_test.go.
+
+		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
+	*/
+	imageIDs := map[string]string{
+		"eu-central-1": "ami-90c152ff",
+		"eu-west-1":    "ami-32d1474b",
+		"us-west-2":    "ami-dc4ce6a4",
+	}
+
+	imageID, ok := imageIDs[region]
+	if !ok {
+		return "", microerror.Maskf(invalidConfigError, "no image id for region '%s'", region)
+	}
+
+	return imageID, nil
+}

--- a/service/keyv2/key.go
+++ b/service/keyv2/key.go
@@ -282,7 +282,10 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
 
 		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
-		NOTE 2: You also need to update service/resource/cloudformationv2/adapter/adapter_test.go.
+		NOTE 2: You also need to update the tests.
+
+		service/keyv2/key_test.go
+		service/resource/cloudformationv2/adapter/adapter_test.go
 
 		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
 	*/

--- a/service/resource/cloudformationv2/adapter/adapter.go
+++ b/service/resource/cloudformationv2/adapter/adapter.go
@@ -72,7 +72,7 @@ func NewGuest(cfg Config) (Adapter, error) {
 	a.ClusterID = keyv2.ClusterID(cfg.CustomObject)
 
 	// Get the EC2 AMI for the configured region.
-	imageID, err := getImageID(cfg.CustomObject)
+	imageID, err := keyv2.ImageID(cfg.CustomObject)
 	if err != nil {
 		return Adapter{}, microerror.Mask(err)
 	}
@@ -133,31 +133,4 @@ func NewHostPost(cfg Config) (Adapter, error) {
 	}
 
 	return a, nil
-}
-
-// getImageID returns the EC2 AMI for the configured region.
-func getImageID(customObject v1alpha1.AWSConfig) (string, error) {
-	region := keyv2.Region(customObject)
-
-	/*
-		Container Linux AMIs for each active AWS region.
-		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
-
-		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
-		NOTE 2: You also need to update adapter_test.go.
-
-		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
-	*/
-	imageIDs := map[string]string{
-		"eu-central-1": "ami-90c152ff",
-		"eu-west-1":    "ami-32d1474b",
-		"us-west-2":    "ami-dc4ce6a4",
-	}
-
-	imageID, ok := imageIDs[region]
-	if !ok {
-		return "", microerror.Maskf(invalidConfigError, "no image id for region '%s'", region)
-	}
-
-	return imageID, nil
 }

--- a/service/resource/cloudformationv2/adapter/adapter_test.go
+++ b/service/resource/cloudformationv2/adapter/adapter_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/keyv2"
 )
 
 var (
@@ -93,7 +95,7 @@ func TestAdapterGuestMain(t *testing.T) {
 					},
 				},
 			},
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: keyv2.IsInvalidConfig,
 		},
 	}
 

--- a/service/resource/cloudformationv2/desired_test.go
+++ b/service/resource/cloudformationv2/desired_test.go
@@ -20,6 +20,9 @@ func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
 			description: "CloudFormation gets name from custom object",
 			obj: &v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
 					Cluster: v1alpha1.Cluster{
 						ID:      "5xchu",
 						Version: "cloud-formation",


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

Fixes a bug with updates because we were still getting the CoreOS AMI from the custom object when getting the desired state.

