### PR TITLE
increase wait time for Vault connection available

### DIFF
--- a/service/controller/v13/templates/cloudconfig/decrypt_keys_assets_script.go
+++ b/service/controller/v13/templates/cloudconfig/decrypt_keys_assets_script.go
@@ -8,7 +8,7 @@ nonce_path=/var/nonce
 wait_for_vault_elb(){
     local service_name="$1"
     local state="${2:-active}"
-    for i in $(seq 20); do
+    for i in $(seq 80); do
         if curl -k -s -o /dev/null -w "%{http_code}" --max-time 3 {{ .VaultAddress }}/v1/sys/health | grep -q "200"; then
             return 0
         fi

--- a/service/controller/v13/templates/cloudconfig/decrypt_tls_assets_script.go
+++ b/service/controller/v13/templates/cloudconfig/decrypt_tls_assets_script.go
@@ -8,7 +8,7 @@ nonce_path=/var/nonce
 wait_for_vault_elb(){
     local service_name="$1"
     local state="${2:-active}"
-    for i in $(seq 20); do
+    for i in $(seq 80); do
         if curl -k -s -o /dev/null -w "%{http_code}" --max-time 3 {{ .VaultAddress }}/v1/sys/health | grep -q "200"; then
             return 0
         fi


### PR DESCRIPTION
5 minutes is not always enough, increasing to 20.

For context, with Vault encryption we use the peering connection for accessing Vault from guest nodes, this resource is created as part of the guest stack, and the routes for the actual access are created in a host stack after the guest stack is done. We need to wait on guest cluster nodes for the routes to be in place in order to be able to decrypt the secrets.