### PR TITLE
fix compiling issues for go1.10

### DIFF
--- a/service/awsconfig/v2/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/create_test.go
@@ -113,7 +113,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
 			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, createChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v2/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/delete_test.go
@@ -106,7 +106,7 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", deleteChange, result)
 			}
 			if *deleteChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, deleteChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *deleteChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v3/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v3/resource/cloudformation/create_test.go
@@ -113,7 +113,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
 			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, createChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v3/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v3/resource/cloudformation/delete_test.go
@@ -106,7 +106,7 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", deleteChange, result)
 			}
 			if *deleteChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, deleteChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *deleteChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v4/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v4/resource/cloudformation/create_test.go
@@ -114,7 +114,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
 			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, createChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v4/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v4/resource/cloudformation/delete_test.go
@@ -109,7 +109,7 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", deleteChange, result)
 			}
 			if *deleteChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, deleteChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *deleteChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v5/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v5/resource/cloudformation/create_test.go
@@ -114,7 +114,7 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", createChange, result)
 			}
 			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, createChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
 			}
 		})
 	}

--- a/service/awsconfig/v5/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v5/resource/cloudformation/delete_test.go
@@ -109,7 +109,7 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 				t.Errorf("expected '%T', got '%T'", deleteChange, result)
 			}
 			if *deleteChange.StackName != tc.expectedStackName {
-				t.Errorf("expected %s, got %s", tc.expectedStackName, deleteChange.StackName)
+				t.Errorf("expected %s, got %s", tc.expectedStackName, *deleteChange.StackName)
 			}
 		})
 	}


### PR DESCRIPTION
There were discussions for upgrading to go1.10. I tried it out just for fun and noticed the tests do not compile in certain cases. This PR fixes this. Note that I modify tests for frozen versions as well. I think in this case it is ok because it does only affect the tests. 