### PR TITLE
Add AWS resource tag with the Giant Swarm Installation

### DIFF
--- a/service/awsconfig/v8/cluster_resource_set.go
+++ b/service/awsconfig/v8/cluster_resource_set.go
@@ -147,6 +147,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*framework.Resource
 				KMS: config.GuestAWSClients.KMS,
 			},
 			Logger: config.Logger,
+
+			InstallationName: config.InstallationName,
 		}
 
 		ops, err := kmskey.New(c)
@@ -168,6 +170,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*framework.Resource
 				S3: config.GuestAWSClients.S3,
 			},
 			Logger: config.Logger,
+
+			InstallationName: config.InstallationName,
 		}
 
 		ops, err := s3bucket.New(c)

--- a/service/awsconfig/v8/key/key.go
+++ b/service/awsconfig/v8/key/key.go
@@ -24,6 +24,9 @@ const (
 	// and managed by a cluster.
 	CloudProviderTagOwnedValue = "owned"
 
+	// InstallationTagName is used for AWS resource tagging.
+	InstallationTagName = "giantswarm.io/installation"
+
 	// OrganizationTagName is used for AWS resource tagging.
 	OrganizationTagName = "giantswarm.io/organization"
 
@@ -142,11 +145,12 @@ func ClusterOrganization(customObject v1alpha1.AWSConfig) string {
 	return ClusterCustomer(customObject)
 }
 
-func ClusterTags(customObject v1alpha1.AWSConfig) map[string]string {
+func ClusterTags(customObject v1alpha1.AWSConfig, installationName string) map[string]string {
 	cloudProviderTag := ClusterCloudProviderTag(customObject)
 	tags := map[string]string{
 		cloudProviderTag:    CloudProviderTagOwnedValue,
 		ClusterTagName:      ClusterID(customObject),
+		InstallationTagName: installationName,
 		OrganizationTagName: ClusterOrganization(customObject),
 	}
 

--- a/service/awsconfig/v8/key/key_test.go
+++ b/service/awsconfig/v8/key/key_test.go
@@ -156,10 +156,13 @@ func Test_ClusterOrganization(t *testing.T) {
 }
 
 func Test_ClusterTags(t *testing.T) {
+	installName := "test-install"
+
 	expectedID := "test-cluster"
 	expectedTags := map[string]string{
 		"kubernetes.io/cluster/test-cluster": "owned",
 		"giantswarm.io/cluster":              "test-cluster",
+		"giantswarm.io/installation":         "test-install",
 		"giantswarm.io/organization":         "test-org",
 	}
 
@@ -175,8 +178,8 @@ func Test_ClusterTags(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject)) {
-		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject))
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject, installName)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject, installName))
 	}
 }
 

--- a/service/awsconfig/v8/resource/cloudformation/create.go
+++ b/service/awsconfig/v8/resource/cloudformation/create.go
@@ -96,7 +96,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 			aws.String(namedIAMCapability),
 		}
 
-		createState.SetTags(getCloudFormationTags(customObject))
+		createState.SetTags(r.getCloudFormationTags(customObject))
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be created")
 	}
@@ -118,7 +118,7 @@ func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1
 			aws.String(namedIAMCapability),
 		},
 	}
-	createStack.SetTags(getCloudFormationTags(customObject))
+	createStack.SetTags(r.getCloudFormationTags(customObject))
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster pre cloud formation stack")
 
@@ -149,7 +149,7 @@ func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha
 		StackName:    aws.String(stackName),
 		TemplateBody: aws.String(mainTemplate),
 	}
-	createStack.SetTags(getCloudFormationTags(customObject))
+	createStack.SetTags(r.getCloudFormationTags(customObject))
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster post cloud formation stack")
 

--- a/service/awsconfig/v8/resource/cloudformation/resource.go
+++ b/service/awsconfig/v8/resource/cloudformation/resource.go
@@ -70,8 +70,8 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func getCloudFormationTags(customObject v1alpha1.AWSConfig) []*awscloudformation.Tag {
-	clusterTags := key.ClusterTags(customObject)
+func (r *Resource) getCloudFormationTags(customObject v1alpha1.AWSConfig) []*awscloudformation.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
 	stackTags := []*awscloudformation.Tag{}
 
 	for k, v := range clusterTags {

--- a/service/awsconfig/v8/resource/cloudformation/resource_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/resource_test.go
@@ -8,8 +8,9 @@ import (
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/aws-operator/service/awsconfig/v8/adapter"
-	cloudformationservice "github.com/giantswarm/aws-operator/service/awsconfig/v8/cloudformation"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	cloudformationservice "github.com/giantswarm/aws-operator/service/awsconfig/v8/cloudformation"
 )
 
 func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {

--- a/service/awsconfig/v8/resource/cloudformation/resource_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/resource_test.go
@@ -7,20 +7,28 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/awsconfig/v8/adapter"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/awsconfig/v8/cloudformation"
+	"github.com/giantswarm/micrologger/microloggertest"
 )
 
 func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
 	testCases := []struct {
+		description  string
+		installation string
 		obj          v1alpha1.AWSConfig
 		expectedTags []*awscloudformation.Tag
-		description  string
 	}{
 		{
-			description: "basic match",
+			description:  "basic match",
+			installation: "test-install",
 			obj: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
 					Cluster: v1alpha1.Cluster{
 						ID: "5xchu",
+						Customer: v1alpha1.ClusterCustomer{
+							ID: "giantswarm",
+						},
 					},
 				},
 			},
@@ -33,13 +41,45 @@ func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
 					Key:   aws.String("giantswarm.io/cluster"),
 					Value: aws.String("5xchu"),
 				},
+				{
+					Key:   aws.String("giantswarm.io/organization"),
+					Value: aws.String("giantswarm"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/installation"),
+					Value: aws.String("test-install"),
+				},
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			tags := getCloudFormationTags(tc.obj)
+			c := Config{}
+
+			c.Clients = &adapter.Clients{
+				EC2: &adapter.EC2ClientMock{},
+				IAM: &adapter.IAMClientMock{},
+				KMS: &adapter.KMSClientMock{},
+			}
+			c.HostClients = &adapter.Clients{
+				EC2:            &adapter.EC2ClientMock{},
+				CloudFormation: &adapter.CloudFormationMock{},
+				IAM:            &adapter.IAMClientMock{},
+			}
+			c.InstallationName = tc.installation
+			c.Logger = microloggertest.New()
+			c.Service = &cloudformationservice.CloudFormation{}
+
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			tags := r.getCloudFormationTags(tc.obj)
+
+			if len(tags) != len(tc.expectedTags) {
+				t.Fatalf("Expected %d tags, found %d", len(tc.expectedTags), len(tags))
+			}
 
 			for _, tag := range tc.expectedTags {
 				if !containsTag(tag, tags) {

--- a/service/awsconfig/v8/resource/cloudformation/resource_test.go
+++ b/service/awsconfig/v8/resource/cloudformation/resource_test.go
@@ -54,24 +54,24 @@ func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
 		},
 	}
 
+	c := Config{}
+
+	c.Clients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+	}
+	c.HostClients = &adapter.Clients{
+		EC2:            &adapter.EC2ClientMock{},
+		CloudFormation: &adapter.CloudFormationMock{},
+		IAM:            &adapter.IAMClientMock{},
+	}
+	c.Logger = microloggertest.New()
+	c.Service = &cloudformationservice.CloudFormation{}
+
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			c := Config{}
-
-			c.Clients = &adapter.Clients{
-				EC2: &adapter.EC2ClientMock{},
-				IAM: &adapter.IAMClientMock{},
-				KMS: &adapter.KMSClientMock{},
-			}
-			c.HostClients = &adapter.Clients{
-				EC2:            &adapter.EC2ClientMock{},
-				CloudFormation: &adapter.CloudFormationMock{},
-				IAM:            &adapter.IAMClientMock{},
-			}
 			c.InstallationName = tc.installation
-			c.Logger = microloggertest.New()
-			c.Service = &cloudformationservice.CloudFormation{}
-
 			r, err := New(c)
 			if err != nil {
 				t.Fatal("expected", nil, "got", err)

--- a/service/awsconfig/v8/resource/kmskey/create.go
+++ b/service/awsconfig/v8/resource/kmskey/create.go
@@ -42,7 +42,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 		if _, err := r.awsClients.KMS.TagResource(&kms.TagResourceInput{
 			KeyId: key.KeyMetadata.KeyId,
-			Tags:  getKMSTags(customObject),
+			Tags:  r.getKMSTags(customObject),
 		}); err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/awsconfig/v8/resource/kmskey/create_test.go
+++ b/service/awsconfig/v8/resource/kmskey/create_test.go
@@ -61,6 +61,8 @@ func Test_Resource_KMSKey_newCreate(t *testing.T) {
 		KMS: &KMSClientMock{},
 	}
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	newResource, err = New(resourceConfig)
 	if err != nil {
 		t.Fatal("expected", nil, "got", err)
@@ -118,6 +120,8 @@ func Test_ApplyCreateChange(t *testing.T) {
 		},
 	}
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	newResource, err = New(resourceConfig)
 	if err != nil {
 		t.Fatal("expected", nil, "got", err)

--- a/service/awsconfig/v8/resource/kmskey/current_test.go
+++ b/service/awsconfig/v8/resource/kmskey/current_test.go
@@ -36,6 +36,8 @@ func Test_CurrentState(t *testing.T) {
 
 	resourceConfig := DefaultConfig()
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			resourceConfig.Clients = Clients{

--- a/service/awsconfig/v8/resource/kmskey/delete_test.go
+++ b/service/awsconfig/v8/resource/kmskey/delete_test.go
@@ -54,6 +54,8 @@ func Test_newDelete(t *testing.T) {
 	resourceConfig := DefaultConfig()
 	resourceConfig.Clients = Clients{}
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	newResource, err = New(resourceConfig)
 	if err != nil {
 		t.Error("expected", nil, "got", err)
@@ -111,6 +113,8 @@ func Test_ApplyDeleteChange(t *testing.T) {
 		},
 	}
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	newResource, err = New(resourceConfig)
 	if err != nil {
 		t.Fatal("expected", nil, "got", err)

--- a/service/awsconfig/v8/resource/kmskey/desired_test.go
+++ b/service/awsconfig/v8/resource/kmskey/desired_test.go
@@ -31,6 +31,8 @@ func Test_DesiredState(t *testing.T) {
 
 	resourceConfig := DefaultConfig()
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			newResource, err = New(resourceConfig)

--- a/service/awsconfig/v8/resource/s3bucket/create.go
+++ b/service/awsconfig/v8/resource/s3bucket/create.go
@@ -38,7 +38,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err := r.clients.S3.PutBucketTagging(&s3.PutBucketTaggingInput{
 			Bucket: aws.String(bucketInput.Name),
 			Tagging: &s3.Tagging{
-				TagSet: getS3BucketTags(customObject),
+				TagSet: r.getS3BucketTags(customObject),
 			},
 		})
 		if err != nil {

--- a/service/awsconfig/v8/resource/s3bucket/create_test.go
+++ b/service/awsconfig/v8/resource/s3bucket/create_test.go
@@ -84,6 +84,8 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 		resourceConfig := DefaultConfig()
 		resourceConfig.AwsService = awsService
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Error("expected", nil, "got", err)

--- a/service/awsconfig/v8/resource/s3bucket/delete_test.go
+++ b/service/awsconfig/v8/resource/s3bucket/delete_test.go
@@ -84,6 +84,8 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 		resourceConfig := DefaultConfig()
 		resourceConfig.AwsService = awsService
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Error("expected", nil, "got", err)

--- a/service/awsconfig/v8/resource/s3bucket/desired_test.go
+++ b/service/awsconfig/v8/resource/s3bucket/desired_test.go
@@ -48,6 +48,8 @@ func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
 		resourceConfig := DefaultConfig()
 		resourceConfig.AwsService = awsService
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/service/awsconfig/v8/version_bundle.go
+++ b/service/awsconfig/v8/version_bundle.go
@@ -14,6 +14,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Fix validation check for existing peering routes.",
 				Kind:        versionbundle.KindFixed,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Add AWS resource tag with the Giant Swarm Installation.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards giantswarm/giantswarm#2775

Adds the installation tag which we want to use for cost tracking. This is configured via a flag so it needed to be added to the `kmskey` and `s3bucket` resources. 

Maybe we should add the installation name to the provider CRDs as IMO it's useful metadata. I've added to the cluster object refactoring issue.

https://github.com/giantswarm/giantswarm/issues/2383#issuecomment-371749665