### PR TITLE
WIP: Detach volumes before deleting them in ebsvolume resource

### DIFF
--- a/service/awsconfig/v9/resource/ebsvolume/delete.go
+++ b/service/awsconfig/v9/resource/ebsvolume/delete.go
@@ -3,9 +3,11 @@ package ebsvolume
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/framework"
 )
@@ -20,31 +22,9 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("deleting %d ebs volumes", len(deleteInput.Volumes)))
 
 		for _, vol := range deleteInput.Volumes {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting ebs volume %s", vol.VolumeID))
-
 			for _, a := range vol.Attachments {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detaching volume %s from instance %s", vol.VolumeID, a.InstanceID))
-
-				_, err := r.clients.EC2.DetachVolume(&ec2.DetachVolumeInput{
-					Device:     aws.String(a.Device),
-					InstanceId: aws.String(a.InstanceID),
-					VolumeId:   aws.String(vol.VolumeID),
-				})
-				if err != nil {
-					return microerror.Mask(err)
-				}
-
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detached volume %s from instance %s", vol.VolumeID, a.InstanceID))
+				r.detachVolume(ctx, vol.VolumeID, a)
 			}
-
-			_, err := r.clients.EC2.DeleteVolume(&ec2.DeleteVolumeInput{
-				VolumeId: aws.String(vol.VolumeID),
-			})
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted ebs volume %s", vol.VolumeID))
 		}
 
 		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("deleted %d ebs volumes", len(deleteInput.Volumes)))
@@ -83,4 +63,53 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 	}
 
 	return volStateToDelete, nil
+}
+
+func (r *Resource) detachVolume(ctx context.Context, volumeID string, attachment VolumeAttachment) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detaching volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	_, err := r.clients.EC2.DetachVolume(&ec2.DetachVolumeInput{
+		Device:     aws.String(attachment.Device),
+		InstanceId: aws.String(attachment.InstanceID),
+		VolumeId:   aws.String(volumeID),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detached volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	return nil
+}
+
+func (r *Resource) deleteVolume(ctx context.Context, volumeID string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting ebs volume %s", volumeID))
+
+	deleteOperation := func() error {
+		_, err := r.clients.EC2.DeleteVolume(&ec2.DeleteVolumeInput{
+			VolumeId: aws.String(volumeID),
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		return nil
+	}
+	deleteNotify := func(err error, delay time.Duration) {
+		r.logger.LogCtx(ctx, "level", "error", fmt.Sprintf("deleting ebs volume failed, retrying with delay %.0fm%.0fs: '%#v'", delay.Minutes(), delay.Seconds(), err))
+	}
+	deleteBackoff := &backoff.ExponentialBackOff{
+		InitialInterval:     backoff.DefaultInitialInterval,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         backoff.DefaultMaxInterval,
+		MaxElapsedTime:      3 * time.Minute,
+		Clock:               backoff.SystemClock,
+	}
+	if err := backoff.RetryNotify(deleteOperation, deleteBackoff, deleteNotify); err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted ebs volume %s", volumeID))
+
+	return nil
 }

--- a/service/awsconfig/v9/resource/ebsvolume/delete_test.go
+++ b/service/awsconfig/v9/resource/ebsvolume/delete_test.go
@@ -30,16 +30,73 @@ func Test_newDeleteChange(t *testing.T) {
 			description: "basic match",
 			obj:         customObject,
 			currentState: &EBSVolumeState{
-				VolumeIDs: []string{
-					"vol-1234",
-					"vol-5678",
+				Volumes: []Volume{
+					{
+						VolumeID: "vol-1234",
+					},
+					{
+						VolumeID: "vol-5678",
+					},
 				},
 			},
 			desiredState: nil,
 			expectedState: &EBSVolumeState{
-				VolumeIDs: []string{
-					"vol-1234",
-					"vol-5678",
+				Volumes: []Volume{
+					{
+						VolumeID: "vol-1234",
+					},
+					{
+						VolumeID: "vol-5678",
+					},
+				},
+			},
+		},
+		{
+			description: "basic match with attachments",
+			obj:         customObject,
+			currentState: &EBSVolumeState{
+				Volumes: []Volume{
+					{
+						Attachments: []VolumeAttachment{
+							{
+								InstanceID: "i-12345",
+								Device:     "/dev/sdh",
+							},
+						},
+						VolumeID: "vol-1234",
+					},
+					{
+						Attachments: []VolumeAttachment{
+							{
+								InstanceID: "i-56789",
+								Device:     "/dev/sdh",
+							},
+						},
+						VolumeID: "vol-5678",
+					},
+				},
+			},
+			desiredState: nil,
+			expectedState: &EBSVolumeState{
+				Volumes: []Volume{
+					{
+						Attachments: []VolumeAttachment{
+							{
+								InstanceID: "i-12345",
+								Device:     "/dev/sdh",
+							},
+						},
+						VolumeID: "vol-1234",
+					},
+					{
+						Attachments: []VolumeAttachment{
+							{
+								InstanceID: "i-56789",
+								Device:     "/dev/sdh",
+							},
+						},
+						VolumeID: "vol-5678",
+					},
 				},
 			},
 		},
@@ -54,7 +111,7 @@ func Test_newDeleteChange(t *testing.T) {
 			description: "return nil when current volumes are empty",
 			obj:         customObject,
 			currentState: &EBSVolumeState{
-				VolumeIDs: []string{},
+				Volumes: []Volume{},
 			},
 			desiredState:  nil,
 			expectedState: nil,
@@ -63,13 +120,17 @@ func Test_newDeleteChange(t *testing.T) {
 			description: "return nil when desired state is not nil",
 			obj:         customObject,
 			currentState: &EBSVolumeState{
-				VolumeIDs: []string{
-					"vol-1234",
+				Volumes: []Volume{
+					{
+						VolumeID: "vol-1234",
+					},
 				},
 			},
 			desiredState: &EBSVolumeState{
-				VolumeIDs: []string{
-					"vol-1234",
+				Volumes: []Volume{
+					{
+						VolumeID: "vol-1234",
+					},
 				},
 			},
 			expectedState: nil,

--- a/service/awsconfig/v9/resource/ebsvolume/mock_test.go
+++ b/service/awsconfig/v9/resource/ebsvolume/mock_test.go
@@ -14,8 +14,9 @@ type EC2ClientMock struct {
 }
 
 type EBSVolumeMock struct {
-	volumeID string
-	tags     []*ec2.Tag
+	volumeID    string
+	attachments []*ec2.VolumeAttachment
+	tags        []*ec2.Tag
 }
 
 func (e *EC2ClientMock) DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
@@ -30,8 +31,9 @@ func (e *EC2ClientMock) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.D
 
 	for _, mock := range e.ebsVolumes {
 		vol := &ec2.Volume{
-			VolumeId: aws.String(mock.volumeID),
-			Tags:     mock.tags,
+			VolumeId:    aws.String(mock.volumeID),
+			Attachments: mock.attachments,
+			Tags:        mock.tags,
 		}
 
 		for _, tag := range mock.tags {
@@ -44,4 +46,8 @@ func (e *EC2ClientMock) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.D
 	output.SetVolumes(volumes)
 
 	return output, nil
+}
+
+func (e *EC2ClientMock) DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	return nil, nil
 }

--- a/service/awsconfig/v9/resource/ebsvolume/spec.go
+++ b/service/awsconfig/v9/resource/ebsvolume/spec.go
@@ -12,8 +12,19 @@ type Clients struct {
 type EC2Client interface {
 	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
+	DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
 }
 
 type EBSVolumeState struct {
-	VolumeIDs []string
+	Volumes []Volume
+}
+
+type Volume struct {
+	VolumeID    string
+	Attachments []VolumeAttachment
+}
+
+type VolumeAttachment struct {
+	Device     string
+	InstanceID string
 }

--- a/service/awsconfig/v9/version_bundle.go
+++ b/service/awsconfig/v9/version_bundle.go
@@ -10,9 +10,9 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "component",
-				Description: "Add your description here",
-				Kind:        versionbundle.KindChanged,
+				Component:   "aws-operator",
+				Description: "Detach EBS volumes before deletion when deleting clusters.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{


### PR DESCRIPTION
Fixes giantswarm/giantswarm#2846

Fixes bug so EBS volumes for k8s Persistent Volumes are now detached before deleting. Otherwise the ebsvolume resource errors and this means the cluster is not deleted correctly.