### PR TITLE
drainer: use GuestAWSConfig as HostAWSConfig when not present

### DIFF
--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -68,14 +68,20 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 	if config.GuestAWSConfig.Region == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GuestAWSConfig.Region must not be empty", config)
 	}
-	if config.HostAWSConfig.AccessKeyID == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.AccessKeyID must not be empty", config)
-	}
-	if config.HostAWSConfig.AccessKeySecret == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.AccessKeySecret must not be empty", config)
-	}
-	if config.HostAWSConfig.Region == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.Region must not be empty", config)
+	// TODO: remove this when all version prior to v11 are removed
+	if config.HostAWSConfig.AccessKeyID == "" && config.HostAWSConfig.AccessKeySecret == "" {
+		config.Logger.Log("debug", "no host cluster account credentials supplied, assuming guest and host uses same account")
+		config.HostAWSConfig = config.GuestAWSConfig
+	} else {
+		if config.HostAWSConfig.AccessKeyID == "" {
+			return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.AccessKeyID must not be empty")
+		}
+		if config.HostAWSConfig.AccessKeySecret == "" {
+			return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.AccessKeySecret must not be empty")
+		}
+		if config.HostAWSConfig.Region == "" {
+			return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.Region must not be empty")
+		}
 	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)


### PR DESCRIPTION
#916 introduced a bug where `DrainerConfig.HostAWSConfig` might be empty in some cases.

And the following issue arise
```
$ k logs -ngiantswarm aws-operator-786f4cbc96-c6gdk
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/client/k8srestconfig/k8s_rest_config.go:121","level":"debug","message":"creating in-cluster config","time":"2018-05-25T14:51:37.655753+00:00"}
{"caller":"github.com/giantswarm/aws-operator/service/controller/cluster.go:119","debug":"no host cluster account credentials supplied, assuming guest and host uses same account","time":"2018-05-25T14:51:37.657438+00:00"}
panic: [{/go/src/github.com/giantswarm/aws-operator/main.go:63: } {/go/src/github.com/giantswarm/aws-operator/service/service.go:183: } {/go/src/github.com/giantswarm/aws-operator/service/controller/drainer.go:72: controller.DrainerConfig.HostAWSConfig.AccessKeyID must not be empty} {invalid config}]
```

To solve this issue, this PR apply the logic used in controller to drainer
see https://github.com/giantswarm/aws-operator/blob/master/service/controller/cluster.go#L118-L120