### PR TITLE
Fail early if VPC peering connection cannot be created

### DIFF
--- a/service/awsconfig/v1/resource/legacy/resource.go
+++ b/service/awsconfig/v1/resource/legacy/resource.go
@@ -394,6 +394,10 @@ func (s *Resource) processCluster(cluster v1alpha1.AWSConfig) error {
 	}
 
 	// Create VPC peering connection.
+	if cluster.Spec.AWS.VPC.PeerID == "" {
+		return microerror.Maskf(invalidConfigError, fmt.Sprintf("could not create VPC peering connection: peer ID is empty for cluster %q", key.ClusterID(cluster)))
+	}
+
 	vpcPeeringConection := &awsresources.VPCPeeringConnection{
 		VPCId:     vpcID,
 		PeerVPCId: cluster.Spec.AWS.VPC.PeerID,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2589

Fail early and with a clear error message if the peering connection cannot be done. This only affects very old legacy clusters (created before VPC peering was available).