### PR TITLE
 awsconfig/v7: update imports and packages

### DIFF
--- a/service/awsconfig/v7/cloudconfig/cloudconfigtest/cloudconfigtest.go
+++ b/service/awsconfig/v7/cloudconfig/cloudconfigtest/cloudconfigtest.go
@@ -3,7 +3,7 @@ package cloudconfigtest
 import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
 )
 
 func New() *cloudconfig.CloudConfig {

--- a/service/awsconfig/v7/cloudconfig/master_template.go
+++ b/service/awsconfig/v7/cloudconfig/master_template.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeytpr"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudconfig"
 )
 
 const (

--- a/service/awsconfig/v7/cloudconfig/worker_template.go
+++ b/service/awsconfig/v7/cloudconfig/worker_template.go
@@ -6,7 +6,7 @@ import (
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_1_1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudconfig"
 )
 
 const (

--- a/service/awsconfig/v7/error.go
+++ b/service/awsconfig/v7/error.go
@@ -1,4 +1,4 @@
-package v6
+package v7
 
 import "github.com/giantswarm/microerror"
 

--- a/service/awsconfig/v7/key/key.go
+++ b/service/awsconfig/v7/key/key.go
@@ -7,10 +7,10 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/hostpost"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/hostpre"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/hostpost"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/hostpre"
 )
 
 const (
@@ -305,8 +305,8 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
 		NOTE 2: You also need to update the tests.
 
-		service/awsconfig/v6/key/key_test.go
-		service/awsconfig/v6/resource/cloudformation/adapter/adapter_test.go
+		service/awsconfig/v7/key/key_test.go
+		service/awsconfig/v7/resource/cloudformation/adapter/adapter_test.go
 		service/resource/cloudformationv2/main_stack_test.go
 
 		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)

--- a/service/awsconfig/v7/resource/cloudformation/adapter/adapter.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/adapter.go
@@ -29,7 +29,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 type hydrater func(Config) error

--- a/service/awsconfig/v7/resource/cloudformation/adapter/adapter_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/adapter_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 var (

--- a/service/awsconfig/v7/resource/cloudformation/adapter/auto_scaling_group.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/auto_scaling_group.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // template related to this adapter: service/templates/cloudformation/guest/auto_scaling_group.yaml

--- a/service/awsconfig/v7/resource/cloudformation/adapter/host_iam_roles.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/host_iam_roles.go
@@ -1,10 +1,10 @@
 package adapter
 
-import "github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+import "github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/hostpre/iam_roles.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/hostpre/iam_roles.go
 //
 
 type hostIamRolesAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/host_route_tables.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/host_route_tables.go
@@ -10,12 +10,12 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/hostpost/route_tables.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/hostpost/route_tables.go
 //
 
 type hostRouteTablesAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/iam_policies.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/iam_policies.go
@@ -7,12 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/iam_policies.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/iam_policies.go
 //
 
 type iamPoliciesAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/instance.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/instance.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/instance.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/instance.go
 //
 
 type instanceAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/launch_configuration.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/launch_configuration.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/launch_configuration.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/launch_configuration.go
 //
 
 type launchConfigAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/load_balancers.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/load_balancers.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/load_balancers.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/load_balancers.go
 //
 
 const (

--- a/service/awsconfig/v7/resource/cloudformation/adapter/load_balancers_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/load_balancers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func TestAdapterLoadBalancersRegularFields(t *testing.T) {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/outputs.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/outputs.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/outputs.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/outputs.go
 //
 
 type outputsAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/recordsets.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/recordsets.go
@@ -2,7 +2,7 @@ package adapter
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/recordsets.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/recordsets.go
 //
 
 type recordSetsAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/route_tables.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/route_tables.go
@@ -3,12 +3,12 @@ package adapter
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/route_tables.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/route_tables.go
 //
 
 type routeTablesAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/security_groups.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/security_groups.go
@@ -4,12 +4,12 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/security_groups.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/security_groups.go
 //
 
 type securityGroupsAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/subnets.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/subnets.go
@@ -1,12 +1,12 @@
 package adapter
 
 import (
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/subnets.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/subnets.go
 //
 
 type subnetsAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/adapter/vpc.go
+++ b/service/awsconfig/v7/resource/cloudformation/adapter/vpc.go
@@ -6,12 +6,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 // The template related to this adapter can be found in the following import.
 //
-//     github.com/giantswarm/aws-operator/service/awsconfig/v6/templates/cloudformation/guest/vpc.go
+//     github.com/giantswarm/aws-operator/service/awsconfig/v7/templates/cloudformation/guest/vpc.go
 //
 
 type vpcAdapter struct {

--- a/service/awsconfig/v7/resource/cloudformation/create.go
+++ b/service/awsconfig/v7/resource/cloudformation/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/awsconfig/v7/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 func Test_Resource_Cloudformation_newCreate(t *testing.T) {

--- a/service/awsconfig/v7/resource/cloudformation/current.go
+++ b/service/awsconfig/v7/resource/cloudformation/current.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework/context/resourcecanceledcontext"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/cloudformation/delete.go
+++ b/service/awsconfig/v7/resource/cloudformation/delete.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )

--- a/service/awsconfig/v7/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/delete_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 func Test_Resource_Cloudformation_newDelete(t *testing.T) {

--- a/service/awsconfig/v7/resource/cloudformation/desired.go
+++ b/service/awsconfig/v7/resource/cloudformation/desired.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/cloudformation/desired_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/desired_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {

--- a/service/awsconfig/v7/resource/cloudformation/main_stack.go
+++ b/service/awsconfig/v7/resource/cloudformation/main_stack.go
@@ -6,10 +6,10 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates"
 )
 
 func newMainStack(customObject v1alpha1.AWSConfig) (StackState, error) {

--- a/service/awsconfig/v7/resource/cloudformation/main_stack_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/main_stack_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 func testConfig() Config {

--- a/service/awsconfig/v7/resource/cloudformation/resource.go
+++ b/service/awsconfig/v7/resource/cloudformation/resource.go
@@ -7,13 +7,13 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 const (
 	// Name is the identifier of the resource.
-	Name = "cloudformationv6"
+	Name = "cloudformationv7"
 )
 
 type AWSConfig struct {

--- a/service/awsconfig/v7/resource/cloudformation/update.go
+++ b/service/awsconfig/v7/resource/cloudformation/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 	"github.com/giantswarm/operatorkit/framework/context/updateallowedcontext"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/awsconfig/v7/resource/cloudformation/update_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/update_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/operatorkit/framework/context/updateallowedcontext"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 )
 
 func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {

--- a/service/awsconfig/v7/resource/cloudformation/validate.go
+++ b/service/awsconfig/v7/resource/cloudformation/validate.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 type validator func(v1alpha1.AWSConfig) error

--- a/service/awsconfig/v7/resource/cloudformation/validate_test.go
+++ b/service/awsconfig/v7/resource/cloudformation/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
 	"github.com/giantswarm/micrologger/microloggertest"
 )
 

--- a/service/awsconfig/v7/resource/ebsvolume/current.go
+++ b/service/awsconfig/v7/resource/ebsvolume/current.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 const (

--- a/service/awsconfig/v7/resource/ebsvolume/mock_test.go
+++ b/service/awsconfig/v7/resource/ebsvolume/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 type EC2ClientMock struct {

--- a/service/awsconfig/v7/resource/ebsvolume/resource.go
+++ b/service/awsconfig/v7/resource/ebsvolume/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "ebsvolumev6"
+	Name = "ebsvolumev7"
 )
 
 // Config represents the configuration used to create a new ebsvolume resource.

--- a/service/awsconfig/v7/resource/endpoints/create.go
+++ b/service/awsconfig/v7/resource/endpoints/create.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/awsconfig/v7/resource/endpoints/current.go
+++ b/service/awsconfig/v7/resource/endpoints/current.go
@@ -8,7 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/endpoints/delete.go
+++ b/service/awsconfig/v7/resource/endpoints/delete.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/awsconfig/v7/resource/endpoints/desired.go
+++ b/service/awsconfig/v7/resource/endpoints/desired.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/endpoints/resource.go
+++ b/service/awsconfig/v7/resource/endpoints/resource.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "endpointsv6"
+	Name = "endpointsv7"
 
 	httpsPort           = 443
 	masterEndpointsName = "master"

--- a/service/awsconfig/v7/resource/endpoints/update.go
+++ b/service/awsconfig/v7/resource/endpoints/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 	apiv1 "k8s.io/api/core/v1"

--- a/service/awsconfig/v7/resource/kmskey/create.go
+++ b/service/awsconfig/v7/resource/kmskey/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/awsconfig/v7/resource/kmskey/current.go
+++ b/service/awsconfig/v7/resource/kmskey/current.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/kmskey/desired.go
+++ b/service/awsconfig/v7/resource/kmskey/desired.go
@@ -3,7 +3,7 @@ package kmskey
 import (
 	"context"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/kmskey/resource.go
+++ b/service/awsconfig/v7/resource/kmskey/resource.go
@@ -9,12 +9,12 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 const (
 	// Name is the identifier of the resource.
-	Name = "kmskeyv6"
+	Name = "kmskeyv7"
 )
 
 // Config represents the configuration used to create a new cloudformation resource.

--- a/service/awsconfig/v7/resource/loadbalancer/current.go
+++ b/service/awsconfig/v7/resource/loadbalancer/current.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 const (

--- a/service/awsconfig/v7/resource/loadbalancer/current.go
+++ b/service/awsconfig/v7/resource/loadbalancer/current.go
@@ -13,6 +13,7 @@ import (
 const (
 	cloudProviderClusterTagValue = "owned"
 	cloudProviderServiceTagKey   = "kubernetes.io/service-name"
+	loadBalancerTagChunkSize     = 20
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -44,10 +45,17 @@ func (r *Resource) clusterLoadBalancers(customObject v1alpha1.AWSConfig) (*LoadB
 		allLBNames = append(allLBNames, lb.LoadBalancerName)
 	}
 
-	if len(allLBNames) > 0 {
-		// We get tags for all load balancers which needs a separate API call.
+	// Get loadbalancer tags in batches due to API restriction.
+	for i := 0; i < len(allLBNames); i += loadBalancerTagChunkSize {
+		endPos := i + loadBalancerTagChunkSize
+
+		if endPos > len(allLBNames) {
+			endPos = len(allLBNames)
+		}
+
+		lbNames := allLBNames[i:endPos]
 		tagsInput := &elb.DescribeTagsInput{
-			LoadBalancerNames: allLBNames,
+			LoadBalancerNames: lbNames,
 		}
 		tagsOutput, err := r.clients.ELB.DescribeTags(tagsInput)
 		if err != nil {

--- a/service/awsconfig/v7/resource/loadbalancer/resource.go
+++ b/service/awsconfig/v7/resource/loadbalancer/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "loadbalancerv6"
+	Name = "loadbalancerv7"
 )
 
 // Config represents the configuration used to create a new loadbalancer resource.

--- a/service/awsconfig/v7/resource/namespace/current.go
+++ b/service/awsconfig/v7/resource/namespace/current.go
@@ -8,7 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/namespace/desired.go
+++ b/service/awsconfig/v7/resource/namespace/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/namespace/resource.go
+++ b/service/awsconfig/v7/resource/namespace/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "namespacev6"
+	Name = "namespacev7"
 )
 
 // Config represents the configuration used to create a new namespace resource.

--- a/service/awsconfig/v7/resource/s3bucket/create.go
+++ b/service/awsconfig/v7/resource/s3bucket/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/awsconfig/v7/resource/s3bucket/current.go
+++ b/service/awsconfig/v7/resource/s3bucket/current.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/awsconfig/v7/resource/s3bucket/desired.go
+++ b/service/awsconfig/v7/resource/s3bucket/desired.go
@@ -3,7 +3,7 @@ package s3bucket
 import (
 	"context"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/awsconfig/v7/resource/s3bucket/resource.go
+++ b/service/awsconfig/v7/resource/s3bucket/resource.go
@@ -8,12 +8,12 @@ import (
 	"github.com/giantswarm/micrologger"
 
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 const (
 	// Name is the identifier of the resource.
-	Name = "s3bucketv6"
+	Name = "s3bucketv7"
 )
 
 // Config represents the configuration used to create a new s3bucket resource.

--- a/service/awsconfig/v7/resource/s3object/current.go
+++ b/service/awsconfig/v7/resource/s3object/current.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/awsconfig/v7/resource/s3object/desired.go
+++ b/service/awsconfig/v7/resource/s3object/desired.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/s3object/resource.go
+++ b/service/awsconfig/v7/resource/s3object/resource.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "s3objectv6"
+	Name = "s3objectv7"
 )
 
 // Config represents the configuration used to create a new cloudformation resource.

--- a/service/awsconfig/v7/resource/service/create.go
+++ b/service/awsconfig/v7/resource/service/create.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/awsconfig/v7/resource/service/current.go
+++ b/service/awsconfig/v7/resource/service/current.go
@@ -8,7 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/service/delete.go
+++ b/service/awsconfig/v7/resource/service/delete.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/awsconfig/v7/resource/service/desired.go
+++ b/service/awsconfig/v7/resource/service/desired.go
@@ -8,7 +8,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/awsconfig/v7/resource/service/resource.go
+++ b/service/awsconfig/v7/resource/service/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "servicev6"
+	Name = "servicev7"
 
 	httpsPort         = 443
 	masterServiceName = "master"

--- a/service/awsconfig/v7/resource_set.go
+++ b/service/awsconfig/v7/resource_set.go
@@ -1,4 +1,4 @@
-package v6
+package v7
 
 import (
 	"context"
@@ -16,18 +16,18 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/key"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/cloudformation/adapter"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/ebsvolume"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/endpoints"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/kmskey"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/loadbalancer"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/namespace"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/s3bucket"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/s3object"
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/resource/service"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/key"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/cloudformation/adapter"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/ebsvolume"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/endpoints"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/kmskey"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/loadbalancer"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/namespace"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/s3bucket"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/s3object"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/resource/service"
 )
 
 const (

--- a/service/awsconfig/v7/templates/templates_test.go
+++ b/service/awsconfig/v7/templates/templates_test.go
@@ -3,7 +3,7 @@ package templates_test
 import (
 	"testing"
 
-	"github.com/giantswarm/aws-operator/service/awsconfig/v6/templates"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v7/templates"
 )
 
 func TestRender(t *testing.T) {

--- a/service/awsconfig/v7/version_bundle.go
+++ b/service/awsconfig/v7/version_bundle.go
@@ -1,4 +1,4 @@
-package v6
+package v7
 
 import (
 	"time"

--- a/service/awsconfig/v7/version_bundle.go
+++ b/service/awsconfig/v7/version_bundle.go
@@ -48,8 +48,8 @@ func VersionBundle() versionbundle.Bundle {
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "aws-operator",
-		Time:         time.Date(2018, time.February, 26, 12, 15, 0, 0, time.UTC),
-		Version:      "2.1.2",
+		Time:         time.Date(2018, time.February, 27, 14, 16, 0, 0, time.UTC),
+		Version:      "2.1.3",
 		WIP:          true,
 	}
 }


### PR DESCRIPTION
The imports PR to add the v7 resources.

Going to ask for reviews because I messed up the copy PR :( I didn't have latest master so the ELB fix was missing. The scaling fix is present.

I know the wiki says you need latest master but maybe the copy scripts could go a git pull anyway. WDYT?