### PR TITLE
opsctl: copy v11 to v12

### DIFF
--- a/service/controller/v12/adapter/adapter.go
+++ b/service/controller/v12/adapter/adapter.go
@@ -1,0 +1,148 @@
+// Package adapter contains the required logic for creating data structures used for
+// feeding CloudFormation templates.
+//
+// It follows the adapter pattern https://en.wikipedia.org/wiki/Adapter_pattern in the
+// sense that it has the knowledge to transform a aws custom object into a data structure
+// easily interpolable into the templates without any additional view logic.
+//
+// There's a base template in `service/templates/cloudformation/guest/main.yaml` which defines
+// the basic structure and includes the rest of templates that form the stack as nested
+// templates. Those subtemplates should use a `define` action with the name that will be
+// used to refer to them from the main template, as explained here
+// https://golang.org/pkg/text/template/#hdr-Nested_template_definitions
+//
+// Each adapter is related to one of these nested templates. It includes the data structure
+// with all the values needed to interpolate in the related template and the logic required
+// to obtain them, this logic is packed into functions called `hydraters`.
+//
+// When extending the stack we will just need to:
+// * Add the template file in `service/template/cloudformation/guest` and modify
+// `service/template/cloudformation/main.yaml` to include the new template.
+// * Add the adapter logic file in `service/resource/cloudformation/adapter` with the type
+// definition and the hydrater function to fill the fields (like asg.go or
+// launch_configuration.go).
+// * Add the new type to the Adapter type in `service/resource/cloudformation/adapter/adapter.go`
+// and include the hydrater function in the `hydraters` slice.
+package adapter
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+type hydrater func(Config) error
+
+type Adapter struct {
+	ASGType                    string
+	AvailabilityZone           string
+	ClusterID                  string
+	MasterInstanceResourceName string
+	WorkerImageID              string
+
+	Instance       *instanceAdapter
+	LifecycleHooks *lifecycleHooksAdapter
+	Outputs        *outputsAdapter
+
+	autoScalingGroupAdapter
+	iamPoliciesAdapter
+	hostIamRolesAdapter
+	launchConfigAdapter
+	loadBalancersAdapter
+	recordSetsAdapter
+	routeTablesAdapter
+	securityGroupsAdapter
+	hostRouteTablesAdapter
+	subnetsAdapter
+	vpcAdapter
+}
+
+type Config struct {
+	APIWhitelist     APIWhitelist
+	CustomObject     v1alpha1.AWSConfig
+	Clients          Clients
+	GuestAccountID   string
+	HostAccountID    string
+	HostClients      Clients
+	InstallationName string
+	Route53Enabled   bool
+	StackState       StackState
+}
+
+func NewGuest(cfg Config) (Adapter, error) {
+	a := Adapter{
+		Instance:       &instanceAdapter{},
+		LifecycleHooks: &lifecycleHooksAdapter{},
+		Outputs:        &outputsAdapter{},
+	}
+
+	a.ASGType = prefixWorker
+	a.ClusterID = key.ClusterID(cfg.CustomObject)
+	a.WorkerImageID = cfg.StackState.WorkerImageID
+	// set api whitelisting
+	a.APIWhitelistEnabled = cfg.APIWhitelist.Enabled
+
+	// TODO this is totally odd but is a necessary evil because of the different
+	// approaches adapters are managed right now. Over time we should refactor the
+	// adapters and get the configuration more straight. Right now it does not
+	// make that much sense to change a lot fo adapters right away since the focus
+	// is to get actual user stories done.
+	a.MasterInstanceResourceName = cfg.StackState.MasterInstanceResourceName
+
+	hydraters := []hydrater{
+		a.getAutoScalingGroup,
+		a.getIamPolicies,
+		a.getLaunchConfiguration,
+		a.getLoadBalancers,
+		a.getRecordSets,
+		a.getRouteTables,
+		a.getSecurityGroups,
+		a.getSubnets,
+		a.getVpc,
+
+		a.Instance.Adapt,
+		a.LifecycleHooks.Adapt,
+		a.Outputs.Adapt,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}
+
+func NewHostPre(cfg Config) (Adapter, error) {
+	a := Adapter{}
+
+	hydraters := []hydrater{
+		a.getHostIamRoles,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}
+
+func NewHostPost(cfg Config) (Adapter, error) {
+	a := Adapter{}
+
+	hydraters := []hydrater{
+		a.getHostRouteTables,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}

--- a/service/controller/v12/adapter/adapter_test.go
+++ b/service/controller/v12/adapter/adapter_test.go
@@ -1,0 +1,130 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+var (
+	defaultCluster = v1alpha1.Cluster{
+		ID: "test-cluster",
+		Kubernetes: v1alpha1.ClusterKubernetes{
+			API: v1alpha1.ClusterKubernetesAPI{
+				Domain: "api.domain",
+			},
+			IngressController: v1alpha1.ClusterKubernetesIngressController{
+				Domain: "ingress.domain",
+			},
+		},
+		Etcd: v1alpha1.ClusterEtcd{
+			Domain: "etcd.domain",
+		},
+	}
+)
+
+func TestAdapterGuestMain(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description           string
+		customObject          v1alpha1.AWSConfig
+		errorMatcher          func(error) bool
+		expectedASGType       string
+		expectedClusterID     string
+		expectedMasterImageID string
+		expectedWorkerImageID string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:     "eu-central-1a",
+						Region: "eu-central-1",
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			errorMatcher:          nil,
+			expectedASGType:       "worker",
+			expectedClusterID:     "test-cluster",
+			expectedMasterImageID: "master-image-id",
+			expectedWorkerImageID: "worker-image-id",
+		},
+		{
+			description: "different region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:     "eu-west-1a",
+						Region: "eu-west-1",
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			errorMatcher:          nil,
+			expectedASGType:       "worker",
+			expectedClusterID:     "test-cluster",
+			expectedMasterImageID: "master-image-id",
+			expectedWorkerImageID: "worker-image-id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			config := Config{
+				CustomObject: tc.customObject,
+				Clients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					KMS: &KMSClientMock{},
+					ELB: &ELBClientMock{},
+					STS: &STSClientMock{},
+				},
+				HostClients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+				InstallationName: "myinstallation",
+				HostAccountID:    "myHostAccountID",
+				StackState: StackState{
+					MasterImageID: "master-image-id",
+					WorkerImageID: "worker-image-id",
+				},
+			}
+			a, err := NewGuest(config)
+			if tc.errorMatcher != nil && err == nil {
+				t.Fatal("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Fatal("expected", true, "got", false)
+			}
+
+			if tc.expectedASGType != a.ASGType {
+				t.Fatalf("unexpected ASG type, expected %q, got %q", tc.expectedASGType, a.ASGType)
+			}
+
+			if tc.expectedClusterID != a.ClusterID {
+				t.Fatalf("unexpected cluster ID, expected %q, got %q", tc.expectedClusterID, a.ClusterID)
+			}
+
+			if tc.expectedWorkerImageID != a.WorkerImageID {
+				t.Fatalf("unexpected WorkerImageID, expected %q, got %q", tc.expectedWorkerImageID, a.WorkerImageID)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/auto_scaling_group.go
+++ b/service/controller/v12/adapter/auto_scaling_group.go
@@ -1,0 +1,49 @@
+package adapter
+
+import (
+	"strconv"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// template related to this adapter: service/templates/cloudformation/guest/auto_scaling_group.yaml
+
+type autoScalingGroupAdapter struct {
+	ASGMaxSize             int
+	ASGMinSize             int
+	HealthCheckGracePeriod int
+	MaxBatchSize           string
+	MinInstancesInService  string
+	RollingUpdatePauseTime string
+	WorkerAZ               string
+}
+
+func (a *autoScalingGroupAdapter) getAutoScalingGroup(cfg Config) error {
+	workers := key.WorkerCount(cfg.CustomObject)
+	if workers <= 0 {
+		return microerror.Maskf(invalidConfigError, "at least 1 worker required, found %d", workers)
+	}
+
+	a.WorkerAZ = key.AvailabilityZone(cfg.CustomObject)
+	a.ASGMaxSize = workers + 1
+	a.ASGMinSize = workers
+	a.MaxBatchSize = workerCountRatio(workers, asgMaxBatchSizeRatio)
+	a.MinInstancesInService = workerCountRatio(workers, asgMinInstancesRatio)
+	a.HealthCheckGracePeriod = gracePeriodSeconds
+	a.RollingUpdatePauseTime = rollingUpdatePauseTime
+
+	return nil
+}
+
+func workerCountRatio(workers int, ratio float32) string {
+	value := float32(workers) * ratio
+	rounded := int(value + 0.5)
+
+	if rounded == 0 {
+		rounded = 1
+	}
+
+	return strconv.Itoa(rounded)
+}

--- a/service/controller/v12/adapter/auto_scaling_group_test.go
+++ b/service/controller/v12/adapter/auto_scaling_group_test.go
@@ -1,0 +1,195 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                    string
+		customObject                   v1alpha1.AWSConfig
+		expectedError                  bool
+		expectedAZ                     string
+		expectedASGMaxSize             int
+		expectedASGMinSize             int
+		expectedHealthCheckGracePeriod int
+		expectedMaxBatchSize           string
+		expectedMinInstancesInService  string
+		expectedRollingUpdatePauseTime string
+	}{
+		{
+			description: "no worker nodes, return error",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:      "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			description: "having one worker leaves 1 worker head room for updates",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             2, // headroom is +1
+			expectedASGMinSize:             1,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "1",
+			expectedMinInstancesInService:  "1",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             4,
+			expectedASGMinSize:             3,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "1",
+			expectedMinInstancesInService:  "2",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+		{
+			description: "7 node cluster, batch size and min instances are correct",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+							{},
+							{},
+							{},
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             8,
+			expectedASGMinSize:             7,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "2",
+			expectedMinInstancesInService:  "5",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  Clients{},
+			}
+			err := a.getAutoScalingGroup(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if !tc.expectedError {
+				if a.ASGMaxSize != tc.expectedASGMaxSize {
+					t.Errorf("unexpected output, got %d, want %d", a.ASGMaxSize, tc.expectedASGMaxSize)
+				}
+
+				if a.ASGMinSize != tc.expectedASGMinSize {
+					t.Errorf("unexpected output, got %d, want %d", a.ASGMinSize, tc.expectedASGMinSize)
+				}
+
+				if a.HealthCheckGracePeriod != tc.expectedHealthCheckGracePeriod {
+					t.Errorf("unexpected output, got %d, want %d", a.HealthCheckGracePeriod, tc.expectedHealthCheckGracePeriod)
+				}
+
+				if a.MaxBatchSize != tc.expectedMaxBatchSize {
+					t.Errorf("unexpected output, got %q, want %q", a.MaxBatchSize, tc.expectedMaxBatchSize)
+				}
+
+				if a.MinInstancesInService != tc.expectedMinInstancesInService {
+					t.Errorf("unexpected output, got %q, want %q", a.MinInstancesInService, tc.expectedMinInstancesInService)
+				}
+
+				if a.RollingUpdatePauseTime != tc.expectedRollingUpdatePauseTime {
+					t.Errorf("unexpected output, got %q, want %q", a.RollingUpdatePauseTime, tc.expectedRollingUpdatePauseTime)
+				}
+
+				if a.WorkerAZ != tc.expectedAZ {
+					t.Errorf("unexpected output, got %q, want %q", a.WorkerAZ, tc.expectedAZ)
+				}
+
+			}
+		})
+	}
+}
+
+func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		description   string
+		workers       int
+		expectedRatio string
+	}{
+		{
+			description:   "scaling down to one worker, one should be up",
+			workers:       1,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to two worker, one should be up",
+			workers:       2,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to zero worker, ratio should be one, because it should never be zero",
+			workers:       0,
+			expectedRatio: "1",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := workerCountRatio(tc.workers, asgMaxBatchSizeRatio)
+
+			if tc.expectedRatio != actual {
+				t.Errorf("wrong worker count ratio, expected %q, actual %q", tc.expectedRatio, actual)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/error.go
+++ b/service/controller/v12/adapter/error.go
@@ -1,0 +1,52 @@
+package adapter
+
+import "github.com/giantswarm/microerror"
+
+var emptyAmazonAccountIDError = microerror.New("empty amazon account ID")
+
+// IsEmptyAmazonAccountID asserts emptyAmazonAccountIDError.
+func IsEmptyAmazonAccountID(err error) bool {
+	return microerror.Cause(err) == emptyAmazonAccountIDError
+}
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var malformedAmazonAccountIDError = microerror.New("malformed amazon account ID")
+
+// IsMalformedAmazonAccountID asserts malformedAmazonAccountIDError.
+func IsMalformedAmazonAccountID(err error) bool {
+	return microerror.Cause(err) == malformedAmazonAccountIDError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongAmazonAccountIDLengthError = microerror.New("wrong amazon account ID length")
+
+// IsWrongAmazonAccountIDLength asserts wrongAmazonAccountIDLengthError.
+func IsWrongAmazonAccountIDLength(err error) bool {
+	return microerror.Cause(err) == wrongAmazonAccountIDLengthError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var tooManyResultsError = microerror.New("too many results")
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return microerror.Cause(err) == tooManyResultsError
+}

--- a/service/controller/v12/adapter/host_iam_roles.go
+++ b/service/controller/v12/adapter/host_iam_roles.go
@@ -1,0 +1,20 @@
+package adapter
+
+import "github.com/giantswarm/aws-operator/service/controller/v11/key"
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/hostpre/iam_roles.go
+//
+
+type hostIamRolesAdapter struct {
+	PeerAccessRoleName string
+	GuestAccountID     string
+}
+
+func (h *hostIamRolesAdapter) getHostIamRoles(cfg Config) error {
+	h.PeerAccessRoleName = key.PeerAccessRoleName(cfg.CustomObject)
+	h.GuestAccountID = cfg.GuestAccountID
+
+	return nil
+}

--- a/service/controller/v12/adapter/host_iam_roles_test.go
+++ b/service/controller/v12/adapter/host_iam_roles_test.go
@@ -1,0 +1,63 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterHostIAMRolesRegularFields(t *testing.T) {
+	t.Parallel()
+	guestAccountID := "myGuestAccountID"
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					HostedZones: "apiHostedZones",
+				},
+				Etcd: v1alpha1.AWSConfigSpecAWSEtcd{
+					HostedZones: "etcdHostedZone",
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					HostedZones: "ingressHostedZone",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		description                string
+		expectedPeerAccessRoleName string
+		expectedGuestAccountID     string
+	}{
+		{
+			description:                "basic matching, all fields present",
+			expectedPeerAccessRoleName: "test-cluster-vpc-peer-access",
+			expectedGuestAccountID:     guestAccountID,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:   customObject,
+				GuestAccountID: guestAccountID,
+			}
+			err := a.getHostIamRoles(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.PeerAccessRoleName != tc.expectedPeerAccessRoleName {
+				t.Errorf("unexpected PeerAccessRoleName, got %q, want %q", a.PeerAccessRoleName, tc.expectedPeerAccessRoleName)
+			}
+			if a.GuestAccountID != tc.expectedGuestAccountID {
+				t.Errorf("unexpected GuestAccountID, got %q, want %q", a.GuestAccountID, tc.expectedGuestAccountID)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/host_route_tables.go
+++ b/service/controller/v12/adapter/host_route_tables.go
@@ -1,0 +1,137 @@
+package adapter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/hostpost/route_tables.go
+//
+
+type hostRouteTablesAdapter struct {
+	RouteTables []RouteTable
+}
+
+type RouteTable struct {
+	Name             string
+	RouteTableID     string
+	CidrBlock        string
+	PeerConnectionID string
+}
+
+func (i *hostRouteTablesAdapter) getHostRouteTables(cfg Config) error {
+	peerConnectionID, err := waitForPeeringConnectionID(cfg)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, routeTableName := range cfg.CustomObject.Spec.AWS.VPC.RouteTableNames {
+		routeTableID, err := routeTableID(routeTableName, cfg)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		rt := RouteTable{
+			Name:         routeTableName,
+			RouteTableID: routeTableID,
+			// Requester CIDR block, we create the peering connection from the guest's private subnet.
+			CidrBlock:        key.PrivateSubnetCIDR(cfg.CustomObject),
+			PeerConnectionID: peerConnectionID,
+		}
+		i.RouteTables = append(i.RouteTables, rt)
+	}
+
+	return nil
+}
+
+// waitForPeeringConnectionID keeps asking for the peering connection ID until it is obtained or
+// a timeout expires. It is needed because the peering connection is created as part of the
+// guest stack, we need to wait until the required resources from the guest are in place.
+func waitForPeeringConnectionID(cfg Config) (string, error) {
+	clusterID := key.ClusterID(cfg.CustomObject)
+	input := &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("status-code"),
+				Values: []*string{
+					aws.String("active"),
+				},
+			},
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(clusterID),
+				},
+			},
+		},
+	}
+	var peeringID string
+	// TODO the logger should be injected and not magically made up in the depths
+	// of the code where nobody knows about it and nobody has control over it.
+	c := micrologger.Config{
+		Caller:             micrologger.DefaultCaller,
+		IOWriter:           micrologger.DefaultIOWriter,
+		TimestampFormatter: micrologger.DefaultTimestampFormatter,
+	}
+	logger, err := micrologger.New(c)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	queryOperation := func() error {
+		output, err := cfg.Clients.EC2.DescribeVpcPeeringConnections(input)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if len(output.VpcPeeringConnections) > 1 {
+			return microerror.Maskf(tooManyResultsError, "peering connections")
+		}
+		peeringID = *output.VpcPeeringConnections[0].VpcPeeringConnectionId
+		return nil
+	}
+	queryNotify := func(err error, delay time.Duration) {
+		logger.Log("error", fmt.Sprintf("query VPC peering connection ID failed, retrying with delay %.0fm%.0fs: '%#v'", delay.Minutes(), delay.Seconds(), err))
+	}
+	bo := &backoff.ExponentialBackOff{
+		InitialInterval:     backoff.DefaultInitialInterval,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         backoff.DefaultMaxInterval,
+		MaxElapsedTime:      2 * time.Minute,
+		Clock:               backoff.SystemClock,
+	}
+	if err := backoff.RetryNotify(queryOperation, bo, queryNotify); err != nil {
+		return "", microerror.Mask(err)
+	}
+	return peeringID, nil
+}
+
+func routeTableID(name string, cfg Config) (string, error) {
+	input := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(name),
+				},
+			},
+		},
+	}
+	output, err := cfg.HostClients.EC2.DescribeRouteTables(input)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	if len(output.RouteTables) > 1 {
+		return "", microerror.Maskf(tooManyResultsError, "route tables: %s", name)
+	}
+
+	return *output.RouteTables[0].RouteTableId, nil
+}

--- a/service/controller/v12/adapter/host_route_tables_test.go
+++ b/service/controller/v12/adapter/host_route_tables_test.go
@@ -1,0 +1,9 @@
+package adapter
+
+import (
+	"testing"
+)
+
+func TestAdapterHostRouteTablesRegularFields(t *testing.T) {
+	t.Parallel()
+}

--- a/service/controller/v12/adapter/iam_policies.go
+++ b/service/controller/v12/adapter/iam_policies.go
@@ -1,0 +1,60 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/iam_policies.go
+//
+
+type iamPoliciesAdapter struct {
+	KMSKeyARN         string
+	MasterRoleName    string
+	MasterPolicyName  string
+	MasterProfileName string
+	RegionARN         string
+	S3Bucket          string
+	WorkerRoleName    string
+	WorkerPolicyName  string
+	WorkerProfileName string
+}
+
+func (i *iamPoliciesAdapter) getIamPolicies(cfg Config) error {
+	clusterID := key.ClusterID(cfg.CustomObject)
+
+	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, prefixMaster)
+	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, prefixMaster)
+	i.MasterRoleName = key.RoleName(cfg.CustomObject, prefixMaster)
+	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, prefixWorker)
+	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, prefixWorker)
+	i.WorkerRoleName = key.RoleName(cfg.CustomObject, prefixWorker)
+	i.RegionARN = key.RegionARN(cfg.CustomObject)
+
+	// KMSKeyARN
+	keyAlias := fmt.Sprintf("alias/%s", clusterID)
+	input := &kms.DescribeKeyInput{
+		KeyId: aws.String(keyAlias),
+	}
+	output, err := cfg.Clients.KMS.DescribeKey(input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	i.KMSKeyARN = *output.KeyMetadata.Arn
+
+	// S3Bucket
+	accountID, err := AccountID(cfg.Clients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	i.S3Bucket = key.BucketName(cfg.CustomObject, accountID)
+
+	return nil
+}

--- a/service/controller/v12/adapter/iam_policies_test.go
+++ b/service/controller/v12/adapter/iam_policies_test.go
@@ -1,0 +1,201 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterIamPoliciesRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description               string
+		customObject              v1alpha1.AWSConfig
+		expectedMasterRoleName    string
+		expectedMasterPolicyName  string
+		expectedMasterProfileName string
+		expectedWorkerRoleName    string
+		expectedWorkerPolicyName  string
+		expectedWorkerProfileName string
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedMasterRoleName:    "test-cluster-master-EC2-K8S-Role",
+			expectedMasterPolicyName:  "test-cluster-master-EC2-K8S-Policy",
+			expectedMasterProfileName: "test-cluster-master-EC2-K8S-Role",
+			expectedWorkerRoleName:    "test-cluster-worker-EC2-K8S-Role",
+			expectedWorkerPolicyName:  "test-cluster-worker-EC2-K8S-Policy",
+			expectedWorkerProfileName: "test-cluster-worker-EC2-K8S-Role",
+		},
+	}
+
+	clients := Clients{
+		KMS: &KMSClientMock{},
+		IAM: &IAMClientMock{},
+		STS: &STSClientMock{},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getIamPolicies(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.MasterPolicyName != tc.expectedMasterPolicyName {
+				t.Errorf("unexpected MasterPolicyName, got %q, want %q", a.MasterPolicyName, tc.expectedMasterPolicyName)
+			}
+
+			if a.MasterRoleName != tc.expectedMasterRoleName {
+				t.Errorf("unexpected MasterRoleName, got %q, want %q", a.MasterRoleName, tc.expectedMasterRoleName)
+			}
+
+			if a.MasterProfileName != tc.expectedMasterProfileName {
+				t.Errorf("unexpected MasterProfileName, got %q, want %q", a.MasterProfileName, tc.expectedMasterProfileName)
+			}
+
+			if a.WorkerPolicyName != tc.expectedWorkerPolicyName {
+				t.Errorf("unexpected WorkerPolicyName, got %q, want %q", a.WorkerPolicyName, tc.expectedWorkerPolicyName)
+			}
+
+			if a.WorkerRoleName != tc.expectedWorkerRoleName {
+				t.Errorf("unexpected WorkerRoleName, got %q, want %q", a.WorkerRoleName, tc.expectedWorkerRoleName)
+			}
+
+			if a.WorkerProfileName != tc.expectedWorkerProfileName {
+				t.Errorf("unexpected WorkerProfileName, got %q, want %q", a.WorkerProfileName, tc.expectedWorkerProfileName)
+			}
+		})
+	}
+}
+
+func TestAdapterIamPoliciesKMSKeyARN(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		customObject      v1alpha1.AWSConfig
+		expectedKMSKeyARN string
+		expectedError     bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedKMSKeyARN: "alias/test-cluster",
+		},
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			clients := Clients{
+				IAM: &IAMClientMock{},
+				KMS: &KMSClientMock{
+					keyARN:  tc.expectedKMSKeyARN,
+					isError: tc.expectedError,
+				},
+				STS: &STSClientMock{},
+			}
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getIamPolicies(cfg)
+			if tc.expectedError && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if !tc.expectedError {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+
+				if a.KMSKeyARN != tc.expectedKMSKeyARN {
+					t.Errorf("unexpected KMSKeyARN, got %q, want %q", a.KMSKeyARN, tc.expectedKMSKeyARN)
+				}
+			}
+		})
+	}
+}
+
+func TestAdapterIamPoliciesS3Bucket(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description      string
+		customObject     v1alpha1.AWSConfig
+		accountID        string
+		expectedS3Bucket string
+		expectedError    bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			accountID:        "111111111111",
+			expectedS3Bucket: "111111111111-g8s-test-cluster",
+		},
+		{
+			description: "client error",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			clients := Clients{
+				KMS: &KMSClientMock{},
+				IAM: &IAMClientMock{},
+				STS: &STSClientMock{
+					accountID: tc.accountID,
+					isError:   tc.expectedError,
+				},
+			}
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getIamPolicies(cfg)
+			if tc.expectedError && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if !tc.expectedError {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+
+				if a.S3Bucket != tc.expectedS3Bucket {
+					t.Errorf("unexpected S3Bucket, got %q, want %q", a.S3Bucket, tc.expectedS3Bucket)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/instance.go
+++ b/service/controller/v12/adapter/instance.go
@@ -1,0 +1,94 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/instance.go
+//
+
+type instanceAdapter struct {
+	Cluster instanceAdapterCluster
+	Image   instanceAdapterImage
+	Master  instanceAdapterMaster
+}
+
+type instanceAdapterCluster struct {
+	ID string
+}
+
+type instanceAdapterImage struct {
+	ID string
+}
+
+type instanceAdapterMaster struct {
+	AZ           string
+	CloudConfig  string
+	DockerVolume instanceAdapterMasterDockerVolume
+	EtcdVolume   instanceAdapterMasterEtcdVolume
+	Instance     instanceAdapterMasterInstance
+}
+
+type instanceAdapterMasterDockerVolume struct {
+	Name string
+}
+
+type instanceAdapterMasterEtcdVolume struct {
+	Name string
+}
+
+type instanceAdapterMasterInstance struct {
+	ResourceName string
+	Type         string
+	Monitoring   bool
+}
+
+func (i *instanceAdapter) Adapt(config Config) error {
+	{
+		i.Cluster.ID = key.ClusterID(config.CustomObject)
+	}
+
+	{
+		i.Image.ID = config.StackState.MasterImageID
+	}
+
+	{
+		i.Master.AZ = key.AvailabilityZone(config.CustomObject)
+
+		accountID, err := AccountID(config.Clients)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		c := SmallCloudconfigConfig{
+			MachineType:        prefixMaster,
+			Region:             key.Region(config.CustomObject),
+			S3URI:              fmt.Sprintf("%s-g8s-%s", accountID, i.Cluster.ID),
+			CloudConfigVersion: config.StackState.MasterCloudConfigVersion,
+		}
+		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		i.Master.CloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
+
+		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
+
+		i.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
+
+		i.Master.Instance.Type = config.StackState.MasterInstanceType
+
+		i.Master.Instance.Monitoring = config.StackState.MasterInstanceMonitoring
+	}
+
+	return nil
+}

--- a/service/controller/v12/adapter/instance_test.go
+++ b/service/controller/v12/adapter/instance_test.go
@@ -1,0 +1,145 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func Test_Adapter_Instance_RegularFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Description            string
+		Config                 Config
+		ExpectedAZ             string
+		ExpectedEtcdVolumeName string
+		ExpectedInstanceType   string
+	}{
+		{
+			Description: "case 0 basic matching, all fields present",
+			Config: Config{
+				Clients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+				CustomObject: v1alpha1.AWSConfig{
+					Spec: v1alpha1.AWSConfigSpec{
+						Cluster: v1alpha1.Cluster{
+							ID: "test-cluster",
+						},
+						AWS: v1alpha1.AWSConfigSpecAWS{
+							AZ:     "eu-central-1a",
+							Region: "eu-west-1",
+						},
+					},
+				},
+				StackState: StackState{
+					MasterInstanceType: "m3.large",
+				},
+			},
+			ExpectedAZ:             "eu-central-1a",
+			ExpectedEtcdVolumeName: "test-cluster-etcd",
+			ExpectedInstanceType:   "m3.large",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &instanceAdapter{}
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			if a.Master.AZ != tc.ExpectedAZ {
+				t.Fatalf("unexpected a.Master.AZ, got %q, want %q", a.Master.AZ, tc.ExpectedAZ)
+			}
+
+			if a.Master.EtcdVolume.Name != tc.ExpectedEtcdVolumeName {
+				t.Fatalf("unexpected a.Master.EtcdVolume.Name, got %q, want %q", a.Master.EtcdVolume.Name, tc.ExpectedEtcdVolumeName)
+			}
+
+			if a.Master.Instance.Type != tc.ExpectedInstanceType {
+				t.Fatalf("unexpected a.Master.Instance.Type, got %q, want %q", a.Master.Instance.Type, tc.ExpectedInstanceType)
+			}
+		})
+	}
+}
+
+func Test_Adapter_Instance_SmallCloudConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Description  string
+		ExpectedLine string
+		Region       string
+	}{
+		{
+			Description:  "case 0 userdata file",
+			ExpectedLine: "USERDATA_FILE=master",
+			Region:       "eu-west-1",
+		},
+		{
+			Description:  "scase 1 http URI",
+			ExpectedLine: "s3_http_uri=\"https://s3.eu-west-1.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/foo/$USERDATA_FILE\"",
+			Region:       "eu-west-1",
+		},
+		{
+			Description:  "scase 2 http URI different region",
+			ExpectedLine: "s3_http_uri=\"https://s3.eu-central-1.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/foo/$USERDATA_FILE\"",
+			Region:       "eu-central-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			clients := Clients{
+				EC2: &EC2ClientMock{},
+				IAM: &IAMClientMock{},
+				STS: &STSClientMock{accountID: "000000000000"},
+			}
+			customObject := v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-test",
+								InstanceType: "m3.large",
+							},
+						},
+						Region: tc.Region,
+					},
+				},
+			}
+			cfg := Config{
+				Clients:      clients,
+				CustomObject: customObject,
+				StackState: StackState{
+					MasterCloudConfigVersion: "foo",
+				},
+			}
+
+			a := &instanceAdapter{}
+			err := a.Adapt(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			data, err := base64.StdEncoding.DecodeString(a.Master.CloudConfig)
+			if err != nil {
+				t.Fatalf("unexpected error decoding a.Master.CloudConfig %v", err)
+			}
+
+			if !strings.Contains(string(data), tc.ExpectedLine) {
+				t.Fatalf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.ExpectedLine, string(data))
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/launch_configuration.go
+++ b/service/controller/v12/adapter/launch_configuration.go
@@ -1,0 +1,70 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/launch_configuration.go
+//
+
+type launchConfigAdapter struct {
+	WorkerAssociatePublicIPAddress bool
+	WorkerBlockDeviceMappings      []BlockDeviceMapping
+	WorkerInstanceMonitoring       bool
+	WorkerInstanceType             string
+	WorkerSecurityGroupID          string
+	WorkerSmallCloudConfig         string
+}
+
+type BlockDeviceMapping struct {
+	DeleteOnTermination bool
+	DeviceName          string
+	VolumeSize          int
+	VolumeType          string
+}
+
+func (l *launchConfigAdapter) getLaunchConfiguration(cfg Config) error {
+	l.WorkerInstanceType = key.WorkerInstanceType(cfg.CustomObject)
+	l.WorkerAssociatePublicIPAddress = false
+
+	l.WorkerBlockDeviceMappings = []BlockDeviceMapping{
+		{
+			DeleteOnTermination: true,
+			DeviceName:          defaultEBSVolumeMountPoint,
+			VolumeSize:          defaultEBSVolumeSize,
+			VolumeType:          defaultEBSVolumeType,
+		},
+	}
+	l.WorkerInstanceMonitoring = cfg.StackState.WorkerInstanceMonitoring
+
+	// small cloud config field.
+	accountID, err := AccountID(cfg.Clients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	clusterID := key.ClusterID(cfg.CustomObject)
+	s3URI := fmt.Sprintf("%s-g8s-%s", accountID, clusterID)
+
+	c := SmallCloudconfigConfig{
+		MachineType:        prefixWorker,
+		Region:             cfg.CustomObject.Spec.AWS.Region,
+		S3URI:              s3URI,
+		CloudConfigVersion: cloudconfig.WorkerCloudConfigVersion,
+	}
+	rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	l.WorkerSmallCloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+	return nil
+}

--- a/service/controller/v12/adapter/launch_configuration_test.go
+++ b/service/controller/v12/adapter/launch_configuration_test.go
@@ -1,0 +1,145 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                      string
+		customObject                     v1alpha1.AWSConfig
+		expectedError                    bool
+		expectedInstanceType             string
+		expectedAssociatePublicIPAddress bool
+		expectedBlockDeviceMappings      []BlockDeviceMapping
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								InstanceType: "myinstancetype",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType:             "myinstancetype",
+			expectedAssociatePublicIPAddress: false,
+			expectedBlockDeviceMappings: []BlockDeviceMapping{
+				{
+					DeleteOnTermination: true,
+					DeviceName:          defaultEBSVolumeMountPoint,
+					VolumeSize:          defaultEBSVolumeSize,
+					VolumeType:          defaultEBSVolumeType,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		clients := Clients{
+			EC2: &EC2ClientMock{},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getLaunchConfiguration(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.WorkerInstanceType != tc.expectedInstanceType {
+				t.Errorf("unexpected InstanceType, got %q, want %q", a.WorkerInstanceType, tc.expectedInstanceType)
+			}
+			if a.WorkerAssociatePublicIPAddress != tc.expectedAssociatePublicIPAddress {
+				t.Errorf("unexpected WorkerAssociatePublicIPAddress, got %t, want %t", a.WorkerAssociatePublicIPAddress, tc.expectedAssociatePublicIPAddress)
+			}
+			if !reflect.DeepEqual(a.WorkerBlockDeviceMappings, tc.expectedBlockDeviceMappings) {
+				t.Errorf("unexpected BlockDeviceMappings, got %v, want %v", a.WorkerBlockDeviceMappings, tc.expectedBlockDeviceMappings)
+			}
+		})
+	}
+}
+
+func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description  string
+		expectedLine string
+	}{
+		{
+			description:  "userdata file",
+			expectedLine: "USERDATA_FILE=worker",
+		},
+		{
+			description:  "s3 http uri",
+			expectedLine: `s3_http_uri="https://s3.myregion.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/v_3_3_1/$USERDATA_FILE"`,
+		},
+	}
+
+	a := Adapter{}
+	clients := Clients{
+		EC2: &EC2ClientMock{},
+		IAM: &IAMClientMock{},
+		STS: &STSClientMock{accountID: "000000000000"},
+	}
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "myregion",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "myimageid",
+						InstanceType: "myinstancetype",
+					},
+				},
+			},
+		},
+	}
+	cfg := Config{
+		CustomObject: customObject,
+		Clients:      clients,
+	}
+	err := a.getLaunchConfiguration(cfg)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(a.WorkerSmallCloudConfig)
+	if err != nil {
+		t.Errorf("unexpected error decoding SmallCloudConfig %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if !strings.Contains(string(data), tc.expectedLine) {
+				t.Errorf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.expectedLine, string(data))
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/lifecycle_hooks.go
+++ b/service/controller/v12/adapter/lifecycle_hooks.go
@@ -1,0 +1,32 @@
+package adapter
+
+import "github.com/giantswarm/aws-operator/service/controller/v11/key"
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/lifecycle_hooks.go
+//
+
+type lifecycleHooksAdapter struct {
+	Worker lifecycleHooksAdapterWorker
+}
+
+type lifecycleHooksAdapterWorker struct {
+	ASG           lifecycleHooksAdapterASG
+	LifecycleHook lifecycleHooksAdapterLifecycleHook
+}
+
+type lifecycleHooksAdapterASG struct {
+	Ref string
+}
+
+type lifecycleHooksAdapterLifecycleHook struct {
+	Name string
+}
+
+func (a *lifecycleHooksAdapter) Adapt(config Config) error {
+	a.Worker.ASG.Ref = key.WorkerASGRef
+	a.Worker.LifecycleHook.Name = key.NodeDrainerLifecycleHookName
+
+	return nil
+}

--- a/service/controller/v12/adapter/load_balancers.go
+++ b/service/controller/v12/adapter/load_balancers.go
@@ -1,0 +1,104 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/load_balancers.go
+//
+
+const (
+	// Default values for health checks.
+	healthCheckHealthyThreshold   = 2
+	healthCheckInterval           = 5
+	healthCheckTimeout            = 3
+	healthCheckUnhealthyThreshold = 2
+)
+
+type loadBalancersAdapter struct {
+	APIElbHealthCheckTarget          string
+	APIElbIdleTimoutSeconds          int
+	APIElbName                       string
+	APIElbPortsToOpen                portPairs
+	APIElbScheme                     string
+	APIElbSecurityGroupID            string
+	ELBHealthCheckHealthyThreshold   int
+	ELBHealthCheckInterval           int
+	ELBHealthCheckTimeout            int
+	ELBHealthCheckUnhealthyThreshold int
+	IngressElbHealthCheckTarget      string
+	IngressElbIdleTimoutSeconds      int
+	IngressElbName                   string
+	IngressElbPortsToOpen            portPairs
+	IngressElbScheme                 string
+}
+
+// portPair is a pair of ports.
+type portPair struct {
+	// PortELB is the port the ELB should listen on.
+	PortELB int
+	// PortInstance is the port on the instance the ELB forwards traffic to.
+	PortInstance int
+}
+
+// portPairs is an array of PortPair.
+type portPairs []portPair
+
+func (lb *loadBalancersAdapter) getLoadBalancers(cfg Config) error {
+	// API load balancer settings.
+	apiElbName, err := key.LoadBalancerName(cfg.CustomObject.Spec.Cluster.Kubernetes.API.Domain, cfg.CustomObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	lb.APIElbHealthCheckTarget = heathCheckTarget(cfg.CustomObject.Spec.Cluster.Kubernetes.API.SecurePort)
+	lb.APIElbIdleTimoutSeconds = cfg.CustomObject.Spec.AWS.API.ELB.IdleTimeoutSeconds
+	lb.APIElbName = apiElbName
+	lb.APIElbPortsToOpen = portPairs{
+		{
+			PortELB:      key.KubernetesAPISecurePort(cfg.CustomObject),
+			PortInstance: key.KubernetesAPISecurePort(cfg.CustomObject),
+		},
+	}
+	lb.APIElbScheme = externalELBScheme
+
+	// Ingress load balancer settings.
+	ingressElbName, err := key.LoadBalancerName(cfg.CustomObject.Spec.Cluster.Kubernetes.IngressController.Domain, cfg.CustomObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	lb.IngressElbHealthCheckTarget = heathCheckTarget(key.IngressControllerSecurePort(cfg.CustomObject))
+	lb.IngressElbIdleTimoutSeconds = cfg.CustomObject.Spec.AWS.Ingress.ELB.IdleTimeoutSeconds
+	lb.IngressElbName = ingressElbName
+	lb.IngressElbPortsToOpen = portPairs{
+		{
+			PortELB: httpsPort,
+
+			PortInstance: key.IngressControllerSecurePort(cfg.CustomObject),
+		},
+		{
+			PortELB:      httpPort,
+			PortInstance: key.IngressControllerInsecurePort(cfg.CustomObject),
+		},
+	}
+	lb.IngressElbScheme = externalELBScheme
+
+	// Load balancer health check settings.
+	lb.ELBHealthCheckHealthyThreshold = healthCheckHealthyThreshold
+	lb.ELBHealthCheckInterval = healthCheckInterval
+	lb.ELBHealthCheckTimeout = healthCheckTimeout
+	lb.ELBHealthCheckUnhealthyThreshold = healthCheckUnhealthyThreshold
+
+	return nil
+}
+
+func heathCheckTarget(port int) string {
+	return fmt.Sprintf("TCP:%d", port)
+}

--- a/service/controller/v12/adapter/load_balancers_test.go
+++ b/service/controller/v12/adapter/load_balancers_test.go
@@ -1,0 +1,174 @@
+package adapter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func TestAdapterLoadBalancersRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                              string
+		customObject                             v1alpha1.AWSConfig
+		errorMatcher                             func(error) bool
+		expectedAPIElbIdleTimoutSeconds          int
+		expectedAPIElbName                       string
+		expectedAPIElbPortsToOpen                portPairs
+		expectedAPIElbScheme                     string
+		expectedAPIElbSecurityGroupID            string
+		expectedAPIElbSubnetID                   string
+		expectedELBAZ                            string
+		expectedELBHealthCheckHealthyThreshold   int
+		expectedELBHealthCheckInterval           int
+		expectedELBHealthCheckTimeout            int
+		expectedELBHealthCheckUnhealthyThreshold int
+		expectedIngressElbIdleTimoutSeconds      int
+		expectedIngressElbName                   string
+		expectedIngressElbPortsToOpen            portPairs
+		expectedIngressElbScheme                 string
+	}{
+		{
+			description:  "empty custom object",
+			customObject: v1alpha1.AWSConfig{},
+			errorMatcher: key.IsMissingCloudConfigKey,
+		},
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								Domain:     "api.test-cluster.aws.giantswarm.io",
+								SecurePort: 443,
+							},
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								Domain:       "ingress.test-cluster.aws.giantswarm.io",
+								InsecurePort: 30010,
+								SecurePort:   30011,
+							},
+						},
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						API: v1alpha1.AWSConfigSpecAWSAPI{
+							ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+								IdleTimeoutSeconds: 3600,
+							},
+						},
+						AZ: "eu-central-1a",
+						Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+							ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+								IdleTimeoutSeconds: 60,
+							},
+						},
+					},
+				},
+			},
+			errorMatcher:                    nil,
+			expectedAPIElbIdleTimoutSeconds: 3600,
+			expectedAPIElbName:              "test-cluster-api",
+			expectedAPIElbPortsToOpen: portPairs{
+				{
+					PortELB:      443,
+					PortInstance: 443,
+				},
+			},
+			expectedAPIElbScheme:                     "internet-facing",
+			expectedELBAZ:                            "eu-central-1a",
+			expectedELBHealthCheckHealthyThreshold:   2,
+			expectedELBHealthCheckInterval:           5,
+			expectedELBHealthCheckTimeout:            3,
+			expectedELBHealthCheckUnhealthyThreshold: 2,
+			expectedIngressElbIdleTimoutSeconds:      60,
+			expectedIngressElbName:                   "test-cluster-ingress",
+			expectedIngressElbPortsToOpen: portPairs{
+				{
+					PortELB:      443,
+					PortInstance: 30011,
+				},
+				{
+					PortELB:      80,
+					PortInstance: 30010,
+				},
+			},
+			expectedIngressElbScheme: "internet-facing",
+		},
+	}
+
+	for _, tc := range testCases {
+		clients := Clients{
+			EC2: &EC2ClientMock{},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getLoadBalancers(cfg)
+
+			if tc.errorMatcher != nil && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Error("expected", true, "got", false)
+			}
+
+			if tc.expectedAPIElbIdleTimoutSeconds != a.APIElbIdleTimoutSeconds {
+				t.Errorf("expected API ELB Idle Timeout Seconds, got %q, want %q", a.APIElbIdleTimoutSeconds, tc.expectedAPIElbIdleTimoutSeconds)
+			}
+
+			if tc.expectedAPIElbName != a.APIElbName {
+				t.Errorf("expected API ELB Name, got %q, want %q", a.APIElbName, tc.expectedAPIElbName)
+			}
+
+			if !reflect.DeepEqual(tc.expectedAPIElbPortsToOpen, a.APIElbPortsToOpen) {
+				t.Errorf("expected API ELB Ports To Open, got %q, want %q", a.APIElbPortsToOpen, tc.expectedAPIElbPortsToOpen)
+			}
+
+			if tc.expectedAPIElbScheme != a.APIElbScheme {
+				t.Errorf("expected API ELB Scheme, got %q, want %q", a.APIElbScheme, tc.expectedAPIElbScheme)
+			}
+
+			if tc.expectedELBHealthCheckHealthyThreshold != a.ELBHealthCheckHealthyThreshold {
+				t.Errorf("expected ELB health check healthy threshold, got %q, want %q", a.ELBHealthCheckHealthyThreshold, tc.expectedELBHealthCheckHealthyThreshold)
+			}
+
+			if tc.expectedELBHealthCheckInterval != a.ELBHealthCheckInterval {
+				t.Errorf("expected ELB health check interval, got %q, want %q", a.ELBHealthCheckInterval, tc.expectedELBHealthCheckInterval)
+			}
+
+			if tc.expectedELBHealthCheckTimeout != a.ELBHealthCheckTimeout {
+				t.Errorf("expected ELB health check timeout, got %q, want %q", a.ELBHealthCheckTimeout, tc.expectedELBHealthCheckTimeout)
+			}
+
+			if tc.expectedELBHealthCheckUnhealthyThreshold != a.ELBHealthCheckUnhealthyThreshold {
+				t.Errorf("expected ELB health check unhealthy threshold, got %q, want %q", a.ELBHealthCheckUnhealthyThreshold, tc.expectedELBHealthCheckUnhealthyThreshold)
+			}
+
+			if tc.expectedIngressElbIdleTimoutSeconds != a.IngressElbIdleTimoutSeconds {
+				t.Errorf("expected Ingress ELB Idle Timeout Seconds, got %q, want %q", a.IngressElbIdleTimoutSeconds, tc.expectedIngressElbIdleTimoutSeconds)
+			}
+
+			if tc.expectedIngressElbName != a.IngressElbName {
+				t.Errorf("expected Ingress ELB Name, got %q, want %q", a.IngressElbName, tc.expectedIngressElbName)
+			}
+
+			if !reflect.DeepEqual(tc.expectedIngressElbPortsToOpen, a.IngressElbPortsToOpen) {
+				t.Errorf("expected Ingress ELB Ports To Open, got %v, want %v", a.IngressElbPortsToOpen, tc.expectedIngressElbPortsToOpen)
+			}
+
+			if tc.expectedIngressElbScheme != a.IngressElbScheme {
+				t.Errorf("expected Ingress ELB Scheme, got %q, want %q", a.IngressElbScheme, tc.expectedIngressElbScheme)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/mocks.go
+++ b/service/controller/v12/adapter/mocks.go
@@ -1,0 +1,265 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+)
+
+type EC2ClientMock struct {
+	ec2iface.EC2API
+
+	unexistingSg        bool
+	sgID                string
+	unexistingSubnet    bool
+	subnetID            string
+	matchingRouteTables int
+	routeTableID        string
+	vpcID               string
+	vpcCIDR             string
+	unexistingVPC       bool
+	peeringID           string
+	elasticIPs          []string
+}
+
+func (e *EC2ClientMock) DescribeAddresses(input *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
+	addresses := make([]*ec2.Address, 0)
+
+	for _, eip := range e.elasticIPs {
+		address := &ec2.Address{
+			PublicIp: aws.String(eip),
+		}
+
+		addresses = append(addresses, address)
+	}
+
+	output := &ec2.DescribeAddressesOutput{
+		Addresses: addresses,
+	}
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	if !e.unexistingSg {
+		output := &ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String(e.sgID),
+				},
+			},
+		}
+		return output, nil
+	}
+
+	return nil, fmt.Errorf("security group not found")
+}
+
+func (e *EC2ClientMock) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	if e.subnetID == "" {
+		e.subnetID = "subnet-1234"
+	}
+
+	if e.unexistingSubnet {
+		return nil, fmt.Errorf("subnet not found")
+	}
+
+	output := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{
+			{
+				SubnetId: aws.String(e.subnetID),
+			},
+		},
+	}
+	return output, nil
+}
+
+func (e *EC2ClientMock) SetMatchingRouteTables(value int) {
+	e.matchingRouteTables = value
+}
+
+func (e *EC2ClientMock) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	if e.matchingRouteTables == 0 {
+		return nil, fmt.Errorf("route table not found")
+	}
+
+	rts := []*ec2.RouteTable{}
+
+	for i := 0; i < e.matchingRouteTables; i++ {
+		rt := &ec2.RouteTable{
+			RouteTableId: aws.String(fmt.Sprintf("%s_%d", e.routeTableID, i)),
+		}
+		rts = append(rts, rt)
+	}
+
+	output := &ec2.DescribeRouteTablesOutput{
+		RouteTables: rts,
+	}
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	if e.unexistingVPC {
+		return nil, fmt.Errorf("vpc not found")
+	}
+
+	output := &ec2.DescribeVpcsOutput{
+		Vpcs: []*ec2.Vpc{
+			{
+				CidrBlock: aws.String(e.vpcCIDR),
+				VpcId:     aws.String(e.vpcID),
+			},
+		},
+	}
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	output := &ec2.DescribeVpcPeeringConnectionsOutput{
+		VpcPeeringConnections: []*ec2.VpcPeeringConnection{
+			{
+				VpcPeeringConnectionId: aws.String(e.peeringID),
+			},
+		},
+	}
+	return output, nil
+}
+
+type CFClientMock struct{}
+
+func (c *CFClientMock) CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error) {
+	return nil, nil
+}
+
+type IAMClientMock struct {
+	iamiface.IAMAPI
+
+	isError     bool
+	peerRoleArn string
+}
+
+func (i *IAMClientMock) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	if i.isError {
+		return nil, fmt.Errorf("error")
+	}
+	output := &iam.GetRoleOutput{
+		Role: &iam.Role{
+			Arn: aws.String(i.peerRoleArn),
+		},
+	}
+
+	return output, nil
+}
+
+type KMSClientMock struct {
+	kmsiface.KMSAPI
+
+	keyARN  string
+	isError bool
+}
+
+func (k *KMSClientMock) DescribeKey(input *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+	if k.isError {
+		return nil, fmt.Errorf("error")
+	}
+
+	output := &kms.DescribeKeyOutput{
+		KeyMetadata: &kms.KeyMetadata{
+			Arn: aws.String(k.keyARN),
+		},
+	}
+	return output, nil
+}
+
+type ELBClientMock struct {
+	elbiface.ELBAPI
+
+	dns        string
+	hostedZone string
+	name       string
+	isError    bool
+}
+
+func (e *ELBClientMock) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	if e.isError {
+		return nil, fmt.Errorf("error")
+	}
+	output := &elb.DescribeLoadBalancersOutput{
+		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
+			{
+				DNSName:                   aws.String(e.dns),
+				CanonicalHostedZoneNameID: aws.String(e.hostedZone),
+			},
+		},
+	}
+	return output, nil
+}
+
+type CloudFormationMock struct{}
+
+func (c *CloudFormationMock) CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) WaitUntilStackCreateComplete(*awscloudformation.DescribeStacksInput) error {
+	return nil
+}
+func (c *CloudFormationMock) WaitUntilStackCreateCompleteWithContext(ctx aws.Context, input *awscloudformation.DescribeStacksInput, opts ...request.WaiterOption) error {
+	return nil
+}
+
+type STSClientMock struct {
+	stsiface.STSAPI
+
+	accountID string
+	isError   bool
+}
+
+func (i *STSClientMock) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	if i.isError {
+		return nil, fmt.Errorf("error")
+	}
+	if i.accountID == "" {
+		i.accountID = "00"
+	}
+	// pad accountID to required length
+	toPad := accountIDLength - len(i.accountID)
+	for j := 0; j < toPad; j++ {
+		i.accountID += "0"
+	}
+	output := &sts.GetCallerIdentityOutput{
+		Arn: aws.String("::::" + i.accountID),
+	}
+
+	return output, nil
+}

--- a/service/controller/v12/adapter/outputs.go
+++ b/service/controller/v12/adapter/outputs.go
@@ -1,0 +1,70 @@
+package adapter
+
+import (
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/outputs.go
+//
+
+type outputsAdapter struct {
+	Master        outputsAdapterMaster
+	Worker        outputsAdapterWorker
+	VersionBundle outputsAdapterVersionBundle
+}
+
+type outputsAdapterMaster struct {
+	ImageID     string
+	Instance    outputsAdapterMasterInstance
+	CloudConfig outputsAdapterMasterCloudConfig
+}
+
+type outputsAdapterMasterInstance struct {
+	ResourceName string
+	Type         string
+}
+
+type outputsAdapterMasterCloudConfig struct {
+	Version string
+}
+
+type outputsAdapterWorker struct {
+	ASG          outputsAdapterWorkerASG
+	Count        string
+	ImageID      string
+	InstanceType string
+	CloudConfig  outputsAdapterWorkerCloudConfig
+}
+
+type outputsAdapterWorkerASG struct {
+	Key string
+	Ref string
+}
+
+type outputsAdapterWorkerCloudConfig struct {
+	Version string
+}
+
+type outputsAdapterVersionBundle struct {
+	Version string
+}
+
+func (a *outputsAdapter) Adapt(config Config) error {
+	a.Master.ImageID = config.StackState.MasterImageID
+	a.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
+	a.Master.Instance.Type = config.StackState.MasterInstanceType
+	a.Master.CloudConfig.Version = config.StackState.MasterCloudConfigVersion
+
+	a.Worker.ASG.Key = key.WorkerASGKey
+	a.Worker.ASG.Ref = key.WorkerASGRef
+	a.Worker.Count = config.StackState.WorkerCount
+	a.Worker.ImageID = config.StackState.WorkerImageID
+	a.Worker.InstanceType = config.StackState.WorkerInstanceType
+	a.Worker.CloudConfig.Version = config.StackState.WorkerCloudConfigVersion
+
+	a.VersionBundle.Version = config.StackState.VersionBundleVersion
+
+	return nil
+}

--- a/service/controller/v12/adapter/outputs_test.go
+++ b/service/controller/v12/adapter/outputs_test.go
@@ -1,0 +1,127 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func Test_CloudFormation_Adapter_Outputs_MasterCloudConfigVersion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description                      string
+		Config                           Config
+		ExpectedMasterCloudConfigVersion string
+	}{
+		{
+			Description: "master CloudConfig version should match the hardcoded value",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					MasterCloudConfigVersion: "foo",
+				},
+			},
+			ExpectedMasterCloudConfigVersion: "foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &outputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Master.CloudConfig.Version != tc.ExpectedMasterCloudConfigVersion {
+				t.Fatalf("expected %s got %s", tc.ExpectedMasterCloudConfigVersion, a.Master.CloudConfig.Version)
+			}
+		})
+	}
+}
+
+func Test_CloudFormation_Adapter_Outputs_WorkerCloudConfigVersion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description                      string
+		Config                           Config
+		ExpectedWorkerCloudConfigVersion string
+	}{
+		{
+			Description: "worker CloudConfig version should match the hardcoded value",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCloudConfigVersion: "foo",
+				},
+			},
+			ExpectedWorkerCloudConfigVersion: "foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &outputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Worker.CloudConfig.Version != tc.ExpectedWorkerCloudConfigVersion {
+				t.Fatalf("expected %s got %s", tc.ExpectedWorkerCloudConfigVersion, a.Worker.CloudConfig.Version)
+			}
+		})
+	}
+}
+
+func Test_CloudFormation_Adapter_Outputs_WorkerCount(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description         string
+		Config              Config
+		ExpectedWorkerCount string
+	}{
+		{
+			Description: "worker count should match the number of workers within the configured custom object when one worker is given",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCount: "1",
+				},
+			},
+			ExpectedWorkerCount: "1",
+		},
+
+		{
+			Description: "worker count should match the number of workers within the configured custom object when three workers are given",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCount: "3",
+				},
+			},
+			ExpectedWorkerCount: "3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &outputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Worker.Count != tc.ExpectedWorkerCount {
+				t.Fatalf("expected %s got %s", tc.ExpectedWorkerCount, a.Worker.Count)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/recordsets.go
+++ b/service/controller/v12/adapter/recordsets.go
@@ -1,0 +1,32 @@
+package adapter
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/recordsets.go
+//
+
+type recordSetsAdapter struct {
+	APIELBHostedZones         string
+	APIELBDomain              string
+	EtcdELBHostedZones        string
+	EtcdELBDomain             string
+	IngressELBDNS             string
+	IngressELBHostedZones     string
+	IngressELBAliasHostedZone string
+	IngressELBDomain          string
+	IngressWildcardELBDomain  string
+	Route53Enabled            bool
+}
+
+func (r *recordSetsAdapter) getRecordSets(cfg Config) error {
+	r.APIELBHostedZones = cfg.CustomObject.Spec.AWS.API.HostedZones
+	r.APIELBDomain = cfg.CustomObject.Spec.Cluster.Kubernetes.API.Domain
+	r.EtcdELBHostedZones = cfg.CustomObject.Spec.AWS.Etcd.HostedZones
+	r.EtcdELBDomain = cfg.CustomObject.Spec.Cluster.Etcd.Domain
+	r.IngressELBHostedZones = cfg.CustomObject.Spec.AWS.Ingress.HostedZones
+	r.IngressELBDomain = cfg.CustomObject.Spec.Cluster.Kubernetes.IngressController.Domain
+	r.IngressWildcardELBDomain = cfg.CustomObject.Spec.Cluster.Kubernetes.IngressController.WildcardDomain
+	r.Route53Enabled = cfg.Route53Enabled
+
+	return nil
+}

--- a/service/controller/v12/adapter/recordsets_test.go
+++ b/service/controller/v12/adapter/recordsets_test.go
@@ -1,0 +1,112 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterRecordSetsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                   string
+		customObject                  v1alpha1.AWSConfig
+		route53Enabled                bool
+		expectedAPIHostedZone         string
+		expectedAPIDomain             string
+		expectedEtcdHostedZone        string
+		expectedEtcdDomain            string
+		expectedIngressHostedZone     string
+		expectedIngressDomain         string
+		expectedIngressWildcardDomain string
+		expectedRoute53Enabled        bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								Domain: "api.domain",
+							},
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								Domain:         "ingress.domain",
+								WildcardDomain: "ingressWildcardDomain",
+							},
+						},
+						Etcd: v1alpha1.ClusterEtcd{
+							Domain: "etcd.domain",
+						},
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						API: v1alpha1.AWSConfigSpecAWSAPI{
+							HostedZones: "apiHostedZones",
+						},
+						Etcd: v1alpha1.AWSConfigSpecAWSEtcd{
+							HostedZones: "etcdHostedZone",
+						},
+						Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+							HostedZones: "ingressHostedZone",
+						},
+					},
+				},
+			},
+			route53Enabled:                true,
+			expectedAPIHostedZone:         "apiHostedZones",
+			expectedAPIDomain:             "api.domain",
+			expectedEtcdHostedZone:        "etcdHostedZone",
+			expectedEtcdDomain:            "etcd.domain",
+			expectedIngressHostedZone:     "ingressHostedZone",
+			expectedIngressDomain:         "ingress.domain",
+			expectedIngressWildcardDomain: "ingressWildcardDomain",
+			expectedRoute53Enabled:        true,
+		},
+	}
+
+	clients := Clients{
+		EC2: &EC2ClientMock{},
+		ELB: &ELBClientMock{},
+		STS: &STSClientMock{},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:   tc.customObject,
+				Clients:        clients,
+				Route53Enabled: tc.route53Enabled,
+			}
+			err := a.getRecordSets(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.APIELBHostedZones != tc.expectedAPIHostedZone {
+				t.Errorf("unexpected APIELBHostedZones, got %q, want %q", a.APIELBHostedZones, tc.expectedAPIHostedZone)
+			}
+			if a.APIELBDomain != tc.expectedAPIDomain {
+				t.Errorf("unexpected APIELBDomain, got %q, want %q", a.APIELBDomain, tc.expectedAPIDomain)
+			}
+			if a.EtcdELBHostedZones != tc.expectedEtcdHostedZone {
+				t.Errorf("unexpected EtcdELBHostedZones, got %q, want %q", a.EtcdELBHostedZones, tc.expectedEtcdHostedZone)
+			}
+			if a.EtcdELBDomain != tc.expectedEtcdDomain {
+				t.Errorf("unexpected EtcdELBDomain, got %q, want %q", a.EtcdELBDomain, tc.expectedEtcdDomain)
+			}
+			if a.IngressELBHostedZones != tc.expectedIngressHostedZone {
+				t.Errorf("unexpected IngressELBHostedZones, got %q, want %q", a.IngressELBHostedZones, tc.expectedIngressHostedZone)
+			}
+			if a.IngressELBDomain != tc.expectedIngressDomain {
+				t.Errorf("unexpected IngressELBDomain, got %q, want %q", a.IngressELBDomain, tc.expectedIngressDomain)
+			}
+			if a.IngressWildcardELBDomain != tc.expectedIngressWildcardDomain {
+				t.Errorf("unexpected IngressWildcardELBDomain, got %q, want %q", a.IngressWildcardELBDomain, tc.expectedIngressWildcardDomain)
+			}
+			if a.Route53Enabled != tc.expectedRoute53Enabled {
+				t.Errorf("unexpected Route53Enabled, got %t, want %t", a.Route53Enabled, tc.expectedRoute53Enabled)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/route_tables.go
+++ b/service/controller/v12/adapter/route_tables.go
@@ -1,0 +1,31 @@
+package adapter
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/route_tables.go
+//
+
+type routeTablesAdapter struct {
+	HostClusterCIDR       string
+	PublicRouteTableName  string
+	PrivateRouteTableName string
+}
+
+func (r *routeTablesAdapter) getRouteTables(cfg Config) error {
+	hostClusterCIDR, err := VpcCIDR(cfg.HostClients, key.PeerID(cfg.CustomObject))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.HostClusterCIDR = hostClusterCIDR
+	r.PublicRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPublic)
+	r.PrivateRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPrivate)
+
+	return nil
+}

--- a/service/controller/v12/adapter/route_tables_test.go
+++ b/service/controller/v12/adapter/route_tables_test.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterRouteTablesRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                   string
+		customObject                  v1alpha1.AWSConfig
+		expectedError                 bool
+		expectedHostClusterCIDR       string
+		expectedPublicRouteTableName  string
+		expectedPrivateRouteTableName string
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedError:                 false,
+			expectedHostClusterCIDR:       "10.0.0.0/16",
+			expectedPublicRouteTableName:  "test-cluster-public",
+			expectedPrivateRouteTableName: "test-cluster-private",
+		},
+	}
+
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				vpcCIDR: tc.expectedHostClusterCIDR,
+			},
+			STS: &STSClientMock{},
+		}
+
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+			err := a.getRouteTables(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.HostClusterCIDR != tc.expectedHostClusterCIDR {
+				t.Errorf("unexpected HostClusterCIDR, got %q, want %q", a.HostClusterCIDR, tc.expectedHostClusterCIDR)
+			}
+
+			if a.PublicRouteTableName != tc.expectedPublicRouteTableName {
+				t.Errorf("unexpected PublicRouteTableName, got %q, want %q", a.PublicRouteTableName, tc.expectedPrivateRouteTableName)
+			}
+
+			if a.PrivateRouteTableName != tc.expectedPrivateRouteTableName {
+				t.Errorf("unexpected PrivateRouteTableName, got %q, want %q", a.PrivateRouteTableName, tc.expectedPrivateRouteTableName)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/security_groups.go
+++ b/service/controller/v12/adapter/security_groups.go
@@ -1,0 +1,283 @@
+package adapter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/security_groups.go
+//
+
+type securityGroupsAdapter struct {
+	APIWhitelistEnabled       bool
+	MasterSecurityGroupName   string
+	MasterSecurityGroupRules  []securityGroupRule
+	WorkerSecurityGroupName   string
+	WorkerSecurityGroupRules  []securityGroupRule
+	IngressSecurityGroupName  string
+	IngressSecurityGroupRules []securityGroupRule
+}
+
+type securityGroupRule struct {
+	Port                int
+	Protocol            string
+	SourceCIDR          string
+	SourceSecurityGroup string
+}
+
+const (
+	allPorts             = -1
+	cadvisorPort         = 4194
+	etcdPort             = 2379
+	kubeletPort          = 10250
+	nodeExporterPort     = 10300
+	kubeStateMetricsPort = 10301
+	sshPort              = 22
+
+	allProtocols = "-1"
+	tcpProtocol  = "tcp"
+
+	defaultCIDR = "0.0.0.0/0"
+
+	ingressSecurityGroupName = "IngressSecurityGroup"
+)
+
+func (s *securityGroupsAdapter) getSecurityGroups(cfg Config) error {
+	hostClusterCIDR, err := VpcCIDR(cfg.HostClients, key.PeerID(cfg.CustomObject))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	masterRules, err := s.getMasterRules(cfg, hostClusterCIDR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixMaster)
+	s.MasterSecurityGroupRules = masterRules
+
+	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixWorker)
+	s.WorkerSecurityGroupRules = s.getWorkerRules(cfg.CustomObject, hostClusterCIDR)
+
+	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixIngress)
+	s.IngressSecurityGroupRules = s.getIngressRules(cfg.CustomObject)
+
+	return nil
+}
+
+func (s *securityGroupsAdapter) getMasterRules(cfg Config, hostClusterCIDR string) ([]securityGroupRule, error) {
+	// Allow traffic to the Kubernetes API server depending on the API
+	// whitelisting rules.
+	apiRules, err := getKubernetesAPIRules(cfg, hostClusterCIDR)
+	if err != nil {
+		return []securityGroupRule{}, microerror.Mask(err)
+	}
+
+	// Other security group rules for the master.
+	otherRules := []securityGroupRule{
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 2379 for etcd backup.
+		{
+			Port:       etcdPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10250 for kubelet scraping.
+		{
+			Port:       kubeletPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10300 for node-exporter scraping.
+		{
+			Port:       nodeExporterPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10301 for kube-state-metrics scraping.
+		{
+			Port:       kubeStateMetricsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Only allow ssh traffic from the host cluster.
+		{
+			Port:       sshPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+	}
+	return append(apiRules, otherRules...), nil
+}
+
+func (s *securityGroupsAdapter) getWorkerRules(customObject v1alpha1.AWSConfig, hostClusterCIDR string) []securityGroupRule {
+	return []securityGroupRule{
+		// Allow traffic from the ingress security group to the ingress controller.
+		{
+			Port:                key.IngressControllerSecurePort(customObject),
+			Protocol:            tcpProtocol,
+			SourceSecurityGroup: ingressSecurityGroupName,
+		},
+		{
+			Port:                key.IngressControllerInsecurePort(customObject),
+			Protocol:            tcpProtocol,
+			SourceSecurityGroup: ingressSecurityGroupName,
+		},
+		// Allow traffic from host cluster to ingress controller secure port,
+		// for guest cluster scraping.
+		{
+			Port:       key.IngressControllerSecurePort(customObject),
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10250 for kubelet scraping.
+		{
+			Port:       kubeletPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10300 for node-exporter scraping.
+		{
+			Port:       nodeExporterPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10301 for kube-state-metrics scraping.
+		{
+			Port:       kubeStateMetricsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Only allow ssh traffic from the host cluster.
+		{
+			Port:       sshPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+	}
+}
+
+func (s *securityGroupsAdapter) getIngressRules(customObject v1alpha1.AWSConfig) []securityGroupRule {
+	return []securityGroupRule{
+		// Allow all http and https traffic to the ingress load balancer.
+		{
+			Port:       httpPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: defaultCIDR,
+		},
+		{
+			Port:       httpsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: defaultCIDR,
+		},
+	}
+}
+
+func getKubernetesAPIRules(cfg Config, hostClusterCIDR string) ([]securityGroupRule, error) {
+	// When API whitelisting is enabled, add separate security group rule per each subnet.
+	if cfg.APIWhitelist.Enabled {
+		rules := []securityGroupRule{
+			// Allow traffic from host cluster CIDR.
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: hostClusterCIDR,
+			},
+			// Allow traffic from guest cluster CIDR.
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: cfg.CustomObject.Spec.AWS.VPC.CIDR,
+			},
+		}
+
+		// Whitelist all configured subnets.
+		whitelistSubnets := strings.Split(cfg.APIWhitelist.SubnetList, ",")
+		for _, subnet := range whitelistSubnets {
+			if subnet != "" {
+				subnetRule := securityGroupRule{
+					Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+					Protocol:   tcpProtocol,
+					SourceCIDR: subnet,
+				}
+				rules = append(rules, subnetRule)
+			}
+		}
+
+		// Whitelist public EIPs of the host cluster NAT gateways.
+		hostClusterNATGatewayRules, err := getHostClusterNATGatewayRules(cfg)
+		if err != nil {
+			return []securityGroupRule{}, microerror.Mask(err)
+		}
+
+		for _, gatewayRule := range hostClusterNATGatewayRules {
+			rules = append(rules, gatewayRule)
+		}
+
+		return rules, nil
+	} else {
+		// When API whitelisting is disabled, allow all traffic.
+		allowAllRule := []securityGroupRule{
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: defaultCIDR,
+			},
+		}
+
+		return allowAllRule, nil
+	}
+}
+
+func getHostClusterNATGatewayRules(cfg Config) ([]securityGroupRule, error) {
+	gatewayRules := []securityGroupRule{}
+
+	// Get all EIPs tagged with the host cluster installation tag.
+	// Each EIP is associated with a host cluster NAT gateway.
+	describeAddressesInput := &ec2.DescribeAddressesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:giantswarm.io/installation"),
+				Values: []*string{
+					aws.String(cfg.InstallationName),
+				},
+			},
+		},
+	}
+	output, err := cfg.HostClients.EC2.DescribeAddresses(describeAddressesInput)
+	if err != nil {
+		return gatewayRules, microerror.Mask(err)
+	}
+
+	for _, address := range output.Addresses {
+		gatewayRule := securityGroupRule{
+			Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+			Protocol:   tcpProtocol,
+			SourceCIDR: fmt.Sprintf("%s/32", *address.PublicIp),
+		}
+
+		gatewayRules = append(gatewayRules, gatewayRule)
+	}
+
+	return gatewayRules, nil
+}

--- a/service/controller/v12/adapter/security_groups_test.go
+++ b/service/controller/v12/adapter/security_groups_test.go
@@ -1,0 +1,494 @@
+package adapter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                       string
+		customObject                      v1alpha1.AWSConfig
+		expectedError                     bool
+		expectedMasterSecurityGroupName   string
+		expectedMasterSecurityGroupRules  []securityGroupRule
+		expectedWorkerSecurityGroupName   string
+		expectedWorkerSecurityGroupRules  []securityGroupRule
+		expectedIngressSecurityGroupName  string
+		expectedIngressSecurityGroupRules []securityGroupRule
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							PeerID: "vpc-1234",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								SecurePort:   30010,
+								InsecurePort: 30011,
+							},
+						},
+					},
+				},
+			},
+			expectedError:                   false,
+			expectedMasterSecurityGroupName: "test-cluster-master",
+			expectedMasterSecurityGroupRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+				{
+					Port:       4194,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10250,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10300,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10301,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       22,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+			},
+			expectedWorkerSecurityGroupName: "test-cluster-worker",
+			expectedWorkerSecurityGroupRules: []securityGroupRule{
+				{
+					Port:                30010,
+					Protocol:            "tcp",
+					SourceSecurityGroup: "IngressSecurityGroup",
+				},
+				{
+					Port:                30011,
+					Protocol:            "tcp",
+					SourceSecurityGroup: "IngressSecurityGroup",
+				},
+				{
+					Port:       30010,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       4194,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10250,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10300,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10301,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       22,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+			},
+			expectedIngressSecurityGroupName: "test-cluster-ingress",
+			expectedIngressSecurityGroupRules: []securityGroupRule{
+				{
+					Port:       80,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				vpcCIDR: "10.0.0.0/16",
+			},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+			err := a.getSecurityGroups(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.MasterSecurityGroupName != tc.expectedMasterSecurityGroupName {
+				t.Errorf("unexpected MasterGroupName, got %q, want %q", a.MasterSecurityGroupName, tc.expectedMasterSecurityGroupName)
+			}
+
+			if a.WorkerSecurityGroupName != tc.expectedWorkerSecurityGroupName {
+				t.Errorf("unexpected WorkerGroupName, got %q, want %q", a.WorkerSecurityGroupName, tc.expectedWorkerSecurityGroupName)
+			}
+
+			if !reflect.DeepEqual(a.WorkerSecurityGroupRules, tc.expectedWorkerSecurityGroupRules) {
+				t.Errorf("unexpected Worker Security Group Rules, got %v, want %v", a.WorkerSecurityGroupRules, tc.expectedWorkerSecurityGroupRules)
+			}
+
+			if a.IngressSecurityGroupName != tc.expectedIngressSecurityGroupName {
+				t.Errorf("unexpected IngressGroupName, got %q, want %q", a.IngressSecurityGroupName, tc.expectedIngressSecurityGroupName)
+			}
+
+			if !reflect.DeepEqual(a.IngressSecurityGroupRules, tc.expectedIngressSecurityGroupRules) {
+				t.Errorf("unexpected Ingress Security Group Rules, got %v, want %v", a.IngressSecurityGroupRules, tc.expectedIngressSecurityGroupRules)
+			}
+		})
+	}
+}
+
+func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description            string
+		customObject           v1alpha1.AWSConfig
+		apiWhitelistingEnabled bool
+		apiWhitelistSubnets    string
+		elasticIPs             []string
+		hostClusterCIDR        string
+		expectedError          bool
+		expectedRules          []securityGroupRule
+	}{
+		{
+			description: "case 0: API whitelisting disabled",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: false,
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+			},
+		},
+		{
+			description: "case 1: API whitelisting enabled with default rules",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+			},
+		},
+		{
+			description: "case 2: API whitelisting enabled with single configured subnet",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32",
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+			},
+		},
+		{
+			description: "case 3: API whitelisting enabled with multiple configured subnets",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32,192.168.1.0/24,10.2.2.0/24",
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "192.168.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.2.2.0/24",
+				},
+			},
+		},
+		{
+			description: "case 4: API whitelisting enabled with NAT gateway EIPs",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			elasticIPs: []string{
+				"21.1.136.42",
+				"21.2.136.84",
+			},
+			hostClusterCIDR: "10.0.0.0/16",
+			expectedError:   false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.1.136.42/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.2.136.84/32",
+				},
+			},
+		},
+		{
+			description: "case 5: API whitelisting enabled with subnets and NAT gateway EIPs",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32,192.168.1.1/24",
+			elasticIPs: []string{
+				"21.1.136.42",
+				"21.2.136.84",
+			},
+			hostClusterCIDR: "10.0.0.0/16",
+			expectedError:   false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "192.168.1.1/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.1.136.42/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.2.136.84/32",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				elasticIPs: tc.elasticIPs,
+			},
+			STS: &STSClientMock{},
+		}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				APIWhitelist: APIWhitelist{
+					Enabled:    tc.apiWhitelistingEnabled,
+					SubnetList: tc.apiWhitelistSubnets,
+				},
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+
+			rules, err := getKubernetesAPIRules(cfg, tc.hostClusterCIDR)
+			if tc.expectedError && err == nil {
+				t.Fatalf("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			if len(tc.expectedRules) != len(rules) {
+				t.Fatalf("expected %d master rules got %d", len(tc.expectedRules), len(rules))
+			}
+
+			if !reflect.DeepEqual(tc.expectedRules, rules) {
+				t.Fatalf("expected master rules %v got %v", tc.expectedRules, rules)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/spec.go
+++ b/service/controller/v12/adapter/spec.go
@@ -1,0 +1,150 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+const (
+	prefixMaster  = "master"
+	prefixWorker  = "worker"
+	prefixIngress = "ingress"
+
+	// asgMaxBatchSizeRatio is the % of instances to be updated during a
+	// rolling update.
+	asgMaxBatchSizeRatio = 0.3
+	// asgMinInstancesRatio is the % of instances to keep in service during a
+	// rolling update.
+	asgMinInstancesRatio = 0.7
+	// defaultEBSVolumeMountPoint is the path for mounting the EBS volume.
+	defaultEBSVolumeMountPoint = "/dev/xvdh"
+	// defaultEBSVolumeSize is expressed in GB.
+	defaultEBSVolumeSize = 50
+	// defaultEBSVolumeType is the EBS volume type.
+	defaultEBSVolumeType = "gp2"
+	// rollingUpdatePauseTime is how long to pause ASG operations after creating
+	// new instances. This allows time for new nodes to join the cluster.
+	rollingUpdatePauseTime = "PT5M"
+
+	// Subnet keys
+	subnetDescription = "description"
+	subnetGroupName   = "group-name"
+
+	// accountIDIndex represents the index in which we can find the account ID in the user ARN
+	// (splitting by colon)
+	accountIDIndex  = 4
+	accountIDLength = 12
+
+	// The number of seconds AWS will wait, before issuing a health check on
+	// instances in an Auto Scaling Group.
+	gracePeriodSeconds = 10
+
+	tagKeyName = "Name"
+
+	suffixPublic  = "public"
+	suffixPrivate = "private"
+
+	externalELBScheme = "internet-facing"
+	internalELBScheme = "internal"
+
+	httpPort  = 80
+	httpsPort = 443
+
+	// RootDirElement marks the directory that should be taken as root when evaluating
+	// template's relative paths.
+	RootDirElement = "aws-operator"
+)
+
+// APIWhitelist defines guest cluster k8s api whitelisting.
+type APIWhitelist struct {
+	Enabled    bool
+	SubnetList string
+}
+
+type Clients struct {
+	CloudFormation CFClient
+	EC2            EC2Client
+	IAM            IAMClient
+	KMS            KMSClient
+	ELB            ELBClient
+	STS            STSClient
+}
+
+// TODO we copy this because of a circular import issue with the cloudformation
+// resource. The way how the resource works with the adapter and how infromation
+// is passed has to be reworked at some point. Just hacking this now to keep
+// going and to keep the changes as minimal as possible.
+type StackState struct {
+	Name string
+
+	MasterImageID              string
+	MasterInstanceType         string
+	MasterInstanceResourceName string
+	MasterCloudConfigVersion   string
+	MasterInstanceMonitoring   bool
+
+	WorkerCount              string
+	WorkerImageID            string
+	WorkerInstanceMonitoring bool
+	WorkerInstanceType       string
+	WorkerCloudConfigVersion string
+
+	VersionBundleVersion string
+}
+
+// CFClient describes the methods required to be implemented by a CloudFormation
+// AWS client.
+type CFClient interface {
+	CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error)
+	DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error)
+	DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error)
+	UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error)
+	WaitUntilStackCreateComplete(*awscloudformation.DescribeStacksInput) error
+	WaitUntilStackCreateCompleteWithContext(ctx aws.Context, input *awscloudformation.DescribeStacksInput, opts ...request.WaiterOption) error
+}
+
+// EC2Client describes the methods required to be implemented by a EC2 AWS client.
+type EC2Client interface {
+	DescribeAddresses(*ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
+}
+
+// IAMClient describes the methods required to be implemented by a IAM AWS client.
+type IAMClient interface {
+	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
+	GetRole(*iam.GetRoleInput) (*iam.GetRoleOutput, error)
+}
+
+// KMSClient describes the methods required to be implemented by a KMS AWS client.
+type KMSClient interface {
+	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
+}
+
+// SmallCloudconfigConfig represents the data structure required for executing the
+// small cloudconfig template.
+type SmallCloudconfigConfig struct {
+	MachineType        string
+	Region             string
+	S3URI              string
+	CloudConfigVersion string
+}
+
+// ELBClient describes the methods required to be implemented by a ELB AWS client.
+type ELBClient interface {
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+}
+
+// STSClient describes the methods required to be implemented by a STS AWS client.
+type STSClient interface {
+	GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+}

--- a/service/controller/v12/adapter/sts.go
+++ b/service/controller/v12/adapter/sts.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/giantswarm/microerror"
+)
+
+func AccountID(clients Clients) (string, error) {
+	resp, err := clients.STS.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	userArn := *resp.Arn
+	accountID := strings.Split(userArn, ":")[accountIDIndex]
+	if err := ValidateAccountID(accountID); err != nil {
+		return "", microerror.Mask(err)
+	}
+	return accountID, nil
+}
+
+func ValidateAccountID(accountID string) error {
+	r, _ := regexp.Compile("^[0-9]*$")
+
+	switch {
+	case accountID == "":
+		return microerror.Mask(emptyAmazonAccountIDError)
+	case len(accountID) != accountIDLength:
+		return microerror.Mask(wrongAmazonAccountIDLengthError)
+	case !r.MatchString(accountID):
+		return microerror.Mask(malformedAmazonAccountIDError)
+	}
+
+	return nil
+}

--- a/service/controller/v12/adapter/sts_test.go
+++ b/service/controller/v12/adapter/sts_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidAmazonAccountID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		amazonAccountID string
+		err             error
+	}{
+		{
+			name:            "ID has wrong length",
+			amazonAccountID: "foo",
+			err:             wrongAmazonAccountIDLengthError,
+		},
+		{
+			name:            "ID contains letters",
+			amazonAccountID: "123foo123foo",
+			err:             malformedAmazonAccountIDError,
+		},
+		{
+			name:            "ID is empty",
+			amazonAccountID: "",
+			err:             emptyAmazonAccountIDError,
+		},
+		{
+			name:            "ID has correct format",
+			amazonAccountID: "123456789012",
+			err:             nil,
+		},
+	}
+
+	for _, tc := range tests {
+		err := ValidateAccountID(tc.amazonAccountID)
+		assert.Equal(t, microerror.Cause(tc.err), microerror.Cause(err), fmt.Sprintf("[%s] The return value was not what we expected", tc.name))
+	}
+}

--- a/service/controller/v12/adapter/subnets.go
+++ b/service/controller/v12/adapter/subnets.go
@@ -1,0 +1,34 @@
+package adapter
+
+import (
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/subnets.go
+//
+
+type subnetsAdapter struct {
+	PublicSubnetAZ                   string
+	PublicSubnetCIDR                 string
+	PublicSubnetName                 string
+	PublicSubnetMapPublicIPOnLaunch  bool
+	PrivateSubnetAZ                  string
+	PrivateSubnetCIDR                string
+	PrivateSubnetName                string
+	PrivateSubnetMapPublicIPOnLaunch bool
+}
+
+func (s *subnetsAdapter) getSubnets(cfg Config) error {
+	s.PublicSubnetAZ = key.AvailabilityZone(cfg.CustomObject)
+	s.PublicSubnetCIDR = cfg.CustomObject.Spec.AWS.VPC.PublicSubnetCIDR
+	s.PublicSubnetName = key.SubnetName(cfg.CustomObject, suffixPublic)
+	s.PublicSubnetMapPublicIPOnLaunch = false
+	s.PrivateSubnetAZ = key.AvailabilityZone(cfg.CustomObject)
+	s.PrivateSubnetCIDR = key.PrivateSubnetCIDR(cfg.CustomObject)
+	s.PrivateSubnetName = key.SubnetName(cfg.CustomObject, suffixPrivate)
+	s.PrivateSubnetMapPublicIPOnLaunch = false
+
+	return nil
+}

--- a/service/controller/v12/adapter/subnets_test.go
+++ b/service/controller/v12/adapter/subnets_test.go
@@ -1,0 +1,103 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterSubnetsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                              string
+		customObject                             v1alpha1.AWSConfig
+		expectedError                            bool
+		expectedPublicSubnetAZ                   string
+		expectedPublicSubnetCIDR                 string
+		expectedPublicSubnetName                 string
+		expectedPublicSubnetMapPublicIPOnLaunch  bool
+		expectedPrivateSubnetAZ                  string
+		expectedPrivateSubnetCIDR                string
+		expectedPrivateSubnetName                string
+		expectedPrivateSubnetMapPublicIPOnLaunch bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "eu-central-1a",
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							PublicSubnetCIDR:  "10.1.1.0/25",
+							PrivateSubnetCIDR: "10.1.2.0/25",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedError:                            false,
+			expectedPublicSubnetAZ:                   "eu-central-1a",
+			expectedPublicSubnetCIDR:                 "10.1.1.0/25",
+			expectedPublicSubnetName:                 "test-cluster-public",
+			expectedPublicSubnetMapPublicIPOnLaunch:  false,
+			expectedPrivateSubnetAZ:                  "eu-central-1a",
+			expectedPrivateSubnetCIDR:                "10.1.2.0/25",
+			expectedPrivateSubnetName:                "test-cluster-private",
+			expectedPrivateSubnetMapPublicIPOnLaunch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		clients := Clients{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.getSubnets(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.PublicSubnetAZ != tc.expectedPublicSubnetAZ {
+				t.Errorf("unexpected PublicSubnetAZ, got %q, want %q", a.PublicSubnetAZ, tc.expectedPublicSubnetAZ)
+			}
+
+			if a.PublicSubnetCIDR != tc.expectedPublicSubnetCIDR {
+				t.Errorf("unexpected PublicSubnetCIDR, got %q, want %q", a.PublicSubnetCIDR, tc.expectedPublicSubnetCIDR)
+			}
+
+			if a.PublicSubnetName != tc.expectedPublicSubnetName {
+				t.Errorf("unexpected PublicSubnetName, got %q, want %q", a.PublicSubnetName, tc.expectedPublicSubnetName)
+			}
+
+			if a.PublicSubnetMapPublicIPOnLaunch != tc.expectedPublicSubnetMapPublicIPOnLaunch {
+				t.Errorf("unexpected PublicSubnetMapPublicIPOnLaunch, got %t, want %t", a.PublicSubnetMapPublicIPOnLaunch, tc.expectedPublicSubnetMapPublicIPOnLaunch)
+			}
+
+			if a.PrivateSubnetAZ != tc.expectedPrivateSubnetAZ {
+				t.Errorf("unexpected PrivateSubnetAZ, got %q, want %q", a.PrivateSubnetAZ, tc.expectedPrivateSubnetAZ)
+			}
+
+			if a.PrivateSubnetCIDR != tc.expectedPrivateSubnetCIDR {
+				t.Errorf("unexpected PrivateSubnetCIDR, got %q, want %q", a.PrivateSubnetCIDR, tc.expectedPrivateSubnetCIDR)
+			}
+
+			if a.PrivateSubnetName != tc.expectedPrivateSubnetName {
+				t.Errorf("unexpected PrivateSubnetName, got %q, want %q", a.PrivateSubnetName, tc.expectedPrivateSubnetName)
+			}
+
+			if a.PrivateSubnetMapPublicIPOnLaunch != tc.expectedPrivateSubnetMapPublicIPOnLaunch {
+				t.Errorf("unexpected PrivateSubnetMapPublicIPOnLaunch, got %t, want %t", a.PrivateSubnetMapPublicIPOnLaunch, tc.expectedPrivateSubnetMapPublicIPOnLaunch)
+			}
+		})
+	}
+}

--- a/service/controller/v12/adapter/vpc.go
+++ b/service/controller/v12/adapter/vpc.go
@@ -1,0 +1,65 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// The template related to this adapter can be found in the following import.
+//
+//     github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest/vpc.go
+//
+
+type vpcAdapter struct {
+	CidrBlock        string
+	InstallationName string
+	HostAccountID    string
+	PeerVPCID        string
+	PeerRoleArn      string
+}
+
+func (v *vpcAdapter) getVpc(cfg Config) error {
+	v.CidrBlock = cfg.CustomObject.Spec.AWS.VPC.CIDR
+	v.InstallationName = cfg.InstallationName
+	v.HostAccountID = cfg.HostAccountID
+	v.PeerVPCID = key.PeerID(cfg.CustomObject)
+
+	// PeerRoleArn.
+	roleName := key.PeerAccessRoleName(cfg.CustomObject)
+	input := &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	}
+	output, err := cfg.HostClients.IAM.GetRole(input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	v.PeerRoleArn = *output.Role.Arn
+
+	return nil
+}
+
+func VpcCIDR(clients Clients, vpcID string) (string, error) {
+	describeVpcInput := &ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(vpcID),
+				},
+			},
+		},
+	}
+	output, err := clients.EC2.DescribeVpcs(describeVpcInput)
+	if err != nil {
+		return "", microerror.Mask(err)
+	} else if len(output.Vpcs) == 0 {
+		return "", microerror.Maskf(notFoundError, "vpc: %s", vpcID)
+	} else if len(output.Vpcs) > 1 {
+		return "", microerror.Maskf(tooManyResultsError, "vpc: %s found %d vpcs", vpcID, len(output.Vpcs))
+	}
+	return *output.Vpcs[0].CidrBlock, nil
+}

--- a/service/controller/v12/adapter/vpc_test.go
+++ b/service/controller/v12/adapter/vpc_test.go
@@ -1,0 +1,123 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterVPCRegularFields(t *testing.T) {
+	t.Parallel()
+	cidr := "10.0.0.0/24"
+	peerID := "mypeerID"
+	installationName := "myinstallation"
+	hostAccountID := "myHostAccountID"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:   cidr,
+					PeerID: peerID,
+				},
+			},
+		},
+	}
+	testCases := []struct {
+		description              string
+		expectedCIDR             string
+		expectedPeerVPCID        string
+		expectedInstallationName string
+		expectedHostAccountID    string
+	}{
+		{
+			description:              "basic matching, all fields present",
+			expectedCIDR:             cidr,
+			expectedPeerVPCID:        peerID,
+			expectedInstallationName: installationName,
+			expectedHostAccountID:    hostAccountID,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:     customObject,
+				Clients:          Clients{},
+				InstallationName: installationName,
+				HostAccountID:    hostAccountID,
+				HostClients: Clients{
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+			}
+			err := a.getVpc(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.CidrBlock != tc.expectedCIDR {
+				t.Errorf("unexpected CidrBlock, got %q, want %q", a.CidrBlock, tc.expectedCIDR)
+			}
+
+			if a.PeerVPCID != tc.expectedPeerVPCID {
+				t.Errorf("unexpected PeerVPCID, got %q, want %q", a.PeerVPCID, tc.expectedPeerVPCID)
+			}
+
+			if a.InstallationName != tc.expectedInstallationName {
+				t.Errorf("unexpected InstallationName, got %q, want %q", a.InstallationName, tc.expectedInstallationName)
+			}
+
+			if a.HostAccountID != tc.expectedHostAccountID {
+				t.Errorf("unexpected HostAccountID, got %q, want %q", a.HostAccountID, tc.expectedHostAccountID)
+			}
+
+		})
+	}
+}
+
+func TestAdapterVPCPeerRoleField(t *testing.T) {
+	t.Parallel()
+	peerRoleArn := "myPeerRoleArn"
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+	testCases := []struct {
+		description         string
+		expectedPeerRoleArn string
+	}{
+		{
+			description:         "basic matching, all fields present",
+			expectedPeerRoleArn: peerRoleArn,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: customObject,
+				HostClients: Clients{
+					IAM: &IAMClientMock{peerRoleArn: peerRoleArn},
+					STS: &STSClientMock{},
+				},
+			}
+			err := a.getVpc(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.PeerRoleArn != tc.expectedPeerRoleArn {
+				t.Errorf("unexpected PeerRoleArn, got %q, want %q", a.PeerRoleArn, tc.expectedPeerRoleArn)
+			}
+		})
+	}
+}

--- a/service/controller/v12/cloudconfig/cloud_config.go
+++ b/service/controller/v12/cloudconfig/cloud_config.go
@@ -1,0 +1,83 @@
+package cloudconfig
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	FileOwner          = "root:root"
+	FilePermission     = 0700
+	GzipBase64Encoding = "gzip+base64"
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	KMSClient KMSClient
+	Logger    micrologger.Logger
+
+	OIDC                   OIDCConfig
+	PodInfraContainerImage string
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	kmsClient KMSClient
+	logger    micrologger.Logger
+
+	k8sAPIExtraArgs     []string
+	k8sKubeletExtraArgs []string
+}
+
+// OIDCConfig represents the configuration of the OIDC authorization provider
+type OIDCConfig struct {
+	ClientID      string
+	IssuerURL     string
+	UsernameClaim string
+	GroupsClaim   string
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	if config.KMSClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.KMSClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var k8sAPIExtraArgs []string
+	{
+		if config.OIDC.ClientID != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-client-id=%s", config.OIDC.ClientID))
+		}
+		if config.OIDC.IssuerURL != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-issuer-url=%s", config.OIDC.IssuerURL))
+		}
+		if config.OIDC.UsernameClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-username-claim=%s", config.OIDC.UsernameClaim))
+		}
+		if config.OIDC.GroupsClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-groups-claim=%s", config.OIDC.GroupsClaim))
+		}
+	}
+
+	var k8sKubeletExtraArgs []string
+	{
+		if config.PodInfraContainerImage != "" {
+			k8sKubeletExtraArgs = append(k8sKubeletExtraArgs, fmt.Sprintf("--pod-infra-container-image=%s", config.PodInfraContainerImage))
+		}
+	}
+
+	newCloudConfig := &CloudConfig{
+		kmsClient: config.KMSClient,
+		logger:    config.Logger,
+
+		k8sAPIExtraArgs:     k8sAPIExtraArgs,
+		k8sKubeletExtraArgs: k8sKubeletExtraArgs,
+	}
+
+	return newCloudConfig, nil
+}

--- a/service/controller/v12/cloudconfig/cloud_config_test.go
+++ b/service/controller/v12/cloudconfig/cloud_config_test.go
@@ -1,0 +1,210 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys"
+)
+
+func Test_Service_CloudConfig_NewMasterTemplate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+		ClusterKeys  randomkeys.Cluster
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Etcd: v1alpha1.ClusterEtcd{
+							Port: 2379,
+						},
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+			ClusterKeys: randomkeys.Cluster{
+				APIServerEncryptionKey: randomkeys.RandomKey("fekhfiwoiqhoifhwqefoiqwefoikqhwef"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		template, err := ccService.NewMasterTemplate(tc.CustomObject, tc.Certs, tc.ClusterKeys, "kms-key-arn")
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerEncryptionKey", func(t *testing.T) {
+			if !strings.Contains(decoded, "H4sIAAAAAAAA/1SNMQ7CMAxF957CF+jQNSviCuwldYgVYTd2aBQh7o4CVREeLL33pf8T8eLgzF7bWkj4JBzoNswrXVCNhB1s06Bo8lCP5gaAEf6wC0OvWOxDq8pGC+oRzmj+6r/UL2GzH43A8x1dt9MhYW90EDDFQFUoR6EQa8YglGv/KceKYR+hBblQaQ6er3cAAAD//9QjGEbUAAAA") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain apiserver encryption config", "wrong config output")
+			}
+		})
+	}
+}
+
+func Test_Service_CloudConfig_NewWorkerTemplate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "123456789-super-magic-aws-region",
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		template, err := ccService.NewWorkerTemplate(tc.CustomObject, tc.Certs)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAWSRegion", func(t *testing.T) {
+			if !strings.Contains(decoded, "--region 123456789-super-magic-aws-region kms decrypt") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain AWS region", "none")
+			}
+		})
+	}
+}
+
+func testDecodeTemplate(template string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(template)
+	if err != nil {
+		return "", err
+	}
+	r, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	_, err = io.Copy(&b, r)
+	if err != nil {
+		return "", err
+	}
+	r.Close()
+
+	return b.String(), nil
+}
+
+func testNewCloudConfigService() (*CloudConfig, error) {
+	var err error
+
+	var ccService *CloudConfig
+	{
+		c := Config{
+			KMSClient: &KMSClientMock{},
+			Logger:    microloggertest.New(),
+		}
+
+		ccService, err = New(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ccService, nil
+}
+
+type KMSClientMock struct{}
+
+func (k *KMSClientMock) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutput, error) {
+	return &kms.EncryptOutput{CiphertextBlob: input.Plaintext}, nil
+}

--- a/service/controller/v12/cloudconfig/compact.go
+++ b/service/controller/v12/cloudconfig/compact.go
@@ -1,0 +1,28 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+
+	"github.com/giantswarm/microerror"
+)
+
+func compactor(data []byte) (string, error) {
+	var err error
+
+	buf := &bytes.Buffer{}
+	gzw := gzip.NewWriter(buf)
+
+	_, err = gzw.Write(data)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	err = gzw.Close()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/service/controller/v12/cloudconfig/encrypt.go
+++ b/service/controller/v12/cloudconfig/encrypt.go
@@ -1,0 +1,21 @@
+package cloudconfig
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+)
+
+func encryptor(kmsClient KMSClient, kmsKeyARN string, data []byte) ([]byte, error) {
+	encryptInput := &kms.EncryptInput{
+		KeyId:     aws.String(kmsKeyARN),
+		Plaintext: data,
+	}
+
+	encryptOutput, err := kmsClient.Encrypt(encryptInput)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return encryptOutput.CiphertextBlob, nil
+}

--- a/service/controller/v12/cloudconfig/error.go
+++ b/service/controller/v12/cloudconfig/error.go
@@ -1,0 +1,17 @@
+package cloudconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/v12/cloudconfig/interface.go
+++ b/service/controller/v12/cloudconfig/interface.go
@@ -1,0 +1,12 @@
+package cloudconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/randomkeys"
+)
+
+type Interface interface {
+	NewMasterTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, clusterKeys randomkeys.Cluster, kmsKeyARN string) (string, error)
+	NewWorkerTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error)
+}

--- a/service/controller/v12/cloudconfig/master_template.go
+++ b/service/controller/v12/cloudconfig/master_template.go
@@ -1,0 +1,317 @@
+package cloudconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_3_1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudconfig"
+)
+
+const (
+	// MasterCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	MasterCloudConfigVersion = "v_3_3_1"
+)
+
+// NewMasterTemplate generates a new master cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, clusterKeys randomkeys.Cluster, kmsKeyARN string) (string, error) {
+	var err error
+
+	randomKeyTmplSet, err := renderRandomKeyTmplSet(c.kmsClient, clusterKeys, kmsKeyARN)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.DisableEncryptionAtREST = true
+		params.EtcdPort = customObject.Spec.Cluster.Etcd.Port
+		params.Extension = &MasterExtension{
+			certs:            certs,
+			customObject:     customObject,
+			RandomKeyTmplSet: randomKeyTmplSet,
+		}
+		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
+		params.Hyperkube.Kubelet.Docker.CommandExtraArgs = c.k8sKubeletExtraArgs
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.MasterTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+// RandomKeyTmplSet holds a collection of rendered templates for random key
+// encryption via KMS.
+type RandomKeyTmplSet struct {
+	APIServerEncryptionKey string
+}
+
+type MasterExtension struct {
+	certs            legacy.CompactTLSAssets
+	customObject     v1alpha1.AWSConfig
+	RandomKeyTmplSet RandomKeyTmplSet
+}
+
+func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsScript,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCrt,
+			Path:         "/etc/kubernetes/ssl/apiserver-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCA,
+			Path:         "/etc/kubernetes/ssl/apiserver-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerKey,
+			Path:         "/etc/kubernetes/ssl/apiserver-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCrt,
+			Path:         "/etc/kubernetes/ssl/service-account-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCA,
+			Path:         "/etc/kubernetes/ssl/service-account-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountKey,
+			Path:         "/etc/kubernetes/ssl/service-account-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/server-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/server-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/server-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		// Add second copy of files for etcd client certs. Will be replaced by
+		// a separate client cert.
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.RandomKeyTmplSet.APIServerEncryptionKey,
+			Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0644,
+		},
+		{
+			AssetContent: cloudconfig.WaitDockerConf,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: cloudconfig.DecryptKeysAssetsScript,
+			Path:         "/opt/bin/decrypt-keys-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Add use-proxy-protocol to ingress-controller ConfigMap, this doesn't work
+		// on KVM because of dependencies on hardware LB configuration.
+		{
+			AssetContent: cloudconfig.IngressControllerConfigMap,
+			Path:         "/srv/ingress-controller-cm.yml",
+			Owner:        FileOwner,
+			Permissions:  0644,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsService,
+			Name:         "decrypt-tls-assets.service",
+			// Do not enable TLS assets decrypt unit so that it won't get automatically
+			// executed on master reboot. This will prevent eventual races with the
+			// asset files creation.
+			Enable:  false,
+			Command: "start",
+		},
+		{
+			AssetContent: cloudconfig.MasterFormatVarLibDockerService,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.EphemeralVarLibDockerMount,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.DecryptKeysAssetsService,
+			Name:         "decrypt-keys-assets.service",
+			// Do not enable key decrypt unit so that it won't get automatically
+			// executed on master reboot. This will prevent eventual races with the
+			// key files creation.
+			Enable:  false,
+			Command: "start",
+		},
+		// Format etcd EBS volume.
+		{
+			AssetContent: cloudconfig.FormatEtcdVolume,
+			Name:         "format-etcd-ebs.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		// Mount etcd EBS volume.
+		{
+			AssetContent: cloudconfig.MountEtcdVolume,
+			Name:         "var-lib-etcd.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *MasterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storage",
+			Content: cloudconfig.InstanceStorage,
+		},
+		{
+			Name:    "storageclass",
+			Content: cloudconfig.InstanceStorageClass,
+		},
+	}
+	return newSections
+}

--- a/service/controller/v12/cloudconfig/randomkeys.go
+++ b/service/controller/v12/cloudconfig/randomkeys.go
@@ -1,0 +1,44 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudconfig"
+)
+
+func renderRandomKeyTmplSet(kmsClient KMSClient, clusterKeys randomkeys.Cluster, kmsKeyARN string) (RandomKeyTmplSet, error) {
+	var randomKeyTmplSet RandomKeyTmplSet
+	{
+		tmpl, err := template.New("encryption-config").Parse(cloudconfig.EncryptionConfig)
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+		buf := new(bytes.Buffer)
+		err = tmpl.Execute(buf, struct {
+			EncryptionKey string
+		}{
+			EncryptionKey: string(clusterKeys.APIServerEncryptionKey),
+		})
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		enc, err := encryptor(kmsClient, kmsKeyARN, buf.Bytes())
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		com, err := compactor(enc)
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		randomKeyTmplSet.APIServerEncryptionKey = com
+	}
+
+	return randomKeyTmplSet, nil
+}

--- a/service/controller/v12/cloudconfig/spec.go
+++ b/service/controller/v12/cloudconfig/spec.go
@@ -1,0 +1,9 @@
+package cloudconfig
+
+import (
+	"github.com/aws/aws-sdk-go/service/kms"
+)
+
+type KMSClient interface {
+	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
+}

--- a/service/controller/v12/cloudconfig/worker_template.go
+++ b/service/controller/v12/cloudconfig/worker_template.go
@@ -1,0 +1,205 @@
+package cloudconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_3_1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudconfig"
+)
+
+const (
+	// WorkerCloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	WorkerCloudConfigVersion = "v_3_3_1"
+)
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &WorkerExtension{
+			certs:        certs,
+			customObject: customObject,
+		}
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.WorkerTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type WorkerExtension struct {
+	certs        legacy.CompactTLSAssets
+	customObject v1alpha1.AWSConfig
+}
+
+func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsScript,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCrt,
+			Path:         "/etc/kubernetes/ssl/worker-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCA,
+			Path:         "/etc/kubernetes/ssl/worker-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerKey,
+			Path:         "/etc/kubernetes/ssl/worker-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: cloudconfig.WaitDockerConf,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, m := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *WorkerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsService,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.WorkerFormatVarLibDockerService,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.PersistentVarLibDockerMount,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, m := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *WorkerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storageclass",
+			Content: cloudconfig.InstanceStorageClass,
+		},
+	}
+
+	return newSections
+}

--- a/service/controller/v12/cloudformation/cloud_formation.go
+++ b/service/controller/v12/cloudformation/cloud_formation.go
@@ -1,0 +1,84 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+type Config struct {
+	Client *cloudformation.CloudFormation
+}
+
+type CloudFormation struct {
+	client *cloudformation.CloudFormation
+}
+
+func New(config Config) (*CloudFormation, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+
+	c := &CloudFormation{
+		client: config.Client,
+	}
+
+	return c, nil
+}
+
+func (c *CloudFormation) DescribeOutputsAndStatus(stackName string) ([]*cloudformation.Output, string, error) {
+	// At first we fetch the CF stack state by describing it via the AWS golang
+	// SDK. We are interested in the stack outputs and the stack status, since
+	// this tells us if we are able to access outputs at all.
+	var stackOutputs []*cloudformation.Output
+	var stackStatus string
+	{
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(stackName),
+		}
+
+		o, err := c.client.DescribeStacks(i)
+		if IsStackNotFound(err) {
+			return nil, "", microerror.Maskf(stackNotFoundError, "stack name '%s'", stackName)
+		} else if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+
+		if len(o.Stacks) > 1 {
+			return nil, "", microerror.Maskf(tooManyStacksError, "expected 1 stack, got %d", len(o.Stacks))
+		}
+
+		stackOutputs = o.Stacks[0].Outputs
+		stackStatus = *o.Stacks[0].StackStatus
+	}
+
+	// We call DescribeOutputsAndStatus in certain GetCurrentState
+	// implementations. If the stack creation failed, the outputs can be
+	// unaccessible. This can lead to a stack that cannot be deleted. it can also
+	// be called during creation, while the outputs are still not accessible.
+	{
+		errorStatuses := []string{
+			cloudformation.StackStatusRollbackInProgress,
+			cloudformation.StackStatusRollbackComplete,
+			cloudformation.StackStatusCreateInProgress,
+		}
+
+		for _, s := range errorStatuses {
+			if stackStatus == s {
+				return nil, "", microerror.Maskf(outputsNotAccessibleError, "due to stack state '%s'", stackStatus)
+			}
+		}
+	}
+
+	return stackOutputs, stackStatus, nil
+}
+
+func (c *CloudFormation) GetOutputValue(outputs []*cloudformation.Output, key string) (string, error) {
+	for _, o := range outputs {
+		if *o.OutputKey == key {
+			return *o.OutputValue, nil
+		}
+	}
+
+	return "", microerror.Maskf(outputNotFoundError, "stack output value for key '%s'", key)
+}

--- a/service/controller/v12/cloudformation/error.go
+++ b/service/controller/v12/cloudformation/error.go
@@ -1,0 +1,60 @@
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var outputNotFoundError = microerror.New("output not found")
+
+// IsOutputNotFound asserts outputNotFoundError.
+func IsOutputNotFound(err error) bool {
+	return microerror.Cause(err) == outputNotFoundError
+}
+
+var outputsNotAccessibleError = microerror.New("outputs not accessible")
+
+// IsOutputsNotAccessible asserts outputsNotAccessibleError.
+func IsOutputsNotAccessible(err error) bool {
+	return microerror.Cause(err) == outputsNotAccessibleError
+}
+
+var stackNotFoundError = microerror.New("stack not found")
+
+// IsStackNotFound asserts stackNotFoundError and stack not found errors from
+// the upstream's API message.
+//
+// FIXME: The validation error returned by the CloudFormation API doesn't make
+// things easy to check, other than looking for the returned string. There's no
+// constant in the AWS golang SDK for defining this string, it comes from the
+// service.
+func IsStackNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if strings.Contains(microerror.Cause(err).Error(), "does not exist") {
+		return true
+	}
+
+	if microerror.Cause(err) == stackNotFoundError {
+		return true
+	}
+
+	return false
+}
+
+var tooManyStacksError = microerror.New("too many stacks")
+
+// IsTooManyStacks asserts tooManyStacksError.
+func IsTooManyStacks(err error) bool {
+	return microerror.Cause(err) == tooManyStacksError
+}

--- a/service/controller/v12/cluster_resource_set.go
+++ b/service/controller/v12/cluster_resource_set.go
@@ -1,0 +1,458 @@
+package v11
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/giantswarm/randomkeys"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v11/cloudformation"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/credential"
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	cloudformationresource "github.com/giantswarm/aws-operator/service/controller/v11/resource/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/ebsvolume"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/endpoints"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/kmskey"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/loadbalancer"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/migration"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/namespace"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/s3bucket"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/s3object"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/service"
+)
+
+const (
+	ResourceRetries uint64 = 3
+)
+
+type ClusterResourceSetConfig struct {
+	CertsSearcher      legacy.Searcher
+	G8sClient          versioned.Interface
+	HostAWSConfig      aws.Config
+	HostAWSClients     aws.Clients
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	RandomkeysSearcher randomkeys.Interface
+
+	AccessLogsExpiration   int
+	AdvancedMonitoringEC2  bool
+	APIWhitelist           adapter.APIWhitelist
+	GuestUpdateEnabled     bool
+	IncludeTags            bool
+	InstallationName       string
+	DeleteLoggingBucket    bool
+	OIDC                   cloudconfig.OIDCConfig
+	ProjectName            string
+	Route53Enabled         bool
+	PodInfraContainerImage string
+}
+
+func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertsSearcher must not be empty")
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.G8sClient must not be empty")
+	}
+	if config.HostAWSConfig.AccessKeyID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.AccessKeyID must not be empty")
+	}
+	if config.HostAWSConfig.AccessKeySecret == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.AccessKeySecret must not be empty")
+	}
+	if config.HostAWSConfig.Region == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSConfig.Region must not be empty")
+	}
+	if config.HostAWSClients.CloudFormation == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSClients.CloudFormation must not be empty")
+	}
+	if config.HostAWSClients.EC2 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSClients.EC2 must not be empty")
+	}
+	if config.HostAWSClients.IAM == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAWSClients.IAM must not be empty")
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.RandomkeysSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.RandomkeysSearcher must not be empty")
+	}
+
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.InstallationName must not be empty")
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
+	}
+	if config.APIWhitelist.Enabled && config.APIWhitelist.SubnetList == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.APIWhitelist.SubnetList must not be empty when %T.APIWhitelist is enabled", config)
+	}
+
+	var kmsKeyResource controller.Resource
+	{
+		c := kmskey.Config{
+			Logger: config.Logger,
+
+			InstallationName: config.InstallationName,
+		}
+
+		ops, err := kmskey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		kmsKeyResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var migrationResource controller.Resource
+	{
+		c := migration.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		migrationResource, err = migration.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var s3BucketResource controller.Resource
+	{
+		c := s3bucket.Config{
+			Logger: config.Logger,
+
+			AccessLogsExpiration: config.AccessLogsExpiration,
+			DeleteLoggingBucket:  config.DeleteLoggingBucket,
+			IncludeTags:          config.IncludeTags,
+			InstallationName:     config.InstallationName,
+		}
+
+		ops, err := s3bucket.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		s3BucketResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var s3BucketObjectResource controller.Resource
+	{
+		c := s3object.Config{
+			CertWatcher:       config.CertsSearcher,
+			Logger:            config.Logger,
+			RandomKeySearcher: config.RandomkeysSearcher,
+		}
+
+		ops, err := s3object.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		s3BucketObjectResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var loadBalancerResource controller.Resource
+	{
+		c := loadbalancer.Config{
+			Logger: config.Logger,
+		}
+
+		loadBalancerResource, err = loadbalancer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ebsVolumeResource controller.Resource
+	{
+		c := ebsvolume.Config{
+			Logger: config.Logger,
+		}
+
+		ebsVolumeResource, err = ebsvolume.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cloudformationResource controller.Resource
+	{
+		c := cloudformationresource.Config{
+			HostClients: &adapter.Clients{
+				EC2:            config.HostAWSClients.EC2,
+				IAM:            config.HostAWSClients.IAM,
+				STS:            config.HostAWSClients.STS,
+				CloudFormation: config.HostAWSClients.CloudFormation,
+			},
+			Logger: config.Logger,
+			APIWhitelist: adapter.APIWhitelist{
+				Enabled:    config.APIWhitelist.Enabled,
+				SubnetList: config.APIWhitelist.SubnetList,
+			},
+
+			AdvancedMonitoringEC2: config.AdvancedMonitoringEC2,
+			InstallationName:      config.InstallationName,
+			Route53Enabled:        config.Route53Enabled,
+		}
+
+		ops, err := cloudformationresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		cloudformationResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource controller.Resource
+	{
+		c := namespace.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource controller.Resource
+	{
+		c := service.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var endpointsResource controller.Resource
+	{
+		c := endpoints.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := endpoints.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		endpointsResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		migrationResource,
+		kmsKeyResource,
+		s3BucketResource,
+		s3BucketObjectResource,
+		loadBalancerResource,
+		ebsVolumeResource,
+		cloudformationResource,
+		namespaceResource,
+		serviceResource,
+		endpointsResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			BackOffFactory: func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), ResourceRetries) },
+			Logger:         config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(customObject) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		var awsClient aws.Clients
+		{
+			arn, err := credential.GetARN(config.K8sClient, obj)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			c := config.HostAWSConfig
+			c.RoleARN = arn
+
+			awsClient = aws.NewClients(c)
+		}
+
+		var awsService *awsservice.Service
+		{
+			c := awsservice.Config{
+				Clients: awsservice.Clients{
+					KMS: awsClient.KMS,
+					STS: awsClient.STS,
+				},
+				Logger: config.Logger,
+			}
+
+			awsService, err = awsservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var cloudConfig *cloudconfig.CloudConfig
+		{
+			c := cloudconfig.Config{
+				KMSClient: awsClient.KMS,
+				Logger:    config.Logger,
+
+				OIDC: config.OIDC,
+				PodInfraContainerImage: config.PodInfraContainerImage,
+			}
+
+			cloudConfig, err = cloudconfig.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var ebsService ebs.Interface
+		{
+			c := ebs.Config{
+				Client: awsClient.EC2,
+				Logger: config.Logger,
+			}
+			ebsService, err = ebs.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var cloudFormationService *cloudformationservice.CloudFormation
+		{
+			c := cloudformationservice.Config{
+				Client: awsClient.CloudFormation,
+			}
+
+			cloudFormationService, err = cloudformationservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		c := servicecontext.Context{
+			AWSClient:      awsClient,
+			AWSService:     awsService,
+			CloudConfig:    cloudConfig,
+			CloudFormation: *cloudFormationService,
+			EBSService:     ebsService,
+		}
+		ctx = servicecontext.NewContext(ctx, c)
+
+		return ctx, nil
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/v12/context/context.go
+++ b/service/controller/v12/context/context.go
@@ -1,0 +1,38 @@
+package context
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v11/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
+)
+
+type contextKey string
+
+const serviceKey contextKey = "service"
+
+type Context struct {
+	AWSClient      awsclient.Clients
+	AWSService     awsservice.Interface
+	CloudConfig    cloudconfig.Interface
+	CloudFormation cloudformationservice.CloudFormation
+	EBSService     ebs.Interface
+}
+
+func NewContext(ctx context.Context, c Context) context.Context {
+	return context.WithValue(ctx, serviceKey, &c)
+}
+
+func FromContext(ctx context.Context) (*Context, error) {
+	c, ok := ctx.Value(serviceKey).(*Context)
+	if !ok {
+		return nil, microerror.Mask(serviceNotFound)
+	}
+
+	return c, nil
+}

--- a/service/controller/v12/context/error.go
+++ b/service/controller/v12/context/error.go
@@ -1,0 +1,12 @@
+package context
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var serviceNotFound = microerror.New("service not found")
+
+// IsServiceNotFoundError asserts serviceNotFound.
+func IsServiceNotFoundError(err error) bool {
+	return microerror.Cause(err) == serviceNotFound
+}

--- a/service/controller/v12/credential/credential.go
+++ b/service/controller/v12/credential/credential.go
@@ -1,0 +1,55 @@
+package credential
+
+import (
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	// awsOperatorArnKey is the key in the Secret under which the ARN for the aws-operator role is held.
+	awsOperatorArnKey = "aws.awsoperator.arn"
+)
+
+func GetARN(k8sClient kubernetes.Interface, obj interface{}) (string, error) {
+	credential, err := readCredential(k8sClient, obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	arn, err := getARN(credential)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return arn, nil
+}
+
+func getARN(credential *v1.Secret) (string, error) {
+	arn, ok := credential.Data[awsOperatorArnKey]
+	if !ok {
+		return "", microerror.Maskf(arnNotFound, awsOperatorArnKey)
+	}
+
+	return string(arn), nil
+}
+
+func readCredential(k8sClient kubernetes.Interface, obj interface{}) (*v1.Secret, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	credentialName := key.CredentialName(customObject)
+	credentialNamespace := key.CredentialNamespace(customObject)
+
+	credential, err := k8sClient.CoreV1().Secrets(credentialNamespace).Get(credentialName, apismetav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return credential, nil
+}

--- a/service/controller/v12/credential/error.go
+++ b/service/controller/v12/credential/error.go
@@ -1,0 +1,10 @@
+package credential
+
+import "github.com/giantswarm/microerror"
+
+var arnNotFound = microerror.New("arn not found")
+
+// IsArnNotFoundError asserts arnNotFound.
+func IsArnNotFoundError(err error) bool {
+	return microerror.Cause(err) == arnNotFound
+}

--- a/service/controller/v12/drainer_resource_set.go
+++ b/service/controller/v12/drainer_resource_set.go
@@ -1,0 +1,144 @@
+package v11
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v11/cloudformation"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/credential"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v11/resource/lifecycle"
+)
+
+type DrainerResourceSetConfig struct {
+	G8sClient     versioned.Interface
+	HostAWSConfig aws.Config
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+
+	GuestUpdateEnabled bool
+	ProjectName        string
+}
+
+func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	var lifecycleResource controller.Resource
+	{
+		c := lifecycle.ResourceConfig{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		lifecycleResource, err = lifecycle.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		lifecycleResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			BackOffFactory: func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), uint64(3)) },
+			Logger:         config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(customObject) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		var awsClient aws.Clients
+		{
+			arn, err := credential.GetARN(config.K8sClient, obj)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			c := config.HostAWSConfig
+			c.RoleARN = arn
+
+			awsClient = aws.NewClients(c)
+		}
+
+		var cloudFormationService *cloudformationservice.CloudFormation
+		{
+			c := cloudformationservice.Config{
+				Client: awsClient.CloudFormation,
+			}
+
+			cloudFormationService, err = cloudformationservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		c := servicecontext.Context{
+			AWSClient:      awsClient,
+			CloudFormation: *cloudFormationService,
+		}
+		ctx = servicecontext.NewContext(ctx, c)
+
+		return ctx, nil
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/service/controller/v12/ebs/ebs.go
+++ b/service/controller/v12/ebs/ebs.go
@@ -1,0 +1,185 @@
+package ebs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	cloudProviderClusterTagValue = "owned"
+)
+
+type Config struct {
+	Client EC2Client
+	Logger micrologger.Logger
+}
+
+type EBS struct {
+	client EC2Client
+	logger micrologger.Logger
+}
+
+func New(config Config) (*EBS, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	e := &EBS{
+		client: config.Client,
+		logger: config.Logger,
+	}
+
+	return e, nil
+}
+
+// DeleteVolume deletes an EBS volume with retry logic.
+func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting EBS volume %s", volumeID))
+
+	deleteOperation := func() error {
+		_, err := e.client.DeleteVolume(&ec2.DeleteVolumeInput{
+			VolumeId: aws.String(volumeID),
+		})
+		if IsVolumeNotFound(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	deleteNotify := func(err error, delay time.Duration) {
+		e.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("deleting EBS volume failed, retrying with delay %s", delay.String()))
+	}
+	deleteBackoff := &backoff.ExponentialBackOff{
+		InitialInterval:     backoff.DefaultInitialInterval,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         backoff.DefaultMaxInterval,
+		MaxElapsedTime:      30 * time.Second,
+		Clock:               backoff.SystemClock,
+	}
+	if err := backoff.RetryNotify(deleteOperation, deleteBackoff, deleteNotify); err != nil {
+		return microerror.Mask(err)
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted EBS volume %s", volumeID))
+
+	return nil
+}
+
+// DetachVolume detaches an EBS volume. If force is specified data loss may occur. If shutdown is
+// specified the instance will be stopped first.
+func (e *EBS) DetachVolume(ctx context.Context, volumeID string, attachment VolumeAttachment, force bool, shutdown bool, wait bool) error {
+	if shutdown {
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("stopping instance %s", attachment.InstanceID))
+
+		i := &ec2.StopInstancesInput{
+			InstanceIds: []*string{
+				aws.String(attachment.InstanceID),
+			},
+		}
+		_, err := e.client.StopInstances(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if wait {
+			e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for instance %s being stopped", attachment.InstanceID))
+
+			i := &ec2.DescribeInstancesInput{
+				InstanceIds: []*string{
+					aws.String(attachment.InstanceID),
+				},
+			}
+			err := e.client.WaitUntilInstanceStopped(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for instance %s being stopped", attachment.InstanceID))
+		}
+
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("stopped instance %s", attachment.InstanceID))
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detaching EBS volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	_, err := e.client.DetachVolume(&ec2.DetachVolumeInput{
+		Device:     aws.String(attachment.Device),
+		InstanceId: aws.String(attachment.InstanceID),
+		VolumeId:   aws.String(volumeID),
+		Force:      aws.Bool(force),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detached EBS volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	return nil
+}
+
+// ListVolumes lists EBS volumes for a guest cluster. If etcdVolume is true
+// the Etcd volume for the master instance will be returned. If persistentVolume
+// is set then any Persistent Volumes associated with the cluster will be
+// returned.
+func (e *EBS) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error) {
+	var volumes []Volume
+
+	// We filter to only select clusters with the cluster cloud provider tag.
+	i := &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", key.ClusterCloudProviderTag(customObject))),
+				Values: []*string{
+					aws.String(cloudProviderClusterTagValue),
+				},
+			},
+		},
+	}
+	o, err := e.client.DescribeVolumes(i)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, v := range o.Volumes {
+		if !IsFiltered(v, filterFuncs) {
+			continue
+		}
+
+		attachments := []VolumeAttachment{}
+
+		if len(v.Attachments) > 0 {
+			for _, a := range v.Attachments {
+				attachments = append(attachments, VolumeAttachment{
+					Device:     *a.Device,
+					InstanceID: *a.InstanceId,
+				})
+			}
+		}
+
+		volume := Volume{
+			VolumeID:    *v.VolumeId,
+			Attachments: attachments,
+		}
+
+		volumes = append(volumes, volume)
+	}
+
+	return volumes, nil
+}

--- a/service/controller/v12/ebs/ebs_test.go
+++ b/service/controller/v12/ebs/ebs_test.go
@@ -1,0 +1,352 @@
+package ebs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_ListVolumes(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description     string
+		obj             v1alpha1.AWSConfig
+		filterFuncs     []func(t *ec2.Tag) bool
+		expectedVolumes []Volume
+		ebsVolumes      []ebsVolumeMock
+	}{
+		{
+			description: "case 0: basic match with no volumes",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+		},
+		{
+			description: "case 1: basic match with pv volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 2: basic match with etcd and multiple pv volumes",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-5678",
+				},
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-6789",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-5678",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-5678"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 3: no match due to cluster tag",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/other-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 4: no match due to missing pv tag",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 5: multiple ebs volumes with attachments",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{
+						{
+							InstanceID: "i-12345",
+							Device:     "/dev/sdh",
+						},
+					},
+					VolumeID: "vol-1234",
+				},
+				{
+					Attachments: []VolumeAttachment{
+						{
+							InstanceID: "i-56789",
+							Device:     "/dev/sdh",
+						},
+					},
+					VolumeID: "vol-5678",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					attachments: []*ec2.VolumeAttachment{
+						{
+							Device:     aws.String("/dev/sdh"),
+							InstanceId: aws.String("i-12345"),
+						},
+					},
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-5678",
+					attachments: []*ec2.VolumeAttachment{
+						{
+							Device:     aws.String("/dev/sdh"),
+							InstanceId: aws.String("i-56789"),
+						},
+					},
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-5678"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 6: only etcd volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-6789",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 7: only pv volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				Client: &EC2ClientMock{
+					customObject: tc.obj,
+					ebsVolumes:   tc.ebsVolumes,
+				},
+				Logger: microloggertest.New(),
+			}
+			e, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			result, err := e.ListVolumes(tc.obj, tc.filterFuncs...)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedVolumes) {
+				t.Fatalf("expected volumes '%#v', got '%#v'", tc.expectedVolumes, result)
+			}
+		})
+	}
+}

--- a/service/controller/v12/ebs/error.go
+++ b/service/controller/v12/ebs/error.go
@@ -1,0 +1,38 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var volumeNotFoundError = microerror.New("volume not found")
+
+// IsVolumeNotFound asserts volume not found error from upstream's API code.
+func IsVolumeNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+	if c == volumeNotFoundError {
+		return true
+	}
+
+	aerr, ok := c.(awserr.Error)
+	if !ok {
+		return false
+	}
+	// TODO Find constant in the Go SDK for the error code.
+	if aerr.Code() == "NotFound" {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v12/ebs/filter.go
+++ b/service/controller/v12/ebs/filter.go
@@ -1,0 +1,52 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	cloudProviderPersistentVolumeTagKey = "kubernetes.io/created-for/pv/name"
+	nameTagKey                          = "Name"
+)
+
+func IsFiltered(vol *ec2.Volume, filterFuncs []func(t *ec2.Tag) bool) bool {
+	for _, f := range filterFuncs {
+		for _, t := range vol.Tags {
+			if f(t) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func NewDockerVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.DockerVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewEtcdVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.EtcdVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewPersistentVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == cloudProviderPersistentVolumeTagKey {
+			return true
+		}
+		return false
+	}
+}

--- a/service/controller/v12/ebs/mock_test.go
+++ b/service/controller/v12/ebs/mock_test.go
@@ -1,0 +1,61 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+type EC2ClientMock struct {
+	customObject v1alpha1.AWSConfig
+	ebsVolumes   []ebsVolumeMock
+}
+
+type ebsVolumeMock struct {
+	volumeID    string
+	attachments []*ec2.VolumeAttachment
+	tags        []*ec2.Tag
+}
+
+func (e *EC2ClientMock) DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
+	output := &ec2.DescribeVolumesOutput{}
+	volumes := []*ec2.Volume{}
+
+	clusterTag := key.ClusterCloudProviderTag(e.customObject)
+
+	for _, mock := range e.ebsVolumes {
+		vol := &ec2.Volume{
+			VolumeId:    aws.String(mock.volumeID),
+			Attachments: mock.attachments,
+			Tags:        mock.tags,
+		}
+
+		for _, tag := range mock.tags {
+			if *tag.Key == clusterTag && *tag.Value == "owned" {
+				volumes = append(volumes, vol)
+			}
+		}
+	}
+
+	output.SetVolumes(volumes)
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error {
+	return nil
+}

--- a/service/controller/v12/ebs/spec.go
+++ b/service/controller/v12/ebs/spec.go
@@ -1,0 +1,43 @@
+package ebs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+// Interface describes the methods provided by the helm client.
+type Interface interface {
+	// DeleteVolume deletes an EBS volume with retry logic.
+	DeleteVolume(ctx context.Context, volumeID string) error
+	// DetachVolume detaches an EBS volume. If force is specified data loss may
+	// occur. If shutdown is specified the instance will be stopped first.
+	DetachVolume(ctx context.Context, volumeID string, attachment VolumeAttachment, force bool, shutdown bool, wait bool) error
+	// ListVolumes lists EBS volumes for a guest cluster. If etcdVolume is true
+	// the Etcd volume for the master instance will be returned. If
+	// persistentVolume is true then any Persistent Volumes associated with the
+	// cluster will be returned.
+	ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error)
+}
+
+// EC2Client describes the methods required to be implemented by an EC2 AWS client.
+type EC2Client interface {
+	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
+	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
+	DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
+	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
+	WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error
+}
+
+// Volume is an EBS volume and its attachments.
+type Volume struct {
+	VolumeID    string
+	Attachments []VolumeAttachment
+}
+
+// VolumeAttachment is an EBS volume attached to an EC2 instance.
+type VolumeAttachment struct {
+	Device     string
+	InstanceID string
+}

--- a/service/controller/v12/error.go
+++ b/service/controller/v12/error.go
@@ -1,0 +1,10 @@
+package v11
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v12/key/error.go
+++ b/service/controller/v12/key/error.go
@@ -1,0 +1,38 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var malformedCloudConfigKeyError = microerror.New("malformed key in the cloudconfig")
+
+// IsMalformedCloudConfigKey asserts malformedCloudConfigKeyError.
+func IsMalformedCloudConfigKey(err error) bool {
+	return microerror.Cause(err) == malformedCloudConfigKeyError
+}
+
+var missingCloudConfigKeyError = microerror.New("missing key in the cloudconfig")
+
+// IsMissingCloudConfigKey asserts missingCloudConfigKeyError.
+func IsMissingCloudConfigKey(err error) bool {
+	return microerror.Cause(err) == missingCloudConfigKeyError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v12/key/key.go
+++ b/service/controller/v12/key/key.go
@@ -1,0 +1,423 @@
+package key
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/guest"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/hostpost"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates/cloudformation/hostpre"
+)
+
+const (
+	// CloudProviderTagName is used to add Cloud Provider tags to AWS resources.
+	CloudProviderTagName = "kubernetes.io/cluster/%s"
+
+	// Cluster tag name for tagging all resources helping cost analysis in AWS.
+	ClusterTagName = "giantswarm.io/cluster"
+
+	// CloudProviderTagOwnedValue is used to indicate an AWS resource is owned
+	// and managed by a cluster.
+	CloudProviderTagOwnedValue = "owned"
+
+	// InstallationTagName is used for AWS resource tagging.
+	InstallationTagName = "giantswarm.io/installation"
+
+	// OrganizationTagName is used for AWS resource tagging.
+	OrganizationTagName = "giantswarm.io/organization"
+
+	// ProfileNameTemplate will be included in the IAM instance profile name.
+	ProfileNameTemplate = "EC2-K8S-Role"
+	// RoleNameTemplate will be included in the IAM role name.
+	RoleNameTemplate = "EC2-K8S-Role"
+	// PolicyNameTemplate will be included in the IAM policy name.
+	PolicyNameTemplate = "EC2-K8S-Policy"
+	// LogDeliveryURI is used for setting the correct ACL in the access log bucket
+	LogDeliveryURI = "uri=http://acs.amazonaws.com/groups/s3/LogDelivery"
+)
+
+const (
+	InstanceIDAnnotation = "aws-operator.giantswarm.io/instance"
+)
+
+const (
+	MasterImageIDKey              = "MasterImageID"
+	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
+	MasterInstanceTypeKey         = "MasterInstanceType"
+	MasterInstanceMonitoring      = "Monitoring"
+	MasterCloudConfigVersionKey   = "MasterCloudConfigVersion"
+	WorkerASGKey                  = "WorkerASGName"
+	WorkerCountKey                = "WorkerCount"
+	WorkerImageIDKey              = "WorkerImageID"
+	WorkerInstanceMonitoring      = "Monitoring"
+	WorkerInstanceTypeKey         = "WorkerInstanceType"
+	WorkerCloudConfigVersionKey   = "WorkerCloudConfigVersion"
+	VersionBundleVersionKey       = "VersionBundleVersion"
+)
+
+const (
+	ClusterIDLabel = "giantswarm.io/cluster"
+)
+
+const (
+	NodeDrainerLifecycleHookName = "NodeDrainer"
+	WorkerASGRef                 = "workerAutoScalingGroup"
+)
+
+func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Kubernetes.API.Domain
+}
+
+func AutoScalingGroupName(customObject v1alpha1.AWSConfig, groupName string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), groupName)
+}
+
+func AvailabilityZone(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.AZ
+}
+
+func BucketName(customObject v1alpha1.AWSConfig, accountID string) string {
+	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(customObject))
+}
+
+func BucketObjectName(templateVersion string, prefix string) string {
+	return fmt.Sprintf("cloudconfig/%s/%s", templateVersion, prefix)
+}
+
+func CredentialName(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.CredentialSecret.Name
+}
+
+func CredentialNamespace(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.CredentialSecret.Namespace
+}
+
+func CloudConfigSmallTemplates() []string {
+	return []string{
+		cloudconfig.Small,
+	}
+}
+
+func CloudFormationGuestTemplates() []string {
+	return []string{
+		guest.AutoScalingGroup,
+		guest.IAMPolicies,
+		guest.Instance,
+		guest.InternetGateway,
+		guest.LaunchConfiguration,
+		guest.LoadBalancers,
+		guest.Main,
+		guest.NatGateway,
+		guest.LifecycleHooks,
+		guest.Outputs,
+		guest.RecordSets,
+		guest.RouteTables,
+		guest.SecurityGroups,
+		guest.Subnets,
+		guest.VPC,
+	}
+}
+
+func CloudFormationHostPostTemplates() []string {
+	return []string{
+		hostpost.Main,
+		hostpost.RouteTables,
+	}
+}
+
+func CloudFormationHostPreTemplates() []string {
+	return []string{
+		hostpre.IAMRoles,
+		hostpre.Main,
+	}
+}
+
+func ClusterCloudProviderTag(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf(CloudProviderTagName, ClusterID(customObject))
+}
+
+func ClusterCustomer(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func ClusterID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.ID
+}
+
+func ClusterNamespace(customObject v1alpha1.AWSConfig) string {
+	return ClusterID(customObject)
+}
+
+// ClusterOrganization returns the org name from the custom object.
+// It uses ClusterCustomer until this field is renamed in the custom object.
+func ClusterOrganization(customObject v1alpha1.AWSConfig) string {
+	return ClusterCustomer(customObject)
+}
+
+func ClusterTags(customObject v1alpha1.AWSConfig, installationName string) map[string]string {
+	cloudProviderTag := ClusterCloudProviderTag(customObject)
+	tags := map[string]string{
+		cloudProviderTag:    CloudProviderTagOwnedValue,
+		ClusterTagName:      ClusterID(customObject),
+		InstallationTagName: installationName,
+		OrganizationTagName: ClusterOrganization(customObject),
+	}
+
+	return tags
+}
+
+func ClusterVersion(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Version
+}
+
+func CustomerID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-docker", ClusterID(customObject))
+}
+
+func EtcdVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-etcd", ClusterID(customObject))
+}
+
+func IngressControllerInsecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.IngressController.InsecurePort
+}
+
+func IngressControllerSecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.IngressController.SecurePort
+}
+
+func InstanceProfileName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, ProfileNameTemplate)
+}
+
+func KubernetesAPISecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.API.SecurePort
+}
+
+// LoadBalancerName produces a unique name for the load balancer.
+// It takes the domain name, extracts the first subdomain, and combines it with the cluster name.
+func LoadBalancerName(domainName string, cluster v1alpha1.AWSConfig) (string, error) {
+	if ClusterID(cluster) == "" {
+		return "", microerror.Maskf(missingCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	componentName, err := componentName(domainName)
+	if err != nil {
+		return "", microerror.Maskf(malformedCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	lbName := fmt.Sprintf("%s-%s", ClusterID(cluster), componentName)
+
+	return lbName, nil
+}
+
+func MainGuestStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-guest-main", clusterID)
+}
+
+func MainHostPreStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-host-setup", clusterID)
+}
+
+func MainHostPostStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-host-main", clusterID)
+}
+
+func MasterCount(customObject v1alpha1.AWSConfig) int {
+	return len(customObject.Spec.AWS.Masters)
+}
+
+func MasterImageID(customObject v1alpha1.AWSConfig) string {
+	var imageID string
+
+	if len(customObject.Spec.AWS.Masters) > 0 {
+		imageID = customObject.Spec.AWS.Masters[0].ImageID
+	}
+
+	return imageID
+}
+
+func MasterInstanceResourceName(customObject v1alpha1.AWSConfig) string {
+	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
+
+	h := sha1.New()
+	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
+	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
+
+	upperTimeHash := strings.ToUpper(timeHash)
+	upperClusterID := strings.ToUpper(clusterID)
+
+	return fmt.Sprintf("MasterInstance%s%s", upperClusterID, upperTimeHash)
+}
+
+func MasterInstanceName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("%s-master", clusterID)
+}
+
+func MasterInstanceType(customObject v1alpha1.AWSConfig) string {
+	var instanceType string
+
+	if len(customObject.Spec.AWS.Masters) > 0 {
+		instanceType = customObject.Spec.AWS.Masters[0].InstanceType
+	}
+
+	return instanceType
+}
+
+func PeerAccessRoleName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-vpc-peer-access", ClusterID(customObject))
+}
+
+func PeerID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.PeerID
+}
+
+func PolicyName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, PolicyNameTemplate)
+}
+
+func PrivateSubnetCIDR(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.PrivateSubnetCIDR
+}
+
+func Region(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.Region
+}
+
+func RegionARN(customObject v1alpha1.AWSConfig) string {
+	regionARN := "aws"
+
+	if Region(customObject) == "cn-north-1" {
+		regionARN += "-cn"
+	}
+
+	return regionARN
+}
+
+func RoleName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, RoleNameTemplate)
+}
+
+func RouteTableName(customObject v1alpha1.AWSConfig, suffix string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), suffix)
+}
+
+func SecurityGroupName(customObject v1alpha1.AWSConfig, groupName string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), groupName)
+}
+
+func SubnetName(customObject v1alpha1.AWSConfig, suffix string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), suffix)
+}
+
+func TargetLogBucketName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-g8s-access-logs", ClusterID(customObject))
+}
+
+func ToCustomObject(v interface{}) (v1alpha1.AWSConfig, error) {
+	if v == nil {
+		return v1alpha1.AWSConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSConfig{}, v)
+	}
+
+	customObjectPointer, ok := v.(*v1alpha1.AWSConfig)
+	if !ok {
+		return v1alpha1.AWSConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSConfig{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
+// VersionBundleVersion returns the version contained in the Version Bundle.
+func VersionBundleVersion(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.VersionBundle.Version
+}
+
+func WorkerCount(customObject v1alpha1.AWSConfig) int {
+	return len(customObject.Spec.AWS.Workers)
+}
+
+func WorkerImageID(customObject v1alpha1.AWSConfig) string {
+	var imageID string
+
+	if len(customObject.Spec.AWS.Workers) > 0 {
+		imageID = customObject.Spec.AWS.Workers[0].ImageID
+	}
+
+	return imageID
+}
+
+func WorkerInstanceType(customObject v1alpha1.AWSConfig) string {
+	var instanceType string
+
+	if len(customObject.Spec.AWS.Workers) > 0 {
+		instanceType = customObject.Spec.AWS.Workers[0].InstanceType
+
+	}
+
+	return instanceType
+}
+
+// componentName returns the first component of a domain name.
+// e.g. apiserver.example.customer.cloud.com -> apiserver
+func componentName(domainName string) (string, error) {
+	splits := strings.SplitN(domainName, ".", 2)
+
+	if len(splits) != 2 {
+		return "", microerror.Mask(malformedCloudConfigKeyError)
+	}
+
+	return splits[0], nil
+}
+
+// ImageID returns the EC2 AMI for the configured region.
+func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
+	region := Region(customObject)
+
+	/*
+		Container Linux AMIs for each active AWS region.
+		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
+
+		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
+		NOTE 2: You also need to update the tests.
+
+		service/awsconfig/v11/key/key_test.go
+		service/awsconfig/v11/resource/cloudformation/adapter/adapter_test.go
+		service/resource/cloudformationv11/main_stack_test.go
+
+		Current Release: CoreOS Container Linux stable 1745.4.0 (HVM)
+	*/
+	imageIDs := map[string]string{
+		"ap-southeast-1": "ami-73b28f0f",
+		"cn-north-1":     "ami-8f05dbe2",
+		"eu-central-1":   "ami-32042fd9",
+		"eu-west-1":      "ami-82645dfb",
+		"us-west-2":      "ami-574f362f",
+	}
+
+	imageID, ok := imageIDs[region]
+	if !ok {
+		return "", microerror.Maskf(invalidConfigError, "no image id for region '%s'", region)
+	}
+
+	return imageID, nil
+}

--- a/service/controller/v12/key/key_test.go
+++ b/service/controller/v12/key/key_test.go
@@ -1,0 +1,1117 @@
+package key
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AutoScalingGroupName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker"
+	groupName := "worker"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if AutoScalingGroupName(customObject, groupName) != expectedName {
+		t.Fatalf("Expected auto scaling group name %s but was %s", expectedName, AutoScalingGroupName(customObject, groupName))
+	}
+}
+
+func Test_AvailabilityZone(t *testing.T) {
+	t.Parallel()
+	expectedAZ := "eu-central-1a"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+			},
+		},
+	}
+
+	if AvailabilityZone(customObject) != expectedAZ {
+		t.Fatalf("Expected availability zone %s but was %s", expectedAZ, AvailabilityZone(customObject))
+	}
+}
+
+func Test_BucketName(t *testing.T) {
+	t.Parallel()
+	accountID := "1234567890"
+	expectedName := "1234567890-g8s-test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	if BucketName(customObject, accountID) != expectedName {
+		t.Fatalf("Expected bucket name %s but was %s", expectedName, BucketName(customObject, accountID))
+	}
+}
+
+func Test_ClusterID(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+
+	cluster := v1alpha1.Cluster{
+		ID: expectedID,
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterID(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterID(customObject))
+	}
+}
+
+func Test_ClusterCustomer(t *testing.T) {
+	t.Parallel()
+	expectedCustomer := "test-customer"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if ClusterCustomer(customObject) != expectedCustomer {
+		t.Fatalf("Expected customer ID %s but was %s", expectedCustomer, ClusterCustomer(customObject))
+	}
+}
+
+func Test_ClusterCloudProviderTag(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+	expectedTag := "kubernetes.io/cluster/test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+			},
+		},
+	}
+
+	if ClusterCloudProviderTag(customObject) != expectedTag {
+		t.Fatalf("Expected cloud provider tag %s but was %s", expectedTag, ClusterCloudProviderTag(customObject))
+	}
+}
+
+func Test_ClusterNamespace(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+			},
+		},
+	}
+
+	if ClusterNamespace(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterNamespace(customObject))
+	}
+}
+
+func Test_ClusterOrganization(t *testing.T) {
+	t.Parallel()
+	expectedOrg := "test-org"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-org",
+				},
+			},
+		},
+	}
+
+	if ClusterOrganization(customObject) != expectedOrg {
+		t.Fatalf("Expected organization ID %s but was %s", expectedOrg, ClusterOrganization(customObject))
+	}
+}
+
+func Test_ClusterTags(t *testing.T) {
+	t.Parallel()
+	installName := "test-install"
+
+	expectedID := "test-cluster"
+	expectedTags := map[string]string{
+		"kubernetes.io/cluster/test-cluster": "owned",
+		"giantswarm.io/cluster":              "test-cluster",
+		"giantswarm.io/installation":         "test-install",
+		"giantswarm.io/organization":         "test-org",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+				// Organization uses Customer until its renamed in the CRD.
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-org",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject, installName)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject, installName))
+	}
+}
+
+func Test_ClusterVersion(t *testing.T) {
+	t.Parallel()
+	expectedVersion := "v_0_1_0"
+
+	cluster := v1alpha1.Cluster{
+		Version: expectedVersion,
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterVersion(customObject) != expectedVersion {
+		t.Fatalf("Expected cluster version %s but was %s", expectedVersion, ClusterVersion(customObject))
+	}
+}
+
+func Test_EtcdVolumeName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-etcd"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if EtcdVolumeName(customObject) != expectedName {
+		t.Fatalf("Expected Etcd volume name %s but was %s", expectedName, EtcdVolumeName(customObject))
+	}
+}
+
+func Test_IngressControllerInsecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 30010
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						InsecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if IngressControllerInsecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected ingress controller insecure port %d but was %d", expectedPort, IngressControllerInsecurePort(customObject))
+	}
+}
+
+func Test_IngressControllerSecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 30011
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						SecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if IngressControllerSecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected ingress controller secure port %d but was %d", expectedPort, IngressControllerSecurePort(customObject))
+	}
+}
+
+func Test_KubernetesAPISecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 443
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						SecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if KubernetesAPISecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected kubernetes api secure port %d but was %d", expectedPort, KubernetesAPISecurePort(customObject))
+	}
+}
+
+func Test_MasterImageID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject    v1alpha1.AWSConfig
+		expectedImageID string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedImageID: "ami-d60ad6b9",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{},
+			},
+			expectedImageID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterImageID(tc.customObject) != tc.expectedImageID {
+			t.Fatalf("Expected master image ID %s but was %s", tc.expectedImageID, MasterImageID(tc.customObject))
+		}
+	}
+}
+
+func Test_MasterInstanceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceName string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedInstanceName: "test-cluster-master",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterInstanceName(tc.customObject) != tc.expectedInstanceName {
+			t.Fatalf("Expected master instance name %s but was %s", tc.expectedInstanceName, MasterInstanceName(tc.customObject))
+		}
+	}
+}
+
+func Test_MasterInstanceResourceName_Format(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := MasterInstanceResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := MasterInstanceResourceName(customObject)
+
+	prefix := "MasterInstance"
+
+	if !strings.HasPrefix(n1, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n1, prefix)
+	}
+	if strings.Contains(n1, "-") {
+		t.Fatalf("expected %s to not contain dashes", n1)
+	}
+	if !strings.HasPrefix(n2, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n2, prefix)
+	}
+	if strings.Contains(n2, "-") {
+		t.Fatalf("expected %s to not contain dashes", n2)
+	}
+}
+
+func Test_MasterInstanceResourceName_Inequivalence(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := MasterInstanceResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := MasterInstanceResourceName(customObject)
+
+	if n1 == n2 {
+		t.Fatalf("expected %s to differ from %s", n1, n2)
+	}
+}
+
+func Test_MasterInstanceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceType string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "m3.medium",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterInstanceType(tc.customObject) != tc.expectedInstanceType {
+			t.Fatalf("Expected master instance type %s but was %s", tc.expectedInstanceType, MasterInstanceType(tc.customObject))
+		}
+	}
+}
+
+func Test_Region(t *testing.T) {
+	t.Parallel()
+	expectedRegion := "eu-central-1"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "eu-central-1",
+			},
+		},
+	}
+
+	if Region(customObject) != expectedRegion {
+		t.Fatalf("Expected region %s but was %s", expectedRegion, Region(customObject))
+	}
+}
+
+func Test_RouteTableName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-private"
+	suffix := "private"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if RouteTableName(customObject, suffix) != expectedName {
+		t.Fatalf("Expected route table name %s but was %s", expectedName, RouteTableName(customObject, suffix))
+	}
+
+}
+func Test_SecurityGroupName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker"
+	groupName := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if SecurityGroupName(customObject, groupName) != expectedName {
+		t.Fatalf("Expected security group name %s but was %s", expectedName, SecurityGroupName(customObject, groupName))
+	}
+}
+
+func Test_SubnetName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-private"
+	suffix := "private"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if SubnetName(customObject, suffix) != expectedName {
+		t.Fatalf("Expected subnet name %s but was %s", expectedName, SubnetName(customObject, suffix))
+	}
+
+}
+
+func Test_WorkerCount(t *testing.T) {
+	t.Parallel()
+	expectedCount := 2
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						InstanceType: "m3.medium",
+					},
+					{
+						InstanceType: "m3.medium",
+					},
+				},
+			},
+		},
+	}
+
+	if WorkerCount(customObject) != expectedCount {
+		t.Fatalf("Expected worker count %d but was %d", expectedCount, WorkerCount(customObject))
+	}
+}
+
+func Test_WorkerImageID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject    v1alpha1.AWSConfig
+		expectedImageID string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedImageID: "ami-d60ad6b9",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedImageID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if WorkerImageID(tc.customObject) != tc.expectedImageID {
+			t.Fatalf("Expected worker image ID %s but was %s", tc.expectedImageID, WorkerImageID(tc.customObject))
+		}
+	}
+}
+
+func Test_WorkerInstanceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceType string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "m3.medium",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedInstanceType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if WorkerInstanceType(tc.customObject) != tc.expectedInstanceType {
+			t.Fatalf("Expected worker instance type %s but was %s", tc.expectedInstanceType, WorkerInstanceType(tc.customObject))
+		}
+	}
+}
+
+func Test_MainGuestStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-guest-main"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainGuestStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_MainHostPreStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-host-setup"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainHostPreStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_MainHostPostStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-host-main"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainHostPostStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_InstanceProfileName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Role"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if InstanceProfileName(customObject, profileType) != expectedName {
+		t.Fatalf("Expected instance profile name '%s' but was '%s'", expectedName, InstanceProfileName(customObject, profileType))
+	}
+}
+
+func TestLoadBalancerName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc       string
+		domainName string
+		tpo        v1alpha1.AWSConfig
+		res        string
+		err        error
+	}{
+		{
+			desc:       "works",
+			domainName: "component.foo.bar.example.com",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "foo-customer-component",
+		},
+		{
+			desc:       "also works",
+			domainName: "component.of.a.well.formed.domain",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "quux-the-customer",
+					},
+				},
+			},
+			res: "quux-the-customer-component",
+		},
+		{
+			desc:       "missing ID key in cloudconfig",
+			domainName: "component.foo.bar.example.com",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "",
+					},
+				},
+			},
+			res: "",
+			err: missingCloudConfigKeyError,
+		},
+		{
+			desc:       "malformed domain name",
+			domainName: "not a domain name",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "missing domain name",
+			domainName: "",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := LoadBalancerName(tc.domainName, tc.tpo)
+
+		if err != nil {
+			underlying := microerror.Cause(err)
+			assert.Equal(t, tc.err, underlying, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}
+
+func TestComponentName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc       string
+		domainName string
+		res        string
+		err        error
+	}{
+		{
+			desc:       "one level of subdomains",
+			domainName: "foo.bar.com",
+			res:        "foo",
+		},
+		{
+			desc:       "two levels of subdomains",
+			domainName: "foo.bar.quux.com",
+			res:        "foo",
+		},
+		{
+			desc:       "malformed domain",
+			domainName: "not a domain name",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "empty domain",
+			domainName: "",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := componentName(tc.domainName)
+
+		if err != nil {
+			assert.True(t, IsMalformedCloudConfigKey(err), fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}
+
+func Test_VersionBundleVersion(t *testing.T) {
+	t.Parallel()
+	expectedVersion := "0.1.0"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			VersionBundle: v1alpha1.AWSConfigSpecVersionBundle{
+				Version: "0.1.0",
+			},
+		},
+	}
+
+	if VersionBundleVersion(customObject) != expectedVersion {
+		t.Fatalf("Expected version in version bundle to be %s but was %s", expectedVersion, VersionBundleVersion(customObject))
+	}
+}
+
+func Test_BucketObjectName(t *testing.T) {
+	t.Parallel()
+	version := "v_0_1_0"
+	suffix := "mysuffix"
+
+	expectedBucketObjectName := "cloudconfig/v_0_1_0/mysuffix"
+	actualBucketObjectName := BucketObjectName(version, suffix)
+	if expectedBucketObjectName != actualBucketObjectName {
+		t.Fatalf("Expected bucket object name %q but was %q", expectedBucketObjectName, actualBucketObjectName)
+	}
+}
+
+func Test_RoleName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Role"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := RoleName(customObject, profileType)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_PolicyName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Policy"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := PolicyName(customObject, profileType)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_PeerAccessRoleName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-vpc-peer-access"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := PeerAccessRoleName(customObject)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_MasterCount(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						InstanceType: "m3.medium",
+					},
+					{
+						InstanceType: "m3.medium",
+					},
+				},
+			},
+		},
+	}
+
+	expected := 2
+	actual := MasterCount(customObject)
+	if actual != expected {
+		t.Fatalf("Expected master count %d but was %d", expected, actual)
+	}
+}
+
+func Test_PrivateSubnetCIDR(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PrivateSubnetCIDR: "172.31.0.0/16",
+				},
+			},
+		},
+	}
+	expected := "172.31.0.0/16"
+	actual := PrivateSubnetCIDR(customObject)
+
+	if actual != expected {
+		t.Fatalf("Expected PrivateSubnetCIDR %s but was %s", expected, actual)
+	}
+}
+
+func Test_PeerID(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PeerID: "vpc-abcd",
+				},
+			},
+		},
+	}
+	expected := "vpc-abcd"
+	actual := PeerID(customObject)
+
+	if actual != expected {
+		t.Fatalf("Expected PeerID %s but was %s", expected, actual)
+	}
+}
+
+func Test_ImageID(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		customObject    v1alpha1.AWSConfig
+		errorMatcher    func(error) bool
+		expectedImageID string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			errorMatcher:    nil,
+			expectedImageID: "ami-32042fd9",
+		},
+		{
+			description: "different region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-west-1",
+					},
+				},
+			},
+			errorMatcher:    nil,
+			expectedImageID: "ami-82645dfb",
+		},
+		{
+			description: "invalid region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "invalid-1",
+					},
+				},
+			},
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			imageID, err := ImageID(tc.customObject)
+			if tc.errorMatcher != nil && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Error("expected", true, "got", false)
+			}
+
+			if tc.expectedImageID != imageID {
+				t.Errorf("unexpected imageID, expecting %q, want %q", tc.expectedImageID, imageID)
+			}
+		})
+	}
+}
+
+func Test_TargetLogBucketName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-g8s-access-logs"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	if TargetLogBucketName(customObject) != expectedName {
+		t.Fatalf("Expected target bucket name %s but was %s", expectedName, TargetLogBucketName(customObject))
+	}
+}
+
+func Test_RegionARN(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		region            string
+		expectedRegionARN string
+		description       string
+	}{
+		{
+			description:       "eu region",
+			region:            "eu-central-1",
+			expectedRegionARN: "aws",
+		},
+		{
+			description:       "china region",
+			region:            "cn-north-1",
+			expectedRegionARN: "aws-cn",
+		},
+		{
+			description:       "unknown region",
+			region:            "unknown-region-1",
+			expectedRegionARN: "aws",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject.Spec.AWS.Region = tc.region
+
+			actual := RegionARN(customObject)
+
+			if actual != tc.expectedRegionARN {
+				t.Fatalf("Expected region ARN %q but was %q", tc.expectedRegionARN, actual)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/cloudformation/create.go
+++ b/service/controller/v12/resource/cloudformation/create.go
@@ -1,0 +1,203 @@
+package cloudformation
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	stackInput, err := toCreateStackInput(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackInput.StackName != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the guest cluster main stack")
+
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		_, err = sc.AWSClient.CloudFormation.CreateStack(&stackInput)
+		if IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		err = sc.AWSClient.CloudFormation.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
+			StackName: stackInput.StackName,
+		})
+		if ctx.Err() == context.DeadlineExceeded {
+			// We waited longer than we wanted to get a reasonable result and be sure
+			// the stack got properly created. We skip here and try again on the next
+			// resync.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster main stack creation is not complete")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+			return nil
+		} else if ctx.Err() != nil {
+			return microerror.Mask(ctx.Err())
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not creating the guest cluster main stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be created")
+
+	createState := cloudformation.CreateStackInput{}
+
+	if currentStackState.Name == "" || desiredStackState.Name != currentStackState.Name {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be created")
+
+		if err := r.validateCluster(customObject); err != nil {
+			return cloudformation.CreateStackInput{}, microerror.Mask(err)
+		}
+
+		// We need to create the required peering resources in the host account before
+		// getting the guest main stack template body, it requires id values from host
+		// resources.
+		err = r.createHostPreStack(ctx, customObject)
+		if err != nil {
+			return cloudformation.CreateStackInput{}, microerror.Mask(err)
+		}
+
+		var mainTemplate string
+		mainTemplate, err := r.getMainGuestTemplateBody(ctx, customObject, desiredStackState)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		createState.StackName = aws.String(desiredStackState.Name)
+		createState.TemplateBody = aws.String(mainTemplate)
+		createState.TimeoutInMinutes = aws.Int64(defaultCreationTimeout)
+		// CAPABILITY_NAMED_IAM is required for creating IAM roles (worker policy)
+		createState.Capabilities = []*string{
+			aws.String(namedIAMCapability),
+		}
+
+		createState.SetTags(r.getCloudFormationTags(customObject))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be created")
+
+		// Create host post-main stack once the guest main stack got created. This
+		// here usually happens on the second or third attempt dependening on the
+		// resnyc period. It includes the peering routes, which need resources from
+		// the guest stack to be in place before it can be created.
+		err = r.createHostPostStack(ctx, customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return createState, nil
+}
+
+func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1.AWSConfig) error {
+	stackName := key.MainHostPreStackName(customObject)
+	mainTemplate, err := r.getMainHostPreTemplateBody(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	createStack := &cloudformation.CreateStackInput{
+		StackName:    aws.String(stackName),
+		TemplateBody: aws.String(mainTemplate),
+		// CAPABILITY_NAMED_IAM is required for creating IAM roles (worker policy)
+		Capabilities: []*string{
+			aws.String(namedIAMCapability),
+		},
+	}
+	createStack.SetTags(r.getCloudFormationTags(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster pre cloud formation stack")
+
+	_, err = r.hostClients.CloudFormation.CreateStack(createStack)
+	if IsAlreadyExists(err) {
+		// TODO this here indicates we should have dedicated resources for the pre,
+		// main and post stacks. The workflow would be more straight forward and
+		// easy to manage. Right now we hack around this and add conditionals to
+		// make it work somehow while bypassing the framework primitives.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the host cluster pre cloud formation stack is already created")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.hostClients.CloudFormation.WaitUntilStackCreateComplete(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created the host cluster pre cloud formation stack")
+
+	return nil
+}
+
+func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha1.AWSConfig) error {
+	stackName := key.MainHostPostStackName(customObject)
+	mainTemplate, err := r.getMainHostPostTemplateBody(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	createStack := &cloudformation.CreateStackInput{
+		StackName:    aws.String(stackName),
+		TemplateBody: aws.String(mainTemplate),
+	}
+	createStack.SetTags(r.getCloudFormationTags(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster post cloud formation stack")
+
+	_, err = r.hostClients.CloudFormation.CreateStack(createStack)
+	if IsAlreadyExists(err) {
+		// TODO this here indicates we should have dedicated resources for the pre,
+		// main and post stacks. The workflow would be more straight forward and
+		// easy to manage. Right now we hack around this and add conditionals to
+		// make it work somehow while bypassing the framework primitives.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the host cluster post cloud formation stack is already created")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created the host cluster post cloud formation stack")
+
+	return nil
+}

--- a/service/controller/v12/resource/cloudformation/create_test.go
+++ b/service/controller/v12/resource/cloudformation/create_test.go
@@ -1,0 +1,128 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_Cloudformation_newCreate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID: "myimageid",
+					},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID: "myimageid",
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj               interface{}
+		currentState      interface{}
+		desiredState      interface{}
+		expectedStackName string
+		description       string
+	}{
+		{
+			description:       "current and desired state empty, expected empty",
+			obj:               clusterTpo,
+			currentState:      StackState{},
+			desiredState:      StackState{},
+			expectedStackName: "",
+		},
+		{
+			description:  "current state empty, desired state not empty, expected desired state",
+			obj:          clusterTpo,
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj:         clusterTpo,
+			currentState: StackState{
+				Name: "current",
+			},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			EC2:            &adapter.EC2ClientMock{},
+			CloudFormation: &adapter.CloudFormationMock{},
+			IAM:            &adapter.IAMClientMock{},
+			STS:            &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			createChange, ok := result.(awscloudformation.CreateStackInput)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", createChange, result)
+			}
+			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
+				t.Fatalf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/cloudformation/current.go
+++ b/service/controller/v12/resource/cloudformation/current.go
@@ -1,0 +1,146 @@
+package cloudformation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v11/cloudformation"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the guest cluster main stack in the AWS API")
+
+	stackName := key.MainGuestStackName(customObject)
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// In order to compute the current state of the guest cluster's cloud
+	// formation stack we have to describe the CF stacks and lookup the right
+	// stack. We dispatch our custom StackState structure and enrich it with all
+	// information necessary to reconcile the cloudformation resource.
+	var stackOutputs []*cloudformation.Output
+	var stackStatus string
+	{
+		stackOutputs, stackStatus, err = sc.CloudFormation.DescribeOutputsAndStatus(stackName)
+		if cloudformationservice.IsStackNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster main stack in the AWS API")
+			return StackState{}, nil
+
+		} else if cloudformationservice.IsOutputsNotAccessible(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack output values are not accessible due to stack state transition")
+			return StackState{}, nil
+
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster main stack in the AWS API")
+
+	// In case the current guest cluster is already being updated, we cancel the
+	// reconciliation until the current update is done in order to reduce
+	// unnecessary friction.
+	if stackStatus == cloudformation.ResourceStatusUpdateInProgress {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("guest cluster main stack is in state '%s'", cloudformation.ResourceStatusUpdateInProgress))
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return StackState{}, nil
+	}
+
+	var currentState StackState
+	{
+		masterImageID, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterImageIDKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterInstanceResourceName, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterInstanceResourceNameKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the master
+			// instance resource name in the CF stack outputs. We ignore this problem
+			// for now and move on regardless. On the next resync period the output
+			// value will be there, once the cluster got updated.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a master instance resource.
+			masterInstanceResourceName = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterInstanceType, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterInstanceTypeKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterCloudConfigVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterCloudConfigVersionKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		workerCount, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerCountKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerImageID, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerImageIDKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerInstanceType, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerInstanceTypeKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerCloudConfigVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerCloudConfigVersionKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		versionBundleVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.VersionBundleVersionKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the version
+			// bundle version in the CF stack outputs. We ignore this problem for now
+			// and move on regardless. The reconciliation will detect the guest cluster
+			// needs to be updated and once this is done, we should be fine again.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a version bundle version.
+			versionBundleVersion = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		currentState = StackState{
+			Name: stackName,
+
+			MasterImageID:              masterImageID,
+			MasterInstanceResourceName: masterInstanceResourceName,
+			MasterInstanceType:         masterInstanceType,
+			MasterCloudConfigVersion:   masterCloudConfigVersion,
+
+			Status: stackStatus,
+
+			WorkerCount:              workerCount,
+			WorkerImageID:            workerImageID,
+			WorkerInstanceType:       workerInstanceType,
+			WorkerCloudConfigVersion: workerCloudConfigVersion,
+
+			VersionBundleVersion: versionBundleVersion,
+		}
+	}
+
+	return currentState, nil
+}

--- a/service/controller/v12/resource/cloudformation/delete.go
+++ b/service/controller/v12/resource/cloudformation/delete.go
@@ -1,0 +1,126 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	stackStateToDelete, err := toStackState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackStateToDelete.Status == cloudformation.ResourceStatusUpdateInProgress {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cannot delete CF stacks due to stack state transitioning")
+
+		// TODO control flow via more proper mechanism via something like the
+		// context like it is done for cancelation already.
+		return microerror.Maskf(deletionMustBeRetriedError, "stack state is transitioning")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the guest cluster main stack")
+
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainGuestStackName(customObject)),
+		}
+		_, err = sc.AWSClient.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the guest cluster main stack")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster pre stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPreStackName(customObject)),
+		}
+		_, err = r.hostClients.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the host cluster pre stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the host cluster pre stack")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster post stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPostStackName(customObject)),
+		}
+		_, err = r.hostClients.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the host cluster post stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the host cluster post stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(deleteChange)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// For deletion we need the current and desired state in order to process it
+	// reliable. There are cases in which the current state does not contain a
+	// name because of stack state transitions but provides the stack status
+	// itself. The desired state never provides the current stack state in return.
+	// This is why we have to compute the delete state using both entities. Note
+	// that for deletion some properties of the stack state are omitted due to
+	// unimportance to the process.
+	deleteState := StackState{
+		Name:   desiredStackState.Name,
+		Status: currentStackState.Status,
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster main stack that has to be deleted")
+
+	return deleteState, nil
+}

--- a/service/controller/v12/resource/cloudformation/delete_test.go
+++ b/service/controller/v12/resource/cloudformation/delete_test.go
@@ -1,0 +1,117 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+)
+
+func Test_Resource_Cloudformation_newDelete(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj               interface{}
+		currentState      interface{}
+		desiredState      interface{}
+		expectedStackName string
+		description       string
+	}{
+		{
+			description: "case 0: current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:      StackState{},
+			desiredState:      StackState{},
+			expectedStackName: "",
+		},
+		{
+			description: "case 1: current state empty, desired state not empty, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "case 2: current state not empty, desired state not empty but different, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{
+				Name: "current",
+			},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "case 3: current state not empty, desired state not empty but equal, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{
+				Name: "equal",
+			},
+			desiredState: StackState{
+				Name: "equal",
+			},
+			expectedStackName: "equal",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{}
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			result, err := newResource.newDeleteChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			deleteChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", deleteChange, result)
+			}
+			if deleteChange.Name != tc.expectedStackName {
+				t.Fatalf("expected %s, got %s", tc.expectedStackName, deleteChange.Name)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/cloudformation/desired.go
+++ b/service/controller/v12/resource/cloudformation/desired.go
@@ -1,0 +1,62 @@
+package cloudformation
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var mainStack StackState
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computing desired state for the guest cluster main stack")
+
+		imageID, err := key.ImageID(customObject)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		// FIXME: the instance type should not depend on the number of workers.
+		// issue: https://github.com/giantswarm/awstpr/issues/47
+		var workerInstanceType string
+		if key.WorkerCount(customObject) > 0 {
+			workerInstanceType = key.WorkerInstanceType(customObject)
+		}
+
+		var masterInstanceType string
+		if len(customObject.Spec.AWS.Masters) > 0 {
+			masterInstanceType = key.MasterInstanceType(customObject)
+		}
+
+		mainStack = StackState{
+			Name: key.MainGuestStackName(customObject),
+
+			MasterImageID:              imageID,
+			MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+			MasterInstanceType:         masterInstanceType,
+			MasterCloudConfigVersion:   cloudconfig.MasterCloudConfigVersion,
+			MasterInstanceMonitoring:   r.monitoring,
+
+			WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+			WorkerImageID:            imageID,
+			WorkerInstanceMonitoring: r.monitoring,
+			WorkerInstanceType:       workerInstanceType,
+			WorkerCloudConfigVersion: cloudconfig.WorkerCloudConfigVersion,
+
+			VersionBundleVersion: key.VersionBundleVersion(customObject),
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computed desired state for the guest cluster main stack")
+	}
+
+	return mainStack, nil
+}

--- a/service/controller/v12/resource/cloudformation/desired_test.go
+++ b/service/controller/v12/resource/cloudformation/desired_test.go
@@ -1,0 +1,70 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+)
+
+func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj          interface{}
+		expectedName string
+		description  string
+	}{
+		{
+			description: "CloudFormation gets name from custom object",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+					Cluster: v1alpha1.Cluster{
+						ID:      "5xchu",
+						Version: "cloud-formation",
+					},
+				},
+			},
+			expectedName: "cluster-5xchu-guest-main",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{}
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			desiredStack, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredStack, result)
+			}
+
+			if tc.expectedName != desiredStack.Name {
+				t.Fatalf("expected cloudformation name '%s' got '%s'", tc.expectedName, desiredStack.Name)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/cloudformation/error.go
+++ b/service/controller/v12/resource/cloudformation/error.go
@@ -1,0 +1,64 @@
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+var alreadyExistsError = microerror.New("already exists")
+
+// IsAlreadyExists asserts alreadyExistsError.
+func IsAlreadyExists(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ErrCodeAlreadyExistsException) {
+		return true
+	}
+
+	if c == alreadyExistsError {
+		return true
+	}
+
+	return false
+}
+
+var deletionMustBeRetriedError = microerror.New("deletion must be retried")
+
+// IsDeletionMustBeRetried asserts deletionMustBeRetriedError.
+func IsDeletionMustBeRetried(err error) bool {
+	return microerror.Cause(err) == deletionMustBeRetriedError
+}
+
+var executionFailedError = microerror.New("execution failed")
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/cloudformation/main_stack.go
+++ b/service/controller/v12/resource/cloudformation/main_stack.go
@@ -1,0 +1,144 @@
+package cloudformation
+
+import (
+	"context"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates"
+)
+
+func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig, stackState StackState) (string, error) {
+	hostAccountID, err := adapter.AccountID(*r.hostClients)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	cfg := adapter.Config{
+		APIWhitelist: adapter.APIWhitelist{
+			Enabled:    r.apiWhiteList.Enabled,
+			SubnetList: r.apiWhiteList.SubnetList,
+		},
+		CustomObject:     customObject,
+		Clients:          adapterClients,
+		HostClients:      *r.hostClients,
+		InstallationName: r.installationName,
+		HostAccountID:    hostAccountID,
+		Route53Enabled:   r.route53Enabled,
+		StackState: adapter.StackState{
+			Name: stackState.Name,
+
+			MasterImageID:              stackState.MasterImageID,
+			MasterInstanceResourceName: stackState.MasterInstanceResourceName,
+			MasterInstanceType:         stackState.MasterInstanceType,
+			MasterCloudConfigVersion:   stackState.MasterCloudConfigVersion,
+			MasterInstanceMonitoring:   stackState.MasterInstanceMonitoring,
+
+			WorkerCount:              stackState.WorkerCount,
+			WorkerImageID:            stackState.WorkerImageID,
+			WorkerInstanceMonitoring: stackState.WorkerInstanceMonitoring,
+			WorkerInstanceType:       stackState.WorkerInstanceType,
+			WorkerCloudConfigVersion: stackState.WorkerCloudConfigVersion,
+
+			VersionBundleVersion: stackState.VersionBundleVersion,
+		},
+	}
+
+	adp, err := adapter.NewGuest(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationGuestTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}
+
+func (r *Resource) getMainHostPreTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	guestAccountID, err := adapter.AccountID(adapterClients)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	cfg := adapter.Config{
+		CustomObject:   customObject,
+		GuestAccountID: guestAccountID,
+	}
+	adp, err := adapter.NewHostPre(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationHostPreTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}
+
+func (r *Resource) getMainHostPostTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	cfg := adapter.Config{
+		CustomObject: customObject,
+		Clients:      adapterClients,
+		HostClients:  *r.hostClients,
+	}
+	adp, err := adapter.NewHostPost(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationHostPostTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}

--- a/service/controller/v12/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v12/resource/cloudformation/main_stack_test.go
@@ -1,0 +1,687 @@
+package cloudformation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func testConfig() Config {
+	c := Config{}
+
+	c.HostClients = &adapter.Clients{}
+	c.Logger = microloggertest.New()
+
+	c.InstallationName = "myinstallation"
+
+	return c
+}
+
+func TestMainGuestTemplateGetEmptyBody(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{}
+
+	c := testConfig()
+	c.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(c)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	_, err = newResource.getMainGuestTemplateBody(ctx, customObject, StackState{})
+	if err == nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+}
+
+func TestMainGuestTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "eu-central-1",
+				AZ:     "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.MasterCloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.WorkerCloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.AdvancedMonitoringEC2 = true
+	cfg.Route53Enabled = true
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Guest CloudFormation stack.") {
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  workerLaunchConfiguration:") {
+		t.Fatal("launch configuration header not found")
+	}
+
+	if !strings.Contains(body, "  workerAutoScalingGroup:") {
+		t.Fatal("asg header not found")
+	}
+
+	if !strings.Contains(body, "InstanceType: m3.large") {
+		t.Fatal("launch configuration element not found")
+	}
+
+	if !strings.Contains(body, "AvailabilityZones: [eu-central-1a]") {
+		fmt.Println(body)
+		t.Fatal("asg element not found")
+	}
+
+	if !strings.Contains(body, "Outputs:") {
+		fmt.Println(body)
+		t.Fatal("outputs header not found")
+	}
+
+	if !strings.Contains(body, key.MasterImageIDKey+":") {
+		fmt.Println(body)
+		t.Fatal("MasterImageID output element not found")
+	}
+	if !strings.Contains(body, key.MasterInstanceMonitoring+": true") {
+		fmt.Println(body)
+		t.Fatal("MasterInstanceMonitoring output element not found")
+	}
+	if !strings.Contains(body, key.MasterInstanceTypeKey+":") {
+		fmt.Println(body)
+		t.Fatal("MasterInstanceType output element not found")
+	}
+	if !strings.Contains(body, key.MasterCloudConfigVersionKey+":") {
+		fmt.Println(body)
+		t.Fatal("master CloudConfig version output element not found")
+	}
+	if !strings.Contains(body, key.WorkerCountKey+":") {
+		fmt.Println(body)
+		t.Fatal("workers output element not found")
+	}
+	if !strings.Contains(body, key.WorkerImageIDKey+":") {
+		fmt.Println(body)
+		t.Fatal("WorkerImageID output element not found")
+	}
+	if !strings.Contains(body, key.WorkerInstanceTypeKey+":") {
+		fmt.Println(body)
+		t.Fatal("WorkerInstanceType output element not found")
+	}
+	if !strings.Contains(body, key.WorkerCloudConfigVersionKey+":") {
+		fmt.Println(body)
+		t.Fatal("worker CloudConfig version output element not found")
+	}
+	if !strings.Contains(body, key.WorkerInstanceMonitoring+": true") {
+		fmt.Println(body)
+		t.Fatal("WorkerInstanceMonitoring output element not found")
+	}
+
+	if !strings.Contains(body, "Value: "+cloudconfig.MasterCloudConfigVersion) {
+		fmt.Println(body)
+		t.Fatal("output element not found")
+	}
+
+	if !strings.Contains(body, workerRoleKey+":") {
+		fmt.Println(body)
+		t.Fatal("workerRole output element not found")
+	}
+	if !strings.Contains(body, "PolicyName: test-cluster-master") {
+		fmt.Println(body)
+		t.Fatal("PolicyName output element not found")
+	}
+	if !strings.Contains(body, "PolicyName: test-cluster-worker") {
+		fmt.Println(body)
+		t.Fatal("PolicyName output element not found")
+	}
+	if !strings.Contains(body, "ApiRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ApiRecordSet element not found")
+	}
+	if !strings.Contains(body, "EtcdRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("EtcdRecordSet element not found")
+	}
+	if !strings.Contains(body, "IngressRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("IngressRecordSet element not found")
+	}
+	if !strings.Contains(body, "IngressWildcardRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ingressWildcardRecordSet element not found")
+	}
+	if !strings.Contains(body, "MasterInstance") {
+		fmt.Println(body)
+		t.Fatal("MasterInstance element not found")
+	}
+	if !strings.Contains(body, "ApiLoadBalancer:") {
+		fmt.Println(body)
+		t.Fatal("ApiLoadBalancer element not found")
+	}
+	if !strings.Contains(body, "IngressLoadBalancer:") {
+		fmt.Println(body)
+		t.Fatal("IngressLoadBalancer element not found")
+	}
+	if !strings.Contains(body, "InternetGateway:") {
+		fmt.Println(body)
+		t.Fatal("InternetGateway element not found")
+	}
+	if !strings.Contains(body, "NATGateway:") {
+		fmt.Println(body)
+		t.Fatal("NATGateway element not found")
+	}
+	if !strings.Contains(body, "PublicRouteTable:") {
+		fmt.Println(body)
+		t.Fatal("PublicRouteTable element not found")
+	}
+	if !strings.Contains(body, "PublicSubnet:") {
+		fmt.Println(body)
+		t.Fatal("PublicSubnet element not found")
+	}
+	if !strings.Contains(body, "PrivateRouteTable:") {
+		fmt.Println(body)
+		t.Fatal("PrivateRouteTable element not found")
+	}
+	if !strings.Contains(body, "PrivateSubnet:") {
+		fmt.Println(body)
+		t.Fatal("PrivateSubnet element not found")
+	}
+	if !strings.Contains(body, "MasterSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("MasterSecurityGroup element not found")
+	}
+	if !strings.Contains(body, "WorkerSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("WorkerSecurityGroup element not found")
+	}
+	if !strings.Contains(body, "IngressSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("IngressSecurityGroup element not found")
+	}
+	if !strings.Contains(body, " VPC:") {
+		fmt.Println(body)
+		t.Fatal("VPC element not found")
+	}
+	if !strings.Contains(body, "CidrBlock: 10.1.1.0/24") {
+		fmt.Println(body)
+		t.Fatal("CidrBlock element not found")
+	}
+
+	// arn depends on region
+	if !strings.Contains(body, `Resource: "arn:aws:s3:::`) {
+		fmt.Println(body)
+		t.Fatal("ARN region dependent element not found")
+	}
+
+	// image ids should be fixed despite the values in the custom object
+	if !strings.Contains(body, "ImageId: ami-32042fd9") {
+		fmt.Println(body)
+		t.Fatal("Fixed image ID not found")
+	}
+}
+
+func TestMainHostPreTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainHostPreTemplateBody(ctx, customObject)
+
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Host Pre-Guest CloudFormation stack.") {
+		fmt.Println(body)
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  PeerRole:") {
+		fmt.Println(body)
+		t.Fatal("peer role header not found")
+	}
+
+	if !strings.Contains(body, "  RoleName: test-cluster-vpc-peer-access") {
+		fmt.Println(body)
+		t.Fatal("role name not found")
+	}
+}
+
+func TestMainHostPostTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					RouteTableNames: []string{
+						"route_table_1",
+						"route_table_2",
+					},
+					PeerID: "mypeerid",
+				},
+			},
+		},
+	}
+
+	cfg := testConfig()
+	ec2Mock := &adapter.EC2ClientMock{}
+	ec2Mock.SetMatchingRouteTables(1)
+	cfg.HostClients = &adapter.Clients{
+		EC2: ec2Mock,
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainHostPostTemplateBody(ctx, customObject)
+
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Host Post-Guest CloudFormation stack.") {
+		fmt.Println(body)
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  PrivateRoute1:") {
+		fmt.Println(body)
+		t.Fatal("route header not found")
+	}
+}
+
+func TestMainGuestTemplateRoute53Disabled(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "eu-central-1",
+				AZ:     "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.MasterCloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.WorkerCloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.Route53Enabled = false
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if strings.Contains(body, "ApiRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ApiRecordSet element found")
+	}
+	if strings.Contains(body, "EtcdRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("EtcdRecordSet element found")
+	}
+	if strings.Contains(body, "IngressRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("IngressRecordSet element found")
+	}
+	if strings.Contains(body, "IngressWildcardRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ingressWildcardRecordSet element found")
+	}
+}
+
+func TestMainGuestTemplateChinaRegion(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "cn-north-1",
+				AZ:     "cn-north-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.MasterCloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.WorkerCloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.Route53Enabled = false
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// arn depends on region
+	if !strings.Contains(body, `Resource: "arn:aws-cn:s3:::`) {
+		fmt.Println(body)
+		t.Fatal("ARN region dependent element not found")
+	}
+}

--- a/service/controller/v12/resource/cloudformation/mock_test.go
+++ b/service/controller/v12/resource/cloudformation/mock_test.go
@@ -1,0 +1,27 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
+)
+
+type EBSServiceMock struct {
+}
+
+func (e *EBSServiceMock) DeleteVolume(ctx context.Context, volumeID string) error {
+	return nil
+}
+
+func (e *EBSServiceMock) DetachVolume(ctx context.Context, volumeID string, attachment ebs.VolumeAttachment, force bool, shutdown bool, wait bool) error {
+	return nil
+}
+
+// ListVolumes always returns a list containing one volume because this is what
+// the update process of the cloudformation resource needs.
+func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]ebs.Volume, error) {
+	return []ebs.Volume{{}}, nil
+}

--- a/service/controller/v12/resource/cloudformation/resource.go
+++ b/service/controller/v12/resource/cloudformation/resource.go
@@ -1,0 +1,142 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cloudformationv11"
+)
+
+type AWSConfig struct {
+	AccessKeyID     string
+	AccessKeySecret string
+	SessionToken    string
+	Region          string
+	accountID       string
+}
+
+// Config represents the configuration used to create a new cloudformation
+// resource.
+type Config struct {
+	APIWhitelist adapter.APIWhitelist
+	HostClients  *adapter.Clients
+	Logger       micrologger.Logger
+
+	AdvancedMonitoringEC2 bool
+	InstallationName      string
+	Route53Enabled        bool
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	apiWhiteList adapter.APIWhitelist
+	hostClients  *adapter.Clients
+	logger       micrologger.Logger
+
+	installationName string
+	monitoring       bool
+	route53Enabled   bool
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	if config.HostClients == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostClients must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		apiWhiteList: config.APIWhitelist,
+		hostClients:  config.HostClients,
+		logger:       config.Logger,
+
+		installationName: config.InstallationName,
+		monitoring:       config.AdvancedMonitoringEC2,
+		route53Enabled:   config.Route53Enabled,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) getCloudFormationTags(customObject v1alpha1.AWSConfig) []*awscloudformation.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
+	stackTags := []*awscloudformation.Tag{}
+
+	for k, v := range clusterTags {
+		tag := &awscloudformation.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		stackTags = append(stackTags, tag)
+	}
+
+	return stackTags
+}
+
+func toCreateStackInput(v interface{}) (awscloudformation.CreateStackInput, error) {
+	if v == nil {
+		return awscloudformation.CreateStackInput{}, nil
+	}
+
+	createStackInput, ok := v.(awscloudformation.CreateStackInput)
+	if !ok {
+		return awscloudformation.CreateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", createStackInput, v)
+	}
+
+	return createStackInput, nil
+}
+
+func toDeleteStackInput(v interface{}) (awscloudformation.DeleteStackInput, error) {
+	if v == nil {
+		return awscloudformation.DeleteStackInput{}, nil
+	}
+
+	deleteStackInput, ok := v.(awscloudformation.DeleteStackInput)
+	if !ok {
+		return awscloudformation.DeleteStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", deleteStackInput, v)
+	}
+
+	return deleteStackInput, nil
+}
+
+func toStackState(v interface{}) (StackState, error) {
+	if v == nil {
+		return StackState{}, nil
+	}
+
+	stackState, ok := v.(StackState)
+	if !ok {
+		return StackState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", stackState, v)
+	}
+
+	return stackState, nil
+}
+
+func toUpdateStackInput(v interface{}) (awscloudformation.UpdateStackInput, error) {
+	if v == nil {
+		return awscloudformation.UpdateStackInput{}, nil
+	}
+
+	updateStackInput, ok := v.(awscloudformation.UpdateStackInput)
+	if !ok {
+		return awscloudformation.UpdateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", updateStackInput, v)
+	}
+
+	return updateStackInput, nil
+}

--- a/service/controller/v12/resource/cloudformation/resource_test.go
+++ b/service/controller/v12/resource/cloudformation/resource_test.go
@@ -1,0 +1,96 @@
+package cloudformation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description  string
+		installation string
+		obj          v1alpha1.AWSConfig
+		expectedTags []*awscloudformation.Tag
+	}{
+		{
+			description:  "basic match",
+			installation: "test-install",
+			obj: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+						Customer: v1alpha1.ClusterCustomer{
+							ID: "giantswarm",
+						},
+					},
+				},
+			},
+			expectedTags: []*awscloudformation.Tag{
+				{
+					Key:   aws.String("kubernetes.io/cluster/5xchu"),
+					Value: aws.String("owned"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/cluster"),
+					Value: aws.String("5xchu"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/organization"),
+					Value: aws.String("giantswarm"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/installation"),
+					Value: aws.String("test-install"),
+				},
+			},
+		},
+	}
+
+	c := Config{}
+
+	c.HostClients = &adapter.Clients{
+		EC2:            &adapter.EC2ClientMock{},
+		CloudFormation: &adapter.CloudFormationMock{},
+		IAM:            &adapter.IAMClientMock{},
+		STS:            &adapter.STSClientMock{},
+	}
+	c.Logger = microloggertest.New()
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.InstallationName = tc.installation
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			tags := r.getCloudFormationTags(tc.obj)
+
+			if len(tags) != len(tc.expectedTags) {
+				t.Fatalf("Expected %d tags, found %d", len(tc.expectedTags), len(tags))
+			}
+
+			for _, tag := range tc.expectedTags {
+				if !containsTag(tag, tags) {
+					t.Fatalf("Expected cloud formation contains tag %v in the slice %v", tag, tags)
+				}
+			}
+		})
+	}
+}
+
+func containsTag(tag *awscloudformation.Tag, tags []*awscloudformation.Tag) bool {
+	for _, inTag := range tags {
+		if reflect.DeepEqual(tag, inTag) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/cloudformation/spec.go
+++ b/service/controller/v12/resource/cloudformation/spec.go
@@ -1,0 +1,39 @@
+package cloudformation
+
+import "github.com/aws/aws-sdk-go/service/cloudformation"
+
+const (
+	// defaultCreationTimeout is the timeout in minutes for the creation of the
+	// stack.
+	defaultCreationTimeout = 10
+
+	workerRoleKey = "WorkerRole"
+
+	namedIAMCapability = "CAPABILITY_NAMED_IAM"
+)
+
+// StackState is the state representation on which the resource methods work.
+type StackState struct {
+	Name string
+
+	MasterImageID              string
+	MasterInstanceType         string
+	MasterInstanceResourceName string
+	MasterCloudConfigVersion   string
+	MasterInstanceMonitoring   bool
+
+	ShouldScale  bool
+	ShouldUpdate bool
+
+	Status string
+
+	WorkerCount              string
+	WorkerImageID            string
+	WorkerInstanceMonitoring bool
+	WorkerInstanceType       string
+	WorkerCloudConfigVersion string
+
+	UpdateStackInput cloudformation.UpdateStackInput
+
+	VersionBundleVersion string
+}

--- a/service/controller/v12/resource/cloudformation/update.go
+++ b/service/controller/v12/resource/cloudformation/update.go
@@ -1,0 +1,249 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	stackStateToUpdate, err := toStackState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackStateToUpdate.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the guest cluster main stack")
+
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if stackStateToUpdate.ShouldUpdate && !stackStateToUpdate.ShouldScale {
+			// Fetch the etcd volume information.
+			filterFuncs := []func(t *ec2.Tag) bool{
+				ebs.NewDockerVolumeFilter(customObject),
+				ebs.NewEtcdVolumeFilter(customObject),
+			}
+			volumes, err := sc.EBSService.ListVolumes(customObject, filterFuncs...)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			// First shutdown the instances and wait for it to be stopped. Then detach
+			// the etcd and docker volume without forcing.
+			force := false
+			shutdown := true
+			wait := true
+			for _, v := range volumes {
+				for _, a := range v.Attachments {
+					err := sc.EBSService.DetachVolume(ctx, v.VolumeID, a, force, shutdown, wait)
+					if err != nil {
+						return microerror.Mask(err)
+					}
+				}
+			}
+		}
+
+		// Once the etcd volume is cleaned up and the master instance is down we can
+		// go ahead to let CloudFormation do its job.
+		_, err = sc.AWSClient.CloudFormation.UpdateStack(&stackStateToUpdate.UpdateStackInput)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not updating the guest cluster main stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) computeUpdateState(ctx context.Context, customObject v1alpha1.AWSConfig, stackState StackState) (cloudformation.UpdateStackInput, error) {
+	mainTemplate, err := r.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		return cloudformation.UpdateStackInput{}, microerror.Mask(err)
+	}
+
+	updateStackInput := cloudformation.UpdateStackInput{
+		Capabilities: []*string{
+			// CAPABILITY_NAMED_IAM is required for updating IAM roles (worker
+			// policy).
+			aws.String(namedIAMCapability),
+		},
+		StackName:    aws.String(stackState.Name),
+		TemplateBody: aws.String(mainTemplate),
+	}
+
+	return updateStackInput, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// We enable/disable updates in order to enable them our test installations
+	// but disable them in production installations. That is useful until we have
+	// full confidence in updating guest clusters. Note that updates also manage
+	// scaling at the same time to be more efficient.
+	if updateallowedcontext.IsUpdateAllowed(ctx) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be updated")
+
+		if shouldUpdate(currentStackState, desiredStackState) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be updated")
+
+			updateStackInput, err := r.computeUpdateState(ctx, customObject, desiredStackState)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+
+			updateState := StackState{
+				Name:             desiredStackState.Name,
+				ShouldScale:      false,
+				ShouldUpdate:     true,
+				UpdateStackInput: updateStackInput,
+			}
+
+			return updateState, nil
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be updated")
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not computing update state of the guest cluster main stack because updates are not allowed")
+	}
+
+	// We manage scaling separately because the impact and implications of scaling
+	// is different compared to updates. We can just process scaling any time. We
+	// cannot just process updates at any time and thus have to separate the
+	// management of both primitives. Note that updates also manage scaling at the
+	// same time for more efficiency. Note that we have to preserve the master
+	// instance resource name when scaling worker nodes to prevent updating the
+	// master node. This is why we set the desired state of the master instance
+	// resource name to the current state below.
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be scaled")
+
+		if shouldScale(currentStackState, desiredStackState) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be scaled")
+
+			desiredStackState.MasterInstanceResourceName = currentStackState.MasterInstanceResourceName
+
+			updateStackInput, err := r.computeUpdateState(ctx, customObject, desiredStackState)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+
+			updateState := StackState{
+				Name:             desiredStackState.Name,
+				ShouldScale:      true,
+				ShouldUpdate:     false,
+				UpdateStackInput: updateStackInput,
+			}
+
+			return updateState, nil
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be scaled")
+		}
+	}
+
+	return StackState{}, nil
+}
+
+// shouldScale determines whether the reconciled guest cluster should be scaled.
+// A guest cluster is only allowed to scale in case nothing but the worker count
+// changes. In case anything else changes as well, scaling is not allowed, since
+// any other changes should be covered by general updates, which is a separate
+// step.
+func shouldScale(currentState, desiredState StackState) bool {
+	if currentState.MasterImageID != desiredState.MasterImageID {
+		return false
+	}
+	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+		return false
+	}
+	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
+		return false
+	}
+	if currentState.WorkerImageID != desiredState.WorkerImageID {
+		return false
+	}
+	if currentState.WorkerInstanceType != desiredState.WorkerInstanceType {
+		return false
+	}
+	if currentState.WorkerCloudConfigVersion != desiredState.WorkerCloudConfigVersion {
+		return false
+	}
+	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {
+		return false
+	}
+
+	if currentState.WorkerCount != desiredState.WorkerCount {
+		return true
+	}
+
+	return false
+}
+
+// shouldUpdate determines whether the reconciled guest cluster should be
+// updated. A guest cluster is only allowed to update in the following cases.
+//
+//     The instance type of master nodes changes (indicates updates).
+//     The instance type of worker nodes changes (indicates updates).
+//     The version bundle version changes (indicates updates).
+//
+func shouldUpdate(currentState, desiredState StackState) bool {
+	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+		return true
+	}
+	if currentState.WorkerInstanceType != desiredState.WorkerInstanceType {
+		return true
+	}
+	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/cloudformation/update_test.go
+++ b/service/controller/v12/resource/cloudformation/update_test.go
@@ -1,0 +1,883 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   interface{}
+		desiredState   interface{}
+		expectedChange awscloudformation.UpdateStackInput
+		description    string
+	}{
+		{
+			description:  "case 0, current state empty, desired state empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description:  "case 1, current state empty, desired state not empty, expected desired state",
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 2, current state not empty, equal desired state, expected empty",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 3, current state not empty, desired state not empty, different master image, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "CHANGED",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 4, current state not empty, desired state not empty, different master CloudConfig version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 5, current state not empty, desired state not empty, different number of workers, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "CHANGED",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 6, current state not empty, desired state not empty, different worker image, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "CHANGED",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 7, current state not empty, desired state not empty, different worker CloudConfig version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 8, current state not empty, desired state not empty, different master instance type, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "CHANGED",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 9, current state not empty, desired state not empty, different worker instance type, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "CHANGED",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 10, current state not empty, desired state not empty, different version bundle version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			IAM: &adapter.IAMClientMock{},
+			EC2: &adapter.EC2ClientMock{},
+			STS: &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := awsclient.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := updateallowedcontext.NewContext(context.Background(), make(chan struct{}))
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+			updateallowedcontext.SetUpdateAllowed(ctx)
+
+			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			updateChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", updateChange, result)
+			}
+			if updateChange.UpdateStackInput.StackName != nil && *updateChange.UpdateStackInput.StackName != *tc.expectedChange.StackName {
+				t.Fatalf("expected %v, got %v", *tc.expectedChange.StackName, *updateChange.UpdateStackInput.StackName)
+			}
+		})
+	}
+}
+
+func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   interface{}
+		desiredState   interface{}
+		expectedChange awscloudformation.UpdateStackInput
+		description    string
+	}{
+		{
+			description:  "case 0, current state empty, desired state empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description:  "case 1, current state empty, desired state not empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 2, current state not empty, equal desired state, expected empty",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 3, current state not empty, desired state not empty, different master image, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "CHANGED",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 4, current state not empty, desired state not empty, different master CloudConfig version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 5, current state not empty, desired state not empty, different number of workers, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "CHANGED",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 6, current state not empty, desired state not empty, different worker image, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "CHANGED",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 7, current state not empty, desired state not empty, different worker CloudConfig version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 8, current state not empty, desired state not empty, different master instance type, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "CHANGED",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 9, current state not empty, desired state not empty, different worker instance type, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "CHANGED",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 10, current state not empty, desired state not empty, different master version bundle version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 11, current state not empty, desired state not empty, different worker version bundle version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			IAM: &adapter.IAMClientMock{},
+			EC2: &adapter.EC2ClientMock{},
+			STS: &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := awsclient.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			updateChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", updateChange, result)
+			}
+			if updateChange.UpdateStackInput.StackName != nil && *updateChange.UpdateStackInput.StackName != *tc.expectedChange.StackName {
+				t.Fatalf("expected %v, got %v", *tc.expectedChange.StackName, *updateChange.UpdateStackInput.StackName)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/cloudformation/validate.go
+++ b/service/controller/v12/resource/cloudformation/validate.go
@@ -1,0 +1,51 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+type validator func(v1alpha1.AWSConfig) error
+
+func (r *Resource) validateCluster(cluster v1alpha1.AWSConfig) error {
+	validators := []validator{
+		r.validateHostPeeringRoutes,
+	}
+
+	for _, v := range validators {
+		if err := v(cluster); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) validateHostPeeringRoutes(cluster v1alpha1.AWSConfig) error {
+	input := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("route.destination-cidr-block"),
+				Values: []*string{
+					aws.String(key.PrivateSubnetCIDR(cluster)),
+				},
+			},
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(key.PeerID(cluster)),
+				},
+			},
+		},
+	}
+	output, err := r.hostClients.EC2.DescribeRouteTables(input)
+	if err == nil && len(output.RouteTables) > 0 {
+		return microerror.Maskf(alreadyExistsError, "route: %s", key.PrivateSubnetCIDR(cluster))
+	}
+
+	return nil
+}

--- a/service/controller/v12/resource/cloudformation/validate_test.go
+++ b/service/controller/v12/resource/cloudformation/validate_test.go
@@ -1,0 +1,79 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/adapter"
+)
+
+func Test_validateHostPeeringRoutes(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PrivateSubnetCIDR: "172.31.0.0/16",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		description         string
+		matchingRouteTables int
+		expectedError       bool
+	}{
+		{
+			description:         "route table doesn't exist, do not expect error",
+			matchingRouteTables: 0,
+			expectedError:       false,
+		},
+		{
+			description:         "route table exists, expect error",
+			matchingRouteTables: 1,
+			expectedError:       true,
+		},
+		{
+			description:         "two route table exist, expect error",
+			matchingRouteTables: 2,
+			expectedError:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		var err error
+		var newResource *Resource
+		{
+			ec2Mock := &adapter.EC2ClientMock{}
+			ec2Mock.SetMatchingRouteTables(tc.matchingRouteTables)
+
+			c := Config{}
+
+			c.HostClients = &adapter.Clients{
+				EC2:            ec2Mock,
+				CloudFormation: &adapter.CloudFormationMock{},
+				IAM:            &adapter.IAMClientMock{},
+				STS:            &adapter.STSClientMock{},
+			}
+			c.Logger = microloggertest.New()
+
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		t.Run(tc.description, func(t *testing.T) {
+			err := newResource.validateHostPeeringRoutes(customObject)
+			if tc.expectedError && err == nil {
+				t.Fatalf("expected error didn't happen")
+			}
+			if !tc.expectedError && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/ebsvolume/create.go
+++ b/service/controller/v12/resource/ebsvolume/create.go
@@ -1,0 +1,11 @@
+package ebsvolume
+
+import (
+	"context"
+)
+
+// EnsureCreated is a no-op, because the ebsvolume resource is only
+// interested in delete events.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v12/resource/ebsvolume/delete.go
+++ b/service/controller/v12/resource/ebsvolume/delete.go
@@ -1,0 +1,84 @@
+package ebsvolume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// EnsureDeleted detaches and deletes the EBS volumes. We don't return
+// errors so deletion logic in following resources is executed.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Get all etcd, docker and persistent volumes.
+	filterFuncs := []func(t *ec2.Tag) bool{
+		ebs.NewDockerVolumeFilter(customObject),
+		ebs.NewEtcdVolumeFilter(customObject),
+		ebs.NewPersistentVolumeFilter(customObject),
+	}
+	volumes, err := sc.EBSService.ListVolumes(customObject, filterFuncs...)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(volumes) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d EBS volumes", len(volumes)))
+
+		// First detach any attached volumes without forcing but shutdown the
+		// instances.
+		for _, vol := range volumes {
+			for _, a := range vol.Attachments {
+				force := false
+				shutdown := true
+				wait := false
+				err := sc.EBSService.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
+				if err != nil {
+					r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to detach EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+				}
+			}
+		}
+
+		// Now force detach so the volumes can be deleted cleanly. Instances
+		// are already shutdown.
+		for _, vol := range volumes {
+			for _, a := range vol.Attachments {
+				force := true
+				shutdown := false
+				wait := false
+				err := sc.EBSService.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
+				if err != nil {
+					r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to force detach EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+				}
+			}
+		}
+
+		// Now delete the volumes.
+		for _, vol := range volumes {
+			err := sc.EBSService.DeleteVolume(ctx, vol.VolumeID)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to delete EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d EBS volumes", len(volumes)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting EBS volumes because there aren't any")
+	}
+
+	return nil
+}

--- a/service/controller/v12/resource/ebsvolume/error.go
+++ b/service/controller/v12/resource/ebsvolume/error.go
@@ -1,0 +1,12 @@
+package ebsvolume
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v12/resource/ebsvolume/resource.go
+++ b/service/controller/v12/resource/ebsvolume/resource.go
@@ -1,0 +1,39 @@
+package ebsvolume
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "ebsvolumev11"
+)
+
+// Config represents the configuration used to create a new ebsvolume resource.
+type Config struct {
+	Logger micrologger.Logger
+}
+
+// Resource implements the ebsvolume resource.
+type Resource struct {
+	logger micrologger.Logger
+}
+
+// New creates a new configured ebsvolume resource.
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v12/resource/endpoints/create.go
+++ b/service/controller/v12/resource/endpoints/create.go
@@ -1,0 +1,58 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToCreate, err := toEndpoints(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err = r.k8sClient.CoreV1().Endpoints(namespace).Create(endpointsToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var endpointsToCreate *apiv1.Endpoints
+	if currentEndpoints == nil || desiredEndpoints.Name != currentEndpoints.Name {
+		endpointsToCreate = desiredEndpoints
+	}
+
+	return endpointsToCreate, nil
+}

--- a/service/controller/v12/resource/endpoints/create_test.go
+++ b/service/controller/v12/resource/endpoints/create_test.go
@@ -1,0 +1,117 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current state matches desired state, desired state is empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: nil,
+		},
+		{
+			description: "current state is empty, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToCreate, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToCreate, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToCreate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToCreate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/endpoints/current.go
+++ b/service/controller/v12/resource/endpoints/current.go
@@ -1,0 +1,40 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master endpoints in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+
+	// Lookup the current state of the endpoints.
+	var endpoints *apiv1.Endpoints
+	{
+		manifest, err := r.k8sClient.CoreV1().Endpoints(namespace).Get(masterEndpointsName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master endpoints in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master endpoints in the Kubernetes API")
+			endpoints = manifest
+		}
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v12/resource/endpoints/delete.go
+++ b/service/controller/v12/resource/endpoints/delete.go
@@ -1,0 +1,76 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToDelete, err := toEndpoints(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().Endpoints(namespace).Delete(endpointsToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the endpoints has to be deleted")
+
+	var endpointsToDelete *apiv1.Endpoints
+	if currentEndpoints != nil && desiredEndpoints.Name == currentEndpoints.Name {
+		endpointsToDelete = desiredEndpoints
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the endpoints has to be deleted")
+
+	return endpointsToDelete, nil
+}

--- a/service/controller/v12/resource/endpoints/delete_test.go
+++ b/service/controller/v12/resource/endpoints/delete_test.go
@@ -1,0 +1,117 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current state matches desired state, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToDelete, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToDelete, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToDelete.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToDelete.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/endpoints/desired.go
+++ b/service/controller/v12/resource/endpoints/desired.go
@@ -1,0 +1,68 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	instanceName := key.MasterInstanceName(customObject)
+	masterInstance, err := r.findMasterInstance(ctx, instanceName)
+	if IsNotFound(err) {
+		// During updates the master instance is shut down and thus cannot be found.
+		// In such cases we cancel the reconciliation for the endpoint resource.
+		// This should be ok since all endpoints should be created and up to date
+		// already. In case we miss an update it will be done on the next resync
+		// period once the master instance is up again.
+		//
+		// TODO we might want to alert at some point when the master instance was
+		// not seen for too long. Like we should be able to find it again after
+		// three resync periods max or something.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "master instance not found")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	endpoints := &v1.Endpoints{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      masterEndpointsName,
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				"app":      masterEndpointsName,
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.CustomerID(customObject),
+			},
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: *masterInstance.PrivateIpAddress,
+					},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Port: httpsPort,
+					},
+				},
+			},
+		},
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v12/resource/endpoints/desired_test.go
+++ b/service/controller/v12/resource/endpoints/desired_test.go
@@ -1,0 +1,91 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_Endpoints_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		expectedNamespace string
+		expectedName      string
+		expectedIPAddress string
+		expectedPort      int
+	}{
+		{
+			description: "basic match",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			expectedNamespace: "al9qy",
+			expectedName:      "master",
+			expectedIPAddress: "10.1.1.1",
+			expectedPort:      443,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				K8sClient: fake.NewSimpleClientset(),
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			awsClients := aws.Clients{
+				EC2: EC2ClientMock{
+					privateIPAddress: tc.expectedIPAddress,
+				},
+			}
+
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatalf("expected '%v' got '%#v'", nil, err)
+			}
+			desiredEndpoints, ok := result.(*apiv1.Endpoints)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredEndpoints, result)
+			}
+
+			if tc.expectedNamespace != desiredEndpoints.ObjectMeta.Namespace {
+				t.Fatalf("expected namespace %q got %q", tc.expectedNamespace, desiredEndpoints.ObjectMeta.Namespace)
+			}
+
+			if tc.expectedName != desiredEndpoints.ObjectMeta.Name {
+				t.Fatalf("expected name %q got %q", tc.expectedName, desiredEndpoints.ObjectMeta.Name)
+			}
+
+			if int32(tc.expectedPort) != desiredEndpoints.Subsets[0].Ports[0].Port {
+				t.Fatalf("expected port %q got %q", int32(tc.expectedPort), desiredEndpoints.Subsets[0].Ports[0].Port)
+			}
+
+			if tc.expectedIPAddress != desiredEndpoints.Subsets[0].Addresses[0].IP {
+				t.Fatalf("expected ip address %s got %s", tc.expectedIPAddress, desiredEndpoints.Subsets[0].Addresses[0].IP)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/endpoints/error.go
+++ b/service/controller/v12/resource/endpoints/error.go
@@ -1,0 +1,31 @@
+package endpoints
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var tooManyResultsError = microerror.New("too many results")
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return microerror.Cause(err) == tooManyResultsError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/endpoints/instance.go
+++ b/service/controller/v12/resource/endpoints/instance.go
@@ -1,0 +1,62 @@
+package endpoints
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+const (
+	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#InstanceState
+	ec2RunningState = 16
+	tagKeyName      = "Name"
+)
+
+func (r Resource) findMasterInstance(ctx context.Context, instanceName string) (*ec2.Instance, error) {
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	filters := []*ec2.Filter{
+		{
+			Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+			Values: []*string{
+				aws.String(instanceName),
+			},
+		},
+	}
+
+	output, err := sc.AWSClient.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
+		Filters: filters,
+	})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var masterInstance *ec2.Instance
+	var instancesFound int
+	for _, reservation := range output.Reservations {
+		for _, instance := range reservation.Instances {
+			if *instance.State.Code == ec2RunningState {
+				masterInstance = instance
+				instancesFound++
+			}
+		}
+	}
+
+	if instancesFound < 1 {
+		return nil, microerror.Maskf(notFoundError, "instance: %s", instanceName)
+	}
+	if instancesFound > 1 {
+		return nil, microerror.Maskf(tooManyResultsError, "instances: %s", instanceName)
+	}
+
+	return masterInstance, nil
+}

--- a/service/controller/v12/resource/endpoints/mock.go
+++ b/service/controller/v12/resource/endpoints/mock.go
@@ -1,0 +1,39 @@
+package endpoints
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+type EC2ClientMock struct {
+	ec2iface.EC2API
+
+	isError          bool
+	privateIPAddress string
+}
+
+func (e EC2ClientMock) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	if e.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						PrivateIpAddress: aws.String(e.privateIPAddress),
+						State: &ec2.InstanceState{
+							Code: aws.Int64(ec2RunningState),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return output, nil
+}

--- a/service/controller/v12/resource/endpoints/resource.go
+++ b/service/controller/v12/resource/endpoints/resource.go
@@ -1,0 +1,66 @@
+package endpoints
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "endpointsv11"
+
+	httpsPort           = 443
+	masterEndpointsName = "master"
+)
+
+// Config represents the configuration used to create a new endpoints resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the endpoints resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured endpoints resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toEndpoints(v interface{}) (*apiv1.Endpoints, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	endpoints, ok := v.(*apiv1.Endpoints)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Endpoints{}, v)
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v12/resource/endpoints/spec.go
+++ b/service/controller/v12/resource/endpoints/spec.go
@@ -1,0 +1,14 @@
+package endpoints
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type Clients struct {
+	EC2 EC2Client
+}
+
+// EC2Client describes the methods required to be implemented by a EC2 AWS client.
+type EC2Client interface {
+	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+}

--- a/service/controller/v12/resource/endpoints/update.go
+++ b/service/controller/v12/resource/endpoints/update.go
@@ -1,0 +1,84 @@
+package endpoints
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToUpdate, err := toEndpoints(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToUpdate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err := r.k8sClient.CoreV1().Endpoints(namespace).Update(endpointsToUpdate)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated Kubernetes endpoints")
+
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Kubernetes endpoints do not need to be updated")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the endpoints has to be updated")
+
+	var endpointsToUpdate *apiv1.Endpoints
+
+	// The subsets can change if the private IP of the master node has changed.
+	// We then need to update the endpoints resource.
+	if currentEndpoints != nil && desiredEndpoints != nil {
+		if !reflect.DeepEqual(desiredEndpoints.Subsets, currentEndpoints.Subsets) {
+			endpointsToUpdate = desiredEndpoints
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the endpoints has to be deleted")
+
+	return endpointsToUpdate, nil
+}

--- a/service/controller/v12/resource/endpoints/update_test.go
+++ b/service/controller/v12/resource/endpoints/update_test.go
@@ -1,0 +1,200 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newUpdateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current and desired states are different, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: nil,
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newUpdateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToUpdate, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToUpdate, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToUpdate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToUpdate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/kmskey/create.go
+++ b/service/controller/v12/resource/kmskey/create.go
@@ -1,0 +1,80 @@
+package kmskey
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	createInput, err := toKMSKeyState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if createInput.KeyAlias != "" {
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		key, err := sc.AWSClient.KMS.CreateKey(&kms.CreateKeyInput{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if _, err := sc.AWSClient.KMS.CreateAlias(&kms.CreateAliasInput{
+			AliasName:   aws.String(createInput.KeyAlias),
+			TargetKeyId: key.KeyMetadata.Arn,
+		}); err != nil {
+			return microerror.Mask(err)
+		}
+
+		if _, err := sc.AWSClient.KMS.EnableKeyRotation(&kms.EnableKeyRotationInput{
+			KeyId: key.KeyMetadata.KeyId,
+		}); err != nil {
+			return microerror.Mask(err)
+		}
+
+		if _, err := sc.AWSClient.KMS.TagResource(&kms.TagResourceInput{
+			KeyId: key.KeyMetadata.KeyId,
+			Tags:  r.getKMSTags(customObject),
+		}); err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating KMS key: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating KMS key: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentKeyState, err := toKMSKeyState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredKeyState, err := toKMSKeyState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if currentKeyState.KeyAlias == "" || desiredKeyState.KeyAlias != currentKeyState.KeyAlias {
+		return desiredKeyState, nil
+	}
+
+	return KMSKeyState{}, nil
+}

--- a/service/controller/v12/resource/kmskey/create_test.go
+++ b/service/controller/v12/resource/kmskey/create_test.go
@@ -1,0 +1,147 @@
+package kmskey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_KMSKey_newCreate(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   KMSKeyState
+		desiredState   KMSKeyState
+		expectedChange KMSKeyState
+		description    string
+	}{
+		{
+			description:    "current state empty, desired state empty, empty create change",
+			currentState:   KMSKeyState{},
+			desiredState:   KMSKeyState{},
+			expectedChange: KMSKeyState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, create change == desired state",
+			currentState: KMSKeyState{},
+			desiredState: KMSKeyState{
+				KeyAlias: "mykeyid",
+			},
+			expectedChange: KMSKeyState{
+				KeyAlias: "mykeyid",
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty, create change == desired state",
+			currentState: KMSKeyState{
+				KeyAlias: "currentkeyid",
+			},
+			desiredState: KMSKeyState{
+				KeyAlias: "mykeyid",
+			},
+			expectedChange: KMSKeyState{
+				KeyAlias: "mykeyid",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	awsClients := aws.Clients{
+		KMS: &KMSClientMock{},
+	}
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.newCreateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChange, ok := result.(KMSKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChange, result)
+			}
+			if createChange.KeyAlias != tc.expectedChange.KeyAlias {
+				t.Errorf("expected %s, got %s", tc.expectedChange.KeyAlias, createChange.KeyAlias)
+			}
+		})
+	}
+}
+
+func Test_ApplyCreateChange(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		createChange KMSKeyState
+		description  string
+	}{
+		{
+			description: "basic case, create",
+			createChange: KMSKeyState{
+				KeyAlias: "alias/test-cluster",
+			},
+		},
+		{
+			description:  "empty create change, not create",
+			createChange: KMSKeyState{},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	awsClients := aws.Clients{
+		KMS: &KMSClientMock{
+			clusterID: "test-cluster",
+		},
+	}
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		ctx := context.TODO()
+		ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+		err := newResource.ApplyCreateChange(ctx, customObject, tc.createChange)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+	}
+}

--- a/service/controller/v12/resource/kmskey/current.go
+++ b/service/controller/v12/resource/kmskey/current.go
@@ -1,0 +1,46 @@
+package kmskey
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	currentState := KMSKeyState{}
+
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return currentState, err
+	}
+
+	clusterID := key.ClusterID(customObject)
+	alias := toAlias(clusterID)
+	input := &kms.DescribeKeyInput{
+		KeyId: aws.String(alias),
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	output, err := sc.AWSClient.KMS.DescribeKey(input)
+	if IsKeyNotFound(err) {
+		// Fall through.
+		return nil, nil
+	}
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
+	currentState.KeyID = *output.KeyMetadata.KeyId
+	currentState.KeyAlias = alias
+
+	return currentState, nil
+}

--- a/service/controller/v12/resource/kmskey/current_test.go
+++ b/service/controller/v12/resource/kmskey/current_test.go
@@ -1,0 +1,79 @@
+package kmskey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_CurrentState(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description      string
+		expectedKeyID    string
+		expectedKMSError bool
+	}{
+		{
+			description:   "basic match",
+			expectedKeyID: "mykeyid",
+		},
+		{
+			description:      "KMS error",
+			expectedKMSError: true,
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				KMS: &KMSClientMock{
+					keyID:   tc.expectedKeyID,
+					isError: tc.expectedKMSError,
+				},
+			}
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.GetCurrentState(ctx, customObject)
+			if err != nil && !tc.expectedKMSError {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(KMSKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if err == nil && tc.expectedKMSError {
+				t.Error("expected KMS error didn't happen")
+			}
+
+			if currentState.KeyID != tc.expectedKeyID {
+				t.Errorf("expected keyID %q, got %q", tc.expectedKeyID, currentState.KeyID)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/kmskey/delete.go
+++ b/service/controller/v12/resource/kmskey/delete.go
@@ -1,0 +1,88 @@
+package kmskey
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	deleteInput, err := toKMSKeyState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if deleteInput.KeyAlias != "" {
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Get the KMS key ID using the key alias.
+		key, err := sc.AWSClient.KMS.DescribeKey(&kms.DescribeKeyInput{
+			KeyId: aws.String(deleteInput.KeyAlias),
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Delete the key alias.
+		if _, err := sc.AWSClient.KMS.DeleteAlias(&kms.DeleteAliasInput{
+			AliasName: aws.String(deleteInput.KeyAlias),
+		}); err != nil {
+			return microerror.Mask(err)
+		}
+
+		// AWS API doesn't allow to delete the KMS key immediately, but we can schedule its deletion.
+		if _, err := sc.AWSClient.KMS.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+			KeyId:               key.KeyMetadata.KeyId,
+			PendingWindowInDays: aws.Int64(pendingDeletionWindow),
+		}); err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting KMS Key: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting KMS Key: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentKeyState, err := toKMSKeyState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredKeyState, err := toKMSKeyState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the KMS key should be deleted")
+
+	var kmsKeyToDelete KMSKeyState
+	if currentKeyState.KeyAlias != "" {
+		kmsKeyToDelete = desiredKeyState
+	}
+
+	return kmsKeyToDelete, nil
+}

--- a/service/controller/v12/resource/kmskey/delete_test.go
+++ b/service/controller/v12/resource/kmskey/delete_test.go
@@ -1,0 +1,136 @@
+package kmskey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_newDelete(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState  KMSKeyState
+		desiredState  KMSKeyState
+		expectedAlias string
+		description   string
+	}{
+		{
+			description:   "current and desired state empty, expected empty",
+			currentState:  KMSKeyState{},
+			desiredState:  KMSKeyState{},
+			expectedAlias: "",
+		},
+		{
+			description:  "current state empty, desired state not empty, expected empty",
+			currentState: KMSKeyState{},
+			desiredState: KMSKeyState{
+				KeyAlias: "desired",
+			},
+			expectedAlias: "",
+		},
+		{
+			description: "current state not empty, desired state not empty but equal, expected current state",
+			currentState: KMSKeyState{
+				KeyAlias: "current",
+			},
+			desiredState: KMSKeyState{
+				KeyAlias: "current",
+			},
+			expectedAlias: "current",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Error("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			deleteChange, ok := result.(KMSKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", deleteChange, result)
+			}
+			if deleteChange.KeyAlias != tc.expectedAlias {
+				t.Errorf("expected %s, got %s", tc.expectedAlias, deleteChange.KeyAlias)
+			}
+		})
+	}
+}
+
+func Test_ApplyDeleteChange(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		deleteChange KMSKeyState
+		description  string
+	}{
+		{
+			description: "basic case, create",
+			deleteChange: KMSKeyState{
+				KeyAlias: "alias/test-cluster",
+			},
+		},
+		{
+			description:  "empty create change, not create",
+			deleteChange: KMSKeyState{},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	awsClients := aws.Clients{
+		KMS: &KMSClientMock{
+			clusterID: "test-cluster",
+		},
+	}
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		ctx := context.TODO()
+		ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+		err := newResource.ApplyDeleteChange(ctx, &customObject, tc.deleteChange)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+	}
+}

--- a/service/controller/v12/resource/kmskey/desired.go
+++ b/service/controller/v12/resource/kmskey/desired.go
@@ -1,0 +1,21 @@
+package kmskey
+
+import (
+	"context"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	desiredState := KMSKeyState{}
+
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return desiredState, err
+	}
+
+	clusterID := key.ClusterID(customObject)
+	desiredState.KeyAlias = toAlias(clusterID)
+
+	return desiredState, nil
+}

--- a/service/controller/v12/resource/kmskey/desired_test.go
+++ b/service/controller/v12/resource/kmskey/desired_test.go
@@ -1,0 +1,58 @@
+package kmskey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_DesiredState(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description      string
+		expectedKeyAlias string
+	}{
+		{
+			description:      "basic match",
+			expectedKeyAlias: "alias/test-cluster",
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			result, err := newResource.GetDesiredState(context.TODO(), customObject)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(KMSKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if currentState.KeyAlias != tc.expectedKeyAlias {
+				t.Errorf("expected keyID %q, got %q", tc.expectedKeyAlias, currentState.KeyAlias)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/kmskey/error.go
+++ b/service/controller/v12/resource/kmskey/error.go
@@ -1,0 +1,30 @@
+package kmskey
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+func IsKeyNotFound(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if ok && aerr.Code() == kms.ErrCodeNotFoundException {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/kmskey/mock.go
+++ b/service/controller/v12/resource/kmskey/mock.go
@@ -1,0 +1,75 @@
+package kmskey
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+)
+
+type KMSClientMock struct {
+	kmsiface.KMSAPI
+
+	keyID     string
+	isError   bool
+	clusterID string
+}
+
+func (k *KMSClientMock) CreateKey(input *kms.CreateKeyInput) (*kms.CreateKeyOutput, error) {
+	return &kms.CreateKeyOutput{
+		KeyMetadata: &kms.KeyMetadata{
+			Arn:   aws.String("myarn"),
+			KeyId: aws.String("mykeyid"),
+		},
+	}, nil
+}
+
+func (k *KMSClientMock) CreateAlias(input *kms.CreateAliasInput) (*kms.CreateAliasOutput, error) {
+	if *input.AliasName != fmt.Sprintf("alias/%s", k.clusterID) {
+		return nil, fmt.Errorf("unexpected alias, %v", input.AliasName)
+	}
+
+	if *input.TargetKeyId != "myarn" {
+		return nil, fmt.Errorf("unexpected targetKeyID, %v", input.TargetKeyId)
+	}
+
+	return &kms.CreateAliasOutput{}, nil
+}
+
+func (k *KMSClientMock) DeleteAlias(input *kms.DeleteAliasInput) (*kms.DeleteAliasOutput, error) {
+	return nil, nil
+}
+
+func (k *KMSClientMock) EnableKeyRotation(input *kms.EnableKeyRotationInput) (*kms.EnableKeyRotationOutput, error) {
+	if *input.KeyId != "mykeyid" {
+		return nil, fmt.Errorf("unexpected keyid, %v", input.KeyId)
+	}
+
+	return &kms.EnableKeyRotationOutput{}, nil
+}
+
+func (k *KMSClientMock) DescribeKey(input *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+	if k.isError {
+		return nil, fmt.Errorf("kms client failure")
+	}
+	output := &kms.DescribeKeyOutput{
+		KeyMetadata: &kms.KeyMetadata{
+			Arn:   aws.String("myarn"),
+			KeyId: aws.String(k.keyID),
+		},
+	}
+	return output, nil
+}
+
+func (k *KMSClientMock) ScheduleKeyDeletion(input *kms.ScheduleKeyDeletionInput) (*kms.ScheduleKeyDeletionOutput, error) {
+	return nil, nil
+}
+
+func (k *KMSClientMock) TagResource(input *kms.TagResourceInput) (*kms.TagResourceOutput, error) {
+	if *input.KeyId != "mykeyid" {
+		return nil, fmt.Errorf("unexpected keyid, %v", input.KeyId)
+	}
+
+	return &kms.TagResourceOutput{}, nil
+}

--- a/service/controller/v12/resource/kmskey/resource.go
+++ b/service/controller/v12/resource/kmskey/resource.go
@@ -1,0 +1,106 @@
+package kmskey
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "kmskeyv11"
+)
+
+// Config represents the configuration used to create a new cloudformation resource.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	InstallationName string
+}
+
+// DefaultConfig provides a default configuration to create a new cloudformation
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	// Dependencies.
+	logger micrologger.Logger
+
+	// Settings.
+	installationName string
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
+
+	// Settings.
+	newService := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+
+		// Settings.
+		installationName: config.InstallationName,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toKMSKeyState(v interface{}) (KMSKeyState, error) {
+	if v == nil {
+		return KMSKeyState{}, nil
+	}
+
+	kmsKey, ok := v.(KMSKeyState)
+	if !ok {
+		return KMSKeyState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", kmsKey, v)
+	}
+
+	return kmsKey, nil
+}
+
+func toAlias(keyID string) string {
+	return fmt.Sprintf("alias/%s", keyID)
+}
+
+func (r *Resource) getKMSTags(customObject v1alpha1.AWSConfig) []*kms.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
+	kmsTags := []*kms.Tag{}
+
+	for k, v := range clusterTags {
+		tag := &kms.Tag{
+			TagKey:   aws.String(k),
+			TagValue: aws.String(v),
+		}
+
+		kmsTags = append(kmsTags, tag)
+	}
+
+	return kmsTags
+}

--- a/service/controller/v12/resource/kmskey/spec.go
+++ b/service/controller/v12/resource/kmskey/spec.go
@@ -1,0 +1,26 @@
+package kmskey
+
+import "github.com/aws/aws-sdk-go/service/kms"
+
+const (
+	pendingDeletionWindow = 7
+)
+
+type KMSKeyState struct {
+	KeyID    string
+	KeyAlias string
+}
+
+type Clients struct {
+	KMS KMSClient
+}
+
+type KMSClient interface {
+	CreateKey(*kms.CreateKeyInput) (*kms.CreateKeyOutput, error)
+	CreateAlias(*kms.CreateAliasInput) (*kms.CreateAliasOutput, error)
+	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
+	DeleteAlias(*kms.DeleteAliasInput) (*kms.DeleteAliasOutput, error)
+	EnableKeyRotation(*kms.EnableKeyRotationInput) (*kms.EnableKeyRotationOutput, error)
+	ScheduleKeyDeletion(*kms.ScheduleKeyDeletionInput) (*kms.ScheduleKeyDeletionOutput, error)
+	TagResource(*kms.TagResourceInput) (*kms.TagResourceOutput, error)
+}

--- a/service/controller/v12/resource/kmskey/update.go
+++ b/service/controller/v12/resource/kmskey/update.go
@@ -1,0 +1,35 @@
+package kmskey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because KMS keys are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v12/resource/lifecycle/create.go
+++ b/service/controller/v12/resource/lifecycle/create.go
@@ -1,0 +1,330 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v11/cloudformation"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// EnsureCreated tries to drain guest cluster nodes when necessary. Once it
+// detects a guest cluster node being in terminating/wait state in EC2 a
+// NodeConfig is created to instruct the node-operator to drain the specific
+// node. The node-operator updates the NodeConfig state as soon as it has
+// drained the node and the aws-operator here completes the lifecycle hook of
+// the drained node and deletes the NodeConfig.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the guest cluster main stack in the AWS API")
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var stackOutputs []*cloudformation.Output
+	{
+		stackOutputs, _, err = sc.CloudFormation.DescribeOutputsAndStatus(key.MainGuestStackName(customObject))
+		if cloudformationservice.IsStackNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster main stack in the AWS API")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+
+		} else if cloudformationservice.IsOutputsNotAccessible(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack output values are not accessible due to stack state transition")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster main stack in the AWS API")
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the guest cluster worker ASG name in the cloud formation stack")
+
+	var workerASGName string
+	{
+		workerASGName, err = sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerASGKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the ASG name in
+			// the CF stack outputs. We stop resource reconciliation at this point to
+			// reconcile again at a later point when the stack got upgraded and
+			// contains the ASG name.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a ASG name.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster worker ASG name in the cloud formation stack")
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for the guest cluster instances being in state '%s'", autoscaling.LifecycleStateTerminatingWait))
+
+	var instances []*autoscaling.Instance
+	{
+		i := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{
+				aws.String(workerASGName),
+			},
+		}
+
+		o, err := sc.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, g := range o.AutoScalingGroups {
+			for _, i := range g.Instances {
+				if *i.LifecycleState == autoscaling.LifecycleStateTerminatingWait {
+					instances = append(instances, i)
+				}
+			}
+		}
+
+		if len(instances) == 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find the guest cluster instances being in state '%s'", autoscaling.LifecycleStateTerminatingWait))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d guest cluster instances being in state '%s'", len(instances), autoscaling.LifecycleStateTerminatingWait))
+		}
+	}
+
+	{
+		for _, instance := range instances {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "looking for node config for the guest cluster")
+
+			privateDNS, err := r.privateDNSForInstance(ctx, *instance.InstanceId)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			n := customObject.GetNamespace()
+			o := metav1.GetOptions{}
+
+			_, err = r.g8sClient.CoreV1alpha1().NodeConfigs(n).Get(privateDNS, o)
+			if errors.IsNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "did not find node config for guest cluster node")
+
+				err := r.createNodeConfig(ctx, customObject, *instance.InstanceId, privateDNS)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+			} else if err != nil {
+				return microerror.Mask(err)
+			} else {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "found node config for the guest cluster")
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for inspection of node config for the guest cluster")
+			}
+		}
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "start inspection of node configs for the guest cluster")
+
+		n := v1.NamespaceAll
+		o := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", key.ClusterIDLabel, key.ClusterID(customObject)),
+		}
+
+		nodeConfigs, err := r.g8sClient.CoreV1alpha1().NodeConfigs(n).List(o)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(nodeConfigs.Items) > 0 {
+			for _, nodeConfig := range nodeConfigs.Items {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "inspecting node config for the guest cluster")
+
+				if !nodeConfig.Status.HasFinalCondition() {
+					r.logger.LogCtx(ctx, "level", "debug", "message", "node config of guest cluster has no final state")
+					continue
+				}
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", "node config of guest cluster has final state")
+
+				// This is a special thing for AWS. We use annotations to transport EC2
+				// instance IDs. Otherwise the lookups of all necessary information
+				// again would be quite a ball ache. Se we take the shortcut leveraging
+				// the k8s API.
+				instanceID, err := instanceIDFromAnnotations(nodeConfig.GetAnnotations())
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+				err = r.completeLifecycleHook(ctx, instanceID, workerASGName)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+				err = r.deleteNodeConfig(ctx, nodeConfig)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", "inspected node config for the guest cluster")
+			}
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "no node configs to inspect for the guest cluster")
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, workerASGName string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completing lifecycle hook action for guest cluster instance '%s'", instanceID))
+
+	i := &autoscaling.CompleteLifecycleActionInput{
+		AutoScalingGroupName:  aws.String(workerASGName),
+		InstanceId:            aws.String(instanceID),
+		LifecycleActionResult: aws.String("CONTINUE"),
+		LifecycleHookName:     aws.String(key.NodeDrainerLifecycleHookName),
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = sc.AWSClient.AutoScaling.CompleteLifecycleAction(i)
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no lifecycle hook action for guest cluster instance '%s'", instanceID))
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster instance '%s'", instanceID))
+	}
+
+	return nil
+}
+
+func (r *Resource) createNodeConfig(ctx context.Context, customObject providerv1alpha1.AWSConfig, instanceID, privateDNS string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating node config for guest cluster node")
+
+	n := customObject.GetNamespace()
+	c := &corev1alpha1.NodeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				key.InstanceIDAnnotation: instanceID,
+			},
+			Labels: map[string]string{
+				key.ClusterIDLabel: key.ClusterID(customObject),
+			},
+			Name: privateDNS,
+		},
+		Spec: corev1alpha1.NodeConfigSpec{
+			Guest: corev1alpha1.NodeConfigSpecGuest{
+				Cluster: corev1alpha1.NodeConfigSpecGuestCluster{
+					API: corev1alpha1.NodeConfigSpecGuestClusterAPI{
+						Endpoint: key.ClusterAPIEndpoint(customObject),
+					},
+					ID: key.ClusterID(customObject),
+				},
+				Node: corev1alpha1.NodeConfigSpecGuestNode{
+					Name: privateDNS,
+				},
+			},
+			VersionBundle: corev1alpha1.NodeConfigSpecVersionBundle{
+				Version: "0.1.0",
+			},
+		},
+	}
+
+	_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(n).Create(c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created node config for guest cluster node")
+
+	return nil
+}
+
+func (r *Resource) deleteNodeConfig(ctx context.Context, nodeConfig corev1alpha1.NodeConfig) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting node config for guest cluster node")
+
+	n := nodeConfig.GetNamespace()
+	i := nodeConfig.GetName()
+	o := &metav1.DeleteOptions{}
+
+	err := r.g8sClient.CoreV1alpha1().NodeConfigs(n).Delete(i, o)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted node config for guest cluster node")
+
+	return nil
+}
+
+func (r *Resource) privateDNSForInstance(ctx context.Context, instanceID string) (string, error) {
+	i := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{
+			aws.String(instanceID),
+		},
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	o, err := sc.AWSClient.EC2.DescribeInstances(i)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if len(o.Reservations) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected 1 reservation, got %d", len(o.Reservations))
+	}
+	if len(o.Reservations[0].Instances) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected 1 instance, got %d", len(o.Reservations[0].Instances))
+	}
+
+	privateDNS := *o.Reservations[0].Instances[0].PrivateDnsName
+
+	return privateDNS, nil
+}
+
+func instanceIDFromAnnotations(annotations map[string]string) (string, error) {
+	instanceID, ok := annotations[key.InstanceIDAnnotation]
+	if !ok {
+		return "", microerror.Maskf(missingAnnotationError, key.InstanceIDAnnotation)
+	}
+	if instanceID == "" {
+		return "", microerror.Maskf(missingAnnotationError, key.InstanceIDAnnotation)
+	}
+
+	return instanceID, nil
+}

--- a/service/controller/v12/resource/lifecycle/delete.go
+++ b/service/controller/v12/resource/lifecycle/delete.go
@@ -1,0 +1,11 @@
+package lifecycle
+
+import (
+	"context"
+)
+
+// EnsureDeleted is a no-op, because the lifecycle resource only has to act on
+// create and update events in order to drain guest cluster nodes.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v12/resource/lifecycle/error.go
+++ b/service/controller/v12/resource/lifecycle/error.go
@@ -1,0 +1,50 @@
+package lifecycle
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = microerror.New("execution failed")
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var missingAnnotationError = microerror.New("missing annotation")
+
+func IsMissingAnnotationError(err error) bool {
+	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = microerror.New("no active lifecycle action")
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/lifecycle/resource.go
+++ b/service/controller/v12/resource/lifecycle/resource.go
@@ -1,0 +1,41 @@
+package lifecycle
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "lifecyclev11"
+)
+
+type ResourceConfig struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func NewResource(config ResourceConfig) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v12/resource/lifecycle/spec.go
+++ b/service/controller/v12/resource/lifecycle/spec.go
@@ -1,0 +1,8 @@
+package lifecycle
+
+import "github.com/aws/aws-sdk-go/service/autoscaling"
+
+type StackState struct {
+	Instances     []*autoscaling.Instance
+	WorkerASGName string
+}

--- a/service/controller/v12/resource/loadbalancer/create.go
+++ b/service/controller/v12/resource/loadbalancer/create.go
@@ -1,0 +1,11 @@
+package loadbalancer
+
+import (
+	"context"
+)
+
+// EnsureCreated is a no-op, because the loadbalancer resource is only
+// interested in delete events.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v12/resource/loadbalancer/delete.go
+++ b/service/controller/v12/resource/loadbalancer/delete.go
@@ -1,0 +1,51 @@
+package loadbalancer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+// EnsureDeleted ensures that any ELBs from Kubernetes LoadBalancer services
+// are deleted. This is needed because the use the VPC public subnet.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	lbState, err := r.clusterLoadBalancers(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if lbState != nil && len(lbState.LoadBalancerNames) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d load balancers", len(lbState.LoadBalancerNames)))
+
+		sc, err := servicecontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, lbName := range lbState.LoadBalancerNames {
+			_, err := sc.AWSClient.ELB.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{
+				LoadBalancerName: aws.String(lbName),
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d load balancers", len(lbState.LoadBalancerNames)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting load balancers because there aren't any")
+	}
+
+	return nil
+}

--- a/service/controller/v12/resource/loadbalancer/elb.go
+++ b/service/controller/v12/resource/loadbalancer/elb.go
@@ -1,0 +1,100 @@
+package loadbalancer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	cloudProviderClusterTagValue = "owned"
+	cloudProviderServiceTagKey   = "kubernetes.io/service-name"
+	loadBalancerTagChunkSize     = 20
+)
+
+func (r *Resource) clusterLoadBalancers(ctx context.Context, customObject v1alpha1.AWSConfig) (*LoadBalancerState, error) {
+	lbState := &LoadBalancerState{}
+	clusterLBNames := []string{}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get all load balancers because the API does not allow tag filters.
+	output, err := sc.AWSClient.ELB.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	allLBNames := []*string{}
+	for _, lb := range output.LoadBalancerDescriptions {
+		allLBNames = append(allLBNames, lb.LoadBalancerName)
+	}
+
+	lbChunks := splitLoadBalancers(allLBNames, loadBalancerTagChunkSize)
+
+	for _, lbNames := range lbChunks {
+		tagsInput := &elb.DescribeTagsInput{
+			LoadBalancerNames: lbNames,
+		}
+		tagsOutput, err := sc.AWSClient.ELB.DescribeTags(tagsInput)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		// We filter based on the AWS cloud provider tags to find load balancers
+		// associated with the cluster being processed.
+		for _, lb := range tagsOutput.TagDescriptions {
+			if containsClusterTag(lb.Tags, customObject) && containsServiceTag(lb.Tags) {
+				clusterLBNames = append(clusterLBNames, *lb.LoadBalancerName)
+			}
+		}
+	}
+
+	lbState.LoadBalancerNames = clusterLBNames
+
+	return lbState, nil
+}
+
+func splitLoadBalancers(loadBalancerNames []*string, chunkSize int) [][]*string {
+	chunks := make([][]*string, 0)
+
+	for i := 0; i < len(loadBalancerNames); i += chunkSize {
+		endPos := i + chunkSize
+
+		if endPos > len(loadBalancerNames) {
+			endPos = len(loadBalancerNames)
+		}
+
+		chunks = append(chunks, loadBalancerNames[i:endPos])
+	}
+
+	return chunks
+}
+
+func containsClusterTag(tags []*elb.Tag, customObject v1alpha1.AWSConfig) bool {
+	tagKey := key.ClusterCloudProviderTag(customObject)
+
+	for _, tag := range tags {
+		if *tag.Key == tagKey && *tag.Value == cloudProviderClusterTagValue {
+			return true
+		}
+	}
+	return false
+}
+
+func containsServiceTag(tags []*elb.Tag) bool {
+	for _, tag := range tags {
+		if *tag.Key == cloudProviderServiceTagKey {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/loadbalancer/elb_test.go
+++ b/service/controller/v12/resource/loadbalancer/elb_test.go
@@ -1,0 +1,318 @@
+package loadbalancer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_clusterLoadBalancers(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		expectedState *LoadBalancerState
+		loadBalancers []LoadBalancerMock
+	}{
+		{
+			description: "basic match with no load balancers",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+		},
+		{
+			description: "basic match with load balancer",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "no matching load balancer",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/other-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "multiple load balancers",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+					"test-elb-2",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-2",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "multiple load balancers some not matching",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+					"test-elb-2",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-2",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-3",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/another-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "missing service tag",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+					},
+				},
+			},
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				Logger: microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			awsClients := awsclient.Clients{
+				ELB: &ELBClientMock{
+					loadBalancers: tc.loadBalancers,
+				},
+			}
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.clusterLoadBalancers(ctx, tc.obj)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedState) {
+				t.Errorf("expected current state '%#v', got '%#v'", tc.expectedState, result)
+			}
+		})
+	}
+}
+
+func Test_splitLoadBalancers(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name              string
+		loadBalancerNames []*string
+		chunkSize         int
+		expectedChunks    [][]*string
+	}{
+		{
+			name:              "case 0: empty lb names returns empty chunks",
+			loadBalancerNames: []*string{},
+			chunkSize:         20,
+			expectedChunks:    [][]*string{},
+		},
+		{
+			name: "case 1: single batch",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+			},
+			chunkSize: 20,
+			expectedChunks: [][]*string{{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+			}},
+		},
+		{
+			name: "case 2: multiple even chunks",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+				aws.String("lb-3"),
+				aws.String("lb-4"),
+				aws.String("lb-5"),
+				aws.String("lb-6"),
+			},
+			chunkSize: 2,
+			expectedChunks: [][]*string{
+				{
+					aws.String("lb-1"),
+					aws.String("lb-2"),
+				},
+				{
+					aws.String("lb-3"),
+					aws.String("lb-4"),
+				},
+				{
+					aws.String("lb-5"),
+					aws.String("lb-6"),
+				},
+			},
+		},
+		{
+			name: "case 3: multiple chunks of different sizes",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+				aws.String("lb-3"),
+				aws.String("lb-4"),
+				aws.String("lb-5"),
+				aws.String("lb-6"),
+				aws.String("lb-7"),
+			},
+			chunkSize: 3,
+			expectedChunks: [][]*string{
+				{
+					aws.String("lb-1"),
+					aws.String("lb-2"),
+					aws.String("lb-3"),
+				},
+				{
+					aws.String("lb-4"),
+					aws.String("lb-5"),
+					aws.String("lb-6"),
+				},
+				{
+					aws.String("lb-7"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitLoadBalancers(tc.loadBalancerNames, tc.chunkSize)
+
+			if !reflect.DeepEqual(result, tc.expectedChunks) {
+				t.Fatalf("chunks == %q, want %q", result, tc.expectedChunks)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/loadbalancer/error.go
+++ b/service/controller/v12/resource/loadbalancer/error.go
@@ -1,0 +1,19 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/loadbalancer/mocks_test.go
+++ b/service/controller/v12/resource/loadbalancer/mocks_test.go
@@ -1,0 +1,53 @@
+package loadbalancer
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+)
+
+type ELBClientMock struct {
+	elbiface.ELBAPI
+
+	loadBalancers []LoadBalancerMock
+}
+
+type LoadBalancerMock struct {
+	loadBalancerName string
+	loadBalancerTags []*elb.Tag
+}
+
+func (e *ELBClientMock) DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error) {
+	return nil, nil
+}
+
+func (e *ELBClientMock) DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	output := &elb.DescribeLoadBalancersOutput{}
+	lbDescs := []*elb.LoadBalancerDescription{}
+
+	for _, lb := range e.loadBalancers {
+		lbDesc := &elb.LoadBalancerDescription{
+			LoadBalancerName: aws.String(lb.loadBalancerName),
+		}
+		lbDescs = append(lbDescs, lbDesc)
+	}
+	output.SetLoadBalancerDescriptions(lbDescs)
+
+	return output, nil
+}
+
+func (e *ELBClientMock) DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {
+	output := &elb.DescribeTagsOutput{}
+	tagDescs := []*elb.TagDescription{}
+
+	for _, lb := range e.loadBalancers {
+		tagDesc := &elb.TagDescription{
+			LoadBalancerName: aws.String(lb.loadBalancerName),
+			Tags:             lb.loadBalancerTags,
+		}
+		tagDescs = append(tagDescs, tagDesc)
+	}
+	output.SetTagDescriptions(tagDescs)
+
+	return output, nil
+}

--- a/service/controller/v12/resource/loadbalancer/resource.go
+++ b/service/controller/v12/resource/loadbalancer/resource.go
@@ -1,0 +1,42 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "loadbalancerv11"
+)
+
+// Config represents the configuration used to create a new loadbalancer resource.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+// Resource implements the loadbalancer resource.
+type Resource struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+// New creates a new configured loadbalancer resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v12/resource/loadbalancer/spec.go
+++ b/service/controller/v12/resource/loadbalancer/spec.go
@@ -1,0 +1,21 @@
+package loadbalancer
+
+import (
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+type Clients struct {
+	ELB ELBClient
+}
+
+// ELBClient describes the methods required to be implemented by an ELB AWS
+// client. The ELB API provides support for classic ELBs.
+type ELBClient interface {
+	DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+	DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error)
+}
+
+type LoadBalancerState struct {
+	LoadBalancerNames []string
+}

--- a/service/controller/v12/resource/migration/error.go
+++ b/service/controller/v12/resource/migration/error.go
@@ -1,0 +1,12 @@
+package migration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v12/resource/migration/resource.go
+++ b/service/controller/v12/resource/migration/resource.go
@@ -1,0 +1,84 @@
+// Package migration provides an operatorkit resource that migrates awsconfig CRs
+// to reference the default credential secret if they do not already.
+// It can be safely removed once all awsconfig CRs reference a credential secret.
+package migration
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	name = "migrationv11"
+
+	awsConfigNamespace               = "default"
+	credentialSecretDefaultNamespace = "giantswarm"
+	credentialSecretDefaultName      = "credential-default"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return name
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// If credential secret is set we have nothing to migrate.
+	if customObject.Spec.AWS.CredentialSecret.Name != "" {
+		return nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing credential, setting the default")
+
+	customObject.Spec.AWS.CredentialSecret.Namespace = credentialSecretDefaultNamespace
+	customObject.Spec.AWS.CredentialSecret.Name = credentialSecretDefaultName
+
+	_, err = r.g8sClient.ProviderV1alpha1().AWSConfigs(awsConfigNamespace).Update(&customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "CR updated with default credential, canceling reconciliation")
+	reconciliationcanceledcontext.SetCanceled(ctx)
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v12/resource/namespace/create.go
+++ b/service/controller/v12/resource/namespace/create.go
@@ -1,0 +1,51 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	namespaceToCreate, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace")
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var namespaceToCreate *apiv1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	return namespaceToCreate, nil
+}

--- a/service/controller/v12/resource/namespace/create_test.go
+++ b/service/controller/v12/resource/namespace/create_test.go
@@ -1,0 +1,126 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v12/resource/namespace/current.go
+++ b/service/controller/v12/resource/namespace/current.go
@@ -1,0 +1,50 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the Kubernetes API")
+
+	// Lookup the current state of the namespace.
+	var namespace *apiv1.Namespace
+	{
+		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the Kubernetes API")
+			namespace = manifest
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. Then we cancel the reconciliation to prevent the current and
+	// any further resource from being processed.
+	if namespace != nil && namespace.Status.Phase == "Terminating" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "namespace is in state 'Terminating'")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v12/resource/namespace/current_test.go
+++ b/service/controller/v12/resource/namespace/current_test.go
@@ -1,0 +1,54 @@
+package namespace
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetCurrentState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetCurrentState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedNamespace, result) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedNamespace, result)
+		}
+	}
+}

--- a/service/controller/v12/resource/namespace/delete.go
+++ b/service/controller/v12/resource/namespace/delete.go
@@ -1,0 +1,69 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	namespaceToDelete, err := toNamespace(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace")
+
+		err = r.k8sClient.CoreV1().Namespaces().Delete(namespaceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the namespace has to be deleted")
+
+	var namespaceToDelete *apiv1.Namespace
+	if currentNamespace != nil {
+		namespaceToDelete = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the namespace has to be deleted")
+
+	return namespaceToDelete, nil
+}

--- a/service/controller/v12/resource/namespace/delete_test.go
+++ b/service/controller/v12/resource/namespace/delete_test.go
@@ -1,0 +1,126 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v12/resource/namespace/desired.go
+++ b/service/controller/v12/resource/namespace/desired.go
@@ -1,0 +1,36 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Compute the desired state of the namespace to have a reference of how
+	// the data should be.
+	namespace := &apiv1.Namespace{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterNamespace(customObject),
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v12/resource/namespace/desired_test.go
+++ b/service/controller/v12/resource/namespace/desired_test.go
@@ -1,0 +1,64 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			ExpectedName: "foobar",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.Namespace).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/controller/v12/resource/namespace/error.go
+++ b/service/controller/v12/resource/namespace/error.go
@@ -1,0 +1,24 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/namespace/resource.go
+++ b/service/controller/v12/resource/namespace/resource.go
@@ -1,0 +1,63 @@
+package namespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "namespacev11"
+)
+
+// Config represents the configuration used to create a new namespace resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the namespace resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured namespace resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toNamespace(v interface{}) (*apiv1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*apiv1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Namespace{}, v)
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v12/resource/namespace/update.go
+++ b/service/controller/v12/resource/namespace/update.go
@@ -1,0 +1,35 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because Kubernetes namespaces are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v12/resource/s3bucket/create.go
+++ b/service/controller/v12/resource/s3bucket/create.go
@@ -1,0 +1,126 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	createBucketsState, err := toBucketState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, bucketInput := range createBucketsState {
+		if bucketInput.Name == "" {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 bucket %q", bucketInput.Name))
+
+		_, err = sc.AWSClient.S3.CreateBucket(&s3.CreateBucketInput{
+			Bucket: aws.String(bucketInput.Name),
+		})
+		if IsBucketAlreadyExists(err) || IsBucketAlreadyOwnedByYou(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		_, err = sc.AWSClient.S3.PutBucketTagging(&s3.PutBucketTaggingInput{
+			Bucket: aws.String(bucketInput.Name),
+			Tagging: &s3.Tagging{
+				TagSet: r.getS3BucketTags(customObject),
+			},
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if bucketInput.IsLoggingBucket {
+			_, err = sc.AWSClient.S3.PutBucketAcl(&s3.PutBucketAclInput{
+				Bucket:       aws.String(key.TargetLogBucketName(customObject)),
+				GrantReadACP: aws.String(key.LogDeliveryURI),
+				GrantWrite:   aws.String(key.LogDeliveryURI),
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutBucketLifecycleConfiguration(&s3.PutBucketLifecycleConfigurationInput{
+				Bucket: aws.String(key.TargetLogBucketName(customObject)),
+				LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+					Rules: []*s3.LifecycleRule{
+						{
+							Expiration: &s3.LifecycleExpiration{
+								Days: aws.Int64(int64(r.accessLogsExpiration)),
+							},
+							Filter: &s3.LifecycleRuleFilter{},
+							ID:     aws.String(LifecycleLoggingBucketID),
+							Status: aws.String("Enabled"),
+						},
+					},
+				},
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		if bucketInput.LoggingEnabled {
+			_, err = sc.AWSClient.S3.PutBucketLogging(&s3.PutBucketLoggingInput{
+				Bucket: aws.String(bucketInput.Name),
+				BucketLoggingStatus: &s3.BucketLoggingStatus{
+					LoggingEnabled: &s3.LoggingEnabled{
+						TargetBucket: aws.String(key.TargetLogBucketName(customObject)),
+						TargetPrefix: aws.String(bucketInput.Name + "/"),
+					},
+				},
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 bucket %q: created", bucketInput.Name))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBuckets, err := toBucketState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredBuckets, err := toBucketState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var createState []BucketState
+	for _, bucket := range desiredBuckets {
+		if !containsBucketState(bucket.Name, currentBuckets) {
+			createState = append(createState, bucket)
+		}
+	}
+
+	return createState, nil
+}

--- a/service/controller/v12/resource/s3bucket/create_test.go
+++ b/service/controller/v12/resource/s3bucket/create_test.go
@@ -1,0 +1,111 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_S3Bucket_newCreate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj                  interface{}
+		currentState         interface{}
+		desiredState         interface{}
+		expectedBucketsState []BucketState
+		description          string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:         []BucketState{},
+			desiredState:         []BucketState{},
+			expectedBucketsState: []BucketState{},
+		},
+		{
+			description: "current state empty, desired state not empty, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketsState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{
+				{
+					Name: "current",
+				},
+			},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketsState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChanges, ok := result.([]BucketState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChanges, result)
+			}
+			for _, expectedBucketState := range tc.expectedBucketsState {
+				if !containsBucketState(expectedBucketState.Name, createChanges) {
+					t.Errorf("expected %v, got %v", expectedBucketState, createChanges)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3bucket/current.go
+++ b/service/controller/v12/resource/s3bucket/current.go
@@ -1,0 +1,121 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the S3 buckets")
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bucketStateNames := []string{
+		key.TargetLogBucketName(customObject),
+		key.BucketName(customObject, accountID),
+	}
+
+	var currentBucketState []BucketState
+	for _, inputBucketName := range bucketStateNames {
+		inputBucket := BucketState{
+			Name: inputBucketName,
+		}
+
+		isCreated, err := r.isBucketCreated(ctx, inputBucketName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if !isCreated {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("find the S3 bucket %q", inputBucketName))
+
+		lc, err := r.getLoggingConfiguration(ctx, inputBucketName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		inputBucket.LoggingEnabled = isLoggingEnabled(lc)
+		inputBucket.IsLoggingBucket = isLoggingBucket(inputBucketName, lc)
+
+		currentBucketState = append(currentBucketState, inputBucket)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the S3 buckets")
+
+	return currentBucketState, nil
+}
+
+func (r *Resource) isBucketCreated(ctx context.Context, name string) (bool, error) {
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	headInput := &s3.HeadBucketInput{
+		Bucket: aws.String(name),
+	}
+	_, err = sc.AWSClient.S3.HeadBucket(headInput)
+	if IsBucketNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func (r *Resource) getLoggingConfiguration(ctx context.Context, name string) (*s3.GetBucketLoggingOutput, error) {
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bucketLoggingInput := &s3.GetBucketLoggingInput{
+		Bucket: aws.String(name),
+	}
+	bucketLoggingOutput, err := sc.AWSClient.S3.GetBucketLogging(bucketLoggingInput)
+	if err != nil {
+		return bucketLoggingOutput, microerror.Mask(err)
+	}
+
+	return bucketLoggingOutput, nil
+}
+
+func isLoggingEnabled(lc *s3.GetBucketLoggingOutput) bool {
+	if lc.LoggingEnabled != nil {
+		return true
+	}
+
+	return false
+}
+
+func isLoggingBucket(name string, lc *s3.GetBucketLoggingOutput) bool {
+	if lc.LoggingEnabled != nil {
+		if *lc.LoggingEnabled.TargetBucket == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v12/resource/s3bucket/delete.go
+++ b/service/controller/v12/resource/s3bucket/delete.go
@@ -1,0 +1,113 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	bucketsInput, err := toBucketState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, bucketInput := range bucketsInput {
+		if bucketInput.Name == "" {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting S3 bucket %q", bucketInput.Name))
+
+		var startAfter *string
+		for {
+			// Make sure the bucket is empty.
+			input := &s3.ListObjectsV2Input{
+				Bucket:     aws.String(bucketInput.Name),
+				StartAfter: startAfter,
+			}
+			result, err := sc.AWSClient.S3.ListObjectsV2(input)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if result.IsTruncated != nil && *result.IsTruncated {
+				startAfter = result.StartAfter
+			} else {
+				startAfter = nil
+			}
+
+			for _, object := range result.Contents {
+				_, err := sc.AWSClient.S3.DeleteObject(&s3.DeleteObjectInput{
+					Bucket: aws.String(bucketInput.Name),
+					Key:    object.Key,
+				})
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+
+			if startAfter == nil {
+				break
+			}
+		}
+
+		_, err = sc.AWSClient.S3.DeleteBucket(&s3.DeleteBucketInput{
+			Bucket: aws.String(bucketInput.Name),
+		})
+		if IsBucketNotFound(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting S3 bucket %q: deleted", bucketInput.Name))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBuckets, err := toBucketState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredBuckets, err := toBucketState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var bucketsToDelete []BucketState
+	for _, bucket := range currentBuckets {
+		// Destination Logs Bucket should not be deleted because it has to keep logs
+		// even when cluster is removed (rotation of these logs are managed externally).
+		if r.canBeDeleted(bucket) && containsBucketState(bucket.Name, desiredBuckets) {
+			bucketsToDelete = append(bucketsToDelete, bucket)
+		}
+	}
+
+	return bucketsToDelete, nil
+}

--- a/service/controller/v12/resource/s3bucket/delete_test.go
+++ b/service/controller/v12/resource/s3bucket/delete_test.go
@@ -1,0 +1,113 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_S3Bucket_newDelete(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj                interface{}
+		currentState       []BucketState
+		desiredState       []BucketState
+		expectedBucketName string
+		description        string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:       []BucketState{},
+			desiredState:       []BucketState{},
+			expectedBucketName: "",
+		},
+		{
+			description: "current state empty, desired state not empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketName: "",
+		},
+		{
+			description: "current state not empty, desired state not empty but equal, expected desired state avoiding delivery log bucket",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{
+				{
+					Name: "current",
+				},
+				{
+					Name:            "log-bucket",
+					IsLoggingBucket: true,
+				},
+			},
+			desiredState: []BucketState{
+				{
+					Name: "current",
+				},
+				{
+					Name:            "log-bucket",
+					IsLoggingBucket: true,
+				},
+			},
+			expectedBucketName: "current",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+
+			deleteChanges, ok := result.([]BucketState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", deleteChanges, result)
+			}
+
+			for _, deleteChange := range deleteChanges {
+				if deleteChange.Name != tc.expectedBucketName {
+					t.Errorf("expected %s, got %s", tc.expectedBucketName, deleteChange.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3bucket/desired.go
+++ b/service/controller/v12/resource/s3bucket/desired.go
@@ -1,0 +1,44 @@
+package s3bucket
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// First bucket must be the delivery log bucket because otherwise
+	// other buckets can not forward logs to it
+	bucketsState := []BucketState{
+		{
+			Name:            key.TargetLogBucketName(customObject),
+			IsLoggingBucket: true,
+			LoggingEnabled:  true,
+		},
+		{
+			Name:            key.BucketName(customObject, accountID),
+			IsLoggingBucket: false,
+			LoggingEnabled:  true,
+		},
+	}
+
+	return bucketsState, nil
+}

--- a/service/controller/v12/resource/s3bucket/desired_test.go
+++ b/service/controller/v12/resource/s3bucket/desired_test.go
@@ -1,0 +1,86 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj           interface{}
+		expectedNames []string
+		description   string
+	}{
+		{
+			description: "Get bucket name from custom object.",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			expectedNames: []string{
+				"5xchu-g8s-access-logs",
+				"000000000000-g8s-5xchu",
+			},
+		},
+	}
+
+	var err error
+	var awsService *awsservice.Service
+	{
+		awsConfig := awsservice.DefaultConfig()
+		awsConfig.Clients = awsservice.Clients{
+			STS: &awsservice.STSClientMock{},
+		}
+		awsConfig.Logger = microloggertest.New()
+		awsService, err = awsservice.New(awsConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, servicecontext.Context{AWSService: awsService})
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatalf("expected '%v' got '%#v'", nil, err)
+			}
+
+			desiredBuckets, ok := result.([]BucketState)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredBuckets, result)
+			}
+
+			// Order should be respected in the slice returned (always delivery log bucket first)
+			for key, desiredBucket := range desiredBuckets {
+				if tc.expectedNames[key] != desiredBucket.Name {
+					t.Fatalf("expected bucket name %q got %q", tc.expectedNames[key], desiredBucket.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3bucket/error.go
+++ b/service/controller/v12/resource/s3bucket/error.go
@@ -1,0 +1,79 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var bucketNotFoundError = microerror.New("bucket not found")
+
+// IsBucketNotFound asserts bucket not found error from upstream's API code.
+func IsBucketNotFound(err error) bool {
+	c := microerror.Cause(err)
+	aerr, ok := c.(awserr.Error)
+	if !ok {
+		return false
+	}
+	// hack for HeadBucket request that returns a wrong error code
+	if aerr.Code() == "NotFound" {
+		return true
+	}
+	if aerr.Code() == s3.ErrCodeNoSuchBucket {
+		return true
+	}
+	if c == bucketNotFoundError {
+		return true
+	}
+
+	return false
+}
+
+// IsBucketAlreadyExists asserts bucket already exists error from upstream's
+// API code.
+func IsBucketAlreadyExists(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	if aerr.Code() == s3.ErrCodeBucketAlreadyExists {
+		return true
+	}
+
+	return false
+}
+
+// IsBucketAlreadyOwnedByYou asserts bucket already owned by you error from
+// upstream's API code.
+func IsBucketAlreadyOwnedByYou(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	if aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou {
+		return true
+	}
+
+	return false
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/s3bucket/resource.go
+++ b/service/controller/v12/resource/s3bucket/resource.go
@@ -1,0 +1,129 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "s3bucketv11"
+	// LifecycleLoggingBucketID is the Lifecycle ID for the logging bucket
+	LifecycleLoggingBucketID = "ExpirationLogs"
+)
+
+// Config represents the configuration used to create a new s3bucket resource.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	AccessLogsExpiration int
+	DeleteLoggingBucket  bool
+	IncludeTags          bool
+	InstallationName     string
+}
+
+// DefaultConfig provides a default configuration to create a new s3bucket
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// Resource implements the s3bucket resource.
+type Resource struct {
+	// Dependencies.
+	logger micrologger.Logger
+
+	// Settings.
+	accessLogsExpiration int
+	deleteLoggingBucket  bool
+	includeTags          bool
+	installationName     string
+}
+
+// New creates a new configured s3bucket resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.AccessLogsExpiration < 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.AccessLogsExpiration must not be lower than 0", config)
+	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+
+		// Settings.
+		accessLogsExpiration: config.AccessLogsExpiration,
+		deleteLoggingBucket:  config.DeleteLoggingBucket,
+		includeTags:          config.IncludeTags,
+		installationName:     config.InstallationName,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toBucketState(v interface{}) ([]BucketState, error) {
+	if v == nil {
+		return []BucketState{}, nil
+	}
+
+	bucketsState, ok := v.([]BucketState)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []BucketState{}, v)
+	}
+
+	return bucketsState, nil
+}
+
+func containsBucketState(bucketStateName string, bucketStateList []BucketState) bool {
+	for _, b := range bucketStateList {
+		if b.Name == bucketStateName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Resource) getS3BucketTags(customObject v1alpha1.AWSConfig) []*s3.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
+	s3Tags := []*s3.Tag{}
+
+	if r.includeTags {
+		for k, v := range clusterTags {
+			tag := &s3.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			}
+
+			s3Tags = append(s3Tags, tag)
+		}
+	}
+
+	return s3Tags
+}
+
+func (r *Resource) canBeDeleted(bucket BucketState) bool {
+	return !bucket.IsLoggingBucket || bucket.IsLoggingBucket && r.deleteLoggingBucket
+}

--- a/service/controller/v12/resource/s3bucket/resource_test.go
+++ b/service/controller/v12/resource/s3bucket/resource_test.go
@@ -1,0 +1,154 @@
+package s3bucket
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_ContainsBucketState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description      string
+		installation     string
+		bucketNameToFind string
+		bucketStateList  []BucketState
+		expectedValue    bool
+	}{
+		{
+			description:      "basic match",
+			installation:     "test-install",
+			bucketNameToFind: "bck1",
+			bucketStateList:  []BucketState{},
+			expectedValue:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := containsBucketState(tc.bucketNameToFind, tc.bucketStateList)
+
+			if result != tc.expectedValue {
+				t.Fatalf("Expected %t tags, found %t", tc.expectedValue, result)
+			}
+		})
+	}
+}
+func Test_BucketCanBeDeleted(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description         string
+		installation        string
+		deleteLoggingBucket bool
+		bucketState         BucketState
+		expectedValue       bool
+	}{
+		{
+			description:         "test env true",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env false",
+			installation:        "test-install",
+			deleteLoggingBucket: false,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env true no logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env true logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState: BucketState{
+				IsLoggingBucket: true,
+			},
+			expectedValue: true,
+		},
+		{
+			description:         "test env false no logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env false logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: false,
+			bucketState: BucketState{
+				IsLoggingBucket: true,
+			},
+			expectedValue: false,
+		},
+	}
+
+	c := Config{}
+
+	c.Logger = microloggertest.New()
+	c.AccessLogsExpiration = 0
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.DeleteLoggingBucket = tc.deleteLoggingBucket
+			c.InstallationName = tc.installation
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			result := r.canBeDeleted(tc.bucketState)
+
+			if result != tc.expectedValue {
+				t.Fatalf("Expected %t, found %t", tc.expectedValue, result)
+			}
+		})
+	}
+}
+
+func Test_getS3BucketTags(t *testing.T) {
+	testCases := []struct {
+		obj          v1alpha1.AWSConfig
+		includeTags  bool
+		expectedTags []*s3.Tag
+		description  string
+	}{
+		{
+			description:  "do not include tags",
+			obj:          v1alpha1.AWSConfig{},
+			includeTags:  false,
+			expectedTags: []*s3.Tag{},
+		},
+	}
+
+	c := Config{}
+
+	c.Logger = microloggertest.New()
+	c.InstallationName = "installation-name"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.IncludeTags = tc.includeTags
+
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			actual := r.getS3BucketTags(tc.obj)
+			if !reflect.DeepEqual(actual, tc.expectedTags) {
+				t.Errorf("tags don't match, want %#v, got %#v", tc.expectedTags, actual)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3bucket/spec.go
+++ b/service/controller/v12/resource/s3bucket/spec.go
@@ -1,0 +1,31 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// BucketState is the state representation on which the resource methods work.
+type BucketState struct {
+	Name            string
+	IsLoggingBucket bool
+	LoggingEnabled  bool
+}
+
+type Clients struct {
+	S3 S3Client
+}
+
+// S3Client describes the methods required to be implemented by a S3 AWS client.
+type S3Client interface {
+	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
+	DeleteBucket(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
+	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+	DeleteObjects(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
+	GetBucketLogging(*s3.GetBucketLoggingInput) (*s3.GetBucketLoggingOutput, error)
+	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+	PutBucketAcl(*s3.PutBucketAclInput) (*s3.PutBucketAclOutput, error)
+	PutBucketLifecycleConfiguration(*s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
+	PutBucketLogging(*s3.PutBucketLoggingInput) (*s3.PutBucketLoggingOutput, error)
+	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
+}

--- a/service/controller/v12/resource/s3bucket/update.go
+++ b/service/controller/v12/resource/s3bucket/update.go
@@ -1,0 +1,35 @@
+package s3bucket
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because S3 buckets are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v12/resource/s3object/certs.go
+++ b/service/controller/v12/resource/s3object/certs.go
@@ -1,0 +1,159 @@
+package s3object
+
+import (
+	"context"
+
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func (r *Resource) encodeTLSAssets(ctx context.Context, assets legacy.AssetsBundle, kmsKeyArn string) (*legacy.CompactTLSAssets, error) {
+	rawTLS := createRawTLSAssets(assets)
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	encTLS, err := rawTLS.encrypt(sc.AWSClient.KMS, kmsKeyArn)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	compTLS, err := encTLS.compact()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return compTLS, nil
+}
+
+type TLSassets struct {
+	APIServerCA       []byte
+	APIServerKey      []byte
+	APIServerCrt      []byte
+	WorkerCA          []byte
+	WorkerKey         []byte
+	WorkerCrt         []byte
+	ServiceAccountCA  []byte
+	ServiceAccountKey []byte
+	ServiceAccountCrt []byte
+	CalicoClientCA    []byte
+	CalicoClientKey   []byte
+	CalicoClientCrt   []byte
+	EtcdServerCA      []byte
+	EtcdServerKey     []byte
+	EtcdServerCrt     []byte
+}
+
+// PEM encoded TLS assets.
+type rawTLSAssets TLSassets
+
+// Encrypted PEM encoded TLS assets
+type encryptedTLSAssets TLSassets
+
+func createRawTLSAssets(assets legacy.AssetsBundle) *rawTLSAssets {
+	// TODO refactor this with a for loop iterating over components and asset types
+	return &rawTLSAssets{
+		APIServerCA:       assets[assetsBundleKey(legacy.APIComponent, legacy.CA)],
+		APIServerCrt:      assets[assetsBundleKey(legacy.APIComponent, legacy.Crt)],
+		APIServerKey:      assets[assetsBundleKey(legacy.APIComponent, legacy.Key)],
+		WorkerCA:          assets[assetsBundleKey(legacy.WorkerComponent, legacy.CA)],
+		WorkerCrt:         assets[assetsBundleKey(legacy.WorkerComponent, legacy.Crt)],
+		WorkerKey:         assets[assetsBundleKey(legacy.WorkerComponent, legacy.Key)],
+		ServiceAccountCA:  assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.CA)],
+		ServiceAccountCrt: assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.Crt)],
+		ServiceAccountKey: assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.Key)],
+		EtcdServerCA:      assets[assetsBundleKey(legacy.EtcdComponent, legacy.CA)],
+		EtcdServerCrt:     assets[assetsBundleKey(legacy.EtcdComponent, legacy.Crt)],
+		EtcdServerKey:     assets[assetsBundleKey(legacy.EtcdComponent, legacy.Key)],
+		CalicoClientCA:    assets[assetsBundleKey(legacy.CalicoComponent, legacy.CA)],
+		CalicoClientCrt:   assets[assetsBundleKey(legacy.CalicoComponent, legacy.Crt)],
+		CalicoClientKey:   assets[assetsBundleKey(legacy.CalicoComponent, legacy.Key)],
+	}
+}
+
+func (r *rawTLSAssets) encrypt(svc KMSClient, kmsKeyARN string) (*encryptedTLSAssets, error) {
+	var err error
+	encrypt := func(data []byte) (b []byte) {
+		if err != nil {
+			return []byte{}
+		}
+
+		b, err = encryptor(svc, kmsKeyARN, data)
+
+		if err != nil {
+			return []byte{}
+		}
+		return b
+	}
+	encryptedAssets := encryptedTLSAssets{
+		APIServerCA:       encrypt(r.APIServerCA),
+		APIServerKey:      encrypt(r.APIServerKey),
+		APIServerCrt:      encrypt(r.APIServerCrt),
+		WorkerCA:          encrypt(r.WorkerCA),
+		WorkerCrt:         encrypt(r.WorkerCrt),
+		WorkerKey:         encrypt(r.WorkerKey),
+		ServiceAccountCA:  encrypt(r.ServiceAccountCA),
+		ServiceAccountCrt: encrypt(r.ServiceAccountCrt),
+		ServiceAccountKey: encrypt(r.ServiceAccountKey),
+		CalicoClientCA:    encrypt(r.CalicoClientCA),
+		CalicoClientKey:   encrypt(r.CalicoClientKey),
+		CalicoClientCrt:   encrypt(r.CalicoClientCrt),
+		EtcdServerCA:      encrypt(r.EtcdServerCA),
+		EtcdServerKey:     encrypt(r.EtcdServerKey),
+		EtcdServerCrt:     encrypt(r.EtcdServerCrt),
+	}
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &encryptedAssets, nil
+}
+
+func (r *encryptedTLSAssets) compact() (*legacy.CompactTLSAssets, error) {
+	var err error
+	compact := func(data []byte) (r string) {
+		if err != nil {
+			return ""
+		}
+
+		r, err = compactor(data)
+		if err != nil {
+			return ""
+		}
+
+		return r
+	}
+
+	compactAssets := legacy.CompactTLSAssets{
+		APIServerCA:       compact(r.APIServerCA),
+		APIServerKey:      compact(r.APIServerKey),
+		APIServerCrt:      compact(r.APIServerCrt),
+		WorkerCA:          compact(r.WorkerCA),
+		WorkerKey:         compact(r.WorkerKey),
+		WorkerCrt:         compact(r.WorkerCrt),
+		ServiceAccountCA:  compact(r.ServiceAccountCA),
+		ServiceAccountKey: compact(r.ServiceAccountKey),
+		ServiceAccountCrt: compact(r.ServiceAccountCrt),
+		CalicoClientCA:    compact(r.CalicoClientCA),
+		CalicoClientKey:   compact(r.CalicoClientKey),
+		CalicoClientCrt:   compact(r.CalicoClientCrt),
+		EtcdServerCA:      compact(r.EtcdServerCA),
+		EtcdServerKey:     compact(r.EtcdServerKey),
+		EtcdServerCrt:     compact(r.EtcdServerCrt),
+	}
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &compactAssets, nil
+}
+
+func assetsBundleKey(c legacy.ClusterComponent, t legacy.TLSAssetType) legacy.AssetsBundleKey {
+	return legacy.AssetsBundleKey{
+		Component: c,
+		Type:      t,
+	}
+}

--- a/service/controller/v12/resource/s3object/create.go
+++ b/service/controller/v12/resource/s3object/create.go
@@ -1,0 +1,69 @@
+package s3object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	createBucketState, err := toBucketObjectState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for key, bucketObject := range createBucketState {
+		if bucketObject.Key != "" {
+			s3PutInput, err := toPutObjectInput(bucketObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutObject(&s3PutInput)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 object '%s': created", key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 object '%s': already created", key))
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBucketState, err := toBucketObjectState(currentState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	desiredBucketState, err := toBucketObjectState(desiredState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the s3 objects should be created")
+
+	createState := map[string]BucketObjectState{}
+
+	for key, bucketObject := range desiredBucketState {
+		if _, ok := currentBucketState[key]; !ok {
+			createState[key] = bucketObject
+		} else {
+			createState[key] = BucketObjectState{}
+		}
+	}
+
+	return createState, nil
+}

--- a/service/controller/v12/resource/s3object/create_test.go
+++ b/service/controller/v12/resource/s3object/create_test.go
@@ -1,0 +1,196 @@
+package s3object
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_S3Object_newCreate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		currentState  map[string]BucketObjectState
+		desiredState  map[string]BucketObjectState
+		expectedState map[string]BucketObjectState
+	}{
+		{
+			description:   "current state empty, desired state empty, empty create change",
+			obj:           clusterTpo,
+			currentState:  map[string]BucketObjectState{},
+			desiredState:  map[string]BucketObjectState{},
+			expectedState: map[string]BucketObjectState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, create change == desired state",
+			obj:          clusterTpo,
+			currentState: map[string]BucketObjectState{},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty, create change == desired state",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"mykey": {
+					Body:   "mykey",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state has 1 object, desired state has 2 objects, create change == missing object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, empty create change",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+				"worker": {},
+			},
+		},
+	}
+
+	awsClients := aws.Clients{
+		S3: &S3ClientMock{},
+	}
+
+	awsService := awsservice.AwsServiceMock{}
+	cloudconfig := &CloudConfigMock{}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+		c.CertWatcher = legacytest.NewService()
+		c.Logger = microloggertest.New()
+		c.RandomKeySearcher = randomkeystest.NewSearcher()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := servicecontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, c)
+
+			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChange, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChange, result)
+			}
+
+			if !reflect.DeepEqual(tc.expectedState, createChange) {
+				t.Error("expected", tc.expectedState, "got", createChange)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3object/current.go
+++ b/service/controller/v12/resource/s3object/current.go
@@ -1,0 +1,95 @@
+package s3object
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	output := map[string]BucketObjectState{}
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for S3 objects")
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	bucketName := key.BucketName(customObject, accountID)
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	}
+	result, err := sc.AWSClient.S3.ListObjectsV2(input)
+	// the bucket can be already deleted with all the objects in it, it is ok if so.
+	if IsBucketNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "S3 object's bucket not found, no current objects present")
+		return output, nil
+	}
+	// we don't expect other errors.
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the S3 objects")
+
+	for _, object := range result.Contents {
+		body, err := r.getBucketObjectBody(ctx, bucketName, *object.Key)
+		if err != nil {
+			return output, microerror.Mask(err)
+		}
+
+		output[*object.Key] = BucketObjectState{
+			Body:   body,
+			Bucket: bucketName,
+			Key:    *object.Key,
+		}
+	}
+
+	return output, nil
+}
+
+func (r *Resource) getBucketObjectBody(ctx context.Context, bucketName string, keyName string) (string, error) {
+	var body string
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return body, microerror.Mask(err)
+	}
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(keyName),
+	}
+	result, err := sc.AWSClient.S3.GetObject(input)
+	if IsObjectNotFound(err) || IsBucketNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("did not find S3 object '%s'", keyName))
+
+		// fall through
+		return body, nil
+	}
+	if err != nil {
+		return body, microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(result.Body)
+	body = buf.String()
+
+	return body, nil
+}

--- a/service/controller/v12/resource/s3object/current_test.go
+++ b/service/controller/v12/resource/s3object/current_test.go
@@ -1,0 +1,132 @@
+package s3object
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_CurrentState(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj              *v1alpha1.AWSConfig
+		description      string
+		expectedIAMError bool
+		expectedS3Error  bool
+		expectedKey      string
+		expectedBucket   string
+		expectedBody     string
+	}{
+		{
+			description:    "basic match",
+			obj:            clusterTpo,
+			expectedKey:    "cloudconfig/myversion/worker",
+			expectedBucket: "myaccountid-g8s-test-cluster",
+			expectedBody:   "mybody",
+		},
+		{
+			description:      "IAM error",
+			obj:              clusterTpo,
+			expectedIAMError: true,
+		},
+
+		{
+			description:     "S3 error",
+			obj:             clusterTpo,
+			expectedS3Error: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				S3: &S3ClientMock{
+					isError: tc.expectedS3Error,
+					body:    tc.expectedBody,
+				},
+			}
+
+			awsService := awsservice.AwsServiceMock{
+				AccountID: "myaccountid",
+				IsError:   tc.expectedIAMError,
+			}
+
+			cloudconfig := &CloudConfigMock{}
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{}
+				c.CertWatcher = legacytest.NewService()
+				c.Logger = microloggertest.New()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+				newResource, err = New(c)
+				if err != nil {
+					t.Error("expected", nil, "got", err)
+				}
+			}
+
+			c := servicecontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, c)
+
+			result, err := newResource.GetCurrentState(ctx, tc.obj)
+			if err != nil && !tc.expectedIAMError && !tc.expectedS3Error {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if err == nil && tc.expectedIAMError {
+				t.Error("expected IAM error didn't happen")
+			}
+
+			if err == nil && tc.expectedS3Error {
+				t.Error("expected S3 error didn't happen")
+			}
+
+			if !tc.expectedIAMError && !tc.expectedS3Error {
+				var bucketObject BucketObjectState
+
+				if bucketObject, ok = currentState[tc.expectedKey]; !ok {
+					t.Errorf("expected S3 key %q not found", tc.expectedKey)
+				}
+
+				if bucketObject.Body != tc.expectedBody {
+					t.Errorf("expected body %q, got %q", tc.expectedBody, bucketObject.Body)
+				}
+
+				if bucketObject.Bucket != tc.expectedBucket {
+					t.Errorf("expected bucket %q, got %q", tc.expectedBucket, bucketObject.Bucket)
+				}
+
+				if bucketObject.Key != tc.expectedKey {
+					t.Errorf("expected key %q, got %q", tc.expectedKey, bucketObject.Key)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3object/desired.go
+++ b/service/controller/v12/resource/s3object/desired.go
@@ -1,0 +1,82 @@
+package s3object
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/cloudconfig"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	output := map[string]BucketObjectState{}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+	kmsKeyARN, err := sc.AWSService.GetKeyArn(clusterID)
+	if IsKeyNotFound(err) {
+		// we can get here during deletion, if the key is already deleted we can safely exit.
+		return output, nil
+	}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	certs, err := r.certWatcher.SearchCerts(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	tlsAssets, err := r.encodeTLSAssets(ctx, certs, kmsKeyARN)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	clusterKeys, err := r.randomKeySearcher.SearchCluster(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	masterBody, err := sc.CloudConfig.NewMasterTemplate(customObject, *tlsAssets, clusterKeys, kmsKeyARN)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	masterObjectName := key.BucketObjectName(cloudconfig.MasterCloudConfigVersion, prefixMaster)
+	masterCloudConfig := BucketObjectState{
+		Bucket: key.BucketName(customObject, accountID),
+		Body:   masterBody,
+		Key:    masterObjectName,
+	}
+	output[masterObjectName] = masterCloudConfig
+
+	workerBody, err := sc.CloudConfig.NewWorkerTemplate(customObject, *tlsAssets)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	workerObjectName := key.BucketObjectName(cloudconfig.WorkerCloudConfigVersion, prefixWorker)
+	workerCloudConfig := BucketObjectState{
+		Bucket: key.BucketName(customObject, accountID),
+		Body:   workerBody,
+		Key:    workerObjectName,
+	}
+	output[workerObjectName] = workerCloudConfig
+
+	return output, nil
+}

--- a/service/controller/v12/resource/s3object/desired_test.go
+++ b/service/controller/v12/resource/s3object/desired_test.go
@@ -1,0 +1,130 @@
+package s3object
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_DesiredState(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj               *v1alpha1.AWSConfig
+		description       string
+		expectedBucket    string
+		expectedBody      string
+		expectedMasterKey string
+		expectedWorkerKey string
+	}{
+		{
+			description:       "basic match",
+			obj:               clusterTpo,
+			expectedBody:      "mybody-",
+			expectedBucket:    "myaccountid-g8s-test-cluster",
+			expectedMasterKey: "cloudconfig/v_3_3_1/master",
+			expectedWorkerKey: "cloudconfig/v_3_3_1/worker",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				KMS: &KMSClientMock{},
+			}
+
+			awsService := awsservice.AwsServiceMock{
+				AccountID: "myaccountid",
+				KeyArn:    "mykeyarn",
+			}
+
+			cloudconfig := &CloudConfigMock{
+				template: tc.expectedBody,
+			}
+
+			var err error
+			var newResource *Resource
+			var masterCloudConfig BucketObjectState
+			var workerCloudConfig BucketObjectState
+			{
+				c := Config{}
+				c.Logger = microloggertest.New()
+				c.CertWatcher = legacytest.NewService()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+				newResource, err = New(c)
+				if err != nil {
+					t.Error("expected", nil, "got", err)
+				}
+			}
+
+			c := servicecontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, c)
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			desiredState, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", desiredState, result)
+			}
+
+			if len(desiredState) != 2 {
+				t.Errorf("expected 2 objects, got %d", len(desiredState))
+			}
+
+			if masterCloudConfig, ok = desiredState[tc.expectedMasterKey]; !ok {
+				t.Errorf("expected key %q, not found", tc.expectedMasterKey)
+			}
+
+			if masterCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expected bucket %q, got %q", tc.expectedBucket, masterCloudConfig.Bucket)
+			}
+
+			if masterCloudConfig.Key != tc.expectedMasterKey {
+				t.Errorf("expected key %q, got %q", tc.expectedMasterKey, masterCloudConfig.Key)
+			}
+
+			if masterCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expected key %q, got %q", tc.expectedBody, masterCloudConfig.Body)
+			}
+
+			if workerCloudConfig, ok = desiredState[tc.expectedWorkerKey]; !ok {
+				t.Errorf("expected key %q, not found", tc.expectedWorkerKey)
+			}
+
+			if workerCloudConfig.Bucket != tc.expectedBucket {
+				t.Errorf("expected bucket %q, got %q", tc.expectedBucket, workerCloudConfig.Bucket)
+			}
+
+			if workerCloudConfig.Key != tc.expectedWorkerKey {
+				t.Errorf("expected key %q, got %q", tc.expectedWorkerKey, workerCloudConfig.Key)
+			}
+
+			if workerCloudConfig.Body != tc.expectedBody {
+				t.Errorf("expected key %q, got %q", tc.expectedBody, workerCloudConfig.Body)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/s3object/encrypt.go
+++ b/service/controller/v12/resource/s3object/encrypt.go
@@ -1,0 +1,36 @@
+package s3object
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+)
+
+func compactor(data []byte) (string, error) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if _, err := gzw.Write(data); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func encryptor(svc KMSClient, kmsKeyARN string, data []byte) ([]byte, error) {
+	encryptInput := kms.EncryptInput{
+		KeyId:     aws.String(kmsKeyARN),
+		Plaintext: data,
+	}
+
+	var encryptOutput *kms.EncryptOutput
+	var err error
+	if encryptOutput, err = svc.Encrypt(&encryptInput); err != nil {
+		return []byte{}, err
+	}
+	return encryptOutput.CiphertextBlob, nil
+}

--- a/service/controller/v12/resource/s3object/error.go
+++ b/service/controller/v12/resource/s3object/error.go
@@ -1,0 +1,45 @@
+package s3object
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+// IsObjectNotFound asserts object not found error from upstream's API message.
+func IsObjectNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NoSuchKey: The specified key does not exist")
+}
+
+// IsBucketNotFound asserts object not found error from upstream's API message.
+func IsBucketNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NoSuchBucket: The specified bucket does not exist")
+}
+
+// IsKeyNotFound asserts key not found error from upstream's API message.
+func IsKeyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NotFoundException: Alias arn:aws:kms:")
+}

--- a/service/controller/v12/resource/s3object/mock.go
+++ b/service/controller/v12/resource/s3object/mock.go
@@ -1,0 +1,87 @@
+package s3object
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/randomkeys"
+)
+
+// nopCloser is required to implement the ReadCloser interface required by
+// the Body field in S3's GetObjectOutput
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+type S3ClientMock struct {
+	s3iface.S3API
+
+	isError bool
+	body    string
+}
+
+func (s *S3ClientMock) PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return nil, nil
+}
+
+func (s *S3ClientMock) DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	return nil, nil
+}
+
+func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.GetObjectOutput{
+		Body: nopCloser{strings.NewReader(s.body)},
+	}
+
+	return output, nil
+}
+
+func (s *S3ClientMock) ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.ListObjectsV2Output{
+		Contents: []*s3.Object{
+			{
+				Key: aws.String("cloudconfig/myversion/worker"),
+			},
+		},
+	}
+
+	return output, nil
+}
+
+type CloudConfigMock struct {
+	template string
+}
+
+func (c *CloudConfigMock) NewMasterTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, randomKeys randomkeys.Cluster, kmsKeyARN string) (string, error) {
+	return c.template, nil
+}
+
+func (c *CloudConfigMock) NewWorkerTemplate(customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error) {
+	return c.template, nil
+}
+
+type KMSClientMock struct {
+	kmsiface.KMSAPI
+}
+
+func (k *KMSClientMock) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutput, error) {
+	return &kms.EncryptOutput{}, nil
+}

--- a/service/controller/v12/resource/s3object/resource.go
+++ b/service/controller/v12/resource/s3object/resource.go
@@ -1,0 +1,103 @@
+package s3object
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/randomkeys"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "s3objectv11"
+)
+
+// Config represents the configuration used to create a new cloudformation resource.
+type Config struct {
+	// Dependencies.
+	CertWatcher       legacy.Searcher
+	Logger            micrologger.Logger
+	RandomKeySearcher randomkeys.Interface
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	// Dependencies.
+	certWatcher       legacy.Searcher
+	logger            micrologger.Logger
+	randomKeySearcher randomkeys.Interface
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.CertWatcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertWatcher must not be empty")
+	}
+	if config.RandomKeySearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.RandomKeySearcher must not be empty")
+	}
+
+	r := &Resource{
+		// Dependencies.
+		certWatcher:       config.CertWatcher,
+		logger:            config.Logger,
+		randomKeySearcher: config.RandomKeySearcher,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return controller.NewPatch(), nil
+}
+
+func toBucketObjectState(v interface{}) (map[string]BucketObjectState, error) {
+	if v == nil {
+		return map[string]BucketObjectState{}, nil
+	}
+
+	bucketObjectState, ok := v.(map[string]BucketObjectState)
+	if !ok {
+		return map[string]BucketObjectState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObjectState, v)
+	}
+
+	return bucketObjectState, nil
+}
+
+func toPutObjectInput(v interface{}) (s3.PutObjectInput, error) {
+	if v == nil {
+		return s3.PutObjectInput{}, nil
+	}
+
+	bucketObject, ok := v.(BucketObjectState)
+	if !ok {
+		return s3.PutObjectInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObject, v)
+	}
+
+	putObjectInput := s3.PutObjectInput{
+		Key:           aws.String(bucketObject.Key),
+		Body:          strings.NewReader(bucketObject.Body),
+		Bucket:        aws.String(bucketObject.Bucket),
+		ContentLength: aws.Int64(int64(len(bucketObject.Body))),
+	}
+
+	return putObjectInput, nil
+}

--- a/service/controller/v12/resource/s3object/spec.go
+++ b/service/controller/v12/resource/s3object/spec.go
@@ -1,0 +1,46 @@
+package s3object
+
+import (
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/randomkeys"
+)
+
+const (
+	prefixMaster = "master"
+	prefixWorker = "worker"
+)
+
+type BucketObjectState struct {
+	Bucket string
+	Body   string
+	Key    string
+}
+
+type Clients struct {
+	S3  S3Client
+	KMS KMSClient
+}
+
+type S3Client interface {
+	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
+	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
+	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+}
+
+type KMSClient interface {
+	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
+}
+
+type AwsService interface {
+	GetAccountID() (string, error)
+	GetKeyArn(string) (string, error)
+}
+
+type CloudConfigService interface {
+	NewMasterTemplate(v1alpha1.AWSConfig, legacy.CompactTLSAssets, randomkeys.Cluster, string) (string, error)
+	NewWorkerTemplate(v1alpha1.AWSConfig, legacy.CompactTLSAssets) (string, error)
+}

--- a/service/controller/v12/resource/s3object/update.go
+++ b/service/controller/v12/resource/s3object/update.go
@@ -1,0 +1,93 @@
+package s3object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	updateBucketState, err := toBucketObjectState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := servicecontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for key, bucketObject := range updateBucketState {
+		if bucketObject.Key != "" {
+			s3PutInput, err := toPutObjectInput(bucketObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutObject(&s3PutInput)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating S3 object '%s': updated", key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating S3 object '%s': already updated", key))
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBucketState, err := toBucketObjectState(currentState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	desiredBucketState, err := toBucketObjectState(desiredState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the s3 objects should be updated")
+
+	updateState := map[string]BucketObjectState{}
+
+	for key, bucketObject := range desiredBucketState {
+		if _, ok := currentBucketState[key]; !ok {
+			updateState[key] = BucketObjectState{}
+		}
+
+		currentObject := currentBucketState[key]
+		if currentObject.Body != "" && bucketObject.Body != currentObject.Body {
+			updateState[key] = bucketObject
+		} else {
+			updateState[key] = BucketObjectState{}
+		}
+	}
+
+	return updateState, nil
+}

--- a/service/controller/v12/resource/s3object/update_test.go
+++ b/service/controller/v12/resource/s3object/update_test.go
@@ -1,0 +1,187 @@
+package s3object
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	servicecontext "github.com/giantswarm/aws-operator/service/controller/v11/context"
+)
+
+func Test_Resource_S3Object_newUpdate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		currentState  map[string]BucketObjectState
+		desiredState  map[string]BucketObjectState
+		expectedState map[string]BucketObjectState
+	}{
+		{
+			description:   "current state empty, desired state empty, empty update change",
+			obj:           clusterTpo,
+			currentState:  map[string]BucketObjectState{},
+			desiredState:  map[string]BucketObjectState{},
+			expectedState: map[string]BucketObjectState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, empty update change",
+			obj:          clusterTpo,
+			currentState: map[string]BucketObjectState{},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+			},
+		},
+		{
+			description: "current state matches desired state, empty update change",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+			},
+		},
+		{
+			description: "current state does not match desired state, update bucket object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state does not match desired state, update bucket object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				S3: &S3ClientMock{},
+			}
+
+			awsService := awsservice.AwsServiceMock{}
+
+			cloudconfig := &CloudConfigMock{}
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{}
+				c.CertWatcher = legacytest.NewService()
+				c.Logger = microloggertest.New()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+
+				newResource, err = New(c)
+				if err != nil {
+					t.Fatal("expected", nil, "got", err)
+				}
+			}
+
+			c := servicecontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = servicecontext.NewContext(ctx, c)
+
+			result, err := newResource.newUpdateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			updateChange, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", updateChange, result)
+			}
+
+			if !reflect.DeepEqual(tc.expectedState, updateChange) {
+				t.Error("expected", tc.expectedState, "got", updateChange)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/service/create.go
+++ b/service/controller/v12/resource/service/create.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToCreate, err := toService(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err = r.k8sClient.CoreV1().Services(namespace).Create(serviceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var serviceToCreate *apiv1.Service
+	if currentService == nil || desiredService.Name != currentService.Name {
+		serviceToCreate = desiredService
+	}
+
+	return serviceToCreate, nil
+}

--- a/service/controller/v12/resource/service/create_test.go
+++ b/service/controller/v12/resource/service/create_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, desired state is empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+
+		{
+			description: "current state is empty, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToCreate, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", serviceToCreate, result)
+				}
+				if tc.expectedService.Name != serviceToCreate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToCreate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/service/current.go
+++ b/service/controller/v12/resource/service/current.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master service in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+
+	// Lookup the current state of the service.
+	var service *apiv1.Service
+	{
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(masterServiceName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master service in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master service in the Kubernetes API")
+			service = manifest
+		}
+	}
+
+	return service, nil
+}

--- a/service/controller/v12/resource/service/delete.go
+++ b/service/controller/v12/resource/service/delete.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToDelete, err := toService(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().Services(namespace).Delete(serviceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the service has to be deleted")
+
+	var serviceToDelete *apiv1.Service
+	if currentService != nil && desiredService.Name == currentService.Name {
+		serviceToDelete = desiredService
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the service has to be deleted")
+
+	return serviceToDelete, nil
+}

--- a/service/controller/v12/resource/service/delete_test.go
+++ b/service/controller/v12/resource/service/delete_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+		{
+			description: "current and desired states are different, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToDelete, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Fatalf("case expected '%T', got '%T'", serviceToDelete, result)
+				}
+				if tc.expectedService.Name != serviceToDelete.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToDelete.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/service/desired.go
+++ b/service/controller/v12/resource/service/desired.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	service := &v1.Service{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      "master",
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				"app":                        "master",
+				"cluster":                    key.ClusterID(customObject),
+				"customer":                   key.CustomerID(customObject),
+				"giantswarm.io/cluster":      key.ClusterID(customObject),
+				"giantswarm.io/organization": key.CustomerID(customObject),
+			},
+			Annotations: map[string]string{
+				"giantswarm.io/prometheus-cluster": key.ClusterID(customObject),
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol:   v1.ProtocolTCP,
+					Port:       httpsPort,
+					TargetPort: intstr.FromInt(httpsPort),
+				},
+			},
+		},
+	}
+
+	return service, nil
+}

--- a/service/controller/v12/resource/service/desired_test.go
+++ b/service/controller/v12/resource/service/desired_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description        string
+		obj                interface{}
+		expectedNamespace  string
+		expectedName       string
+		expectedPort       int
+		expectedTargetPort string
+	}{
+		{
+			description: "Get service from custom object",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			expectedNamespace:  "al9qy",
+			expectedName:       "master",
+			expectedPort:       443,
+			expectedTargetPort: "443",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			desiredService, ok := result.(*apiv1.Service)
+			if !ok {
+				t.Errorf("case expected '%T', got '%T'", desiredService, result)
+			}
+
+			if tc.expectedNamespace != desiredService.ObjectMeta.Namespace {
+				t.Errorf("expected namespace %q got %q", tc.expectedNamespace, desiredService.ObjectMeta.Namespace)
+			}
+
+			if tc.expectedName != desiredService.ObjectMeta.Name {
+				t.Errorf("expected name %q got %q", tc.expectedName, desiredService.ObjectMeta.Name)
+			}
+
+			if int32(tc.expectedPort) != desiredService.Spec.Ports[0].Port {
+				t.Errorf("expected port %q got %q", int32(tc.expectedPort), desiredService.Spec.Ports[0].Port)
+			}
+
+			if intstr.FromInt(tc.expectedPort) != desiredService.Spec.Ports[0].TargetPort {
+				t.Errorf("expected target port %q got %q", intstr.FromInt(tc.expectedPort), desiredService.Spec.Ports[0].TargetPort)
+			}
+		})
+	}
+}

--- a/service/controller/v12/resource/service/error.go
+++ b/service/controller/v12/resource/service/error.go
@@ -1,0 +1,24 @@
+package service
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v12/resource/service/resource.go
+++ b/service/controller/v12/resource/service/resource.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "servicev11"
+
+	httpsPort         = 443
+	masterServiceName = "master"
+)
+
+// Config represents the configuration used to create a new service resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the service resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured service resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toService(v interface{}) (*apiv1.Service, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	service, ok := v.(*apiv1.Service)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Service{}, v)
+	}
+
+	return service, nil
+}

--- a/service/controller/v12/resource/service/update.go
+++ b/service/controller/v12/resource/service/update.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// Service resources are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v12/templates/cloudconfig/decrypt_keys_assets_script.go
+++ b/service/controller/v12/templates/cloudconfig/decrypt_keys_assets_script.go
@@ -1,0 +1,30 @@
+package cloudconfig
+
+const DecryptKeysAssetsScript = `#!/bin/bash -e
+
+rkt run \
+  --volume=keys,kind=host,source=/etc/kubernetes/encryption,readOnly=false \
+  --mount=volume=keys,target=/etc/kubernetes/encryption \
+  --uuid-file-save=/var/run/coreos/decrypt-keys-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting keys assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/encryption -name "*.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;
+    echo done.'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-keys-assets.uuid || :
+`

--- a/service/controller/v12/templates/cloudconfig/decrypt_keys_assets_service.go
+++ b/service/controller/v12/templates/cloudconfig/decrypt_keys_assets_service.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const DecryptKeysAssetsService = `
+[Unit]
+Description=Decrypt Secret Keys
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-keys-assets
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudconfig/decrypt_tls_assets_script.go
+++ b/service/controller/v12/templates/cloudconfig/decrypt_tls_assets_script.go
@@ -1,0 +1,30 @@
+package cloudconfig
+
+const DecryptTLSAssetsScript = `#!/bin/bash -e
+
+rkt run \
+  --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
+  --mount=volume=ssl,target=/etc/kubernetes/ssl \
+  --uuid-file-save=/var/run/coreos/decrypt-tls-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting tls assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/ssl -name "*.pem.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :
+
+chown -R etcd:etcd /etc/kubernetes/ssl/etcd`

--- a/service/controller/v12/templates/cloudconfig/decrypt_tls_assets_service.go
+++ b/service/controller/v12/templates/cloudconfig/decrypt_tls_assets_service.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const DecryptTLSAssetsService = `
+[Unit]
+Description=Decrypt TLS certificates
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-tls-assets
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudconfig/encryption_config.go
+++ b/service/controller/v12/templates/cloudconfig/encryption_config.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const EncryptionConfig = `kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{.EncryptionKey}}
+    - identity: {}`

--- a/service/controller/v12/templates/cloudconfig/ephemeral_var_lib_docker_mount.go
+++ b/service/controller/v12/templates/cloudconfig/ephemeral_var_lib_docker_mount.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const EphemeralVarLibDockerMount = `
+[Unit]
+Description=Mount ephemeral volume on /var/lib/docker
+
+[Mount]
+What=/dev/disk/by-label/docker
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/controller/v12/templates/cloudconfig/format_etcd_volume.go
+++ b/service/controller/v12/templates/cloudconfig/format_etcd_volume.go
@@ -1,0 +1,26 @@
+package cloudconfig
+
+const FormatEtcdVolume = `
+[Unit]
+Description=Formats EBS volume for etcd
+Before=docker.service var-lib-etcd.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# Do not wipe the disk if it's already being used, so the etcd data is
+# persistent across reboots and updates.
+Environment=DEV=/dev/nvme2n1
+
+# line 1: For compatibility with m3.large that has xvdX disks.
+# line 2: Create filesystem if does not exist.
+# line 3: For compatibility with older clusters. Label existing filesystem with etcd label.
+ExecStart=/bin/bash -c "\
+[ -b /dev/xvdh ] && export DEV=/dev/xvdh ;\
+if ! blkid $DEV; then mkfs.ext4 -L etcd $DEV; fi ;\
+[ -L /dev/disk/by-label/etcd ] || e2label $DEV etcd"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudconfig/ingress_controller_config_map.go
+++ b/service/controller/v12/templates/cloudconfig/ingress_controller_config_map.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const IngressControllerConfigMap = `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  server-name-hash-bucket-size: "1024"
+  server-name-hash-max-size: "1024"
+  use-proxy-protocol: "true"
+`

--- a/service/controller/v12/templates/cloudconfig/instance_storage.go
+++ b/service/controller/v12/templates/cloudconfig/instance_storage.go
@@ -1,0 +1,12 @@
+package cloudconfig
+
+const InstanceStorage = `
+storage:
+  filesystems:
+    - name: ephemeral1
+      mount:
+        device: /dev/xvdb
+        format: xfs
+        create:
+          force: true
+`

--- a/service/controller/v12/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/v12/templates/cloudconfig/instance_storage_class.go
@@ -1,0 +1,23 @@
+package cloudconfig
+
+const InstanceStorageClass = `
+write_files:
+- path: /srv/default-storage-class.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: storage.k8s.io/v1beta1
+    kind: StorageClass
+    metadata:
+      name: gp2
+      annotations:
+        storageclass.beta.kubernetes.io/is-default-class: "true"
+      labels:
+        kubernetes.io/cluster-service: "true"
+        addonmanager.kubernetes.io/mode: EnsureExists
+    provisioner: kubernetes.io/aws-ebs
+    allowVolumeExpansion: true
+    parameters:
+      type: gp2
+      encrypted: "true"
+`

--- a/service/controller/v12/templates/cloudconfig/master_format_var_lib_docker_service.go
+++ b/service/controller/v12/templates/cloudconfig/master_format_var_lib_docker_service.go
@@ -1,0 +1,15 @@
+package cloudconfig
+
+const MasterFormatVarLibDockerService = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "([ -b "/dev/xvdc" ] && /usr/sbin/mkfs.xfs -f /dev/xvdc -L docker) || ([ -b "/dev/nvme1n1" ] && /usr/sbin/mkfs.xfs -f /dev/nvme1n1 -L docker)"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudconfig/mount_etcd_volume.go
+++ b/service/controller/v12/templates/cloudconfig/mount_etcd_volume.go
@@ -1,0 +1,17 @@
+package cloudconfig
+
+const MountEtcdVolume = `
+[Unit]
+Description=etcd3 data volume
+Requires=format-etcd-ebs.service
+After=format-etcd-ebs.service
+Before=etcd3.service
+
+[Mount]
+What=/dev/disk/by-label/etcd
+Where=/var/lib/etcd
+Type=ext4
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudconfig/persistent_var_lib_docker_mount.go
+++ b/service/controller/v12/templates/cloudconfig/persistent_var_lib_docker_mount.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const PersistentVarLibDockerMount = `
+[Unit]
+Description=Mount persistent volume on /var/lib/docker
+
+[Mount]
+What=/dev/disk/by-label/docker
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/controller/v12/templates/cloudconfig/small.go
+++ b/service/controller/v12/templates/cloudconfig/small.go
@@ -1,0 +1,44 @@
+package cloudconfig
+
+const Small = `#!/bin/bash
+
+# user-data in EC2 instances has a 16KB limit.
+# To circumvent this limit, we:
+#
+# 1. Upload the final cloudconfig to s3
+# 2. Generate a "small cloudconfig" whose only task is fetching the
+#    final cloudconfig from s3
+# 3. Configure the instance to be able to access the s3 URI where the
+#    final cloudconfig is stored
+# 4. Start the instance with the "small cloudconfig"
+#
+# This file is the "small cloudconfig" mentioned before. Here we simply fetch a
+# gzip+base64 file (the final cloudconfig) from AWS S3 and run coreos-cloudinit
+# with it as an argument.
+
+. /etc/environment
+USERDATA_FILE={{.MachineType}}
+
+# Wait for S3 bucket to be available.
+s3_http_uri="https://s3.{{.Region}}.amazonaws.com/{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE"
+retry=30
+
+until [ $(curl --output /dev/null --silent --head --fail -w "%{http_code}" $s3_http_uri) -eq "403" ]; do
+   retry=$(( retry - 1))
+   if [ $retry -le 0 ]; then
+     echo "timed out waiting for s3 bucket"
+     exit 1
+   fi
+
+   echo "waiting for $s3_http_uri to be available"
+   sleep 5
+done
+
+/usr/bin/rkt run \
+    --net=host \
+    --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf  \
+    --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
+    --trust-keys-from-https \
+    quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 -- aws s3 --region {{.Region}} cp s3://{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE /var/run/coreos/temp.txt
+base64 -d /var/run/coreos/temp.txt | gunzip > /var/run/coreos/$USERDATA_FILE
+exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE`

--- a/service/controller/v12/templates/cloudconfig/wait_docker_conf.go
+++ b/service/controller/v12/templates/cloudconfig/wait_docker_conf.go
@@ -1,0 +1,7 @@
+package cloudconfig
+
+const WaitDockerConf = `
+[Unit]
+After=var-lib-docker.mount
+Requires=var-lib-docker.mount
+`

--- a/service/controller/v12/templates/cloudconfig/worker_format_var_lib_docker_service.go
+++ b/service/controller/v12/templates/cloudconfig/worker_format_var_lib_docker_service.go
@@ -1,0 +1,15 @@
+package cloudconfig
+
+const WorkerFormatVarLibDockerService = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "([ -b "/dev/xvdh" ] && /usr/sbin/mkfs.xfs -f /dev/xvdh -L docker) || ([ -b "/dev/nvme1n1" ] && /usr/sbin/mkfs.xfs -f /dev/nvme1n1 -L docker)"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/cloudformation/guest/auto_scaling_group.go
+++ b/service/controller/v12/templates/cloudformation/guest/auto_scaling_group.go
@@ -1,0 +1,31 @@
+package guest
+
+const AutoScalingGroup = `{{define "autoscaling_group"}}
+  {{ .ASGType }}AutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      VPCZoneIdentifier:
+        - !Ref PrivateSubnet
+      AvailabilityZones: [{{ .WorkerAZ }}]
+      DesiredCapacity: {{ .ASGMinSize }}
+      MinSize: {{ .ASGMinSize }}
+      MaxSize: {{ .ASGMaxSize }}
+      LaunchConfigurationName: !Ref {{ .ASGType }}LaunchConfiguration
+      LoadBalancerNames:
+        - !Ref IngressLoadBalancer
+      HealthCheckGracePeriod: {{ .HealthCheckGracePeriod }}
+      MetricsCollection:
+        - Granularity: "1Minute"
+      Tags:
+        - Key: Name
+          Value: {{ .ClusterID }}-{{ .ASGType }}
+          PropagateAtLaunch: true
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        # minimum amount of instances that must always be running during a rolling update
+        MinInstancesInService: {{ .MinInstancesInService }}
+        # only do a rolling update of this amount of instances max
+        MaxBatchSize: {{ .MaxBatchSize }}
+        # after creating a new instance, pause operations on the ASG for this amount of time
+        PauseTime: {{ .RollingUpdatePauseTime }}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/iam_policies.go
+++ b/service/controller/v12/templates/cloudformation/guest/iam_policies.go
@@ -1,0 +1,122 @@
+package guest
+
+const IAMPolicies = `{{define "iam_policies"}}
+  MasterRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{.MasterRoleName}}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            Service: "ec2.amazonaws.com"
+          Action: "sts:AssumeRole"
+  MasterRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: {{.MasterPolicyName}}
+      Roles:
+        - Ref: "MasterRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "ec2:*"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "kms:Decrypt"
+            Resource: "{{.KMSKeyARN}}"
+
+          - Effect: "Allow"
+            Action:
+              - "s3:GetBucketLocation"
+              - "s3:ListAllMyBuckets"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "s3:ListBucket"
+            Resource: "arn:{{.RegionARN}}:s3:::{{.S3Bucket}}"
+
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "arn:{{.RegionARN}}:s3:::{{.S3Bucket}}/*"
+
+          - Effect: "Allow"
+            Action: "elasticloadbalancing:*"
+            Resource: "*"
+  MasterInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: {{.MasterProfileName}}
+      Roles:
+        - Ref: "MasterRole"
+
+  WorkerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{.WorkerRoleName}}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            Service: "ec2.amazonaws.com"
+          Action: "sts:AssumeRole"
+  WorkerRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: {{.WorkerPolicyName}}
+      Roles:
+        - Ref: "WorkerRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "ec2:Describe*"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "ec2:AttachVolume"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "ec2:DetachVolume"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "kms:Decrypt"
+            Resource: "{{.KMSKeyARN}}"
+
+          - Effect: "Allow"
+            Action:
+              - "s3:GetBucketLocation"
+              - "s3:ListAllMyBuckets"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "s3:ListBucket"
+            Resource: "arn:{{.RegionARN}}:s3:::{{.S3Bucket}}"
+
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "arn:{{.RegionARN}}:s3:::{{.S3Bucket}}/*"
+
+          - Effect: "Allow"
+            Action:
+              - "ecr:GetAuthorizationToken"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:DescribeRepositories"
+              - "ecr:ListImages"
+              - "ecr:BatchGetImage"
+            Resource: "*"
+  WorkerInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: {{.WorkerProfileName}}
+      Roles:
+        - Ref: "WorkerRole"
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/instance.go
+++ b/service/controller/v12/templates/cloudformation/guest/instance.go
@@ -1,0 +1,56 @@
+package guest
+
+const Instance = `{{define "instance"}}
+  {{ .Instance.Master.Instance.ResourceName }}:
+    Type: "AWS::EC2::Instance"
+    Description: Master instance
+    Properties:
+      AvailabilityZone: {{ .Instance.Master.AZ }}
+      IamInstanceProfile: !Ref MasterInstanceProfile
+      ImageId: {{ .Instance.Image.ID }}
+      InstanceType: {{ .Instance.Master.Instance.Type }}
+      Monitoring: {{ .Instance.Master.Instance.Monitoring }}
+      SecurityGroupIds:
+      - !Ref MasterSecurityGroup
+      SubnetId: !Ref PrivateSubnet
+      UserData: {{ .Instance.Master.CloudConfig }}
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Cluster.ID }}-master
+  DockerVolume:
+    Type: AWS::EC2::Volume
+    DependsOn:
+    - {{ .Instance.Master.Instance.ResourceName }}
+    Properties:
+      Encrypted: true
+      Size: 50
+      VolumeType: gp2
+      AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Master.DockerVolume.Name }}
+  EtcdVolume:
+    Type: AWS::EC2::Volume
+    DependsOn:
+    - {{ .Instance.Master.Instance.ResourceName }}
+    Properties:
+      Encrypted: true
+      Size: 100
+      VolumeType: gp2
+      AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
+      Tags:
+      - Key: Name
+        Value: {{ .Instance.Master.EtcdVolume.Name }}
+  {{ .Instance.Master.Instance.ResourceName }}DockerMountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref {{ .Instance.Master.Instance.ResourceName }}
+      VolumeId: !Ref DockerVolume
+      Device: /dev/xvdc
+  {{ .Instance.Master.Instance.ResourceName }}EtcdMountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref {{ .Instance.Master.Instance.ResourceName }}
+      VolumeId: !Ref EtcdVolume
+      Device: /dev/xvdh
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/internet_gateway.go
+++ b/service/controller/v12/templates/cloudformation/guest/internet_gateway.go
@@ -1,0 +1,30 @@
+package guest
+
+const InternetGateway = `{{define "internet_gateway"}}
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: {{ .ClusterID }}
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    DependsOn:
+      - PublicRouteTable
+      - PrivateRouteTable
+    Properties:
+      InternetGatewayId:
+        Ref: InternetGateway
+      VpcId: !Ref VPC
+
+  InternetGatewayRoute:
+    Type: AWS::EC2::Route
+    DependsOn:
+      - VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: InternetGateway
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/launch_configuration.go
+++ b/service/controller/v12/templates/cloudformation/guest/launch_configuration.go
@@ -1,0 +1,24 @@
+package guest
+
+const LaunchConfiguration = `{{define "launch_configuration"}}
+  {{ .ASGType }}LaunchConfiguration:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Description: {{ .ASGType }} launch configuration
+    Properties:
+      ImageId: {{ .WorkerImageID }}
+      SecurityGroups:
+      - !Ref WorkerSecurityGroup
+      InstanceType: {{ .WorkerInstanceType }}
+      InstanceMonitoring: {{ .WorkerInstanceMonitoring }}
+      IamInstanceProfile: !Ref WorkerInstanceProfile
+      BlockDeviceMappings:
+      {{ range .WorkerBlockDeviceMappings }}
+      - DeviceName: "{{ .DeviceName }}"
+        Ebs:
+          DeleteOnTermination: {{ .DeleteOnTermination }}
+          VolumeSize: {{ .VolumeSize }}
+          VolumeType: {{ .VolumeType }}
+      {{ end }}
+      AssociatePublicIpAddress: {{ .WorkerAssociatePublicIPAddress }}
+      UserData: {{ .WorkerSmallCloudConfig }}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/lifecycle_hooks.go
+++ b/service/controller/v12/templates/cloudformation/guest/lifecycle_hooks.go
@@ -1,0 +1,13 @@
+package guest
+
+const LifecycleHooks = `{{define "lifecycle_hooks"}}
+  {{ .LifecycleHooks.Worker.LifecycleHook.Name }}LifecycleHook:
+    Type: "AWS::AutoScaling::LifecycleHook"
+    Properties:
+      AutoScalingGroupName:
+        Ref: {{ .LifecycleHooks.Worker.ASG.Ref }}
+      DefaultResult: CONTINUE
+      HeartbeatTimeout: 3600
+      LifecycleHookName: {{ .LifecycleHooks.Worker.LifecycleHook.Name }}
+      LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING"
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/load_balancers.go
+++ b/service/controller/v12/templates/cloudformation/guest/load_balancers.go
@@ -1,0 +1,66 @@
+package guest
+
+const LoadBalancers = `{{define "load_balancers"}}
+  ApiLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: {{ .APIElbIdleTimoutSeconds }}
+      HealthCheck:
+        HealthyThreshold: {{ .ELBHealthCheckHealthyThreshold }}
+        Interval: {{ .ELBHealthCheckInterval }}
+        Target: {{ .APIElbHealthCheckTarget }}
+        Timeout: {{ .ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ .ELBHealthCheckUnhealthyThreshold }}
+      Instances:
+      - !Ref {{ .MasterInstanceResourceName }}
+      Listeners:
+      {{ range .APIElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ .APIElbName }}
+      Scheme: {{ .APIElbScheme }}
+      SecurityGroups:
+        - !Ref MasterSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet
+
+  IngressLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: {{ .IngressElbIdleTimoutSeconds }}
+      HealthCheck:
+        HealthyThreshold: {{ .ELBHealthCheckHealthyThreshold }}
+        Interval: {{ .ELBHealthCheckInterval }}
+        Target: {{ .IngressElbHealthCheckTarget }}
+        Timeout: {{ .ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ .ELBHealthCheckUnhealthyThreshold }}
+      Listeners:
+      {{ range .IngressElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ .IngressElbName }}
+      Policies:
+      - PolicyName: "EnableProxyProtocol"
+        PolicyType: "ProxyProtocolPolicyType"
+        Attributes:
+        - Name: "ProxyProtocol"
+          Value: "true"
+        InstancePorts:
+        {{ range .IngressElbPortsToOpen}}
+        - {{ .PortInstance }}
+        {{ end }}
+      Scheme: {{ .IngressElbScheme }}
+      SecurityGroups:
+        - !Ref IngressSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/main.go
+++ b/service/controller/v12/templates/cloudformation/guest/main.go
@@ -1,0 +1,20 @@
+package guest
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Guest CloudFormation stack.
+Resources:
+  {{template "vpc" .}}
+  {{template "iam_policies" .}}
+  {{template "security_groups" .}}
+  {{template "route_tables" .}}
+  {{template "subnets" .}}
+  {{template "internet_gateway" .}}
+  {{template "nat_gateway" .}}
+  {{template "instance" .}}
+  {{template "load_balancers" .}}
+  {{template "launch_configuration" .}}
+  {{template "lifecycle_hooks" .}}
+  {{template "autoscaling_group" .}}
+  {{template "recordsets" .}}
+{{template "outputs" .}}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v12/templates/cloudformation/guest/nat_gateway.go
@@ -1,0 +1,26 @@
+package guest
+
+const NatGateway = `{{define "nat_gateway"}}
+  NATGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+        - NATEIP
+        - AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags:
+        - Key: Name
+          Value: {{ .ClusterID }}
+  NATEIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+  NATRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: "NATGateway"
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/outputs.go
+++ b/service/controller/v12/templates/cloudformation/guest/outputs.go
@@ -1,0 +1,25 @@
+package guest
+
+const Outputs = `{{define "outputs"}}
+Outputs:
+  MasterImageID:
+    Value: {{ .Outputs.Master.ImageID }}
+  MasterInstanceResourceName:
+    Value: {{ .Outputs.Master.Instance.ResourceName }}
+  MasterInstanceType:
+    Value: {{ .Outputs.Master.Instance.Type }}
+  MasterCloudConfigVersion:
+    Value: {{ .Outputs.Master.CloudConfig.Version }}
+  {{ .Outputs.Worker.ASG.Key }}:
+    Value: !Ref {{ .Outputs.Worker.ASG.Ref }}
+  WorkerCount:
+    Value: {{ .Outputs.Worker.Count }}
+  WorkerImageID:
+    Value: {{ .Outputs.Worker.ImageID }}
+  WorkerInstanceType:
+    Value: {{ .Outputs.Worker.InstanceType }}
+  WorkerCloudConfigVersion:
+    Value: {{ .Outputs.Worker.CloudConfig.Version }}
+  VersionBundleVersion:
+    Value: {{ .Outputs.VersionBundle.Version }}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/record_sets.go
+++ b/service/controller/v12/templates/cloudformation/guest/record_sets.go
@@ -1,0 +1,44 @@
+package guest
+
+const RecordSets = `{{define "recordsets"}}
+{{ if .Route53Enabled }}
+  ApiRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt ApiLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApiLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: {{.APIELBDomain}}
+      HostedZoneId: {{.APIELBHostedZones}}
+      Type: A
+  EtcdRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: {{.EtcdELBDomain}}
+      HostedZoneId: {{.EtcdELBHostedZones}}
+      TTL: '900'
+      Type: CNAME
+      ResourceRecords:
+        - !GetAtt {{ .MasterInstanceResourceName }}.PrivateDnsName
+  IngressRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt IngressLoadBalancer.DNSName
+        HostedZoneId: !GetAtt IngressLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: {{.IngressELBDomain}}
+      HostedZoneId: {{.IngressELBHostedZones}}
+      Type: A
+  IngressWildcardRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '{{.IngressWildcardELBDomain}}'
+      HostedZoneId: {{.IngressELBHostedZones}}
+      TTL: '900'
+      Type: CNAME
+      ResourceRecords:
+        - {{.IngressELBDomain}}
+{{end}}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/route_tables.go
+++ b/service/controller/v12/templates/cloudformation/guest/route_tables.go
@@ -1,0 +1,27 @@
+package guest
+
+const RouteTables = `{{define "route_tables"}}
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: {{ .PublicRouteTableName }}
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: {{ .PrivateRouteTableName }}
+
+  VPCPeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: {{ .HostClusterCIDR }}
+      VpcPeeringConnectionId:
+        Ref: "VPCPeeringConnection"
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v12/templates/cloudformation/guest/security_groups.go
@@ -1,0 +1,108 @@
+package guest
+
+const SecurityGroups = `{{define "security_groups" }}
+  MasterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ .MasterSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range .MasterSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        CidrIp: {{ .SourceCIDR }}
+      {{ end }}
+      {{- if .APIWhitelistEnabled }}
+      -
+        IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: !Join [ "/", [ !Ref NATEIP, "32" ] ]
+      {{- end }}
+      Tags:
+        - Key: Name
+          Value:  {{ .MasterSecurityGroupName }}
+
+  WorkerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ .WorkerSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range .WorkerSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        {{ if .SourceCIDR }}
+        CidrIp: {{ .SourceCIDR }}
+        {{ else }}
+        SourceSecurityGroupId: !Ref {{ .SourceSecurityGroup }}
+        {{ end }}
+      {{ end }}
+      Tags:
+        - Key: Name
+          Value:  {{ .WorkerSecurityGroupName }}
+
+  IngressSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ .IngressSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range .IngressSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        CidrIp: {{ .SourceCIDR }}
+      {{ end }}
+      Tags:
+        - Key: Name
+          Value: {{ .IngressSecurityGroupName }}
+
+  # Allow all access between masters and workers for calico. This is done after
+  # the other rules to avoid circular dependencies.
+  MasterAllowCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: MasterSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+
+  MasterAllowWorkerCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: MasterSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+
+  WorkerAllowCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: WorkerSecurityGroup
+    Properties:
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+
+  WorkerAllowMasterCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: WorkerSecurityGroup
+    Properties:
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/subnets.go
+++ b/service/controller/v12/templates/cloudformation/guest/subnets.go
@@ -1,0 +1,37 @@
+package guest
+
+const Subnets = `{{define "subnets"}}
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: {{ .PublicSubnetAZ }}
+      CidrBlock: {{ .PublicSubnetCIDR }}
+      MapPublicIpOnLaunch: {{ .PublicSubnetMapPublicIPOnLaunch }}
+      Tags:
+      - Key: Name
+        Value: {{ .PublicSubnetName }}
+      VpcId: !Ref VPC
+
+  PublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet
+
+  PrivateSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: {{ .PrivateSubnetAZ }}
+      CidrBlock: {{ .PrivateSubnetCIDR }}
+      MapPublicIpOnLaunch: {{ .PrivateSubnetMapPublicIPOnLaunch }}
+      Tags:
+      - Key: Name
+        Value: {{ .PrivateSubnetName }}
+      VpcId: !Ref VPC
+
+  PrivateSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/guest/vpc.go
+++ b/service/controller/v12/templates/cloudformation/guest/vpc.go
@@ -1,0 +1,25 @@
+package guest
+
+const VPC = `{{define "vpc"}}
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ .CidrBlock }}
+      EnableDnsSupport: 'true'
+      EnableDnsHostnames: 'true'
+      Tags:
+      - Key: Name
+        Value: {{ .ClusterID }}
+      - Key: Installation
+        Value: {{ .InstallationName }}
+  VPCPeeringConnection:
+    Type: 'AWS::EC2::VPCPeeringConnection'
+    Properties:
+      VpcId: !Ref VPC
+      PeerVpcId: {{ .PeerVPCID }}
+      PeerOwnerId: '{{ .HostAccountID }}'
+      PeerRoleArn: {{ .PeerRoleArn }}
+      Tags:
+        - Key: Name
+          Value: {{ .ClusterID }}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/hostpost/main.go
+++ b/service/controller/v12/templates/cloudformation/hostpost/main.go
@@ -1,0 +1,7 @@
+package hostpost
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Host Post-Guest CloudFormation stack.
+Resources:
+  {{template "route_tables" .}}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/hostpost/route_tables.go
+++ b/service/controller/v12/templates/cloudformation/hostpost/route_tables.go
@@ -1,0 +1,12 @@
+package hostpost
+
+const RouteTables = `{{define "route_tables"}}
+  {{ range $i, $v := .RouteTables }}
+  PrivateRoute{{$i}}:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: {{$v.RouteTableID}}
+      DestinationCidrBlock: {{$v.CidrBlock}}
+      VpcPeeringConnectionId: {{$v.PeerConnectionID}}
+  {{end}}
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/hostpre/iam_roles.go
+++ b/service/controller/v12/templates/cloudformation/hostpre/iam_roles.go
@@ -1,0 +1,24 @@
+package hostpre
+
+const IAMRoles = `{{define "iam_roles"}}
+  PeerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: {{ .PeerAccessRoleName }}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Principal:
+              AWS: '{{ .GuestAccountID }}'
+            Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 'ec2:AcceptVpcPeeringConnection'
+                Resource: '*'
+{{end}}`

--- a/service/controller/v12/templates/cloudformation/hostpre/main.go
+++ b/service/controller/v12/templates/cloudformation/hostpre/main.go
@@ -1,0 +1,7 @@
+package hostpre
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Host Pre-Guest CloudFormation stack.
+Resources:
+  {{template "iam_roles" .}}
+{{end}}`

--- a/service/controller/v12/templates/templates.go
+++ b/service/controller/v12/templates/templates.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+func Render(templates []string, data interface{}) (string, error) {
+	var err error
+
+	main := template.New("main")
+	for _, t := range templates {
+		main, err = main.Parse(t)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	var b bytes.Buffer
+	err = main.ExecuteTemplate(&b, "main", data)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return b.String(), nil
+}

--- a/service/controller/v12/templates/templates_test.go
+++ b/service/controller/v12/templates/templates_test.go
@@ -1,0 +1,25 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/giantswarm/aws-operator/service/controller/v11/templates"
+)
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+	tpl := "some string <{{.Value}}> another string"
+	d := struct {
+		Value string
+	}{"myvalue"}
+	expected := "some string <myvalue> another string"
+
+	actual, err := templates.Render([]string{tpl}, d)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if actual != expected {
+		t.Errorf("unexpected output, want %q, got %q", expected, actual)
+	}
+}

--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -1,0 +1,100 @@
+package v11
+
+import (
+	"time"
+
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "aws-operator",
+				Description: "Changed logging buckets to be deleted on test environments.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Added support for advanced monitoring in EC2.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Added Kubernetes API server whitelisting for NAT gateway EIPs.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Added support for disabling Route53.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Added support for making pause container configurable.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Added support for not including S3 bucket tags.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Allow port 2379 from host cluster to add support for etcd backup.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "kubernetes",
+				Description: "Updated to 1.10.3.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "cloudconfig",
+				Description: "Removed kube-state-metrics so it can be managed by chart-operator.",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
+				Component:   "containerlinux",
+				Description: "Updated to 1745.4.0.",
+				Kind:        versionbundle.KindChanged,
+			},
+		},
+		Components: []versionbundle.Component{
+			{
+				Name:    "calico",
+				Version: "3.0.5",
+			},
+			{
+				Name:    "containerlinux",
+				Version: "1745.4.0",
+			},
+			{
+				Name:    "docker",
+				Version: "18.03.1",
+			},
+			{
+				Name:    "etcd",
+				Version: "3.3.3",
+			},
+			{
+				Name:    "coredns",
+				Version: "1.1.1",
+			},
+			{
+				Name:    "kubernetes",
+				Version: "1.10.3",
+			},
+			{
+				Name:    "nginx-ingress-controller",
+				Version: "0.12.0",
+			},
+		},
+		Dependencies: []versionbundle.Dependency{},
+		Deprecated:   false,
+		Name:         "aws-operator",
+		Time:         time.Date(2018, time.May, 28, 8, 24, 0, 0, time.UTC),
+		Version:      "3.1.1",
+		WIP:          false,
+	}
+}


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.