### PR TITLE
Whitelist host cluster NAT gateway EIPs

### DIFF
--- a/service/controller/v11/adapter/mocks.go
+++ b/service/controller/v11/adapter/mocks.go
@@ -23,6 +23,25 @@ type EC2ClientMock struct {
 	vpcCIDR             string
 	unexistingVPC       bool
 	peeringID           string
+	elasticIPs          []string
+}
+
+func (e *EC2ClientMock) DescribeAddresses(input *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
+	addresses := make([]*ec2.Address, 0)
+
+	for _, eip := range e.elasticIPs {
+		address := &ec2.Address{
+			PublicIp: aws.String(eip),
+		}
+
+		addresses = append(addresses, address)
+	}
+
+	output := &ec2.DescribeAddressesOutput{
+		Addresses: addresses,
+	}
+
+	return output, nil
 }
 
 func (e *EC2ClientMock) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {

--- a/service/controller/v11/adapter/spec.go
+++ b/service/controller/v11/adapter/spec.go
@@ -109,6 +109,7 @@ type CFClient interface {
 
 // EC2Client describes the methods required to be implemented by a EC2 AWS client.
 type EC2Client interface {
+	DescribeAddresses(*ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error)
 	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -19,6 +19,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for advanced monitoring in EC2.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Added Kubernetes API server whitelisting for NAT gateway EIPs.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Extends the K8s API server whitelisting to include the elastic IPs of the host cluster NAT gateways. This is so cluster-operator can connect to AWS guest clusters when the whitelisting is enabled.