### PR TITLE
v14/resource/bridgezone: fix getting final zone ID

### DIFF
--- a/service/controller/v14/resource/bridgezone/resource.go
+++ b/service/controller/v14/resource/bridgezone/resource.go
@@ -164,7 +164,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "getting final zone ID")
 
-		finalZoneID, err = r.findHostedZoneID(ctx, defaultGuest, finalZone)
+		finalZoneID, err = r.findHostedZoneID(ctx, guest, finalZone)
 		if IsNotFound(err) {
 			// The final zone is not yet created. Retry in the next
 			// reconciliation loop.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3314

Final zone is in the BYOC guset cluster, not in the default one.