### PR TITLE
v12: use constant LB idle timeouts

### DIFF
--- a/service/controller/v12/adapter/load_balancers.go
+++ b/service/controller/v12/adapter/load_balancers.go
@@ -23,7 +23,6 @@ const (
 
 type loadBalancersAdapter struct {
 	APIElbHealthCheckTarget          string
-	APIElbIdleTimoutSeconds          int
 	APIElbName                       string
 	APIElbPortsToOpen                portPairs
 	APIElbScheme                     string
@@ -33,7 +32,6 @@ type loadBalancersAdapter struct {
 	ELBHealthCheckTimeout            int
 	ELBHealthCheckUnhealthyThreshold int
 	IngressElbHealthCheckTarget      string
-	IngressElbIdleTimoutSeconds      int
 	IngressElbName                   string
 	IngressElbPortsToOpen            portPairs
 	IngressElbScheme                 string
@@ -58,7 +56,6 @@ func (lb *loadBalancersAdapter) getLoadBalancers(cfg Config) error {
 	}
 
 	lb.APIElbHealthCheckTarget = heathCheckTarget(cfg.CustomObject.Spec.Cluster.Kubernetes.API.SecurePort)
-	lb.APIElbIdleTimoutSeconds = cfg.CustomObject.Spec.AWS.API.ELB.IdleTimeoutSeconds
 	lb.APIElbName = apiElbName
 	lb.APIElbPortsToOpen = portPairs{
 		{
@@ -75,7 +72,6 @@ func (lb *loadBalancersAdapter) getLoadBalancers(cfg Config) error {
 	}
 
 	lb.IngressElbHealthCheckTarget = heathCheckTarget(key.IngressControllerSecurePort(cfg.CustomObject))
-	lb.IngressElbIdleTimoutSeconds = cfg.CustomObject.Spec.AWS.Ingress.ELB.IdleTimeoutSeconds
 	lb.IngressElbName = ingressElbName
 	lb.IngressElbPortsToOpen = portPairs{
 		{

--- a/service/controller/v12/adapter/load_balancers_test.go
+++ b/service/controller/v12/adapter/load_balancers_test.go
@@ -14,7 +14,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 		description                              string
 		customObject                             v1alpha1.AWSConfig
 		errorMatcher                             func(error) bool
-		expectedAPIElbIdleTimoutSeconds          int
 		expectedAPIElbName                       string
 		expectedAPIElbPortsToOpen                portPairs
 		expectedAPIElbScheme                     string
@@ -25,7 +24,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 		expectedELBHealthCheckInterval           int
 		expectedELBHealthCheckTimeout            int
 		expectedELBHealthCheckUnhealthyThreshold int
-		expectedIngressElbIdleTimoutSeconds      int
 		expectedIngressElbName                   string
 		expectedIngressElbPortsToOpen            portPairs
 		expectedIngressElbScheme                 string
@@ -54,23 +52,12 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 						},
 					},
 					AWS: v1alpha1.AWSConfigSpecAWS{
-						API: v1alpha1.AWSConfigSpecAWSAPI{
-							ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
-								IdleTimeoutSeconds: 3600,
-							},
-						},
 						AZ: "eu-central-1a",
-						Ingress: v1alpha1.AWSConfigSpecAWSIngress{
-							ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
-								IdleTimeoutSeconds: 60,
-							},
-						},
 					},
 				},
 			},
-			errorMatcher:                    nil,
-			expectedAPIElbIdleTimoutSeconds: 3600,
-			expectedAPIElbName:              "test-cluster-api",
+			errorMatcher:       nil,
+			expectedAPIElbName: "test-cluster-api",
 			expectedAPIElbPortsToOpen: portPairs{
 				{
 					PortELB:      443,
@@ -83,7 +70,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 			expectedELBHealthCheckInterval:           5,
 			expectedELBHealthCheckTimeout:            3,
 			expectedELBHealthCheckUnhealthyThreshold: 2,
-			expectedIngressElbIdleTimoutSeconds:      60,
 			expectedIngressElbName:                   "test-cluster-ingress",
 			expectedIngressElbPortsToOpen: portPairs{
 				{
@@ -122,10 +108,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 				t.Error("expected", true, "got", false)
 			}
 
-			if tc.expectedAPIElbIdleTimoutSeconds != a.APIElbIdleTimoutSeconds {
-				t.Errorf("expected API ELB Idle Timeout Seconds, got %q, want %q", a.APIElbIdleTimoutSeconds, tc.expectedAPIElbIdleTimoutSeconds)
-			}
-
 			if tc.expectedAPIElbName != a.APIElbName {
 				t.Errorf("expected API ELB Name, got %q, want %q", a.APIElbName, tc.expectedAPIElbName)
 			}
@@ -152,10 +134,6 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 
 			if tc.expectedELBHealthCheckUnhealthyThreshold != a.ELBHealthCheckUnhealthyThreshold {
 				t.Errorf("expected ELB health check unhealthy threshold, got %q, want %q", a.ELBHealthCheckUnhealthyThreshold, tc.expectedELBHealthCheckUnhealthyThreshold)
-			}
-
-			if tc.expectedIngressElbIdleTimoutSeconds != a.IngressElbIdleTimoutSeconds {
-				t.Errorf("expected Ingress ELB Idle Timeout Seconds, got %q, want %q", a.IngressElbIdleTimoutSeconds, tc.expectedIngressElbIdleTimoutSeconds)
 			}
 
 			if tc.expectedIngressElbName != a.IngressElbName {

--- a/service/controller/v12/templates/cloudformation/guest/load_balancers.go
+++ b/service/controller/v12/templates/cloudformation/guest/load_balancers.go
@@ -5,7 +5,7 @@ const LoadBalancers = `{{define "load_balancers"}}
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:
-        IdleTimeout: {{ .APIElbIdleTimoutSeconds }}
+        IdleTimeout: 1200
       HealthCheck:
         HealthyThreshold: {{ .ELBHealthCheckHealthyThreshold }}
         Interval: {{ .ELBHealthCheckInterval }}
@@ -33,7 +33,7 @@ const LoadBalancers = `{{define "load_balancers"}}
     DependsOn: VPCGatewayAttachment
     Properties:
       ConnectionSettings:
-        IdleTimeout: {{ .IngressElbIdleTimoutSeconds }}
+        IdleTimeout: 60
       HealthCheck:
         HealthyThreshold: {{ .ELBHealthCheckHealthyThreshold }}
         Interval: {{ .ELBHealthCheckInterval }}

--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -14,6 +14,11 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "aws-operator",
+				Description: "Use global LB idle timeout settings, instead of CR configured ones.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "aws-operator",
 				Description: "Increased ASG rolling update pause time to 15 minutes.",
 				Kind:        versionbundle.KindChanged,
 			},

--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -14,7 +14,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "aws-operator",
-				Description: "Use global LB idle timeout settings, instead of CR configured ones.",
+				Description: "Use global ELB idle timeout settings, instead of CR configured ones.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3314
Towards https://github.com/giantswarm/giantswarm/issues/2383

@rossf7 I'm fine if it doesn't land in v12. I prefer that, but if not possible I'll migrate to v13.