### PR TITLE
Implement deleting EBS volumes

### DIFF
--- a/service/awsconfig/v5/resource/ebsvolume/delete.go
+++ b/service/awsconfig/v5/resource/ebsvolume/delete.go
@@ -2,13 +2,37 @@ package ebsvolume
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-// TODO
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	deleteInput, err := toEBSVolumeState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if deleteInput != nil && len(deleteInput.VolumeIDs) > 0 {
+		r.logger.LogCtx(ctx, "debug", fmt.Sprintf("deleting %d ebs volumes", len(deleteInput.VolumeIDs)))
+
+		for _, volID := range deleteInput.VolumeIDs {
+			_, err := r.clients.EC2.DeleteVolume(&ec2.DeleteVolumeInput{
+				VolumeId: aws.String(volID),
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", fmt.Sprintf("deleted %d ebs volumes", len(deleteInput.VolumeIDs)))
+	} else {
+		r.logger.LogCtx(ctx, "debug", "not deleting load ebs volumes because there aren't any")
+	}
+
 	return nil
 }
 
@@ -24,7 +48,20 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// TODO
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	return nil, nil
+	currentVolState, err := toEBSVolumeState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredVolState, err := toEBSVolumeState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var volStateToDelete *EBSVolumeState
+	if desiredVolState == nil && currentVolState != nil && len(currentVolState.VolumeIDs) > 0 {
+		volStateToDelete = currentVolState
+	}
+
+	return volStateToDelete, nil
 }

--- a/service/awsconfig/v5/resource/ebsvolume/delete_test.go
+++ b/service/awsconfig/v5/resource/ebsvolume/delete_test.go
@@ -1,0 +1,108 @@
+package ebsvolume
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_newDeleteChange(t *testing.T) {
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           *v1alpha1.AWSConfig
+		currentState  *EBSVolumeState
+		desiredState  *EBSVolumeState
+		expectedState *EBSVolumeState
+	}{
+		{
+			description: "basic match",
+			obj:         customObject,
+			currentState: &EBSVolumeState{
+				VolumeIDs: []string{
+					"vol-1234",
+					"vol-5678",
+				},
+			},
+			desiredState: nil,
+			expectedState: &EBSVolumeState{
+				VolumeIDs: []string{
+					"vol-1234",
+					"vol-5678",
+				},
+			},
+		},
+		{
+			description:   "return nil when current state is nil",
+			obj:           customObject,
+			currentState:  nil,
+			desiredState:  nil,
+			expectedState: nil,
+		},
+		{
+			description: "return nil when current volumes are empty",
+			obj:         customObject,
+			currentState: &EBSVolumeState{
+				VolumeIDs: []string{},
+			},
+			desiredState:  nil,
+			expectedState: nil,
+		},
+		{
+			description: "return nil when desired state is not nil",
+			obj:         customObject,
+			currentState: &EBSVolumeState{
+				VolumeIDs: []string{
+					"vol-1234",
+				},
+			},
+			desiredState: &EBSVolumeState{
+				VolumeIDs: []string{
+					"vol-1234",
+				},
+			},
+			expectedState: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				Clients: Clients{
+					EC2: &EC2ClientMock{},
+				},
+				Logger: microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+			deleteState, ok := result.(*EBSVolumeState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", deleteState, result)
+			}
+
+			if !reflect.DeepEqual(deleteState, tc.expectedState) {
+				t.Errorf("expected delete state '%#v', got '%#v'", tc.expectedState, deleteState)
+			}
+		})
+	}
+}

--- a/service/awsconfig/v5/resource/ebsvolume/error.go
+++ b/service/awsconfig/v5/resource/ebsvolume/error.go
@@ -10,3 +10,10 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/awsconfig/v5/resource/ebsvolume/resource.go
+++ b/service/awsconfig/v5/resource/ebsvolume/resource.go
@@ -55,3 +55,16 @@ func (r *Resource) Name() string {
 func (r *Resource) Underlying() framework.Resource {
 	return r
 }
+
+func toEBSVolumeState(v interface{}) (*EBSVolumeState, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	volState, ok := v.(*EBSVolumeState)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", volState, v)
+	}
+
+	return volState, nil
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#2544

Implements deleting EBS volumes for cloud provider persistent volumes. This is so they are not left behind when the cluster is deleted.