### PR TITLE
Fix validate check for existing peering routes

### DIFF
--- a/service/awsconfig/v8/resource/cloudformation/create.go
+++ b/service/awsconfig/v8/resource/cloudformation/create.go
@@ -64,16 +64,16 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 		return cloudformation.CreateStackInput{}, microerror.Mask(err)
 	}
 
-	if err := r.validateCluster(customObject); err != nil {
-		return cloudformation.CreateStackInput{}, microerror.Mask(err)
-	}
-
 	r.logger.LogCtx(ctx, "debug", "finding out if the main stack should be created")
 
 	createState := cloudformation.CreateStackInput{}
 
 	if currentStackState.Name == "" || desiredStackState.Name != currentStackState.Name {
 		r.logger.LogCtx(ctx, "debug", "main stack should be created")
+
+		if err := r.validateCluster(customObject); err != nil {
+			return cloudformation.CreateStackInput{}, microerror.Mask(err)
+		}
 
 		// We need to create the required peering resources in the host account before
 		// getting the guest main stack template body, it requires id values from host

--- a/service/awsconfig/v8/resource/cloudformation/create_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/create_test.go
@@ -89,10 +89,8 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 			IAM: &adapter.IAMClientMock{},
 			KMS: &adapter.KMSClientMock{},
 		}
-		ec2Mock := &adapter.EC2ClientMock{}
-		ec2Mock.SetUnexistingRouteTable(true)
 		c.HostClients = &adapter.Clients{
-			EC2:            ec2Mock,
+			EC2:            &adapter.EC2ClientMock{},
 			CloudFormation: &adapter.CloudFormationMock{},
 			IAM:            &adapter.IAMClientMock{},
 		}

--- a/service/awsconfig/v8/resource/cloudformation/main_stack_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/main_stack_test.go
@@ -351,8 +351,10 @@ func TestMainHostPostTemplateExistingFields(t *testing.T) {
 	cfg.Clients = &adapter.Clients{
 		EC2: &adapter.EC2ClientMock{},
 	}
+	ec2Mock := &adapter.EC2ClientMock{}
+	ec2Mock.SetMatchingRouteTables(1)
 	cfg.HostClients = &adapter.Clients{
-		EC2: &adapter.EC2ClientMock{},
+		EC2: ec2Mock,
 		IAM: &adapter.IAMClientMock{},
 	}
 	newResource, err := New(cfg)

--- a/service/awsconfig/v8/resource/cloudformation/validate.go
+++ b/service/awsconfig/v8/resource/cloudformation/validate.go
@@ -43,7 +43,7 @@ func (r *Resource) validateHostPeeringRoutes(cluster v1alpha1.AWSConfig) error {
 		},
 	}
 	output, err := r.hostClients.EC2.DescribeRouteTables(input)
-	if err == nil && len(output.RouteTables) == 1 {
+	if err == nil && len(output.RouteTables) >= 1 {
 		return microerror.Maskf(alreadyExistsError, "route: %s", key.PrivateSubnetCIDR(cluster))
 	}
 

--- a/service/awsconfig/v8/resource/cloudformation/validate.go
+++ b/service/awsconfig/v8/resource/cloudformation/validate.go
@@ -43,7 +43,7 @@ func (r *Resource) validateHostPeeringRoutes(cluster v1alpha1.AWSConfig) error {
 		},
 	}
 	output, err := r.hostClients.EC2.DescribeRouteTables(input)
-	if err == nil && len(output.RouteTables) >= 1 {
+	if err == nil && len(output.RouteTables) > 0 {
 		return microerror.Maskf(alreadyExistsError, "route: %s", key.PrivateSubnetCIDR(cluster))
 	}
 

--- a/service/awsconfig/v8/resource/cloudformation/validate_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/validate_test.go
@@ -22,19 +22,24 @@ func Test_validateHostPeeringRoutes(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description          string
-		unexistentRouteTable bool
-		expectedError        bool
+		description         string
+		matchingRouteTables int
+		expectedError       bool
 	}{
 		{
-			description:          "route table doesn't exist, do not expect error",
-			unexistentRouteTable: true,
-			expectedError:        false,
+			description:         "route table doesn't exist, do not expect error",
+			matchingRouteTables: 0,
+			expectedError:       false,
 		},
 		{
-			description:          "route table exists, expect error",
-			unexistentRouteTable: false,
-			expectedError:        true,
+			description:         "route table exists, expect error",
+			matchingRouteTables: 1,
+			expectedError:       true,
+		},
+		{
+			description:         "two route table exist, expect error",
+			matchingRouteTables: 2,
+			expectedError:       true,
 		},
 	}
 
@@ -50,7 +55,7 @@ func Test_validateHostPeeringRoutes(t *testing.T) {
 				KMS: &adapter.KMSClientMock{},
 			}
 			ec2Mock := &adapter.EC2ClientMock{}
-			ec2Mock.SetUnexistingRouteTable(tc.unexistentRouteTable)
+			ec2Mock.SetMatchingRouteTables(tc.matchingRouteTables)
 			c.HostClients = &adapter.Clients{
 				EC2:            ec2Mock,
 				CloudFormation: &adapter.CloudFormationMock{},

--- a/service/awsconfig/v8/version_bundle.go
+++ b/service/awsconfig/v8/version_bundle.go
@@ -10,9 +10,9 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
-				Kind:        versionbundle.KindChanged,
+				Component:   "aws-operator",
+				Description: "Fix validation check for existing peering routes",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/awsconfig/v8/version_bundle.go
+++ b/service/awsconfig/v8/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Fix validation check for existing peering routes",
+				Description: "Fix validation check for existing peering routes.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/2736

The validation for existing peering routes was failing, we were querying for route tables belonging to the peering VPC and with routes with target the private subnet CIDR of the cluster. Then we checked that the nunber of route tables is 1, this is wrong, it should be 2 (the two private route tables used for peering in the host cluster).