### PR TITLE
fix workerCountRatio when scaling down to 1 worker

### DIFF
--- a/service/awsconfig/v6/resource/cloudformation/adapter/auto_scaling_group.go
+++ b/service/awsconfig/v6/resource/cloudformation/adapter/auto_scaling_group.go
@@ -41,5 +41,9 @@ func workerCountRatio(workers int, ratio float32) string {
 	value := float32(workers) * ratio
 	rounded := int(value + 0.5)
 
+	if workers > 0 && rounded == 0 {
+		rounded = 1
+	}
+
 	return strconv.Itoa(rounded)
 }

--- a/service/awsconfig/v6/resource/cloudformation/adapter/auto_scaling_group_test.go
+++ b/service/awsconfig/v6/resource/cloudformation/adapter/auto_scaling_group_test.go
@@ -136,3 +136,36 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
+	tcs := []struct {
+		description   string
+		workers       int
+		expectedRatio string
+	}{
+		{
+			description:   "scaling down to one worker, one should be up",
+			workers:       1,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to two worker, one should be up",
+			workers:       2,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to zero worker, none should be up",
+			workers:       0,
+			expectedRatio: "0",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := workerCountRatio(tc.workers, asgMaxBatchSizeRatio)
+
+			if tc.expectedRatio != actual {
+				t.Errorf("wrong worker count ratio, expected %q, actual %q", tc.expectedRatio, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will prevent errors when scaling down to 1 worker:
```
Invalid Autoscaling rolling update policy: MaxBatchSize must be greater than or equal to 1
```