### PR TITLE
v15: Cancel reconciliation on delete when stack is updating

### DIFF
--- a/service/controller/v15/resource/cloudformation/delete.go
+++ b/service/controller/v15/resource/cloudformation/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v15/controllercontext"
@@ -28,6 +29,8 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", "cannot delete CF stacks due to stack state transitioning")
 
 		resourcecanceledcontext.SetCanceled(ctx)
+		finalizerskeptcontext.SetKept(ctx)
+
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil

--- a/service/controller/v15/resource/cloudformation/delete.go
+++ b/service/controller/v15/resource/cloudformation/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v15/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v15/encrypter"
@@ -26,9 +27,10 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if stackStateToDelete.Status == cloudformation.ResourceStatusUpdateInProgress {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "cannot delete CF stacks due to stack state transitioning")
 
-		// TODO control flow via more proper mechanism via something like the
-		// context like it is done for cancelation already.
-		return microerror.Maskf(deletionMustBeRetriedError, "stack state is transitioning")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
 	}
 
 	if stackStateToDelete.Name != "" {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/3672

Cancels reconciliation and preserves finalizers if the stack state is updating.