### PR TITLE
handles missing lifecycle actions more gracefully

### DIFF
--- a/service/controller/v10/resource/lifecycle/create.go
+++ b/service/controller/v10/resource/lifecycle/create.go
@@ -207,11 +207,13 @@ func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, worker
 	}
 
 	_, err := r.aws.AutoScaling.CompleteLifecycleAction(i)
-	if err != nil {
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no lifecycle hook action for guest cluster instance '%s'", instanceID))
+	} else if err != nil {
 		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 
 	return nil
 }

--- a/service/controller/v10/resource/lifecycle/error.go
+++ b/service/controller/v10/resource/lifecycle/error.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var executionFailedError = microerror.New("execution failed")
 
@@ -20,4 +24,27 @@ var missingAnnotationError = microerror.New("missing annotation")
 
 func IsMissingAnnotationError(err error) bool {
 	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = microerror.New("no active lifecycle action")
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
 }

--- a/service/controller/v11/resource/lifecycle/create.go
+++ b/service/controller/v11/resource/lifecycle/create.go
@@ -207,11 +207,13 @@ func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, worker
 	}
 
 	_, err := r.aws.AutoScaling.CompleteLifecycleAction(i)
-	if err != nil {
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no lifecycle hook action for guest cluster instance '%s'", instanceID))
+	} else if err != nil {
 		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 
 	return nil
 }

--- a/service/controller/v11/resource/lifecycle/error.go
+++ b/service/controller/v11/resource/lifecycle/error.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var executionFailedError = microerror.New("execution failed")
 
@@ -20,4 +24,27 @@ var missingAnnotationError = microerror.New("missing annotation")
 
 func IsMissingAnnotationError(err error) bool {
 	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = microerror.New("no active lifecycle action")
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
 }

--- a/service/controller/v9/resource/lifecycle/current.go
+++ b/service/controller/v9/resource/lifecycle/current.go
@@ -201,11 +201,13 @@ func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, worker
 	}
 
 	_, err := r.aws.AutoScaling.CompleteLifecycleAction(i)
-	if err != nil {
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no lifecycle hook action for guest cluster instance '%s'", instanceID))
+	} else if err != nil {
 		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 
 	return nil
 }

--- a/service/controller/v9/resource/lifecycle/error.go
+++ b/service/controller/v9/resource/lifecycle/error.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var executionFailedError = microerror.New("execution failed")
 
@@ -18,6 +22,30 @@ func IsInvalidConfig(err error) bool {
 
 var missingAnnotationError = microerror.New("missing annotation")
 
+// IsMissingAnnotationError asserts missingAnnotationError.
 func IsMissingAnnotationError(err error) bool {
 	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = microerror.New("no active lifecycle action")
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
 }

--- a/service/controller/v9patch1/resource/lifecycle/current.go
+++ b/service/controller/v9patch1/resource/lifecycle/current.go
@@ -201,11 +201,13 @@ func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, worker
 	}
 
 	_, err := r.aws.AutoScaling.CompleteLifecycleAction(i)
-	if err != nil {
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no lifecycle hook action for guest cluster instance '%s'", instanceID))
+	} else if err != nil {
 		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
 
 	return nil
 }

--- a/service/controller/v9patch1/resource/lifecycle/error.go
+++ b/service/controller/v9patch1/resource/lifecycle/error.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
 
 var executionFailedError = microerror.New("execution failed")
 
@@ -20,4 +24,27 @@ var missingAnnotationError = microerror.New("missing annotation")
 
 func IsMissingAnnotationError(err error) bool {
 	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = microerror.New("no active lifecycle action")
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This is to make draining more reliable when guest cluster nodes are missing and we still try to drain them. See also https://github.com/giantswarm/node-operator/pull/42. 