### PR TITLE
handle bound_iam_role_arn as string alice

### DIFF
--- a/service/controller/v13/encrypter/vault/spec.go
+++ b/service/controller/v13/encrypter/vault/spec.go
@@ -64,11 +64,5 @@ type AWSAuthRoleResponse struct {
 }
 
 type AWSAuthRole struct {
-	AuthType                 string   `json:"auth_type"`
-	BoundRegion              string   `json:"bound_region"`
-	BoundIAMRoleARN          string   `json:"bound_iam_role_arn"`
-	Policies                 []string `json:"policies"`
-	MaxTTL                   int      `json:"max_ttl"`
-	DisallowReauthentication bool     `json:"disallow_reauthentication"`
-	AllowInstanceMigration   bool     `json:"allow_instance_migration"`
+	BoundIAMRoleARN []string `json:"bound_iam_role_arn"`
 }


### PR DESCRIPTION
With the recent update of Vault we should handle `bound_iam_role_arn` as a string slice. Also we only manage this field now, no need to unmarshal/marshal the rest of them if we only change the IAM roles.