### PR TITLE
Do not enable decrypt units to prevent race

### DIFF
--- a/service/cloudconfigv4/cloud_config.go
+++ b/service/cloudconfigv4/cloud_config.go
@@ -1,0 +1,48 @@
+package cloudconfigv3
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	FileOwner          = "root:root"
+	FilePermission     = 0700
+	GzipBase64Encoding = "gzip+base64"
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
+	}
+
+	newCloudConfig := &CloudConfig{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newCloudConfig, nil
+}

--- a/service/cloudconfigv4/cloud_config.go
+++ b/service/cloudconfigv4/cloud_config.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/cloudconfigv4/cloud_config_test.go
+++ b/service/cloudconfigv4/cloud_config_test.go
@@ -1,0 +1,200 @@
+package cloudconfigv3
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeytpr"
+)
+
+func Test_Service_CloudConfig_NewMasterTemplate(t *testing.T) {
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+		ClusterKeys  randomkeytpr.CompactRandomKeyAssets
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Etcd: v1alpha1.ClusterEtcd{
+							Port: 2379,
+						},
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+			ClusterKeys: randomkeytpr.CompactRandomKeyAssets{
+				APIServerEncryptionKey: "fekhfiwoiqhoifhwqefoiqwefoikqhwef",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		template, err := ccService.NewMasterTemplate(tc.CustomObject, tc.Certs, tc.ClusterKeys)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerEncryptionKey", func(t *testing.T) {
+			if !strings.Contains(decoded, "fekhfiwoiqhoifhwqefoiqwefoikqhwef") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain apiserver encryption key", "none")
+			}
+		})
+	}
+}
+
+func Test_Service_CloudConfig_NewWorkerTemplate(t *testing.T) {
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "123456789-super-magic-aws-region",
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		template, err := ccService.NewWorkerTemplate(tc.CustomObject, tc.Certs)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAWSRegion", func(t *testing.T) {
+			if !strings.Contains(decoded, "--region 123456789-super-magic-aws-region kms decrypt") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain AWS region", "none")
+			}
+		})
+	}
+}
+
+func testDecodeTemplate(template string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(template)
+	if err != nil {
+		return "", err
+	}
+	r, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	_, err = io.Copy(&b, r)
+	if err != nil {
+		return "", err
+	}
+	r.Close()
+
+	return b.String(), nil
+}
+
+func testNewCloudConfigService() (*CloudConfig, error) {
+	var err error
+
+	var ccService *CloudConfig
+	{
+		ccConfig := DefaultConfig()
+
+		ccConfig.Logger = microloggertest.New()
+
+		ccService, err = New(ccConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ccService, nil
+}

--- a/service/cloudconfigv4/cloud_config_test.go
+++ b/service/cloudconfigv4/cloud_config_test.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 import (
 	"bytes"

--- a/service/cloudconfigv4/cloudconfigtest/cloudconfigtest.go
+++ b/service/cloudconfigv4/cloudconfigtest/cloudconfigtest.go
@@ -1,0 +1,20 @@
+package cloudconfigtest
+
+import (
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/cloudconfigv3"
+)
+
+func New() *cloudconfigv3.CloudConfig {
+	c := cloudconfigv3.DefaultConfig()
+
+	c.Logger = microloggertest.New()
+
+	newCloudConfig, err := cloudconfigv3.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return newCloudConfig
+}

--- a/service/cloudconfigv4/error.go
+++ b/service/cloudconfigv4/error.go
@@ -1,0 +1,17 @@
+package cloudconfigv3
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/cloudconfigv4/error.go
+++ b/service/cloudconfigv4/error.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 import "github.com/giantswarm/microerror"
 

--- a/service/cloudconfigv4/master_template.go
+++ b/service/cloudconfigv4/master_template.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -225,8 +225,11 @@ func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		{
 			AssetContent: decryptTLSAssetsServiceTemplate,
 			Name:         "decrypt-tls-assets.service",
-			Enable:       true,
-			Command:      "start",
+			// Do not enable TLS assets decrypt unit so that it won't get autmatically
+			// executed on master reboot. This will prevent eventual races with the
+			// asset files creation.
+			Enable:  false,
+			Command: "start",
 		},
 		{
 			AssetContent: masterFormatVarLibDockerServiceTemplate,
@@ -243,8 +246,11 @@ func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		{
 			AssetContent: decryptKeysServiceTemplate,
 			Name:         "decrypt-keys-assets.service",
-			Enable:       true,
-			Command:      "start",
+			// Do not enable key decrypt unit so that it won't get autmatically
+			// executed on master reboot. This will prevent eventual races with the
+			// key files creation.
+			Enable:  false,
+			Command: "start",
 		},
 		// Format etcd EBS volume.
 		{

--- a/service/cloudconfigv4/master_template.go
+++ b/service/cloudconfigv4/master_template.go
@@ -1,0 +1,296 @@
+package cloudconfigv3
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_0_0"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeytpr"
+)
+
+const (
+	// MasterCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	MasterCloudConfigVersion = "v_3_0_0"
+)
+
+// NewMasterTemplate generates a new master cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, keys randomkeytpr.CompactRandomKeyAssets) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.ApiserverEncryptionKey = keys.APIServerEncryptionKey
+		params.Cluster = customObject.Spec.Cluster
+		params.EtcdPort = customObject.Spec.Cluster.Etcd.Port
+		params.Extension = &MasterExtension{
+			certs:        certs,
+			customObject: customObject,
+			keys:         keys,
+		}
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.MasterTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type MasterExtension struct {
+	certs        legacy.CompactTLSAssets
+	customObject v1alpha1.AWSConfig
+	keys         randomkeytpr.CompactRandomKeyAssets
+}
+
+func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: decryptTLSAssetsScriptTemplate,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCrt,
+			Path:         "/etc/kubernetes/ssl/apiserver-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCA,
+			Path:         "/etc/kubernetes/ssl/apiserver-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerKey,
+			Path:         "/etc/kubernetes/ssl/apiserver-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCrt,
+			Path:         "/etc/kubernetes/ssl/service-account-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCA,
+			Path:         "/etc/kubernetes/ssl/service-account-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountKey,
+			Path:         "/etc/kubernetes/ssl/service-account-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/server-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/server-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/server-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		// Add second copy of files for etcd client certs. Will be replaced by
+		// a separate client cert.
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: waitDockerConfTemplate,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: decryptKeysAssetsScriptTemplate,
+			Path:         "/opt/bin/decrypt-keys-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.keys.APIServerEncryptionKey,
+			Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0644,
+		},
+		// Add use-proxy-protocol to ingress-controller ConfigMap, this doesn't work
+		// on KVM because of dependencies on hardware LB configuration.
+		{
+			AssetContent: ingressControllerConfigMapTemplate,
+			Path:         "/srv/ingress-controller-cm.yml",
+			Owner:        FileOwner,
+			Permissions:  0644,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			AssetContent: decryptTLSAssetsServiceTemplate,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: masterFormatVarLibDockerServiceTemplate,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: ephemeralVarLibDockerMountTemplate,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: decryptKeysServiceTemplate,
+			Name:         "decrypt-keys-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		// Format etcd EBS volume.
+		{
+			AssetContent: formatEtcdVolume,
+			Name:         "format-etcd-ebs.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		// Mount etcd EBS volume.
+		{
+			AssetContent: mountEtcdVolume,
+			Name:         "etc-kubernetes-data-etcd.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *MasterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storage",
+			Content: instanceStorageTemplate,
+		},
+		{
+			Name:    "storageclass",
+			Content: instanceStorageClassTemplate,
+		},
+	}
+	return newSections
+}

--- a/service/cloudconfigv4/master_template.go
+++ b/service/cloudconfigv4/master_template.go
@@ -225,7 +225,7 @@ func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		{
 			AssetContent: decryptTLSAssetsServiceTemplate,
 			Name:         "decrypt-tls-assets.service",
-			// Do not enable TLS assets decrypt unit so that it won't get autmatically
+			// Do not enable TLS assets decrypt unit so that it won't get automatically
 			// executed on master reboot. This will prevent eventual races with the
 			// asset files creation.
 			Enable:  false,
@@ -246,7 +246,7 @@ func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		{
 			AssetContent: decryptKeysServiceTemplate,
 			Name:         "decrypt-keys-assets.service",
-			// Do not enable key decrypt unit so that it won't get autmatically
+			// Do not enable key decrypt unit so that it won't get automatically
 			// executed on master reboot. This will prevent eventual races with the
 			// key files creation.
 			Enable:  false,

--- a/service/cloudconfigv4/templates.go
+++ b/service/cloudconfigv4/templates.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 const (
 	decryptTLSAssetsScriptTemplate = `#!/bin/bash -e

--- a/service/cloudconfigv4/templates.go
+++ b/service/cloudconfigv4/templates.go
@@ -1,0 +1,219 @@
+package cloudconfigv3
+
+const (
+	decryptTLSAssetsScriptTemplate = `#!/bin/bash -e
+
+rkt run \
+  --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
+  --mount=volume=ssl,target=/etc/kubernetes/ssl \
+  --uuid-file-save=/var/run/coreos/decrypt-tls-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting tls assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/ssl -name "*.pem.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :
+
+chown -R etcd:etcd /etc/kubernetes/ssl/etcd`
+
+	decryptTLSAssetsServiceTemplate = `
+[Unit]
+Description=Decrypt TLS certificates
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-tls-assets
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	decryptKeysAssetsScriptTemplate = `#!/bin/bash -e
+
+rkt run \
+  --volume=keys,kind=host,source=/etc/kubernetes/encryption,readOnly=false \
+  --mount=volume=keys,target=/etc/kubernetes/encryption \
+  --uuid-file-save=/var/run/coreos/decrypt-keys-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting keys assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/encryption -name "*.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;
+    echo done.'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-keys-assets.uuid || :
+`
+
+	decryptKeysServiceTemplate = `
+[Unit]
+Description=Decrypt Secret Keys
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-keys-assets
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	masterFormatVarLibDockerServiceTemplate = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/mkfs.xfs -f /dev/xvdb
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	workerFormatVarLibDockerServiceTemplate = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/mkfs.xfs -f /dev/xvdh
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	ephemeralVarLibDockerMountTemplate = `
+[Unit]
+Description=Mount ephemeral volume on /var/lib/docker
+
+[Mount]
+What=/dev/xvdb
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`
+	persistentVarLibDockerMountTemplate = `
+[Unit]
+Description=Mount persistent volume on /var/lib/docker
+
+[Mount]
+What=/dev/xvdh
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`
+
+	waitDockerConfTemplate = `
+[Unit]
+After=var-lib-docker.mount
+Requires=var-lib-docker.mount
+`
+
+	instanceStorageTemplate = `
+storage:
+  filesystems:
+    - name: ephemeral1
+      mount:
+        device: /dev/xvdb
+        format: xfs
+        create:
+          force: true
+`
+
+	instanceStorageClassTemplate = `
+write_files:
+- path: /srv/default-storage-class.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: storage.k8s.io/v1beta1
+    kind: StorageClass
+    metadata:
+      name: gp2
+      annotations:
+        storageclass.beta.kubernetes.io/is-default-class: "true"
+      labels:
+        kubernetes.io/cluster-service: "true"
+        addonmanager.kubernetes.io/mode: EnsureExists
+    provisioner: kubernetes.io/aws-ebs
+    parameters:
+      type: gp2
+      encrypted: "true"
+`
+
+	ingressControllerConfigMapTemplate = `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  server-name-hash-bucket-size: "1024"
+  server-name-hash-max-size: "1024"
+  use-proxy-protocol: "true"
+`
+	formatEtcdVolume = `
+[Unit]
+Description=Formats EBS /dev/xvdh volume
+Requires=dev-xvdh.device
+After=dev-xvdh.device
+ConditionPathExists=!/var/lib/etcd-volume-formated
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/mkfs.ext4 /dev/xvdh
+ExecStartPost=/usr/bin/touch /var/lib/etcd-volume-formated
+
+[Install]
+WantedBy=multi-user.target
+`
+	mountEtcdVolume = `
+[Unit]
+Description=etcd3 data volume
+Requires=format-etcd-ebs.service
+After=format-etcd-ebs.service
+Before=set-ownership-etcd-data-dir.service etcd3.service
+
+[Mount]
+What=/dev/xvdh
+Where=/etc/kubernetes/data/etcd
+Type=ext4
+
+[Install]
+WantedBy=multi-user.target
+`
+)

--- a/service/cloudconfigv4/worker_template.go
+++ b/service/cloudconfigv4/worker_template.go
@@ -1,4 +1,4 @@
-package cloudconfigv3
+package cloudconfigv4
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"

--- a/service/cloudconfigv4/worker_template.go
+++ b/service/cloudconfigv4/worker_template.go
@@ -1,0 +1,203 @@
+package cloudconfigv3
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_0_0"
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	// WorkerCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	WorkerCloudConfigVersion = "v_3_0_0"
+)
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &WorkerExtension{
+			certs:        certs,
+			customObject: customObject,
+		}
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.WorkerTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type WorkerExtension struct {
+	certs        legacy.CompactTLSAssets
+	customObject v1alpha1.AWSConfig
+}
+
+func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: decryptTLSAssetsScriptTemplate,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCrt,
+			Path:         "/etc/kubernetes/ssl/worker-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCA,
+			Path:         "/etc/kubernetes/ssl/worker-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerKey,
+			Path:         "/etc/kubernetes/ssl/worker-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: waitDockerConfTemplate,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, m := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *WorkerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			AssetContent: decryptTLSAssetsServiceTemplate,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: workerFormatVarLibDockerServiceTemplate,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: persistentVarLibDockerMountTemplate,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, m := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *WorkerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storageclass",
+			Content: instanceStorageClassTemplate,
+		},
+	}
+
+	return newSections
+}

--- a/service/framework.go
+++ b/service/framework.go
@@ -415,32 +415,12 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 
 	// We create the list of resources and wrap each resource around some common
 	// resources like metrics and retry resources.
-	var resourcesV1 []framework.Resource
-	{
-		resourcesV1 = []framework.Resource{
-			kmsKeyResource,
-			s3BucketResource,
-			s3BucketObjectResourceV2,
-			cloudformationResource,
-			namespaceResource,
-			serviceResource,
-			endpointsResource,
-		}
-
-		resourcesV1, err = metricsresource.Wrap(resourcesV1, metricsWrapConfig)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	// We create the list of resources and wrap each resource around some common
-	// resources like metrics and retry resources.
 	var resourcesV2 []framework.Resource
 	{
 		resourcesV2 = []framework.Resource{
 			kmsKeyResource,
 			s3BucketResource,
-			s3BucketObjectResourceV3,
+			s3BucketObjectResourceV2,
 			cloudformationResource,
 			namespaceResource,
 			serviceResource,
@@ -453,16 +433,36 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		}
 	}
 
+	// We create the list of resources and wrap each resource around some common
+	// resources like metrics and retry resources.
+	var resourcesV2_0_1 []framework.Resource
+	{
+		resourcesV2_0_1 = []framework.Resource{
+			kmsKeyResource,
+			s3BucketResource,
+			s3BucketObjectResourceV3,
+			cloudformationResource,
+			namespaceResource,
+			serviceResource,
+			endpointsResource,
+		}
+
+		resourcesV2_0_1, err = metricsresource.Wrap(resourcesV2_0_1, metricsWrapConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	// We provide a map of resource lists keyed by the version bundle version
 	// to the resource router.
 	versionedResources := map[string][]framework.Resource{
 		// Clusters without a version use the legacy resource.
 		"":      legacyResources,
 		"0.1.0": legacyResources,
-		"0.2.0": resourcesV1,
+		"0.2.0": resourcesV2,
 		"1.0.0": legacyResources,
-		"2.0.0": resourcesV1,
-		"2.0.1": resourcesV2,
+		"2.0.0": resourcesV2,
+		"2.0.1": resourcesV2_0_1,
 	}
 
 	return versionedResources, nil

--- a/service/framework.go
+++ b/service/framework.go
@@ -30,6 +30,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/resource/namespacev2"
 	"github.com/giantswarm/aws-operator/service/resource/s3bucketv2"
 	"github.com/giantswarm/aws-operator/service/resource/s3objectv2"
+	"github.com/giantswarm/aws-operator/service/resource/s3objectv3"
 	"github.com/giantswarm/aws-operator/service/resource/servicev2"
 )
 
@@ -222,7 +223,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		}
 	}
 
-	// ccServiceV3 is used by the s3objectv2 resource for s3BucketObjectResourceV1.
+	// ccServiceV3 is used by the s3objectv2.
 	var ccServiceV3 *cloudconfigv3.CloudConfig
 	{
 		ccServiceConfig := cloudconfigv3.DefaultConfig()
@@ -235,7 +236,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		}
 	}
 
-	// ccServiceV4 is used by the s3objectv2 resource for s3BucketObjectResourceV2.
+	// ccServiceV4 is used by the s3objectv3.
 	var ccServiceV4 *cloudconfigv4.CloudConfig
 	{
 		ccServiceConfig := cloudconfigv4.DefaultConfig()
@@ -320,7 +321,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		}
 	}
 
-	var s3BucketObjectResourceV1 framework.Resource
+	var s3BucketObjectResourceV2 framework.Resource
 	{
 		s3BucketObjectConfig := s3objectv2.DefaultConfig()
 		s3BucketObjectConfig.AwsService = awsService
@@ -331,15 +332,15 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		s3BucketObjectConfig.Logger = config.Logger
 		s3BucketObjectConfig.RandomKeyWatcher = keyWatcher
 
-		s3BucketObjectResourceV1, err = s3objectv2.New(s3BucketObjectConfig)
+		s3BucketObjectResourceV2, err = s3objectv2.New(s3BucketObjectConfig)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var s3BucketObjectResourceV2 framework.Resource
+	var s3BucketObjectResourceV3 framework.Resource
 	{
-		c := s3objectv2.DefaultConfig()
+		c := s3objectv3.DefaultConfig()
 		c.AwsService = awsService
 		c.Clients.S3 = awsClients.S3
 		c.Clients.KMS = awsClients.KMS
@@ -348,7 +349,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		c.Logger = config.Logger
 		c.RandomKeyWatcher = keyWatcher
 
-		s3BucketObjectResourceV2, err = s3objectv2.New(c)
+		s3BucketObjectResourceV3, err = s3objectv3.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -419,7 +420,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		resourcesV1 = []framework.Resource{
 			kmsKeyResource,
 			s3BucketResource,
-			s3BucketObjectResourceV1,
+			s3BucketObjectResourceV2,
 			cloudformationResource,
 			namespaceResource,
 			serviceResource,
@@ -439,7 +440,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		resourcesV2 = []framework.Resource{
 			kmsKeyResource,
 			s3BucketResource,
-			s3BucketObjectResourceV2,
+			s3BucketObjectResourceV3,
 			cloudformationResource,
 			namespaceResource,
 			serviceResource,
@@ -461,7 +462,7 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 		"0.2.0": resourcesV1,
 		"1.0.0": legacyResources,
 		"2.0.0": resourcesV1,
-		"2.1.0": resourcesV2,
+		"2.0.1": resourcesV2,
 	}
 
 	return versionedResources, nil

--- a/service/framework.go
+++ b/service/framework.go
@@ -339,16 +339,16 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 
 	var s3BucketObjectResourceV2 framework.Resource
 	{
-		s3BucketObjectConfig := s3objectv2.DefaultConfig()
-		s3BucketObjectConfig.AwsService = awsService
-		s3BucketObjectConfig.Clients.S3 = awsClients.S3
-		s3BucketObjectConfig.Clients.KMS = awsClients.KMS
-		s3BucketObjectConfig.CloudConfig = ccServiceV4
-		s3BucketObjectConfig.CertWatcher = certWatcher
-		s3BucketObjectConfig.Logger = config.Logger
-		s3BucketObjectConfig.RandomKeyWatcher = keyWatcher
+		c := s3objectv2.DefaultConfig()
+		c.AwsService = awsService
+		c.Clients.S3 = awsClients.S3
+		c.Clients.KMS = awsClients.KMS
+		c.CloudConfig = ccServiceV4
+		c.CertWatcher = certWatcher
+		c.Logger = config.Logger
+		c.RandomKeyWatcher = keyWatcher
 
-		s3BucketObjectResourceV2, err = s3objectv2.New(s3BucketObjectConfig)
+		s3BucketObjectResourceV2, err = s3objectv2.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -426,21 +426,6 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 			endpointsResource,
 		}
 
-		// Disable retry wrapper due to problems with the legacy resource.
-		//
-		// NOTE that the retry resources wrap the underlying resources first. The
-		// wrapped resources are then wrapped around the metrics resource. That way
-		// the metrics also consider execution times and execution attempts including
-		// retries.
-		/*
-			retryWrapConfig := retryresource.DefaultWrapConfig()
-			retryWrapConfig.Logger = config.Logger
-			cloudFormationResources, err = retryresource.Wrap(cloudFormationResources, retryWrapConfig)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		*/
-
 		resourcesV1, err = metricsresource.Wrap(resourcesV1, metricsWrapConfig)
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -460,21 +445,6 @@ func NewVersionedResources(config Config, k8sClient kubernetes.Interface, awsCon
 			serviceResource,
 			endpointsResource,
 		}
-
-		// Disable retry wrapper due to problems with the legacy resource.
-		//
-		// NOTE that the retry resources wrap the underlying resources first. The
-		// wrapped resources are then wrapped around the metrics resource. That way
-		// the metrics also consider execution times and execution attempts including
-		// retries.
-		/*
-			retryWrapConfig := retryresource.DefaultWrapConfig()
-			retryWrapConfig.Logger = config.Logger
-			cloudFormationResources, err = retryresource.Wrap(cloudFormationResources, retryWrapConfig)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		*/
 
 		resourcesV2, err = metricsresource.Wrap(resourcesV2, metricsWrapConfig)
 		if err != nil {

--- a/service/framework_test.go
+++ b/service/framework_test.go
@@ -65,6 +65,15 @@ func Test_Service_NewVersionedResources(t *testing.T) {
 					"servicev2",
 					"endpointsv2",
 				},
+				"2.1.0": []string{
+					"kmskeyv2",
+					"s3bucketv2",
+					"s3objectv2",
+					"cloudformationv2",
+					"namespacev2",
+					"servicev2",
+					"endpointsv2",
+				},
 			},
 		},
 	}

--- a/service/framework_test.go
+++ b/service/framework_test.go
@@ -65,10 +65,10 @@ func Test_Service_NewVersionedResources(t *testing.T) {
 					"servicev2",
 					"endpointsv2",
 				},
-				"2.1.0": []string{
+				"2.0.1": []string{
 					"kmskeyv2",
 					"s3bucketv2",
-					"s3objectv2",
+					"s3objectv3",
 					"cloudformationv2",
 					"namespacev2",
 					"servicev2",

--- a/service/resource/s3objectv3/assets.go
+++ b/service/resource/s3objectv3/assets.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"bytes"

--- a/service/resource/s3objectv3/create.go
+++ b/service/resource/s3objectv3/create.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/create_test.go
+++ b/service/resource/s3objectv3/create_test.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/current.go
+++ b/service/resource/s3objectv3/current.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"bytes"

--- a/service/resource/s3objectv3/current_test.go
+++ b/service/resource/s3objectv3/current_test.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/desired.go
+++ b/service/resource/s3objectv3/desired.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/desired_test.go
+++ b/service/resource/s3objectv3/desired_test.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/encrypt.go
+++ b/service/resource/s3objectv3/encrypt.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"bytes"

--- a/service/resource/s3objectv3/error.go
+++ b/service/resource/s3objectv3/error.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"strings"

--- a/service/resource/s3objectv3/mock.go
+++ b/service/resource/s3objectv3/mock.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"fmt"

--- a/service/resource/s3objectv3/resource.go
+++ b/service/resource/s3objectv3/resource.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "s3objectv2"
+	Name = "s3objectv3"
 )
 
 // Config represents the configuration used to create a new cloudformation resource.

--- a/service/resource/s3objectv3/spec.go
+++ b/service/resource/s3objectv3/spec.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/service/resource/s3objectv3/update.go
+++ b/service/resource/s3objectv3/update.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/resource/s3objectv3/update_test.go
+++ b/service/resource/s3objectv3/update_test.go
@@ -1,4 +1,4 @@
-package s3objectv2
+package s3objectv3
 
 import (
 	"context"

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -227,5 +227,46 @@ func newVersionBundles() []versionbundle.Bundle {
 			Version:      "2.0.0",
 			WIP:          false,
 		},
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "cloudconfig",
+					Description: "Fix eventual decryption race.",
+					Kind:        versionbundle.KindFixed,
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "calico",
+					Version: "3.0.1",
+				},
+				{
+					Name:    "docker",
+					Version: "17.09.0",
+				},
+				{
+					Name:    "etcd",
+					Version: "3.2.7",
+				},
+				{
+					Name:    "coredns",
+					Version: "1.0.5",
+				},
+				{
+					Name:    "kubernetes",
+					Version: "1.9.2",
+				},
+				{
+					Name:    "nginx-ingress-controller",
+					Version: "0.10.2",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{},
+			Deprecated:   false,
+			Name:         "aws-operator",
+			Time:         time.Date(2018, time.January, 30, 11, 55, 0, 0, time.UTC),
+			Version:      "2.0.1",
+			WIP:          true,
+		},
 	}
 }

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -221,7 +221,7 @@ func newVersionBundles() []versionbundle.Bundle {
 				},
 			},
 			Dependencies: []versionbundle.Dependency{},
-			Deprecated:   false,
+			Deprecated:   true,
 			Name:         "aws-operator",
 			Time:         time.Date(2018, time.January, 22, 16, 00, 0, 0, time.UTC),
 			Version:      "2.0.0",
@@ -266,7 +266,7 @@ func newVersionBundles() []versionbundle.Bundle {
 			Name:         "aws-operator",
 			Time:         time.Date(2018, time.January, 30, 11, 55, 0, 0, time.UTC),
 			Version:      "2.0.1",
-			WIP:          true,
+			WIP:          false,
 		},
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/aws-operator/issues/658

These changes aim to prevent a race condition that can happen during certificate decryption on master reboot. The decrypt units are created but not enabled, so that on master reboot the existing units are not started by default, they are only run after they are created (ie. the units started but not enabled), and this will always happen after the certificate files have been created by cloud-init.

The changes are added to a new `2.1.0` version bundle so that `2.0.0` is kept without changes.