### PR TITLE
Fix key not found detection

### DIFF
--- a/service/controller/v13/encrypter/kms/error.go
+++ b/service/controller/v13/encrypter/kms/error.go
@@ -21,12 +21,13 @@ func IsKeyNotFound(err error) bool {
 		return false
 	}
 
-	aerr, ok := err.(awserr.Error)
+	c := microerror.Cause(err)
+
+	aerr, ok := c.(awserr.Error)
 	if ok && aerr.Code() == kms.ErrCodeNotFoundException {
 		return true
 	}
 
-	c := microerror.Cause(err)
 	if c == keyNotFoundError {
 		return true
 	}

--- a/service/controller/v13/encrypter/kms/error.go
+++ b/service/controller/v13/encrypter/kms/error.go
@@ -13,9 +13,21 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var keyNotFoundError = microerror.New("key not found")
+
+// IsKeyNotFound asserts keyNotFoundError.
 func IsKeyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	aerr, ok := err.(awserr.Error)
 	if ok && aerr.Code() == kms.ErrCodeNotFoundException {
+		return true
+	}
+
+	c := microerror.Cause(err)
+	if c == keyNotFoundError {
 		return true
 	}
 

--- a/service/controller/v13/encrypter/kms/kms.go
+++ b/service/controller/v13/encrypter/kms/kms.go
@@ -202,6 +202,9 @@ func (k *Encrypter) describeKey(ctx context.Context, customObject v1alpha1.AWSCo
 	}
 
 	output, err := sc.AWSClient.KMS.DescribeKey(input)
+	if IsKeyNotFound(err) {
+		return nil, microerror.Mask(keyNotFoundError)
+	}
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/v13/encrypter/kms/kms.go
+++ b/service/controller/v13/encrypter/kms/kms.go
@@ -203,7 +203,7 @@ func (k *Encrypter) describeKey(ctx context.Context, customObject v1alpha1.AWSCo
 
 	output, err := sc.AWSClient.KMS.DescribeKey(input)
 	if IsKeyNotFound(err) {
-		return nil, microerror.Mask(keyNotFoundError)
+		return nil, microerror.Maskf(keyNotFoundError, "could not find key with alias %q: %#v", err)
 	}
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/v13/encrypter/kms/kms.go
+++ b/service/controller/v13/encrypter/kms/kms.go
@@ -203,9 +203,8 @@ func (k *Encrypter) describeKey(ctx context.Context, customObject v1alpha1.AWSCo
 
 	output, err := sc.AWSClient.KMS.DescribeKey(input)
 	if IsKeyNotFound(err) {
-		return nil, microerror.Maskf(keyNotFoundError, "could not find key with alias %q: %#v", err)
-	}
-	if err != nil {
+		return nil, microerror.Mask(keyNotFoundError)
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 


### PR DESCRIPTION
Masked aws API error is not being properly detected and we are getting:
```
2018/06/13 15:21:14 {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:71","event":"delete","function":"GetCurrentState","level":"warning","message":"retrying due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/ci-wip-45b63-5e958","resource":"kmskeyv13","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:64: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/resource/encryptionkey/current.go:19: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/encrypter/kms/kms.go:130: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/encrypter/kms/kms.go:206: } {NotFoundException: Alias arn:aws:kms:eu-central-1:270935918670:alias/ci-wip-45b63-5e958 is not found.\n\tstatus code: 400, request id: 69299e76-6f1d-11e8-8bbe-31a93f20fb76}]","time":"2018-06-13T15:21:14.479649+00:00","underlyingResource":"kmskeyv13"}
```