### PR TITLE
Change installation name in integration tests for reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ e2eTest: &e2eTest
 
     - run:
         name: set CLUSTER_NAME env var
-        command: echo 'export CLUSTER_NAME=ci-awsop-${TESTED_VERSION}-${CIRCLE_SHA1:0:5}' >> $BASH_ENV
+        command: echo 'export CLUSTER_NAME=ci-aws-operator-${TESTED_VERSION}-${CIRCLE_SHA1:0:5}' >> $BASH_ENV
 
     - run: ./e2e-harness test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ e2eTest: &e2eTest
 
     - run:
         name: set CLUSTER_NAME env var
-        command: echo 'export CLUSTER_NAME=ci-aws-operator-${TESTED_VERSION}-${CIRCLE_SHA1:0:5}' >> $BASH_ENV
+        command: echo 'export CLUSTER_NAME=ci-awsop-${TESTED_VERSION}-${CIRCLE_SHA1:0:5}' >> $BASH_ENV
 
     - run: ./e2e-harness test
 

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -36,7 +36,7 @@ const (
                 GroupsClaim: ""
       Update:
         Enabled: ${GUEST_UPDATE_ENABLED}
-    Name: ci-awsop
+    Name: ci-aws-operator
     Provider:
       AWS:
         Region: ${AWS_REGION}


### PR DESCRIPTION
Towards giantswarm/giantswarm#2775

Makes installation name clearer for cost reporting on the AWS resources we use for CI.

See https://github.com/giantswarm/giantswarm/issues/2775#issuecomment-371525532