### PR TITLE
Opens cadvisor port from host to guest

### DIFF
--- a/service/awsconfig/v10/adapter/security_groups.go
+++ b/service/awsconfig/v10/adapter/security_groups.go
@@ -30,6 +30,7 @@ type securityGroupRule struct {
 
 const (
 	allPorts             = -1
+	cadvisorPort         = 4194
 	kubeletPort          = 10250
 	nodeExporterPort     = 10300
 	kubeStateMetricsPort = 10301
@@ -68,6 +69,12 @@ func (s *securityGroupsAdapter) getMasterRules(customObject v1alpha1.AWSConfig, 
 			Port:       key.KubernetesAPISecurePort(customObject),
 			Protocol:   tcpProtocol,
 			SourceCIDR: defaultCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
 		},
 		// Allow traffic from host cluster CIDR to 10250 for kubelet scraping.
 		{
@@ -113,6 +120,12 @@ func (s *securityGroupsAdapter) getWorkerRules(customObject v1alpha1.AWSConfig, 
 		// for guest cluster scraping.
 		{
 			Port:       key.IngressControllerSecurePort(customObject),
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
 			Protocol:   tcpProtocol,
 			SourceCIDR: hostClusterCIDR,
 		},

--- a/service/awsconfig/v10/adapter/security_groups_test.go
+++ b/service/awsconfig/v10/adapter/security_groups_test.go
@@ -49,6 +49,11 @@ func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
 					SourceCIDR: "0.0.0.0/0",
 				},
 				{
+					Port:       4194,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
 					Port:       10250,
 					Protocol:   "tcp",
 					SourceCIDR: "10.0.0.0/16",
@@ -83,6 +88,11 @@ func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
 				},
 				{
 					Port:       30010,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       4194,
 					Protocol:   "tcp",
 					SourceCIDR: "10.0.0.0/16",
 				},


### PR DESCRIPTION
We currently go via the apiserver proxy to scrape cadvisor.
This will allow us to scrape cadvisor directly in future,
which is slightly more efficient.