### PR TITLE
e2e: remove version bundle check

### DIFF
--- a/integration/framework.go
+++ b/integration/framework.go
@@ -308,10 +308,8 @@ func (f *framework) DeleteGuestCluster() error {
 		return microerror.Mask(err)
 	}
 
-	logEntry := "cluster '${CLUSTER_NAME}' deleted"
-	if os.Getenv("VERSION_BUNDLE_VERSION") == "2.0.0" {
-		logEntry = "deleting AWS Host Post-Guest CloudFormation stack: deleted"
-	}
+	logEntry := "deleting AWS Host Post-Guest CloudFormation stack: deleted"
+
 	return f.WaitForPodLog("giantswarm", logEntry, operatorPodName)
 }
 

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -229,10 +229,7 @@ func operatorSetup() error {
 		return microerror.Maskf(err, "unexpected error installing aws-resource-lab chart: %v")
 	}
 
-	logEntry := "cluster '${CLUSTER_NAME}' processed"
-	if os.Getenv("VERSION_BUNDLE_VERSION") == "2.0.0" {
-		logEntry = "creating AWS cloudformation stack: created"
-	}
+	logEntry := "creating AWS cloudformation stack: created"
 
 	operatorPodName, err := f.PodName("giantswarm", "app=aws-operator")
 	if err != nil {


### PR DESCRIPTION
Now that CloudFormation is rolled out we don't need to keep checking the legacy log entries for created and deleted clusters.