### PR TITLE
Increase Docker volume to 100 GB and update Container Linux

### DIFF
--- a/service/controller/v9patch2/adapter/spec.go
+++ b/service/controller/v9patch2/adapter/spec.go
@@ -24,7 +24,7 @@ const (
 	// defaultEBSVolumeMountPoint is the path for mounting the EBS volume.
 	defaultEBSVolumeMountPoint = "/dev/xvdh"
 	// defaultEBSVolumeSize is expressed in GB.
-	defaultEBSVolumeSize = 50
+	defaultEBSVolumeSize = 100
 	// defaultEBSVolumeType is the EBS volume type.
 	defaultEBSVolumeType = "gp2"
 	// rollingUpdatePauseTime is how long to pause ASG operations after creating

--- a/service/controller/v9patch2/key/key.go
+++ b/service/controller/v9patch2/key/key.go
@@ -384,13 +384,13 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 		service/controller/v9patch2/resource/cloudformation/adapter/adapter_test.go
 		service/controller/v9patch2/resource/cloudformation/main_stack_test.go
 
-		Current Release: CoreOS Container Linux stable 1576.5.0 (HVM)
+		Current Release: CoreOS Container Linux stable 1745.4.0 (HVM)
 	*/
 	imageIDs := map[string]string{
-		"ap-southeast-1": "ami-41461c3d",
-		"eu-central-1":   "ami-604e118b",
-		"eu-west-1":      "ami-34237c4d",
-		"us-west-2":      "ami-b41377cc",
+		"ap-southeast-1": "ami-73b28f0f",
+		"eu-central-1":   "ami-32042fd9",
+		"eu-west-1":      "ami-82645dfb",
+		"us-west-2":      "ami-574f362f",
 	}
 
 	imageID, ok := imageIDs[region]

--- a/service/controller/v9patch2/key/key_test.go
+++ b/service/controller/v9patch2/key/key_test.go
@@ -1008,7 +1008,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-604e118b",
+			expectedImageID: "ami-32042fd9",
 		},
 		{
 			description: "different region",
@@ -1020,7 +1020,7 @@ func Test_ImageID(t *testing.T) {
 				},
 			},
 			errorMatcher:    nil,
-			expectedImageID: "ami-34237c4d",
+			expectedImageID: "ami-82645dfb",
 		},
 		{
 			description: "invalid region",

--- a/service/controller/v9patch2/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v9patch2/resource/cloudformation/main_stack_test.go
@@ -300,7 +300,7 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	}
 
 	// image ids should be fixed despite the values in the custom object
-	if !strings.Contains(body, "ImageId: ami-604e118b") {
+	if !strings.Contains(body, "ImageId: ami-32042fd9") {
 		fmt.Println(body)
 		t.Fatal("Fixed image ID not found")
 	}

--- a/service/controller/v9patch2/templates/cloudformation/guest/instance.go
+++ b/service/controller/v9patch2/templates/cloudformation/guest/instance.go
@@ -22,7 +22,7 @@ const Instance = `{{define "instance"}}
     - {{ .Instance.Master.Instance.ResourceName }}
     Properties:
       Encrypted: true
-      Size: 50
+      Size: 100
       VolumeType: gp2
       AvailabilityZone: !GetAtt {{ .Instance.Master.Instance.ResourceName }}.AvailabilityZone
       Tags:

--- a/service/controller/v9patch2/version_bundle.go
+++ b/service/controller/v9patch2/version_bundle.go
@@ -14,6 +14,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Increased Docker EBS volume size from 50 to 100 GB.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "containerlinux",
+				Description: "Updated to 1745.4.0.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
@@ -22,11 +27,11 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "1688.5.3",
+				Version: "1745.4.0",
 			},
 			{
 				Name:    "docker",
-				Version: "17.12.1",
+				Version: "18.03.1",
 			},
 			{
 				Name:    "etcd",

--- a/service/controller/v9patch2/version_bundle.go
+++ b/service/controller/v9patch2/version_bundle.go
@@ -11,7 +11,7 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Add your changes here.",
+				Description: "Increased Docker EBS volume size from 50 to 100 GB.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
Towards giantswarm/giantswarm#3159 and  giantswarm/giantswarm#3118

Fixes postmortems on K8s 1.9.