### PR TITLE
Increase Docker EBS volume from 50 to 100 GB

### DIFF
--- a/service/controller/v12/adapter/spec.go
+++ b/service/controller/v12/adapter/spec.go
@@ -25,7 +25,7 @@ const (
 	// defaultEBSVolumeMountPoint is the path for mounting the EBS volume.
 	defaultEBSVolumeMountPoint = "/dev/xvdh"
 	// defaultEBSVolumeSize is expressed in GB.
-	defaultEBSVolumeSize = 50
+	defaultEBSVolumeSize = 100
 	// defaultEBSVolumeType is the EBS volume type.
 	defaultEBSVolumeType = "gp2"
 	// rollingUpdatePauseTime is how long to pause ASG operations after creating

--- a/service/controller/v12/templates/cloudformation/guest/instance.go
+++ b/service/controller/v12/templates/cloudformation/guest/instance.go
@@ -23,7 +23,7 @@ const Instance = `{{define "instance"}}
     - {{ .Instance.Master.Instance.ResourceName }}
     Properties:
       Encrypted: true
-      Size: 50
+      Size: 100
       VolumeType: gp2
       AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
       Tags:

--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Add your changes here.",
+				Description: "Increased Docker EBS volume size from 50 to 100 GB.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
Towards giantswarm/giantswarm#3118

Increases the volume size to resolve the PM above. As in some installations we were filling the 50 GB volume.