### PR TITLE
Use Kubernetes 1.10.2 for latest release

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -281,7 +281,7 @@
     "v_3_3_1",
     "v_3_3_2"
   ]
-  revision = "119402e11843b12ffcc2c5f88997f1ec3849e14b"
+  revision = "f43d2065fcb7b9ffc5947a467c9175388cfea6e1"
 
 [[projects]]
   branch = "master"

--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -22,6 +22,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Removed node-exporter so it can be managed by chart-operator.",
 				Kind:        versionbundle.KindRemoved,
 			},
+			{
+				Component:   "kubernetes",
+				Description: "Updated to 1.10.2 due to regression in 1.10.3 with configmaps.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
@@ -46,7 +51,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.10.3",
+				Version: "1.10.2",
 			},
 			{
 				Name:    "nginx-ingress-controller",

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_2/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_2/master_template.go
@@ -763,7 +763,7 @@ write_files:
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy
-              image: quay.io/giantswarm/hyperkube:v1.10.3
+              image: quay.io/giantswarm/hyperkube:v1.10.2
               command:
               - /hyperkube
               - proxy
@@ -1528,7 +1528,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-api-server
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         env:
         - name: HOST_IP
           valueFrom:
@@ -1650,7 +1650,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-controller-manager
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         command:
         - /hyperkube
         - controller-manager
@@ -1723,7 +1723,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-scheduler
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         command:
         - /hyperkube
         - scheduler
@@ -2011,7 +2011,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_2/worker_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_2/worker_template.go
@@ -248,7 +248,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/3332

Updates K8s to `1.10.2` in `v12` which will then be made the active release. `v13` is coming! 😱 ☘️ 