### PR TITLE
Wire up v9patch2 resource

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -522,7 +522,7 @@ func newClusterResourceRouter(config ClusterConfig) (*controller.ResourceRouter,
 			return nil, microerror.Mask(err)
 		}
 	}
-	
+
 	var resourceSetV9Patch2 *controller.ResourceSet
 	{
 		c := v9patch2.ClusterResourceSetConfig{

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v8"
 	"github.com/giantswarm/aws-operator/service/controller/v9"
 	"github.com/giantswarm/aws-operator/service/controller/v9patch1"
+	"github.com/giantswarm/aws-operator/service/controller/v9patch2"
 )
 
 type DrainerConfig struct {
@@ -237,6 +238,24 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 			return nil, microerror.Mask(err)
 		}
 	}
+	
+	var v9patch2ResourceSet *controller.ResourceSet
+	{
+		c := v9patch2.DrainerResourceSetConfig{
+			AWS:       awsClients,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+
+			GuestUpdateEnabled: config.GuestUpdateEnabled,
+			ProjectName:        config.ProjectName,
+		}
+
+		v9patch2ResourceSet, err = v9patch2.NewDrainerResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 
 	var v10ResourceSet *controller.ResourceSet
 	{
@@ -301,6 +320,7 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 				v8ResourceSet,
 				v9ResourceSet,
 				v9patch1ResourceSet,
+				v9patch2ResourceSet,
 				v10ResourceSet,
 				v11ResourceSet,
 				v12ResourceSet,

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -238,7 +238,7 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 			return nil, microerror.Mask(err)
 		}
 	}
-	
+
 	var v9patch2ResourceSet *controller.ResourceSet
 	{
 		c := v9patch2.DrainerResourceSetConfig{

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -256,7 +256,6 @@ func newDrainerResourceRouter(config DrainerConfig) (*controller.ResourceRouter,
 		}
 	}
 
-
 	var v10ResourceSet *controller.ResourceSet
 	{
 		c := v10.DrainerResourceSetConfig{

--- a/service/controller/v9patch2/version_bundle.go
+++ b/service/controller/v9patch2/version_bundle.go
@@ -10,99 +10,9 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cloudconfig",
-				Description: "Enabled volume resizing feature.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Masked systemd-networkd-wait-online unit.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Fixed unencrypted encryption key injection via Cloud Config S3 uploads.",
-				Kind:        versionbundle.KindSecurity,
-			},
-			{
 				Component:   "aws-operator",
-				Description: "Fixed idempotency of format-var-lib-docker service.",
+				Description: "Add your changes here.",
 				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "aws-operator",
-				Description: "Detach EBS volumes before deletion when deleting clusters.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "aws-operator",
-				Description: "Added S3 access logs for cluster buckets.",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
-				Component:   "aws-operator",
-				Description: "Opened port 4194 for cAdvisor scraping from host cluster.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "aws-operator",
-				Description: "Fixed updating master nodes on all kinds of cluster updates.",
-				Kind:        versionbundle.KindFixed,
-			},
-			{
-				Component:   "aws-operator",
-				Description: "Added support for k8s API whitelisting.",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
-				Component:   "containerlinux",
-				Description: "Updated to 1688.5.3.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated kube-state-metrics to version 1.3.1.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Changed kubelet bind mount mode from shared to rshared.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Disabled etcd3-defragmentation service in favor systemd timer.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Added /lib/modules mount for kubelet.",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated CoreDNS to 1.1.1.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated Calico to 3.0.5.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated Etcd to 3.3.3.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Removed docker flag --disable-legacy-registry.",
-				Kind:        versionbundle.KindRemoved,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Removed calico-ipip-pinger.",
-				Kind:        versionbundle.KindRemoved,
 			},
 		},
 		Components: []versionbundle.Component{
@@ -139,7 +49,7 @@ func VersionBundle() versionbundle.Bundle {
 		Deprecated:   false,
 		Name:         "aws-operator",
 		Time:         time.Date(2018, time.May, 8, 12, 00, 0, 0, time.UTC),
-		Version:      "3.0.3",
-		WIP:          false,
+		Version:      "3.0.4",
+		WIP:          true,
 	}
 }

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v8"
 	"github.com/giantswarm/aws-operator/service/controller/v9"
 	"github.com/giantswarm/aws-operator/service/controller/v9patch1"
+	"github.com/giantswarm/aws-operator/service/controller/v9patch2"
 )
 
 // NewVersionBundles returns the array of version bundles defined for the
@@ -33,6 +34,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 	versionBundles = append(versionBundles, v8.VersionBundle())
 	versionBundles = append(versionBundles, v9.VersionBundle())
 	versionBundles = append(versionBundles, v9patch1.VersionBundle())
+	versionBundles = append(versionBundles, v9patch2.VersionBundle())
 	versionBundles = append(versionBundles, v10.VersionBundle())
 	versionBundles = append(versionBundles, v11.VersionBundle())
 	versionBundles = append(versionBundles, v12.VersionBundle())


### PR DESCRIPTION
Wires up the resource so it can be used for postmortems that need K8s 1.9 fixes.