### PR TITLE
Add missing check for encryption key

### DIFF
--- a/service/controller/v13/resource/s3object/desired.go
+++ b/service/controller/v13/resource/s3object/desired.go
@@ -29,6 +29,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	clusterID := key.ClusterID(customObject)
 
+	_, err = r.encrypter.EncryptionKey(ctx, customObject)
 	if IsKeyNotFound(err) {
 		// we can get here during deletion, if the key is already deleted we can safely exit.
 		return output, nil

--- a/service/controller/v13/resource/s3object/desired.go
+++ b/service/controller/v13/resource/s3object/desired.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/service/controller/v13/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/controller/v13/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v13/encrypter/kms"
 	"github.com/giantswarm/aws-operator/service/controller/v13/key"
 )
 
@@ -30,7 +31,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	clusterID := key.ClusterID(customObject)
 
 	_, err = r.encrypter.EncryptionKey(ctx, customObject)
-	if IsKeyNotFound(err) {
+	if kms.IsKeyNotFound(err) {
 		// we can get here during deletion, if the key is already deleted we can safely exit.
 		return output, nil
 	}


### PR DESCRIPTION
We are getting this errors on e2e during cluster deletion:
```
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:206","event":"delete","level":"error","message":"stop reconciliation due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/ci-wip-80cba-5e958","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:393: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:78: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:91: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:226: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:78: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:102: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:89: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/resource/s3object/desired.go:57: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/cloudconfig/master_template.go:22: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/encrypter/kms/kms.go:151: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v13/encrypter/kms/kms.go:206: } {key not found}]","time":"2018-06-14T07:40:11.01476+00:00"}
```
The encryption key retrieval was missed during the migration of resource `kmskey` -> `encryptionkey`.