### PR TITLE
Vendor update e2e-harness and versionbundle

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -245,7 +245,7 @@
     "pkg/framework",
     "pkg/harness"
   ]
-  revision = "e48967bc28cef0ecc56bf4c7387400987d1de694"
+  revision = "eccb060d743da4f0b3086feb2b04267432a0648b"
 
 [[projects]]
   branch = "master"
@@ -375,7 +375,7 @@
   branch = "master"
   name = "github.com/giantswarm/versionbundle"
   packages = ["."]
-  revision = "da2469c864842ff01892ad70b1f99b247b0a2aef"
+  revision = "5a861dc7cd1cc6c24816af3aadadb85ea1b372ff"
 
 [[projects]]
   name = "github.com/go-ini/ini"

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/framework/version_bundle.go
@@ -18,12 +18,6 @@ const (
 	defaultRepo  = "installations"
 )
 
-type SortReleasesByTime []versionbundle.IndexRelease
-
-func (b SortReleasesByTime) Len() int           { return len(b) }
-func (b SortReleasesByTime) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b SortReleasesByTime) Less(i, j int) bool { return b[i].Date.UnixNano() < b[j].Date.UnixNano() }
-
 type VBVParams struct {
 	Component string
 	Provider  string
@@ -102,7 +96,7 @@ func extractReleaseVersion(content, vType, component string) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	sortedReleases := SortReleasesByTime(indexReleases)
+	sortedReleases := versionbundle.SortIndexReleasesByVersion(indexReleases)
 	sort.Sort(sort.Reverse(sortedReleases))
 	for _, ir := range sortedReleases {
 		if vType == "wip" && !ir.Active || vType == "current" && ir.Active {

--- a/vendor/github.com/giantswarm/versionbundle/components_sort.go
+++ b/vendor/github.com/giantswarm/versionbundle/components_sort.go
@@ -1,0 +1,7 @@
+package versionbundle
+
+type SortComponentsByName []Component
+
+func (c SortComponentsByName) Len() int           { return len(c) }
+func (c SortComponentsByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c SortComponentsByName) Less(i, j int) bool { return c[i].Name < c[j].Name }

--- a/vendor/github.com/giantswarm/versionbundle/index_releases_sort.go
+++ b/vendor/github.com/giantswarm/versionbundle/index_releases_sort.go
@@ -1,0 +1,15 @@
+package versionbundle
+
+import (
+	"github.com/coreos/go-semver/semver"
+)
+
+type SortIndexReleasesByVersion []IndexRelease
+
+func (r SortIndexReleasesByVersion) Len() int      { return len(r) }
+func (r SortIndexReleasesByVersion) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r SortIndexReleasesByVersion) Less(i, j int) bool {
+	verA := semver.New(r[i].Version)
+	verB := semver.New(r[j].Version)
+	return verA.LessThan(*verB)
+}

--- a/vendor/github.com/giantswarm/versionbundle/release.go
+++ b/vendor/github.com/giantswarm/versionbundle/release.go
@@ -114,8 +114,15 @@ func aggregateReleaseComponents(bundles []Bundle) ([]Component, error) {
 	var components []Component
 
 	for _, b := range bundles {
+		bundleAsComponent := Component{
+			Name:    b.Name,
+			Version: b.Version,
+		}
+		components = append(components, bundleAsComponent)
 		components = append(components, b.Components...)
 	}
+
+	sort.Sort(SortComponentsByName(components))
 
 	return components, nil
 }


### PR DESCRIPTION
Aims to fix how versions are determined in e2e tests after recent index release changes.