### PR TITLE
Fix version for v13

### DIFF
--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -54,6 +54,6 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    "aws-operator",
-		Version: "3.1.3",
+		Version: "3.2.0",
 	}
 }


### PR DESCRIPTION
This should be a minor version not a patch. I messed this up when I added v13. Updating and 3.1.3 will be used for v12patch1.

See https://github.com/giantswarm/installations/pull/419 for the release index change.