### PR TITLE
Add MIT licence for ebs-automatic-nvme-mapping

### DIFF
--- a/third_party/licenses/LICENSE.ebs-automatic-nvme-mapping.txt
+++ b/third_party/licenses/LICENSE.ebs-automatic-nvme-mapping.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Omachonu Ogali
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
We added [scripts for NVMe](https://github.com/giantswarm/aws-operator/pull/999) mapping that are published with MIT licence [here](https://github.com/oogali/ebs-automatic-nvme-mapping). This PR adds new directory for third party licenses and puts MIT license source repo.

NOTE: This also was requested by author [here](https://github.com/giantswarm/aws-operator/pull/999#issuecomment-396402114)