### PR TITLE
v13: Make master docker volume ephemeral

### DIFF
--- a/service/controller/v13/adapter/adapter.go
+++ b/service/controller/v13/adapter/adapter.go
@@ -38,6 +38,7 @@ type Adapter struct {
 	ASGType                    string
 	AvailabilityZone           string
 	ClusterID                  string
+	DockerVolumeResourceName   string
 	MasterInstanceResourceName string
 	WorkerImageID              string
 
@@ -91,6 +92,7 @@ func NewGuest(cfg Config) (Adapter, error) {
 	// make that much sense to change a lot fo adapters right away since the focus
 	// is to get actual user stories done.
 	a.MasterInstanceResourceName = cfg.StackState.MasterInstanceResourceName
+	a.DockerVolumeResourceName = cfg.StackState.DockerVolumeResourceName
 
 	hydraters := []hydrater{
 		a.getAutoScalingGroup,

--- a/service/controller/v13/adapter/instance.go
+++ b/service/controller/v13/adapter/instance.go
@@ -39,7 +39,8 @@ type instanceAdapterMaster struct {
 }
 
 type instanceAdapterMasterDockerVolume struct {
-	Name string
+	Name         string
+	ResourceName string
 }
 
 type instanceAdapterMasterEtcdVolume struct {
@@ -86,6 +87,8 @@ func (i *instanceAdapter) Adapt(config Config) error {
 		i.Master.EncrypterBackend = config.EncrypterBackend
 
 		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
+
+		i.Master.DockerVolume.ResourceName = config.StackState.DockerVolumeResourceName
 
 		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
 

--- a/service/controller/v13/adapter/outputs.go
+++ b/service/controller/v13/adapter/outputs.go
@@ -16,9 +16,10 @@ type outputsAdapter struct {
 }
 
 type outputsAdapterMaster struct {
-	ImageID     string
-	Instance    outputsAdapterMasterInstance
-	CloudConfig outputsAdapterMasterCloudConfig
+	ImageID      string
+	Instance     outputsAdapterMasterInstance
+	CloudConfig  outputsAdapterMasterCloudConfig
+	DockerVolume outputsAdapterMasterDockerVolume
 }
 
 type outputsAdapterMasterInstance struct {
@@ -28,6 +29,10 @@ type outputsAdapterMasterInstance struct {
 
 type outputsAdapterMasterCloudConfig struct {
 	Version string
+}
+
+type outputsAdapterMasterDockerVolume struct {
+	ResourceName string
 }
 
 type outputsAdapterWorker struct {
@@ -52,6 +57,7 @@ type outputsAdapterVersionBundle struct {
 }
 
 func (a *outputsAdapter) Adapt(config Config) error {
+	a.Master.DockerVolume.ResourceName = config.StackState.DockerVolumeResourceName
 	a.Master.ImageID = config.StackState.MasterImageID
 	a.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
 	a.Master.Instance.Type = config.StackState.MasterInstanceType

--- a/service/controller/v13/adapter/spec.go
+++ b/service/controller/v13/adapter/spec.go
@@ -83,6 +83,7 @@ type Clients struct {
 type StackState struct {
 	Name string
 
+	DockerVolumeResourceName   string
 	MasterImageID              string
 	MasterInstanceType         string
 	MasterInstanceResourceName string

--- a/service/controller/v13/key/key.go
+++ b/service/controller/v13/key/key.go
@@ -49,6 +49,7 @@ const (
 )
 
 const (
+	DockerVolumeResourceNameKey   = "DockerVolumeResourceName"
 	MasterImageIDKey              = "MasterImageID"
 	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
 	MasterInstanceTypeKey         = "MasterInstanceType"
@@ -187,6 +188,19 @@ func ClusterVersion(customObject v1alpha1.AWSConfig) string {
 
 func CustomerID(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
+}
+
+func DockerVolumeResourceName(customObject v1alpha1.AWSConfig) string {
+	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
+
+	h := sha1.New()
+	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
+	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
+
+	upperTimeHash := strings.ToUpper(timeHash)
+	upperClusterID := strings.ToUpper(clusterID)
+
+	return fmt.Sprintf("DockerVolume%s%s", upperClusterID, upperTimeHash)
 }
 
 func DockerVolumeName(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v13/key/key.go
+++ b/service/controller/v13/key/key.go
@@ -191,16 +191,7 @@ func CustomerID(customObject v1alpha1.AWSConfig) string {
 }
 
 func DockerVolumeResourceName(customObject v1alpha1.AWSConfig) string {
-	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
-
-	h := sha1.New()
-	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
-	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
-
-	upperTimeHash := strings.ToUpper(timeHash)
-	upperClusterID := strings.ToUpper(clusterID)
-
-	return fmt.Sprintf("DockerVolume%s%s", upperClusterID, upperTimeHash)
+	return getResourcenameWithTimeHash("DockerVolume", customObject)
 }
 
 func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
@@ -303,16 +294,7 @@ func MasterImageID(customObject v1alpha1.AWSConfig) string {
 }
 
 func MasterInstanceResourceName(customObject v1alpha1.AWSConfig) string {
-	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
-
-	h := sha1.New()
-	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
-	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
-
-	upperTimeHash := strings.ToUpper(timeHash)
-	upperClusterID := strings.ToUpper(clusterID)
-
-	return fmt.Sprintf("MasterInstance%s%s", upperClusterID, upperTimeHash)
+	return getResourcenameWithTimeHash("MasterInstance", customObject)
 }
 
 func MasterInstanceName(customObject v1alpha1.AWSConfig) string {
@@ -499,4 +481,19 @@ func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
 	}
 
 	return imageID, nil
+}
+
+// getResourcenameWithTimeHash returns the string compared from specific prefix,
+// time hash and cluster ID.
+func getResourcenameWithTimeHash(prefix string, customObject v1alpha1.AWSConfig) string {
+	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
+
+	h := sha1.New()
+	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
+	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
+
+	upperTimeHash := strings.ToUpper(timeHash)
+	upperClusterID := strings.ToUpper(clusterID)
+
+	return fmt.Sprintf("%s%s%s", prefix, upperClusterID, upperTimeHash)
 }

--- a/service/controller/v13/key/key_test.go
+++ b/service/controller/v13/key/key_test.go
@@ -277,23 +277,12 @@ func Test_DockerVolumeResourceName_Format(t *testing.T) {
 		},
 	}
 
-	n1 := DockerVolumeResourceName(customObject)
-	time.Sleep(1 * time.Millisecond)
-	n2 := DockerVolumeResourceName(customObject)
+	n := DockerVolumeResourceName(customObject)
 
 	prefix := "DockerVolume"
 
-	if !strings.HasPrefix(n1, prefix) {
-		t.Fatalf("expected %s to have prefix %s", n1, prefix)
-	}
-	if strings.Contains(n1, "-") {
-		t.Fatalf("expected %s to not contain dashes", n1)
-	}
-	if !strings.HasPrefix(n2, prefix) {
-		t.Fatalf("expected %s to have prefix %s", n2, prefix)
-	}
-	if strings.Contains(n2, "-") {
-		t.Fatalf("expected %s to not contain dashes", n2)
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
 	}
 }
 
@@ -533,23 +522,12 @@ func Test_MasterInstanceResourceName_Format(t *testing.T) {
 		},
 	}
 
-	n1 := MasterInstanceResourceName(customObject)
-	time.Sleep(1 * time.Millisecond)
-	n2 := MasterInstanceResourceName(customObject)
+	n := MasterInstanceResourceName(customObject)
 
 	prefix := "MasterInstance"
 
-	if !strings.HasPrefix(n1, prefix) {
-		t.Fatalf("expected %s to have prefix %s", n1, prefix)
-	}
-	if strings.Contains(n1, "-") {
-		t.Fatalf("expected %s to not contain dashes", n1)
-	}
-	if !strings.HasPrefix(n2, prefix) {
-		t.Fatalf("expected %s to have prefix %s", n2, prefix)
-	}
-	if strings.Contains(n2, "-") {
-		t.Fatalf("expected %s to not contain dashes", n2)
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
 	}
 }
 
@@ -1452,5 +1430,29 @@ func Test_WorkerRoleARN(t *testing.T) {
 				t.Errorf("unexpected Worker role ARN, expecting %q, want %q", tc.expectedRoleARN, roleARN)
 			}
 		})
+	}
+}
+
+func Test_getResourcenameWithTimeHash_Format(t *testing.T) {
+	t.Parallel()
+
+	clusterID := "test-cluster"
+	prefix := "FooResource"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: clusterID,
+			},
+		},
+	}
+
+	n := getResourcenameWithTimeHash(prefix, customObject)
+
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
+	}
+	if strings.Contains(n, "-") {
+		t.Fatalf("expected %s to not contain dashes", n)
 	}
 }

--- a/service/controller/v13/key/key_test.go
+++ b/service/controller/v13/key/key_test.go
@@ -266,6 +266,57 @@ func Test_EC2ServiceDomain(t *testing.T) {
 	}
 }
 
+func Test_DockerVolumeResourceName_Format(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := DockerVolumeResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := DockerVolumeResourceName(customObject)
+
+	prefix := "DockerVolume"
+
+	if !strings.HasPrefix(n1, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n1, prefix)
+	}
+	if strings.Contains(n1, "-") {
+		t.Fatalf("expected %s to not contain dashes", n1)
+	}
+	if !strings.HasPrefix(n2, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n2, prefix)
+	}
+	if strings.Contains(n2, "-") {
+		t.Fatalf("expected %s to not contain dashes", n2)
+	}
+}
+
+func Test_DockerVolumeResourceName_Inequivalence(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := DockerVolumeResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := DockerVolumeResourceName(customObject)
+
+	if n1 == n2 {
+		t.Fatalf("expected %s to differ from %s", n1, n2)
+	}
+}
+
 func Test_EtcdVolumeName(t *testing.T) {
 	t.Parallel()
 	expectedName := "test-cluster-etcd"

--- a/service/controller/v13/resource/cloudformation/current.go
+++ b/service/controller/v13/resource/cloudformation/current.go
@@ -67,13 +67,13 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		dockerVolumeResourceName, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.DockerVolumeResourceNameKey)
 		if cloudformationservice.IsOutputNotFound(err) {
 			// Since we are transitioning between versions we will have situations in
-			// which old clusters are updated to new versions and miss the master
-			// instance resource name in the CF stack outputs. We ignore this problem
+			// which old clusters are updated to new versions and miss the docker
+			// volume resource name in the CF stack outputs. We ignore this problem
 			// for now and move on regardless. On the next resync period the output
 			// value will be there, once the cluster got updated.
 			//
 			// TODO remove this condition as soon as all guest clusters in existence
-			// obtain a master instance resource.
+			// obtain a docker volume resource.
 			dockerVolumeResourceName = ""
 		} else if err != nil {
 			return StackState{}, microerror.Mask(err)

--- a/service/controller/v13/resource/cloudformation/current.go
+++ b/service/controller/v13/resource/cloudformation/current.go
@@ -64,6 +64,20 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	var currentState StackState
 	{
+		dockerVolumeResourceName, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.DockerVolumeResourceNameKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the master
+			// instance resource name in the CF stack outputs. We ignore this problem
+			// for now and move on regardless. On the next resync period the output
+			// value will be there, once the cluster got updated.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a master instance resource.
+			dockerVolumeResourceName = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
 		masterImageID, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterImageIDKey)
 		if err != nil {
 			return StackState{}, microerror.Mask(err)
@@ -126,6 +140,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		currentState = StackState{
 			Name: stackName,
 
+			DockerVolumeResourceName:   dockerVolumeResourceName,
 			MasterImageID:              masterImageID,
 			MasterInstanceResourceName: masterInstanceResourceName,
 			MasterInstanceType:         masterInstanceType,

--- a/service/controller/v13/resource/cloudformation/desired.go
+++ b/service/controller/v13/resource/cloudformation/desired.go
@@ -40,6 +40,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		mainStack = StackState{
 			Name: key.MainGuestStackName(customObject),
 
+			DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
 			MasterImageID:              imageID,
 			MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
 			MasterInstanceType:         masterInstanceType,

--- a/service/controller/v13/resource/cloudformation/main_stack.go
+++ b/service/controller/v13/resource/cloudformation/main_stack.go
@@ -48,6 +48,7 @@ func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1
 		StackState: adapter.StackState{
 			Name: stackState.Name,
 
+			DockerVolumeResourceName:   stackState.DockerVolumeResourceName,
 			MasterImageID:              stackState.MasterImageID,
 			MasterInstanceResourceName: stackState.MasterInstanceResourceName,
 			MasterInstanceType:         stackState.MasterInstanceType,

--- a/service/controller/v13/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v13/resource/cloudformation/main_stack_test.go
@@ -124,6 +124,7 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	stackState := StackState{
 		Name: key.MainGuestStackName(customObject),
 
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
 		MasterImageID:              imageID,
 		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
 		MasterInstanceType:         key.MasterInstanceType(customObject),
@@ -510,6 +511,7 @@ func TestMainGuestTemplateRoute53Disabled(t *testing.T) {
 	stackState := StackState{
 		Name: key.MainGuestStackName(customObject),
 
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
 		MasterImageID:              imageID,
 		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
 		MasterInstanceType:         key.MasterInstanceType(customObject),
@@ -636,6 +638,7 @@ func TestMainGuestTemplateChinaRegion(t *testing.T) {
 	stackState := StackState{
 		Name: key.MainGuestStackName(customObject),
 
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
 		MasterImageID:              imageID,
 		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
 		MasterInstanceType:         key.MasterInstanceType(customObject),

--- a/service/controller/v13/resource/cloudformation/spec.go
+++ b/service/controller/v13/resource/cloudformation/spec.go
@@ -20,6 +20,7 @@ const (
 type StackState struct {
 	Name string
 
+	DockerVolumeResourceName   string
 	MasterImageID              string
 	MasterInstanceType         string
 	MasterInstanceResourceName string

--- a/service/controller/v13/resource/cloudformation/update.go
+++ b/service/controller/v13/resource/cloudformation/update.go
@@ -183,6 +183,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be scaled")
 
 			desiredStackState.MasterInstanceResourceName = currentStackState.MasterInstanceResourceName
+			desiredStackState.DockerVolumeResourceName = currentStackState.DockerVolumeResourceName
 
 			updateStackInput, err := r.computeUpdateState(ctx, customObject, desiredStackState)
 			if err != nil {

--- a/service/controller/v13/templates/cloudformation/guest/instance.go
+++ b/service/controller/v13/templates/cloudformation/guest/instance.go
@@ -5,7 +5,7 @@ const Instance = `{{define "instance"}}
     Type: "AWS::EC2::Instance"
     Description: Master instance
     DependsOn:
-    - DockerVolume
+    - {{ .Instance.Master.DockerVolume.ResourceName }}
     - EtcdVolume
     Properties:
       AvailabilityZone: {{ .Instance.Master.AZ }}
@@ -20,7 +20,7 @@ const Instance = `{{define "instance"}}
       Tags:
       - Key: Name
         Value: {{ .Instance.Cluster.ID }}-master
-  DockerVolume:
+  {{ .Instance.Master.DockerVolume.ResourceName }}:
     Type: AWS::EC2::Volume
     Properties:
 {{ if eq .Instance.Master.EncrypterBackend "kms" }}
@@ -48,7 +48,7 @@ const Instance = `{{define "instance"}}
     Type: AWS::EC2::VolumeAttachment
     Properties:
       InstanceId: !Ref {{ .Instance.Master.Instance.ResourceName }}
-      VolumeId: !Ref DockerVolume
+      VolumeId: !Ref {{ .Instance.Master.DockerVolume.ResourceName }}
       Device: /dev/xvdc
   {{ .Instance.Master.Instance.ResourceName }}EtcdMountPoint:
     Type: AWS::EC2::VolumeAttachment

--- a/service/controller/v13/templates/cloudformation/guest/outputs.go
+++ b/service/controller/v13/templates/cloudformation/guest/outputs.go
@@ -2,6 +2,8 @@ package guest
 
 const Outputs = `{{define "outputs"}}
 Outputs:
+  DockerVolumeResourceName:
+    Value: {{ .Outputs.Master.DockerVolume.ResourceName }}
   MasterImageID:
     Value: {{ .Outputs.Master.ImageID }}
   MasterInstanceResourceName:

--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -19,7 +19,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "aws-operator",
-				Description: "Make master docker volume ephemeral.",
+				Description: "Made master docker volume ephemeral.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},

--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added CA public key into trusted user keys for SSO ssh.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Make master docker volume ephemeral.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/giantswarm/issues/3655

Make master docker ephemral. For that generate unique CF resource name, similar to master instance.

This change will be backported to prev. version (new patch release) in a separate PR.