### PR TITLE
reconcile services

### DIFF
--- a/service/controller/v13/key/key.go
+++ b/service/controller/v13/key/key.go
@@ -168,7 +168,7 @@ func ClusterCustomer(customObject v1alpha1.AWSConfig) string {
 }
 
 func ClusterEtcdDomain(customObject v1alpha1.AWSConfig) string {
-	return fmt.Sprintf("%s:%d,", customObject.Spec.Cluster.Etcd.Domain, customObject.Spec.Cluster.Etcd.Port)
+	return fmt.Sprintf("%s:%d", customObject.Spec.Cluster.Etcd.Domain, customObject.Spec.Cluster.Etcd.Port)
 }
 
 func ClusterID(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v13/key/key.go
+++ b/service/controller/v13/key/key.go
@@ -168,7 +168,7 @@ func ClusterCustomer(customObject v1alpha1.AWSConfig) string {
 }
 
 func ClusterEtcdDomain(customObject v1alpha1.AWSConfig) string {
-	return customObject.Spec.Cluster.Etcd.Domain
+	return fmt.Sprintf("%s:%d,", customObject.Spec.Cluster.Etcd.Domain, customObject.Spec.Cluster.Etcd.Port)
 }
 
 func ClusterID(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v13/resource/service/resource.go
+++ b/service/controller/v13/resource/service/resource.go
@@ -64,7 +64,7 @@ func getServiceByName(list []*apiv1.Service, name string) (*apiv1.Service, error
 }
 
 func isServiceModified(a, b *apiv1.Service) bool {
-	if !reflect.DeepEqual(a.Spec, b.Spec) {
+	if !portsEqual(a, b) {
 		return true
 	}
 
@@ -103,4 +103,27 @@ func toServices(v interface{}) ([]*apiv1.Service, error) {
 	}
 
 	return services, nil
+}
+
+// portsEqual is a function that is checking if ports in the service have same important values.
+func portsEqual(a, b *apiv1.Service) bool {
+	if len(a.Spec.Ports) != len(b.Spec.Ports) {
+		return false
+	}
+
+	for i := 0; i < len(a.Spec.Ports); i++ {
+		portA := a.Spec.Ports[i]
+		portB := b.Spec.Ports[i]
+
+		if portA.Name != portB.Name {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Port, portB.Port) {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Protocol, portB.Protocol) {
+			return false
+		}
+	}
+	return true
 }

--- a/service/controller/v13/resource/service/resource.go
+++ b/service/controller/v13/resource/service/resource.go
@@ -92,21 +92,11 @@ func toService(v interface{}) (*apiv1.Service, error) {
 	return service, nil
 }
 
-func toServices(v interface{}) ([]*apiv1.Service, error) {
-	if v == nil {
-		return nil, nil
-	}
-
-	services, ok := v.([]*apiv1.Service)
-	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.Service{}, v)
-	}
-
-	return services, nil
-}
-
 // portsEqual is a function that is checking if ports in the service have same important values.
 func portsEqual(a, b *apiv1.Service) bool {
+	if a == nil || b == nil {
+		return false
+	}
 	if len(a.Spec.Ports) != len(b.Spec.Ports) {
 		return false
 	}

--- a/service/controller/v13/resource/service/update.go
+++ b/service/controller/v13/resource/service/update.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+
+	"fmt"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -29,7 +32,42 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// Service resources are not updated.
+// Service resources are updated.
 func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	return nil, nil
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be updated")
+
+	servicesToUpdate := make([]*apiv1.Service, 0)
+
+	for _, currentService := range currentServices {
+		desiredService, err := getServiceByName(desiredServices, currentService.Name)
+		if IsNotFound(err) {
+			// Ignore here. These are handled by newDeleteChangeForUpdatePatch().
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if isServiceModified(desiredService, currentService) {
+			// Make a copy and set the resource version so the service can be updated.
+			serviceToUpdate := desiredService.DeepCopy()
+			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
+
+			servicesToUpdate = append(servicesToUpdate, serviceToUpdate)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found service '%s' that has to be updated", desiredService.GetName()))
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d chartconfigs which have to be updated", len(servicesToUpdate)))
+
+	return servicesToUpdate, nil
 }

--- a/service/controller/v13/resource/service/update.go
+++ b/service/controller/v13/resource/service/update.go
@@ -78,6 +78,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			// Make a copy and set the resource version so the service can be updated.
 			serviceToUpdate := desiredService.DeepCopy()
 			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
+			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
 
 			servicesToUpdate = append(servicesToUpdate, serviceToUpdate)
 


### PR DESCRIPTION
As the annotation is now needed for guest cluster monitoring we need to be able to update old cluster and the that means enable reconciliation of the service to desired state

Also since the etcd port is different across providers and it needs to be part of annotation