### PR TITLE
filters for installation specific VPCs

### DIFF
--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -11,19 +11,22 @@ import (
 const (
 	Namespace = "aws_operator"
 
-	gaugeValue = float64(1)
+	gaugeValue         float64 = 1
+	tagKeyInstallation string  = "giantswarm.io/installation"
 )
 
 type Config struct {
 	Logger micrologger.Logger
 
-	AwsConfig awsutil.Config
+	AwsConfig        awsutil.Config
+	InstallationName string
 }
 
 type Collector struct {
 	logger micrologger.Logger
 
-	awsClients awsutil.Clients
+	awsClients       awsutil.Clients
+	installationName string
 }
 
 func New(config Config) (*Collector, error) {
@@ -35,13 +38,17 @@ func New(config Config) (*Collector, error) {
 	if config.AwsConfig == emptyAwsConfig {
 		return nil, microerror.Maskf(invalidConfigError, "%T.AwsConfig must not be empty", config)
 	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
 
 	awsClients := awsutil.NewClients(config.AwsConfig)
 
 	c := &Collector{
 		logger: config.Logger,
 
-		awsClients: awsClients,
+		awsClients:       awsClients,
+		installationName: config.InstallationName,
 	}
 
 	return c, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3107. This topic here is a bit between `#sig-operator` and `#sig-monitoring`. This is about the alert `VPCWithNoCluster`. See also [the Prometheus rule](https://github.com/giantswarm/g8s-prometheus/blob/4b2ec449582519e1b25dc6e3b8987c238d35bfc1/helm/g8s-prometheus-chart/prometheus-rules/aws.rules.yml#L44-L50). The metric being used in the rule is `aws_operator_vpc_info`. This metric is updated by a collector in the `aws-operator`, which is the right approach from the metrics design point of view IMO. See also [the collector implementation](https://github.com/giantswarm/aws-operator/blob/33abdfb47724bb6fc6a08ebc4ba88d805cf60c18/service/collector/vpc.go#L45). The thing is that the collector does not distinguish between VPCs of `gauss` and `ginger` because these share an AWS account. I just discovered by accident that we have the same functionality covered by the alerter service and the collector. Only the collector is effectively used AFAICT. All the time I was wondering why we even have the problem the postmortem talks about, because the alerter service we have in the `aws-operator` does the filtering right already. Then I stumbled upon the collector. I already talked with Ross about some future vision of the alerter/collector stuff. We agreed the collector is what we want. If you think differently please provide some feedback. This change here should fix the postmortem, but does not cleanup the alerter. WDYT should happen with it? Should we start to remove "useless" magic? 