### PR TITLE
Update state check to prevent 2nd master being created

### DIFF
--- a/resources/aws/instance.go
+++ b/resources/aws/instance.go
@@ -55,6 +55,16 @@ func statePendingOrRunning(instance *ec2.Instance) bool {
 	return false
 }
 
+func stateTerminated(instance *ec2.Instance) bool {
+	stateCode := *instance.State.Code
+	switch stateCode {
+	case int64(EC2TerminatedState):
+		return true
+	}
+
+	return false
+}
+
 func (i Instance) findExisting() (*ec2.Instance, error) {
 	filters := []*ec2.Filter{}
 	if i.ClusterName != "" {
@@ -93,7 +103,7 @@ func (i Instance) findExisting() (*ec2.Instance, error) {
 	var instancesFound int
 	for _, reservation := range reservations.Reservations {
 		for _, instance := range reservation.Instances {
-			if statePendingOrRunning(instance) {
+			if !stateTerminated(instance) {
 				existingInstance = instance
 				instancesFound++
 			}

--- a/resources/aws/instance.go
+++ b/resources/aws/instance.go
@@ -56,13 +56,7 @@ func statePendingOrRunning(instance *ec2.Instance) bool {
 }
 
 func stateTerminated(instance *ec2.Instance) bool {
-	stateCode := *instance.State.Code
-	switch stateCode {
-	case int64(EC2TerminatedState):
-		return true
-	}
-
-	return false
+	return *instance.State.Code == int64(EC2TerminatedState)
 }
 
 func (i Instance) findExisting() (*ec2.Instance, error) {


### PR DESCRIPTION
Fixes giantswarm/giantswarm#2392

The `findExisting` check only considers instances with status `pending` or `running`. If the node is rebooting when the operator reprocesses the cluster a 2nd master node is launched.

The check now passes with any status except `terminated`. Bug only affects legacy clusters and legacy cluster creation is deprecated.