### PR TITLE
fix template rendering

### DIFF
--- a/service/awsconfig/v5/templates/templates.go
+++ b/service/awsconfig/v5/templates/templates.go
@@ -2,7 +2,7 @@ package templates
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 
 	"github.com/giantswarm/microerror"
 )

--- a/service/awsconfig/v5/templates/templates_test.go
+++ b/service/awsconfig/v5/templates/templates_test.go
@@ -1,0 +1,24 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/giantswarm/aws-operator/service/awsconfig/v5/templates"
+)
+
+func TestRender(t *testing.T) {
+	tpl := "some string <{{.Value}}> another string"
+	d := struct {
+		Value string
+	}{"myvalue"}
+	expected := "some string <myvalue> another string"
+
+	actual, err := templates.Render([]string{tpl}, d)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if actual != expected {
+		t.Errorf("unexpected output, want %q, got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
We are getting errors on WIP (v5) that prevents the guest stack to be created, the reported error is:
```
Invalid BASE64 encoding of user data
```
These changes fix it, and is indeed an error to use html instead of text templates, now investigating why this has started happening now.