### PR TITLE
Fix default pub key path for legacy clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.AWS.Region, "", "Region for checking for orphan AWS resources.")
 
 	// TODO(nhlfr): Deprecate these options when cert-operator will be implemented.
-	daemonCommand.PersistentFlags().String(f.Service.AWS.PubKeyFile, path.Join(os.Getenv("HOME"), ".ssh", "id_rsa.pub"), "Public key to be imported as a keypair in AWS.")
+	daemonCommand.PersistentFlags().String(f.Service.AWS.PubKeyFile, path.Join(string(os.PathSeparator), ".ssh", "id_rsa.pub"), "Public key to be imported as a keypair in AWS.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Installation name for tagging AWS resources.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.ClientID, "", "OIDC authorization provider ClientID.")


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2581

This only affects very old clusters (legacy without cluster version https://github.com/giantswarm/aws-operator/blob/master/service/awsconfig/v1/resource/legacy/resource.go#L252) which need an SSH KeyPair to be created. The right path of the public key is `/.ssh/id_rsa.pub`, this is where the secret with the file content is mounted https://github.com/giantswarm/aws-operator/blob/master/helm/aws-operator-chart/templates/08-deployment.yaml#L53. 