### PR TITLE
make pause image configurable

### DIFF
--- a/flag/service/aws/aws.go
+++ b/flag/service/aws/aws.go
@@ -11,6 +11,7 @@ type AWS struct {
 	AdvancedMonitoringEC2  string
 	LoggingBucket          loggingbucket.LoggingBucket
 	HostAccessKey          accesskey.AccessKey
+	PodInfraContainerImage string
 	PubKeyFile             string
 	Region                 string
 	Route53                route53.Route53

--- a/helm/aws-operator-chart/templates/03-configmap.yaml
+++ b/helm/aws-operator-chart/templates/03-configmap.yaml
@@ -14,6 +14,7 @@ data:
         advancedMonitoringEC2: '{{ .Values.Installation.V1.Provider.AWS.AdvancedMonitoringEC2 }}'
         loggingBucket:
           delete: '{{ .Values.Installation.V1.Provider.AWS.DeleteLoggingBucket }}'
+        podInfraContainerImage: '{{ .Values.Installation.V1.Provider.AWS.PodInfraContainerImage }}'
         region: '{{ .Values.Installation.V1.Provider.AWS.Region }}'
         route53:
           enabled: '{{ .Values.Installation.V1.Provider.AWS.Route53.Enabled }}'

--- a/main.go
+++ b/main.go
@@ -125,6 +125,8 @@ func mainError() error {
 
 	daemonCommand.PersistentFlags().Bool(f.Service.AWS.Route53.Enabled, true, "Should Route53 be enabled.")
 
+	daemonCommand.PersistentFlags().String(f.Service.AWS.PodInfraContainerImage, "", "Image to be used for the pause container. If empty, default image from gcr.io/google_containers/pause-amd64 is used.")
+
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Installation name for tagging AWS resources.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.ClientID, "", "OIDC authorization provider ClientID.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.IssuerURL, "", "OIDC authorization provider IssuerURL.")

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -47,18 +47,19 @@ type ClusterConfig struct {
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
 
-	AccessLogsExpiration  int
-	AdvancedMonitoringEC2 bool
-	APIWhitelist          FrameworkConfigAPIWhitelistConfig
-	DeleteLoggingBucket   bool
-	GuestAWSConfig        ClusterConfigAWSConfig
-	GuestUpdateEnabled    bool
-	HostAWSConfig         ClusterConfigAWSConfig
-	InstallationName      string
-	OIDC                  ClusterConfigOIDC
-	ProjectName           string
-	PubKeyFile            string
-	Route53Enabled        bool
+	AccessLogsExpiration   int
+	AdvancedMonitoringEC2  bool
+	APIWhitelist           FrameworkConfigAPIWhitelistConfig
+	DeleteLoggingBucket    bool
+	GuestAWSConfig         ClusterConfigAWSConfig
+	GuestUpdateEnabled     bool
+	HostAWSConfig          ClusterConfigAWSConfig
+	InstallationName       string
+	OIDC                   ClusterConfigOIDC
+	PodInfraContainerImage string
+	ProjectName            string
+	PubKeyFile             string
+	Route53Enabled         bool
 }
 
 type ClusterConfigAWSConfig struct {
@@ -556,12 +557,13 @@ func newClusterResourceRouter(config ClusterConfig) (*controller.ResourceRouter,
 			Logger:             config.Logger,
 			RandomkeysSearcher: randomKeySearcher,
 
-			AccessLogsExpiration:  config.AccessLogsExpiration,
-			AdvancedMonitoringEC2: config.AdvancedMonitoringEC2,
-			DeleteLoggingBucket:   config.DeleteLoggingBucket,
-			GuestUpdateEnabled:    config.GuestUpdateEnabled,
-			Route53Enabled:        config.Route53Enabled,
-			InstallationName:      config.InstallationName,
+			AccessLogsExpiration:   config.AccessLogsExpiration,
+			AdvancedMonitoringEC2:  config.AdvancedMonitoringEC2,
+			DeleteLoggingBucket:    config.DeleteLoggingBucket,
+			GuestUpdateEnabled:     config.GuestUpdateEnabled,
+			PodInfraContainerImage: config.PodInfraContainerImage,
+			Route53Enabled:         config.Route53Enabled,
+			InstallationName:       config.InstallationName,
 			OIDC: v11cloudconfig.OIDCConfig{
 				ClientID:      config.OIDC.ClientID,
 				IssuerURL:     config.OIDC.IssuerURL,

--- a/service/controller/v11/cloudconfig/cloud_config.go
+++ b/service/controller/v11/cloudconfig/cloud_config.go
@@ -18,7 +18,8 @@ type Config struct {
 	KMSClient KMSClient
 	Logger    micrologger.Logger
 
-	OIDC OIDCConfig
+	OIDC                   OIDCConfig
+	PodInfraContainerImage string
 }
 
 // CloudConfig implements the cloud config service interface.
@@ -26,7 +27,8 @@ type CloudConfig struct {
 	kmsClient KMSClient
 	logger    micrologger.Logger
 
-	k8sAPIExtraArgs []string
+	k8sAPIExtraArgs     []string
+	k8sKubeletExtraArgs []string
 }
 
 // OIDCConfig represents the configuration of the OIDC authorization provider
@@ -62,11 +64,19 @@ func New(config Config) (*CloudConfig, error) {
 		}
 	}
 
+	var k8sKubeletExtraArgs []string
+	{
+		if config.PodInfraContainerImage != "" {
+			k8sKubeletExtraArgs = append(k8sKubeletExtraArgs, fmt.Sprintf("--pod-infra-container-image=%s", config.PodInfraContainerImage))
+		}
+	}
+
 	newCloudConfig := &CloudConfig{
 		kmsClient: config.KMSClient,
 		logger:    config.Logger,
 
-		k8sAPIExtraArgs: k8sAPIExtraArgs,
+		k8sAPIExtraArgs:     k8sAPIExtraArgs,
+		k8sKubeletExtraArgs: k8sKubeletExtraArgs,
 	}
 
 	return newCloudConfig, nil

--- a/service/controller/v11/cloudconfig/master_template.go
+++ b/service/controller/v11/cloudconfig/master_template.go
@@ -37,6 +37,7 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.AWSConfig, certs l
 			RandomKeyTmplSet: randomKeyTmplSet,
 		}
 		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
+		params.Hyperkube.Kubelet.Docker.CommandExtraArgs = c.k8sKubeletExtraArgs
 	}
 
 	var newCloudConfig *k8scloudconfig.CloudConfig

--- a/service/controller/v11/cluster_resource_set.go
+++ b/service/controller/v11/cluster_resource_set.go
@@ -44,15 +44,16 @@ type ClusterResourceSetConfig struct {
 	Logger             micrologger.Logger
 	RandomkeysSearcher randomkeys.Interface
 
-	AccessLogsExpiration  int
-	AdvancedMonitoringEC2 bool
-	APIWhitelist          adapter.APIWhitelist
-	GuestUpdateEnabled    bool
-	InstallationName      string
-	DeleteLoggingBucket   bool
-	OIDC                  cloudconfig.OIDCConfig
-	ProjectName           string
-	Route53Enabled        bool
+	AccessLogsExpiration   int
+	AdvancedMonitoringEC2  bool
+	APIWhitelist           adapter.APIWhitelist
+	GuestUpdateEnabled     bool
+	InstallationName       string
+	DeleteLoggingBucket    bool
+	OIDC                   cloudconfig.OIDCConfig
+	ProjectName            string
+	Route53Enabled         bool
+	PodInfraContainerImage string
 }
 
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
@@ -131,6 +132,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			Logger:    config.Logger,
 
 			OIDC: config.OIDC,
+			PodInfraContainerImage: config.PodInfraContainerImage,
 		}
 
 		cloudConfig, err = cloudconfig.New(c)

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -29,6 +29,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for disabling Route53.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Added support for making pause container configurable.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/service.go
+++ b/service/service.go
@@ -141,9 +141,10 @@ func New(config Config) (*Service, error) {
 				GroupsClaim:   config.Viper.GetString(config.Flag.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim),
 			},
 
-			ProjectName:    config.ProjectName,
-			PubKeyFile:     config.Viper.GetString(config.Flag.Service.AWS.PubKeyFile),
-			Route53Enabled: config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
+			PodInfraContainerImage: config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
+			ProjectName:            config.ProjectName,
+			PubKeyFile:             config.Viper.GetString(config.Flag.Service.AWS.PubKeyFile),
+			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 		}
 
 		clusterController, err = controller.NewCluster(c)


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/307

Takes advantage of `.Hyperkube.Kubelet.Docker.CommandExtraArgs` in k8scloudconfig, the args in that array are included in master https://github.com/giantswarm/k8scloudconfig/blob/master/v_3_3_1/master_template.go#L2242-L2244 and worker https://github.com/giantswarm/k8scloudconfig/blob/master/v_3_3_1/worker_template.go#L290-L292 calls for starting kubelets.