### PR TITLE
Increase ASG pause time from 5 to 15 mins

### DIFF
--- a/service/controller/v9patch2/adapter/spec.go
+++ b/service/controller/v9patch2/adapter/spec.go
@@ -29,7 +29,7 @@ const (
 	defaultEBSVolumeType = "gp2"
 	// rollingUpdatePauseTime is how long to pause ASG operations after creating
 	// new instances. This allows time for new nodes to join the cluster.
-	rollingUpdatePauseTime = "PT5M"
+	rollingUpdatePauseTime = "PT15M"
 
 	// Subnet keys
 	subnetDescription = "description"

--- a/service/controller/v9patch2/version_bundle.go
+++ b/service/controller/v9patch2/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Updated to 1745.4.0.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Increased ASG rolling update pause time to 15 minutes.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards giantswarm/giantswarm#3118

Before rolling out 3.4.4 -> v9patch2 we want to increase the rolling update pause time to 15 mins. Previous value of 5 mins caused some disruption.

Will update v12 if this increase resolves the problem.