### PR TITLE
Make etcd volume dependent on master instance

### DIFF
--- a/service/awsconfig/v5/templates/cloudformation/guest/instance.go
+++ b/service/awsconfig/v5/templates/cloudformation/guest/instance.go
@@ -18,6 +18,8 @@ const Instance = `{{define "instance"}}
         Value: {{ .ClusterID }}-master
   EtcdVolume:
     Type: AWS::EC2::Volume
+    DependsOn:
+      - MasterInstance
     Properties:
       Size: 100
       VolumeType: gp2

--- a/service/awsconfig/v5/templates/cloudformation/guest/instance.go
+++ b/service/awsconfig/v5/templates/cloudformation/guest/instance.go
@@ -19,7 +19,7 @@ const Instance = `{{define "instance"}}
   EtcdVolume:
     Type: AWS::EC2::Volume
     DependsOn:
-      - MasterInstance
+    - MasterInstance
     Properties:
       Size: 100
       VolumeType: gp2


### PR DESCRIPTION
Cloud Formation template change so the etcd volume is deleted correctly.  Adds a DependsOn attribute for the EtcdVolume to the MasterInstance. Without this I've seen the guest stack fail to delete on `gauss`.

Previous error

![screen shot 2018-02-22 at 3 19 02 pm](https://user-images.githubusercontent.com/311527/36543329-c6a09c08-17e3-11e8-9f61-c9ce125e2c5f.png)

