### PR TITLE
Remove t.Parallel from subtests to prevent races

### DIFF
--- a/service/awsconfig/v2/cloudconfig/cloud_config_test.go
+++ b/service/awsconfig/v2/cloudconfig/cloud_config_test.go
@@ -133,35 +133,30 @@ func Test_Service_CloudConfig_NewWorkerTemplate(t *testing.T) {
 		}
 
 		t.Run("VerifyAPIServerCA", func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
 				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
 			}
 		})
 
 		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
 				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
 			}
 		})
 
 		t.Run("VerifyAPIServerKey", func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
 				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
 			}
 		})
 
 		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
 				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
 			}
 		})
 
 		t.Run("VerifyAWSRegion", func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(decoded, "--region 123456789-super-magic-aws-region kms decrypt") {
 				t.Fatalf("expected %#v got %#v", "cloud config to contain AWS region", "none")
 			}

--- a/service/awsconfig/v2/key/key_test.go
+++ b/service/awsconfig/v2/key/key_test.go
@@ -807,7 +807,6 @@ func TestRootDir(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			actual, err := RootDir(tc.baseDir, tc.rootElement)
 
 			if err != nil && !tc.expectedError {
@@ -1021,7 +1020,6 @@ func Test_ImageID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			imageID, err := ImageID(tc.customObject)
 			if tc.errorMatcher != nil && err == nil {
 				t.Error("expected error didn't happen")

--- a/service/awsconfig/v2/resource/cloudformation/adapter/adapter_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/adapter_test.go
@@ -113,7 +113,6 @@ func TestAdapterGuestMain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject:     tc.customObject,
 				Clients:          clients,

--- a/service/awsconfig/v2/resource/cloudformation/adapter/auto_scaling_group_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/auto_scaling_group_test.go
@@ -90,7 +90,6 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      Clients{},

--- a/service/awsconfig/v2/resource/cloudformation/adapter/host_iam_roles_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/host_iam_roles_test.go
@@ -43,7 +43,6 @@ func TestAdapterHostIAMRolesRegularFields(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject:   customObject,
 				GuestAccountID: guestAccountID,

--- a/service/awsconfig/v2/resource/cloudformation/adapter/iam_policies_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/iam_policies_test.go
@@ -41,7 +41,6 @@ func TestAdapterIamPoliciesRegularFields(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,
@@ -108,7 +107,6 @@ func TestAdapterIamPoliciesKMSKeyARN(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			clients := Clients{
 				IAM: &IAMClientMock{},
 				KMS: &KMSClientMock{
@@ -170,7 +168,6 @@ func TestAdapterIamPoliciesS3Bucket(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			clients := Clients{
 				KMS: &KMSClientMock{},
 				IAM: &IAMClientMock{

--- a/service/awsconfig/v2/resource/cloudformation/adapter/instance_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/instance_test.go
@@ -54,7 +54,6 @@ func TestAdapterInstanceRegularFields(t *testing.T) {
 		a := Adapter{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,
@@ -133,7 +132,6 @@ func TestAdapterInstanceSmallCloudConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(string(data), tc.expectedLine) {
 				t.Errorf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.expectedLine, string(data))
 			}

--- a/service/awsconfig/v2/resource/cloudformation/adapter/launch_configuration_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/launch_configuration_test.go
@@ -55,7 +55,6 @@ func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
 		a := Adapter{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,
@@ -136,7 +135,6 @@ func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			if !strings.Contains(string(data), tc.expectedLine) {
 				t.Errorf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.expectedLine, string(data))
 			}

--- a/service/awsconfig/v2/resource/cloudformation/adapter/load_balancers_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/load_balancers_test.go
@@ -107,7 +107,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 		a := Adapter{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,

--- a/service/awsconfig/v2/resource/cloudformation/adapter/outputs_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/outputs_test.go
@@ -23,7 +23,6 @@ func TestAdapterOutputsRegularFields(t *testing.T) {
 		a := Adapter{}
 		clients := Clients{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				Clients: clients,
 			}

--- a/service/awsconfig/v2/resource/cloudformation/adapter/recordsets_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/recordsets_test.go
@@ -68,7 +68,6 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,

--- a/service/awsconfig/v2/resource/cloudformation/adapter/route_tables_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/route_tables_test.go
@@ -42,7 +42,6 @@ func TestAdapterRouteTablesRegularFields(t *testing.T) {
 		a := Adapter{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      Clients{},

--- a/service/awsconfig/v2/resource/cloudformation/adapter/security_groups_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/security_groups_test.go
@@ -132,7 +132,6 @@ func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
 		a := Adapter{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      Clients{},

--- a/service/awsconfig/v2/resource/cloudformation/adapter/subnets_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/subnets_test.go
@@ -54,7 +54,6 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 		clients := Clients{}
 
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: tc.customObject,
 				Clients:      clients,

--- a/service/awsconfig/v2/resource/cloudformation/adapter/vpc_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/adapter/vpc_test.go
@@ -45,7 +45,6 @@ func TestAdapterVPCRegularFields(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject:     customObject,
 				Clients:          Clients{},
@@ -103,7 +102,6 @@ func TestAdapterVPCPeerRoleField(t *testing.T) {
 	for _, tc := range testCases {
 		a := Adapter{}
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			cfg := Config{
 				CustomObject: customObject,
 				HostClients: Clients{

--- a/service/awsconfig/v2/resource/cloudformation/delete_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/delete_test.go
@@ -98,7 +98,6 @@ func Test_Resource_Cloudformation_newDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/cloudformation/desired_test.go
+++ b/service/awsconfig/v2/resource/cloudformation/desired_test.go
@@ -48,7 +48,6 @@ func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
 			if err != nil {
 				t.Fatalf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/endpoints/create_test.go
+++ b/service/awsconfig/v2/resource/endpoints/create_test.go
@@ -94,7 +94,6 @@ func Test_Resource_Endpoints_newCreateChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/endpoints/delete_test.go
+++ b/service/awsconfig/v2/resource/endpoints/delete_test.go
@@ -94,7 +94,6 @@ func Test_Resource_Endpoints_newDeleteChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/endpoints/desired_test.go
+++ b/service/awsconfig/v2/resource/endpoints/desired_test.go
@@ -45,7 +45,6 @@ func Test_Resource_Endpoints_GetDesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			resourceConfig.Clients.EC2 = &EC2ClientMock{
 				privateIPAddress: tc.expectedIPAddress,
 			}

--- a/service/awsconfig/v2/resource/endpoints/update_test.go
+++ b/service/awsconfig/v2/resource/endpoints/update_test.go
@@ -177,7 +177,6 @@ func Test_Resource_Endpoints_newUpdateChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newUpdateChange(context.TODO(), tc.obj, tc.cur, tc.des)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/kmskey/create_test.go
+++ b/service/awsconfig/v2/resource/kmskey/create_test.go
@@ -69,7 +69,6 @@ func Test_Resource_KMSKey_newCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newCreateChange(context.TODO(), customObject, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/kmskey/current_test.go
+++ b/service/awsconfig/v2/resource/kmskey/current_test.go
@@ -39,7 +39,6 @@ func Test_CurrentState(t *testing.T) {
 	resourceConfig.Logger = microloggertest.New()
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			resourceConfig.Clients = Clients{
 				KMS: &KMSClientMock{
 					keyID:   tc.expectedKeyID,

--- a/service/awsconfig/v2/resource/kmskey/delete_test.go
+++ b/service/awsconfig/v2/resource/kmskey/delete_test.go
@@ -62,7 +62,6 @@ func Test_newDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newDeleteChange(context.TODO(), customObject, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/kmskey/desired_test.go
+++ b/service/awsconfig/v2/resource/kmskey/desired_test.go
@@ -34,7 +34,6 @@ func Test_DesiredState(t *testing.T) {
 	resourceConfig.Logger = microloggertest.New()
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			newResource, err = New(resourceConfig)
 			if err != nil {
 				t.Error("expected", nil, "got", err)

--- a/service/awsconfig/v2/resource/s3bucket/create_test.go
+++ b/service/awsconfig/v2/resource/s3bucket/create_test.go
@@ -93,7 +93,6 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/s3bucket/delete_test.go
+++ b/service/awsconfig/v2/resource/s3bucket/delete_test.go
@@ -93,7 +93,6 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/s3bucket/desired_test.go
+++ b/service/awsconfig/v2/resource/s3bucket/desired_test.go
@@ -57,7 +57,6 @@ func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
 			if err != nil {
 				t.Fatalf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/s3object/create_test.go
+++ b/service/awsconfig/v2/resource/s3object/create_test.go
@@ -165,7 +165,6 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/s3object/desired_test.go
+++ b/service/awsconfig/v2/resource/s3object/desired_test.go
@@ -58,7 +58,6 @@ func Test_DesiredState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			resourceConfig.CloudConfig = &CloudConfigMock{
 				template: tc.expectedBody,
 			}

--- a/service/awsconfig/v2/resource/s3object/update_test.go
+++ b/service/awsconfig/v2/resource/s3object/update_test.go
@@ -156,7 +156,6 @@ func Test_Resource_S3Object_newUpdate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newUpdateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/service/create_test.go
+++ b/service/awsconfig/v2/resource/service/create_test.go
@@ -95,7 +95,6 @@ func Test_Resource_Service_newCreateChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)

--- a/service/awsconfig/v2/resource/service/delete_test.go
+++ b/service/awsconfig/v2/resource/service/delete_test.go
@@ -115,7 +115,6 @@ func Test_Resource_Service_newDeleteChange(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
 			if err != nil {
 				t.Errorf("expected '%v' got '%#v'", nil, err)


### PR DESCRIPTION
This will prevent errors like:
```
Goroutine 30 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:824 +0x564
  github.com/giantswarm/aws-operator/service/awsconfig/v2/resource/kmskey.Test_CurrentState()
      /go/src/github.com/giantswarm/aws-operator/service/awsconfig/v2/resource/kmskey/current_test.go:41 +0x312
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
--- FAIL: Test_DesiredState (0.00s)
--- FAIL: Test_CurrentState (0.00s)
    --- FAIL: Test_CurrentState/KMS_error (0.00s)
    --- FAIL: Test_CurrentState/basic_match (0.00s)
    	testing.go:730: race detected during execution of test
FAIL
```