### PR TITLE
awsconfig/v5: add loadbalancer resource structure

### DIFF
--- a/service/awsconfig/v5/resource/loadbalancer/create.go
+++ b/service/awsconfig/v5/resource/loadbalancer/create.go
@@ -1,0 +1,14 @@
+package loadbalancer
+
+import (
+	"context"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}
+
+// newCreateChange is a no-op because load balancers are not updated.
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/awsconfig/v5/resource/loadbalancer/current.go
+++ b/service/awsconfig/v5/resource/loadbalancer/current.go
@@ -1,0 +1,10 @@
+package loadbalancer
+
+import (
+	"context"
+)
+
+// TODO
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/awsconfig/v5/resource/loadbalancer/delete.go
+++ b/service/awsconfig/v5/resource/loadbalancer/delete.go
@@ -1,0 +1,30 @@
+package loadbalancer
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+// TODO
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+// TODO
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/awsconfig/v5/resource/loadbalancer/desired.go
+++ b/service/awsconfig/v5/resource/loadbalancer/desired.go
@@ -1,0 +1,10 @@
+package loadbalancer
+
+import (
+	"context"
+)
+
+// TODO
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/awsconfig/v5/resource/loadbalancer/error.go
+++ b/service/awsconfig/v5/resource/loadbalancer/error.go
@@ -1,0 +1,12 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/awsconfig/v5/resource/loadbalancer/resource.go
+++ b/service/awsconfig/v5/resource/loadbalancer/resource.go
@@ -1,6 +1,8 @@
 package loadbalancer
 
 import (
+	"reflect"
+
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
@@ -21,17 +23,6 @@ type Config struct {
 	Logger     micrologger.Logger
 }
 
-// DefaultConfig provides a default configuration to create a new loadbalancer
-// resource by best effort.
-func DefaultConfig() Config {
-	return Config{
-		// Dependencies.
-		AwsService: nil,
-		Clients:    Clients{},
-		Logger:     nil,
-	}
-}
-
 // Resource implements the loadbalancer resource.
 type Resource struct {
 	// Dependencies.
@@ -45,6 +36,9 @@ func New(config Config) (*Resource, error) {
 	// Dependencies.
 	if config.AwsService == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.AwsService must not be empty")
+	}
+	if reflect.DeepEqual(config.Clients, Clients{}) {
+		return nil, microerror.Maskf(invalidConfigError, "config.Clients must not be empty")
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")

--- a/service/awsconfig/v5/resource/loadbalancer/resource.go
+++ b/service/awsconfig/v5/resource/loadbalancer/resource.go
@@ -1,0 +1,71 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "loadbalancerv5"
+)
+
+// Config represents the configuration used to create a new loadbalancer resource.
+type Config struct {
+	// Dependencies.
+	AwsService *awsservice.Service
+	Clients    Clients
+	Logger     micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new loadbalancer
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		AwsService: nil,
+		Clients:    Clients{},
+		Logger:     nil,
+	}
+}
+
+// Resource implements the loadbalancer resource.
+type Resource struct {
+	// Dependencies.
+	awsService *awsservice.Service
+	clients    Clients
+	logger     micrologger.Logger
+}
+
+// New creates a new configured loadbalancer resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.AwsService == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.AwsService must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		awsService: config.AwsService,
+		clients:    config.Clients,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}

--- a/service/awsconfig/v5/resource/loadbalancer/spec.go
+++ b/service/awsconfig/v5/resource/loadbalancer/spec.go
@@ -1,0 +1,16 @@
+package loadbalancer
+
+import (
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+type Clients struct {
+	ELB ELBClient
+}
+
+// ELBClient describes the methods required to be implemented by an ELB AWS client.
+type ELBClient interface {
+	DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+	DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error)
+}

--- a/service/awsconfig/v5/resource/loadbalancer/update.go
+++ b/service/awsconfig/v5/resource/loadbalancer/update.go
@@ -1,0 +1,35 @@
+package loadbalancer
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because load balancers are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/awsconfig/v5/resource_set.go
+++ b/service/awsconfig/v5/resource_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/cloudformation/adapter"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/endpoints"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/kmskey"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/loadbalancer"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/namespace"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v5/resource/s3object"
@@ -176,6 +177,22 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 		}
 	}
 
+	var loadBalancerResource framework.Resource
+	{
+		c := loadbalancer.Config{
+			AwsService: awsService,
+			Clients: loadbalancer.Clients{
+				ELB: config.GuestAWSClients.ELB,
+			},
+			Logger: config.Logger,
+		}
+
+		loadBalancerResource, err = loadbalancer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var cloudformationResource framework.Resource
 	{
 		c := cloudformation.Config{
@@ -248,6 +265,7 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 		kmsKeyResource,
 		s3BucketResource,
 		s3BucketObjectResource,
+		loadBalancerResource,
 		cloudformationResource,
 		namespaceResource,
 		serviceResource,

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -366,5 +366,50 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Version:      "2.1.0",
 			WIP:          false,
 		},
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "aws-operator",
+					Description: "Delete AWS Cloud Provider resources when deleting clusters.",
+					Kind:        versionbundle.KindAdded,
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "calico",
+					Version: "3.0.1",
+				},
+				{
+					Name:    "containerlinux",
+					Version: "1576.5.0",
+				},
+				{
+					Name:    "docker",
+					Version: "17.09.0",
+				},
+				{
+					Name:    "etcd",
+					Version: "3.2.7",
+				},
+				{
+					Name:    "coredns",
+					Version: "1.0.5",
+				},
+				{
+					Name:    "kubernetes",
+					Version: "1.9.2",
+				},
+				{
+					Name:    "nginx-ingress-controller",
+					Version: "0.10.2",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{},
+			Deprecated:   false,
+			Name:         "aws-operator",
+			Time:         time.Date(2018, time.February, 15, 10, 0, 0, 0, time.UTC),
+			Version:      "2.1.1",
+			WIP:          true,
+		},
 	}
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#2544

Adds 2.1.1 WIP version bundle and structure for new loadbalancer resource. Deletion logic will come in later PRs.