### PR TITLE
add ami for china region

### DIFF
--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -390,6 +390,7 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 	*/
 	imageIDs := map[string]string{
 		"ap-southeast-1": "ami-41461c3d",
+		"cn-north-1":     "ami-39ee3154",
 		"eu-central-1":   "ami-604e118b",
 		"eu-west-1":      "ami-34237c4d",
 		"us-west-2":      "ami-b41377cc",


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/307

AMI id from https://coreos.com/os/docs/latest/booting-on-ec2.html