### PR TITLE
Add support for m5.large master

### DIFF
--- a/service/controller/v10/templates/cloudconfig/format_etcd_volume.go
+++ b/service/controller/v10/templates/cloudconfig/format_etcd_volume.go
@@ -13,6 +13,9 @@ RemainAfterExit=yes
 # persistent across reboots and updates.
 Environment=DEV=/dev/nvme2n1
 
+# line 1: For compatibility with m3.large that has xvdX disks.
+# line 2: Create filesystem if does not exist.
+# line 3: For compatibility with older clusters. Label existing filesystem with etcd label.
 ExecStart=/bin/bash -c "\
 [ -b /dev/xvdh ] && export DEV=/dev/xvdh ;\
 if ! blkid $DEV; then mkfs.ext4 -L etcd $DEV; fi ;\

--- a/service/controller/v10/templates/cloudconfig/master_format_var_lib_docker_service.go
+++ b/service/controller/v10/templates/cloudconfig/master_format_var_lib_docker_service.go
@@ -8,7 +8,7 @@ ConditionPathExists=!/var/lib/docker
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "([ -b "/dev/xvdb" ] && /usr/sbin/mkfs.xfs -f /dev/xvdb -L docker) || ([ -b "/dev/nvme1n1" ] && /usr/sbin/mkfs.xfs -f /dev/nvme1n1 -L docker)"
+ExecStart=/bin/bash -c "([ -b "/dev/xvdc" ] && /usr/sbin/mkfs.xfs -f /dev/xvdc -L docker) || ([ -b "/dev/nvme1n1" ] && /usr/sbin/mkfs.xfs -f /dev/nvme1n1 -L docker)"
 
 [Install]
 WantedBy=multi-user.target

--- a/service/controller/v10/templates/cloudconfig/mount_etcd_volume.go
+++ b/service/controller/v10/templates/cloudconfig/mount_etcd_volume.go
@@ -8,7 +8,7 @@ After=format-etcd-ebs.service
 Before=etcd3.service
 
 [Mount]
-What=/dev/xvdh
+What=/dev/disk/by-label/etcd
 Where=/var/lib/etcd
 Type=ext4
 

--- a/service/controller/v10/templates/cloudformation/guest/instance.go
+++ b/service/controller/v10/templates/cloudformation/guest/instance.go
@@ -16,6 +16,15 @@ const Instance = `{{define "instance"}}
       Tags:
       - Key: Name
         Value: {{ .Instance.Cluster.ID }}-master
+  DockerVolume:
+    Type: AWS::EC2::Volume
+    DependsOn:
+    - {{ .Instance.Master.Instance.ResourceName }}
+    Properties:
+      Encrypted: true
+      Size: 50
+      VolumeType: gp2
+      AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
   EtcdVolume:
     Type: AWS::EC2::Volume
     DependsOn:
@@ -28,10 +37,16 @@ const Instance = `{{define "instance"}}
       Tags:
       - Key: Name
         Value: {{ .Instance.Master.EtcdVolume.Name }}
-  {{ .Instance.Master.Instance.ResourceName }}MountPoint:
+  {{ .Instance.Master.Instance.ResourceName }}DockerMountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref {{ .Instance.Master.Instance.ResourceName }}
+      VolumeId: !Ref DockerVolume
+      Device: /dev/xvdc
+  {{ .Instance.Master.Instance.ResourceName }}EtcdMountPoint:
     Type: AWS::EC2::VolumeAttachment
     Properties:
       InstanceId: !Ref {{ .Instance.Master.Instance.ResourceName }}
       VolumeId: !Ref EtcdVolume
-      Device: /dev/sdh
+      Device: /dev/xvdh
 {{end}}`

--- a/service/controller/v10/version_bundle.go
+++ b/service/controller/v10/version_bundle.go
@@ -64,11 +64,56 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Updated to 1688.5.3.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "cloudconfig",
+				Description: "Updated kube-state-metrics to version 1.3.1.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Changed kubelet bind mount mode from shared to rshared.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Disabled etcd3-defragmentation service in favor systemd timer.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Added /lib/modules mount for kubelet.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Updated CoreDNS to 1.1.1.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Updated Calico to 3.0.5.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Updated Etcd to 3.3.3.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Removed docker flag --disable-legacy-registry.",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Removed calico-ipip-pinger.",
+				Kind:        versionbundle.KindRemoved,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "calico",
-				Version: "3.0.2",
+				Version: "3.0.5",
 			},
 			{
 				Name:    "containerlinux",
@@ -80,11 +125,11 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "etcd",
-				Version: "3.3.1",
+				Version: "3.3.3",
 			},
 			{
 				Name:    "coredns",
-				Version: "1.0.6",
+				Version: "1.1.1",
 			},
 			{
 				Name:    "kubernetes",

--- a/service/controller/v10/version_bundle.go
+++ b/service/controller/v10/version_bundle.go
@@ -82,7 +82,7 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Component:   "cloudconfig",
 				Description: "Added /lib/modules mount for kubelet.",
-				Kind:        versionbundle.KindChanged,
+				Kind:        versionbundle.KindAdded,
 			},
 			{
 				Component:   "cloudconfig",


### PR DESCRIPTION
This change adds support for `m5.large` instance type. Specifics that new `m5` instances use nvme disks and don't have ephemenral disk (second disk).

Change is compatible with `m5.large`, `m3.large` and with old clusters that will be upgraded.

# QA
- [x] master vm should come up successfully with `m5.large` type
- [x] master vm should come up successfully with `m3.large` type
- [x] master vm should be upgraded successfully from prev.release with `m3.large` type