### PR TITLE
Use Container Linux 1745.4.0

### DIFF
--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -392,11 +392,11 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
 		NOTE 2: You also need to update the tests.
 
-		service/awsconfig/v10/key/key_test.go
-		service/awsconfig/v10/resource/cloudformation/adapter/adapter_test.go
-		service/resource/cloudformationv2/main_stack_test.go
+		service/awsconfig/v11/key/key_test.go
+		service/awsconfig/v11/resource/cloudformation/adapter/adapter_test.go
+		service/resource/cloudformationv11/main_stack_test.go
 
-		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
+		Current Release: CoreOS Container Linux stable 1745.4.0 (HVM)
 	*/
 	imageIDs := map[string]string{
 		"ap-southeast-1": "ami-b5714cc9",

--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -399,11 +399,11 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		Current Release: CoreOS Container Linux stable 1745.4.0 (HVM)
 	*/
 	imageIDs := map[string]string{
-		"ap-southeast-1": "ami-b5714cc9",
-		"cn-north-1":     "ami-9712ccfa",
-		"eu-central-1":   "ami-6abd9581",
-		"eu-west-1":      "ami-62e3dc1b",
-		"us-west-2":      "ami-2eba5649",
+		"ap-southeast-1": "ami-73b28f0f",
+		"cn-north-1":     "ami-8f05dbe2",
+		"eu-central-1":   "ami-32042fd9",
+		"eu-west-1":      "ami-82645dfb",
+		"us-west-2":      "ami-574f362f",
 	}
 
 	imageID, ok := imageIDs[region]

--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -399,11 +399,11 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
 	*/
 	imageIDs := map[string]string{
-		"ap-southeast-1": "ami-41461c3d",
-		"cn-north-1":     "ami-39ee3154",
-		"eu-central-1":   "ami-604e118b",
-		"eu-west-1":      "ami-34237c4d",
-		"us-west-2":      "ami-b41377cc",
+		"ap-southeast-1": "ami-b5714cc9",
+		"cn-north-1":     "ami-9712ccfa",
+		"eu-central-1":   "ami-6abd9581",
+		"eu-west-1":      "ami-62e3dc1b",
+		"us-west-2":      "ami-2eba5649",
 	}
 
 	imageID, ok := imageIDs[region]

--- a/service/controller/v11/key/key_test.go
+++ b/service/controller/v11/key/key_test.go
@@ -1008,7 +1008,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-6abd9581",
+			expectedImageID: "ami-32042fd9",
 		},
 		{
 			description: "different region",
@@ -1020,7 +1020,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-62e3dc1b",
+			expectedImageID: "ami-82645dfb",
 		},
 		{
 			description: "invalid region",

--- a/service/controller/v11/key/key_test.go
+++ b/service/controller/v11/key/key_test.go
@@ -1008,7 +1008,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-604e118b",
+			expectedImageID: "ami-6abd9581",
 		},
 		{
 			description: "different region",
@@ -1020,7 +1020,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-34237c4d",
+			expectedImageID: "ami-62e3dc1b",
 		},
 		{
 			description: "invalid region",

--- a/service/controller/v11/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v11/resource/cloudformation/main_stack_test.go
@@ -318,7 +318,7 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	}
 
 	// image ids should be fixed despite the values in the custom object
-	if !strings.Contains(body, "ImageId: ami-6abd9581") {
+	if !strings.Contains(body, "ImageId: ami-32042fd9") {
 		fmt.Println(body)
 		t.Fatal("Fixed image ID not found")
 	}

--- a/service/controller/v11/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v11/resource/cloudformation/main_stack_test.go
@@ -318,7 +318,7 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	}
 
 	// image ids should be fixed despite the values in the custom object
-	if !strings.Contains(body, "ImageId: ami-604e118b") {
+	if !strings.Contains(body, "ImageId: ami-6abd9581") {
 		fmt.Println(body)
 		t.Fatal("Fixed image ID not found")
 	}

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -54,6 +54,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Removed kube-state-metrics so it can be managed by chart-operator.",
 				Kind:        versionbundle.KindRemoved,
 			},
+			{
+				Component:   "containerlinux",
+				Description: "Updated to 1745.3.1.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
@@ -62,11 +67,11 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "1688.5.3",
+				Version: "1745.3.1",
 			},
 			{
 				Name:    "docker",
-				Version: "17.12.1",
+				Version: "18.03.1",
 			},
 			{
 				Name:    "etcd",

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -56,7 +56,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "containerlinux",
-				Description: "Updated to 1745.3.1.",
+				Description: "Updated to 1745.4.0.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},
@@ -67,7 +67,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "1745.3.1",
+				Version: "1745.4.0",
 			},
 			{
 				Name:    "docker",


### PR DESCRIPTION
Updates AMIs to use latest stable `1745.4.0` this also updates Docker to `18.03.1`.

This was due to failed cluster upgrades due to the Etcd volume not attaching to the new master EC2 instance with m5.large instances. With this upgrade the updates seem much more stable.

Should also help with giantswarm/giantswarm#3159.

EDIT: Latest is now `1745.4.0`.