### PR TITLE
Get load balancer tags in batches

### DIFF
--- a/service/awsconfig/v5/version_bundle.go
+++ b/service/awsconfig/v5/version_bundle.go
@@ -91,7 +91,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Dependencies: []versionbundle.Dependency{},
-		Deprecated:   false,
+		Deprecated:   true,
 		Name:         "aws-operator",
 		Time:         time.Date(2018, time.February, 15, 10, 0, 0, 0, time.UTC),
 		Version:      "2.1.1",

--- a/service/awsconfig/v6/resource/loadbalancer/current.go
+++ b/service/awsconfig/v6/resource/loadbalancer/current.go
@@ -13,6 +13,7 @@ import (
 const (
 	cloudProviderClusterTagValue = "owned"
 	cloudProviderServiceTagKey   = "kubernetes.io/service-name"
+	loadBalancerTagChunkSize     = 20
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -44,10 +45,17 @@ func (r *Resource) clusterLoadBalancers(customObject v1alpha1.AWSConfig) (*LoadB
 		allLBNames = append(allLBNames, lb.LoadBalancerName)
 	}
 
-	if len(allLBNames) > 0 {
-		// We get tags for all load balancers which needs a separate API call.
+	// Get loadbalancer tags in batches due to API restriction.
+	for i := 0; i < len(allLBNames); i += loadBalancerTagChunkSize {
+		endPos := i + loadBalancerTagChunkSize
+
+		if endPos > len(allLBNames) {
+			endPos = len(allLBNames)
+		}
+
+		lbNames := allLBNames[i:endPos]
 		tagsInput := &elb.DescribeTagsInput{
-			LoadBalancerNames: allLBNames,
+			LoadBalancerNames: lbNames,
 		}
 		tagsOutput, err := r.clients.ELB.DescribeTags(tagsInput)
 		if err != nil {

--- a/service/awsconfig/v6/version_bundle.go
+++ b/service/awsconfig/v6/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Get ELB tags in batches due to API restriction.",
+				Description: "Fix limitation getting ELB tags that affected cluster creation.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/service/awsconfig/v6/version_bundle.go
+++ b/service/awsconfig/v6/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Fix problem getting tags data for ELBs.",
+				Description: "Get ELB tags in batches due to API restriction.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/service/awsconfig/v6/version_bundle.go
+++ b/service/awsconfig/v6/version_bundle.go
@@ -14,6 +14,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Fix limitation getting ELB tags that affected cluster creation.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Fix error scaling down to 1 worker.",
+				Kind:        versionbundle.KindFixed,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/awsconfig/v6/version_bundle.go
+++ b/service/awsconfig/v6/version_bundle.go
@@ -11,8 +11,8 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "There are no changes yet, replace this with something useful.",
-				Kind:        versionbundle.KindChanged,
+				Description: "Fix problem getting tags data for ELBs.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{
@@ -50,6 +50,6 @@ func VersionBundle() versionbundle.Bundle {
 		Name:         "aws-operator",
 		Time:         time.Date(2018, time.February, 26, 12, 15, 0, 0, time.UTC),
 		Version:      "2.1.2",
-		WIP:          true,
+		WIP:          false,
 	}
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#2667

Get load balancer tags in batches of 20 due to restriction in the AWS ELB API.
