### PR TITLE
fixes Docker volume management and updating clusters that only have one worker

### DIFF
--- a/service/controller/v10/adapter/auto_scaling_group.go
+++ b/service/controller/v10/adapter/auto_scaling_group.go
@@ -41,7 +41,7 @@ func workerCountRatio(workers int, ratio float32) string {
 	value := float32(workers) * ratio
 	rounded := int(value + 0.5)
 
-	if workers > 0 && rounded == 0 {
+	if rounded == 0 {
 		rounded = 1
 	}
 

--- a/service/controller/v10/adapter/auto_scaling_group_test.go
+++ b/service/controller/v10/adapter/auto_scaling_group_test.go
@@ -156,9 +156,9 @@ func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
 			expectedRatio: "1",
 		},
 		{
-			description:   "scaling down to zero worker, none should be up",
+			description:   "scaling down to zero worker, ratio should be one, because it should never be zero",
 			workers:       0,
-			expectedRatio: "0",
+			expectedRatio: "1",
 		},
 	}
 	for _, tc := range tcs {

--- a/service/controller/v10/adapter/instance.go
+++ b/service/controller/v10/adapter/instance.go
@@ -30,10 +30,15 @@ type instanceAdapterImage struct {
 }
 
 type instanceAdapterMaster struct {
-	AZ          string
-	CloudConfig string
-	EtcdVolume  instanceAdapterMasterEtcdVolume
-	Instance    instanceAdapterMasterInstance
+	AZ           string
+	CloudConfig  string
+	DockerVolume instanceAdapterMasterDockerVolume
+	EtcdVolume   instanceAdapterMasterEtcdVolume
+	Instance     instanceAdapterMasterInstance
+}
+
+type instanceAdapterMasterDockerVolume struct {
+	Name string
 }
 
 type instanceAdapterMasterEtcdVolume struct {
@@ -72,6 +77,8 @@ func (i *instanceAdapter) Adapt(config Config) error {
 			return microerror.Mask(err)
 		}
 		i.Master.CloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
 
 		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
 

--- a/service/controller/v10/ebs/filter.go
+++ b/service/controller/v10/ebs/filter.go
@@ -4,7 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
-	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v10/key"
 )
 
 const (

--- a/service/controller/v10/ebs/spec.go
+++ b/service/controller/v10/ebs/spec.go
@@ -18,7 +18,7 @@ type Interface interface {
 	// the Etcd volume for the master instance will be returned. If
 	// persistentVolume is true then any Persistent Volumes associated with the
 	// cluster will be returned.
-	ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]Volume, error)
+	ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error)
 }
 
 // EC2Client describes the methods required to be implemented by an EC2 AWS client.

--- a/service/controller/v10/key/key.go
+++ b/service/controller/v10/key/key.go
@@ -171,6 +171,10 @@ func CustomerID(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
 }
 
+func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-docker", ClusterID(customObject))
+}
+
 func EtcdVolumeName(customObject v1alpha1.AWSConfig) string {
 	return fmt.Sprintf("%s-etcd", ClusterID(customObject))
 }

--- a/service/controller/v10/resource/cloudformation/mock_test.go
+++ b/service/controller/v10/resource/cloudformation/mock_test.go
@@ -3,6 +3,7 @@ package cloudformation
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/v10/ebs"
@@ -21,6 +22,6 @@ func (e *EBSServiceMock) DetachVolume(ctx context.Context, volumeID string, atta
 
 // ListVolumes always returns a list containing one volume because this is what
 // the update process of the cloudformation resource needs.
-func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]ebs.Volume, error) {
+func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]ebs.Volume, error) {
 	return []ebs.Volume{{}}, nil
 }

--- a/service/controller/v10/resource/cloudformation/update.go
+++ b/service/controller/v10/resource/cloudformation/update.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
 
+	"github.com/giantswarm/aws-operator/service/controller/v10/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/v10/key"
 )
 
@@ -28,26 +30,26 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		if stackStateToUpdate.ShouldUpdate && !stackStateToUpdate.ShouldScale {
 			// Fetch the etcd volume information.
-			etcdVolume := true
-			persistentVolume := false
-			volumes, err := r.ebs.ListVolumes(customObject, etcdVolume, persistentVolume)
+			filterFuncs := []func(t *ec2.Tag) bool{
+				ebs.NewDockerVolumeFilter(customObject),
+				ebs.NewEtcdVolumeFilter(customObject),
+			}
+			volumes, err := r.ebs.ListVolumes(customObject, filterFuncs...)
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			if len(volumes) != 1 {
-				return microerror.Maskf(executionFailedError, "there must be 1 volume for etcd, got %d", len(volumes))
-			}
-			vol := volumes[0]
 
 			// First shutdown the instances and wait for it to be stopped. Then detach
-			// the etcd volume without forcing.
+			// the etcd and docker volume without forcing.
 			force := false
 			shutdown := true
 			wait := true
-			for _, a := range vol.Attachments {
-				err := r.ebs.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
-				if err != nil {
-					return microerror.Mask(err)
+			for _, v := range volumes {
+				for _, a := range v.Attachments {
+					err := r.ebs.DetachVolume(ctx, v.VolumeID, a, force, shutdown, wait)
+					if err != nil {
+						return microerror.Mask(err)
+					}
 				}
 			}
 		}

--- a/service/controller/v10/templates/cloudformation/guest/instance.go
+++ b/service/controller/v10/templates/cloudformation/guest/instance.go
@@ -25,6 +25,9 @@ const Instance = `{{define "instance"}}
       Size: 50
       VolumeType: gp2
       AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Master.DockerVolume.Name }}
   EtcdVolume:
     Type: AWS::EC2::Volume
     DependsOn:

--- a/service/controller/v11/adapter/auto_scaling_group.go
+++ b/service/controller/v11/adapter/auto_scaling_group.go
@@ -41,7 +41,7 @@ func workerCountRatio(workers int, ratio float32) string {
 	value := float32(workers) * ratio
 	rounded := int(value + 0.5)
 
-	if workers > 0 && rounded == 0 {
+	if rounded == 0 {
 		rounded = 1
 	}
 

--- a/service/controller/v11/adapter/auto_scaling_group_test.go
+++ b/service/controller/v11/adapter/auto_scaling_group_test.go
@@ -156,9 +156,9 @@ func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
 			expectedRatio: "1",
 		},
 		{
-			description:   "scaling down to zero worker, none should be up",
+			description:   "scaling down to zero worker, ratio should be one, because it should never be zero",
 			workers:       0,
-			expectedRatio: "0",
+			expectedRatio: "1",
 		},
 	}
 	for _, tc := range tcs {

--- a/service/controller/v11/adapter/instance.go
+++ b/service/controller/v11/adapter/instance.go
@@ -30,10 +30,15 @@ type instanceAdapterImage struct {
 }
 
 type instanceAdapterMaster struct {
-	AZ          string
-	CloudConfig string
-	EtcdVolume  instanceAdapterMasterEtcdVolume
-	Instance    instanceAdapterMasterInstance
+	AZ           string
+	CloudConfig  string
+	DockerVolume instanceAdapterMasterDockerVolume
+	EtcdVolume   instanceAdapterMasterEtcdVolume
+	Instance     instanceAdapterMasterInstance
+}
+
+type instanceAdapterMasterDockerVolume struct {
+	Name string
 }
 
 type instanceAdapterMasterEtcdVolume struct {
@@ -72,6 +77,8 @@ func (i *instanceAdapter) Adapt(config Config) error {
 			return microerror.Mask(err)
 		}
 		i.Master.CloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
 
 		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
 

--- a/service/controller/v11/ebs/filter.go
+++ b/service/controller/v11/ebs/filter.go
@@ -1,0 +1,52 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	cloudProviderPersistentVolumeTagKey = "kubernetes.io/created-for/pv/name"
+	nameTagKey                          = "Name"
+)
+
+func IsFiltered(vol *ec2.Volume, filterFuncs []func(t *ec2.Tag) bool) bool {
+	for _, f := range filterFuncs {
+		for _, t := range vol.Tags {
+			if f(t) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func NewDockerVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.DockerVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewEtcdVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.EtcdVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewPersistentVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == cloudProviderPersistentVolumeTagKey {
+			return true
+		}
+		return false
+	}
+}

--- a/service/controller/v11/ebs/spec.go
+++ b/service/controller/v11/ebs/spec.go
@@ -18,7 +18,7 @@ type Interface interface {
 	// the Etcd volume for the master instance will be returned. If
 	// persistentVolume is true then any Persistent Volumes associated with the
 	// cluster will be returned.
-	ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]Volume, error)
+	ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error)
 }
 
 // EC2Client describes the methods required to be implemented by an EC2 AWS client.

--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -171,6 +171,10 @@ func CustomerID(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
 }
 
+func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-docker", ClusterID(customObject))
+}
+
 func EtcdVolumeName(customObject v1alpha1.AWSConfig) string {
 	return fmt.Sprintf("%s-etcd", ClusterID(customObject))
 }

--- a/service/controller/v11/resource/cloudformation/mock_test.go
+++ b/service/controller/v11/resource/cloudformation/mock_test.go
@@ -3,6 +3,7 @@ package cloudformation
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
@@ -21,6 +22,6 @@ func (e *EBSServiceMock) DetachVolume(ctx context.Context, volumeID string, atta
 
 // ListVolumes always returns a list containing one volume because this is what
 // the update process of the cloudformation resource needs.
-func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]ebs.Volume, error) {
+func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]ebs.Volume, error) {
 	return []ebs.Volume{{}}, nil
 }

--- a/service/controller/v11/resource/cloudformation/update.go
+++ b/service/controller/v11/resource/cloudformation/update.go
@@ -38,9 +38,6 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			if len(volumes) != 2 {
-				return microerror.Maskf(executionFailedError, "there must be 2 volumes for etcd and docker, got %d", len(volumes))
-			}
 
 			// First shutdown the instances and wait for it to be stopped. Then detach
 			// the etcd and docker volume without forcing.

--- a/service/controller/v11/resource/cloudformation/update.go
+++ b/service/controller/v11/resource/cloudformation/update.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
 
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/v11/key"
 )
 
@@ -28,26 +30,29 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		if stackStateToUpdate.ShouldUpdate && !stackStateToUpdate.ShouldScale {
 			// Fetch the etcd volume information.
-			etcdVolume := true
-			persistentVolume := false
-			volumes, err := r.ebs.ListVolumes(customObject, etcdVolume, persistentVolume)
+			filterFuncs := []func(t *ec2.Tag) bool{
+				ebs.NewDockerVolumeFilter(customObject),
+				ebs.NewEtcdVolumeFilter(customObject),
+			}
+			volumes, err := r.ebs.ListVolumes(customObject, filterFuncs...)
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			if len(volumes) != 1 {
-				return microerror.Maskf(executionFailedError, "there must be 1 volume for etcd, got %d", len(volumes))
+			if len(volumes) != 2 {
+				return microerror.Maskf(executionFailedError, "there must be 2 volumes for etcd and docker, got %d", len(volumes))
 			}
-			vol := volumes[0]
 
 			// First shutdown the instances and wait for it to be stopped. Then detach
-			// the etcd volume without forcing.
+			// the etcd and docker volume without forcing.
 			force := false
 			shutdown := true
 			wait := true
-			for _, a := range vol.Attachments {
-				err := r.ebs.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
-				if err != nil {
-					return microerror.Mask(err)
+			for _, v := range volumes {
+				for _, a := range v.Attachments {
+					err := r.ebs.DetachVolume(ctx, v.VolumeID, a, force, shutdown, wait)
+					if err != nil {
+						return microerror.Mask(err)
+					}
 				}
 			}
 		}

--- a/service/controller/v11/resource/ebsvolume/delete.go
+++ b/service/controller/v11/resource/ebsvolume/delete.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/v11/key"
 )
 
@@ -17,10 +19,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	// Get both the Etcd volume and any Persistent Volumes.
-	etcdVolume := true
-	persistentVolume := true
-	volumes, err := r.service.ListVolumes(customObject, etcdVolume, persistentVolume)
+	// Get all etcd, docker and persistent volumes.
+	filterFuncs := []func(t *ec2.Tag) bool{
+		ebs.NewDockerVolumeFilter(customObject),
+		ebs.NewEtcdVolumeFilter(customObject),
+		ebs.NewPersistentVolumeFilter(customObject),
+	}
+	volumes, err := r.service.ListVolumes(customObject, filterFuncs...)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/v11/templates/cloudformation/guest/instance.go
+++ b/service/controller/v11/templates/cloudformation/guest/instance.go
@@ -25,6 +25,9 @@ const Instance = `{{define "instance"}}
       Size: 50
       VolumeType: gp2
       AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Master.DockerVolume.Name }}
   EtcdVolume:
     Type: AWS::EC2::Volume
     DependsOn:

--- a/service/controller/v9patch1/adapter/auto_scaling_group.go
+++ b/service/controller/v9patch1/adapter/auto_scaling_group.go
@@ -41,7 +41,7 @@ func workerCountRatio(workers int, ratio float32) string {
 	value := float32(workers) * ratio
 	rounded := int(value + 0.5)
 
-	if workers > 0 && rounded == 0 {
+	if rounded == 0 {
 		rounded = 1
 	}
 

--- a/service/controller/v9patch1/adapter/auto_scaling_group_test.go
+++ b/service/controller/v9patch1/adapter/auto_scaling_group_test.go
@@ -156,9 +156,9 @@ func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
 			expectedRatio: "1",
 		},
 		{
-			description:   "scaling down to zero worker, none should be up",
+			description:   "scaling down to zero worker, ratio should be one, because it should never be zero",
 			workers:       0,
-			expectedRatio: "0",
+			expectedRatio: "1",
 		},
 	}
 	for _, tc := range tcs {

--- a/service/controller/v9patch1/adapter/instance.go
+++ b/service/controller/v9patch1/adapter/instance.go
@@ -30,10 +30,15 @@ type instanceAdapterImage struct {
 }
 
 type instanceAdapterMaster struct {
-	AZ          string
-	CloudConfig string
-	EtcdVolume  instanceAdapterMasterEtcdVolume
-	Instance    instanceAdapterMasterInstance
+	AZ           string
+	CloudConfig  string
+	DockerVolume instanceAdapterMasterDockerVolume
+	EtcdVolume   instanceAdapterMasterEtcdVolume
+	Instance     instanceAdapterMasterInstance
+}
+
+type instanceAdapterMasterDockerVolume struct {
+	Name string
 }
 
 type instanceAdapterMasterEtcdVolume struct {
@@ -72,6 +77,8 @@ func (i *instanceAdapter) Adapt(config Config) error {
 			return microerror.Mask(err)
 		}
 		i.Master.CloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
 
 		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
 

--- a/service/controller/v9patch1/ebs/filter.go
+++ b/service/controller/v9patch1/ebs/filter.go
@@ -4,7 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
-	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v9patch1/key"
 )
 
 const (

--- a/service/controller/v9patch1/ebs/spec.go
+++ b/service/controller/v9patch1/ebs/spec.go
@@ -18,7 +18,7 @@ type Interface interface {
 	// the Etcd volume for the master instance will be returned. If
 	// persistentVolume is true then any Persistent Volumes associated with the
 	// cluster will be returned.
-	ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]Volume, error)
+	ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error)
 }
 
 // EC2Client describes the methods required to be implemented by an EC2 AWS client.

--- a/service/controller/v9patch1/key/key.go
+++ b/service/controller/v9patch1/key/key.go
@@ -171,6 +171,10 @@ func CustomerID(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
 }
 
+func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-docker", ClusterID(customObject))
+}
+
 func EtcdVolumeName(customObject v1alpha1.AWSConfig) string {
 	return fmt.Sprintf("%s-etcd", ClusterID(customObject))
 }

--- a/service/controller/v9patch1/resource/cloudformation/mock_test.go
+++ b/service/controller/v9patch1/resource/cloudformation/mock_test.go
@@ -3,6 +3,7 @@ package cloudformation
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/v9patch1/ebs"
@@ -21,6 +22,6 @@ func (e *EBSServiceMock) DetachVolume(ctx context.Context, volumeID string, atta
 
 // ListVolumes always returns a list containing one volume because this is what
 // the update process of the cloudformation resource needs.
-func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, etcdVolume bool, persistentVolume bool) ([]ebs.Volume, error) {
+func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]ebs.Volume, error) {
 	return []ebs.Volume{{}}, nil
 }

--- a/service/controller/v9patch1/resource/cloudformation/update.go
+++ b/service/controller/v9patch1/resource/cloudformation/update.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
 
+	"github.com/giantswarm/aws-operator/service/controller/v9patch1/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/v9patch1/key"
 )
 
@@ -28,26 +30,26 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		if stackStateToUpdate.ShouldUpdate && !stackStateToUpdate.ShouldScale {
 			// Fetch the etcd volume information.
-			etcdVolume := true
-			persistentVolume := false
-			volumes, err := r.ebs.ListVolumes(customObject, etcdVolume, persistentVolume)
+			filterFuncs := []func(t *ec2.Tag) bool{
+				ebs.NewDockerVolumeFilter(customObject),
+				ebs.NewEtcdVolumeFilter(customObject),
+			}
+			volumes, err := r.ebs.ListVolumes(customObject, filterFuncs...)
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			if len(volumes) != 1 {
-				return microerror.Maskf(executionFailedError, "there must be 1 volume for etcd, got %d", len(volumes))
-			}
-			vol := volumes[0]
 
 			// First shutdown the instances and wait for it to be stopped. Then detach
-			// the etcd volume without forcing.
+			// the etcd and docker volume without forcing.
 			force := false
 			shutdown := true
 			wait := true
-			for _, a := range vol.Attachments {
-				err := r.ebs.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
-				if err != nil {
-					return microerror.Mask(err)
+			for _, v := range volumes {
+				for _, a := range v.Attachments {
+					err := r.ebs.DetachVolume(ctx, v.VolumeID, a, force, shutdown, wait)
+					if err != nil {
+						return microerror.Mask(err)
+					}
 				}
 			}
 		}

--- a/service/controller/v9patch1/resource/ebsvolume/delete.go
+++ b/service/controller/v9patch1/resource/ebsvolume/delete.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/controller/v9patch1/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/v9patch1/key"
 )
 
@@ -17,10 +19,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	// Get both the Etcd volume and any Persistent Volumes.
-	etcdVolume := true
-	persistentVolume := true
-	volumes, err := r.service.ListVolumes(customObject, etcdVolume, persistentVolume)
+	// Get all etcd, docker and persistent volumes.
+	filterFuncs := []func(t *ec2.Tag) bool{
+		ebs.NewDockerVolumeFilter(customObject),
+		ebs.NewEtcdVolumeFilter(customObject),
+		ebs.NewPersistentVolumeFilter(customObject),
+	}
+	volumes, err := r.service.ListVolumes(customObject, filterFuncs...)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/v9patch1/templates/cloudformation/guest/instance.go
+++ b/service/controller/v9patch1/templates/cloudformation/guest/instance.go
@@ -25,6 +25,9 @@ const Instance = `{{define "instance"}}
       Size: 50
       VolumeType: gp2
       AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Master.DockerVolume.Name }}
   EtcdVolume:
     Type: AWS::EC2::Volume
     DependsOn:


### PR DESCRIPTION
This PR fixes the Docker volume management. Docker volumes where recently added without proper update support. Note that we need to backport the fix so this PR modifies `v9patch1`, `v10` and `v11` resources. Note this is also towards https://github.com/giantswarm/giantswarm/issues/3054 to ensure updates work when having only 1 worker. 

This got successfully tested for updates from `v10` to `v11`. We need to test from `v9patch1` to `v10` separately with https://github.com/giantswarm/aws-operator/pull/921. 