### PR TITLE
helm: increase probing timeouts and intervals

### DIFF
--- a/helm/aws-operator-chart/templates/08-deployment.yaml
+++ b/helm/aws-operator-chart/templates/08-deployment.yaml
@@ -66,14 +66,14 @@ spec:
           httpGet:
             path: /healthz
             port: 8000
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8000
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
/helthz enpoint timeout is 5s but our probles are timouting after 1s.
This is causing pages.