### PR TITLE
add-etcd-backup-support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,7 +257,7 @@
   branch = "master"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
-  revision = "fa0cb6e79704cafaa67cec66b11adec7d639b418"
+  revision = "0f1af4c3bd3b0d6f445494bed71cf2cfd8de2edd"
 
 [[projects]]
   branch = "master"

--- a/service/controller/v11/adapter/security_groups.go
+++ b/service/controller/v11/adapter/security_groups.go
@@ -37,6 +37,7 @@ type securityGroupRule struct {
 const (
 	allPorts             = -1
 	cadvisorPort         = 4194
+	etcdPort             = 2379
 	kubeletPort          = 10250
 	nodeExporterPort     = 10300
 	kubeStateMetricsPort = 10301
@@ -86,6 +87,12 @@ func (s *securityGroupsAdapter) getMasterRules(cfg Config, hostClusterCIDR strin
 		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
 		{
 			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 2379 for etcd backup.
+		{
+			Port:       etcdPort,
 			Protocol:   tcpProtocol,
 			SourceCIDR: hostClusterCIDR,
 		},

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -39,6 +39,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for not including S3 bucket tags.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Allow port 2379 from Host cluster to add support for etcd backup.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -41,7 +41,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "aws-operator",
-				Description: "Allow port 2379 from Host cluster to add support for etcd backup.",
+				Description: "Allow port 2379 from host cluster to add support for etcd backup.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},

--- a/vendor/github.com/giantswarm/helmclient/spec.go
+++ b/vendor/github.com/giantswarm/helmclient/spec.go
@@ -4,7 +4,7 @@ import "k8s.io/helm/pkg/helm"
 
 const (
 	tillerDefaultNamespace = "kube-system"
-	tillerImageSpec        = "quay.io/giantswarm/tiller:v2.8.1"
+	tillerImageSpec        = "quay.io/giantswarm/tiller:v2.8.2"
 	tillerLabelSelector    = "app=helm,name=tiller"
 	tillerPodName          = "tiller-giantswarm"
 	tillerPort             = 44134


### PR DESCRIPTION
allow access 2379 port from host cluster in order to do etcd backups

towards https://github.com/giantswarm/giantswarm/issues/3136