### PR TITLE
Add v12 to version bundles and drainer framework

### DIFF
--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -16,6 +16,7 @@ import (
 	awsclient "github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v10"
 	"github.com/giantswarm/aws-operator/service/controller/v11"
+	"github.com/giantswarm/aws-operator/service/controller/v12"
 	"github.com/giantswarm/aws-operator/service/controller/v7"
 	"github.com/giantswarm/aws-operator/service/controller/v8"
 	"github.com/giantswarm/aws-operator/service/controller/v9"
@@ -271,6 +272,24 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 			return nil, microerror.Mask(err)
 		}
 	}
+	
+	var v12ResourceSet *controller.ResourceSet
+	{
+		c := v12.DrainerResourceSetConfig{
+			G8sClient:     config.G8sClient,
+			HostAWSConfig: hostAWSConfig,
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+
+			GuestUpdateEnabled: config.GuestUpdateEnabled,
+			ProjectName:        config.ProjectName,
+		}
+
+		v12ResourceSet, err = v12.NewDrainerResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var resourceRouter *controller.ResourceRouter
 	{
@@ -284,6 +303,7 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 				v9patch1ResourceSet,
 				v10ResourceSet,
 				v11ResourceSet,
+				v12ResourceSet,
 			},
 		}
 

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -272,7 +272,7 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 			return nil, microerror.Mask(err)
 		}
 	}
-	
+
 	var v12ResourceSet *controller.ResourceSet
 	{
 		c := v12.DrainerResourceSetConfig{

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v1"
 	"github.com/giantswarm/aws-operator/service/controller/v10"
 	"github.com/giantswarm/aws-operator/service/controller/v11"
+	"github.com/giantswarm/aws-operator/service/controller/v12"
 	"github.com/giantswarm/aws-operator/service/controller/v2"
 	"github.com/giantswarm/aws-operator/service/controller/v3"
 	"github.com/giantswarm/aws-operator/service/controller/v4"
@@ -34,6 +35,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 	versionBundles = append(versionBundles, v9patch1.VersionBundle())
 	versionBundles = append(versionBundles, v10.VersionBundle())
 	versionBundles = append(versionBundles, v11.VersionBundle())
+	versionBundles = append(versionBundles, v12.VersionBundle())
 
 	return versionBundles
 }


### PR DESCRIPTION
This step got missed when I wired up v12.