### PR TITLE
e2e: use localkube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 e2eTest: &e2eTest
     machine: true
     working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/aws-operator
+    environment:
+      MINIKUBE_VERSION: v0.25.0
     steps:
     - checkout
 
@@ -8,7 +10,9 @@ e2eTest: &e2eTest
         wget -q $(curl -sS https://api.github.com/repos/giantswarm/e2e-harness/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
         chmod +x ./e2e-harness
 
-    - run: ./e2e-harness setup --name=ci-awsop-${CIRCLE_SHA1:0:7}
+    - run: ./e2e-harness localkube
+
+    - run: ./e2e-harness setup --remote=false
 
     - run:
         name: set CLUSTER_NAME env var


### PR DESCRIPTION
Uses localkube (minikube with `--vm-driver=none`) from e2e-harness. This way minikube is run on circleCI machines and we don't need to spin up an AWS instance for each e2e execution. Also the setup is slightly quicker.

All good in the first executions https://circleci.com/gh/giantswarm/aws-operator/3044 we need to keep an eye on the results, this e2e test requires more resources from circleCI's test machine than others.