### PR TITLE
Downgrade version as release will be k8s 1.10

### DIFF
--- a/service/controller/v15/version_bundle.go
+++ b/service/controller/v15/version_bundle.go
@@ -44,6 +44,6 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    "aws-operator",
-		Version: "4.0.0",
+		Version: "3.4.0",
 	}
 }

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v12patch1"
 	"github.com/giantswarm/aws-operator/service/controller/v13"
 	"github.com/giantswarm/aws-operator/service/controller/v14"
+	"github.com/giantswarm/aws-operator/service/controller/v15"
 	"github.com/giantswarm/aws-operator/service/controller/v2"
 	"github.com/giantswarm/aws-operator/service/controller/v3"
 	"github.com/giantswarm/aws-operator/service/controller/v6"
@@ -32,6 +33,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 	versionBundles = append(versionBundles, v12patch1.VersionBundle())
 	versionBundles = append(versionBundles, v13.VersionBundle())
 	versionBundles = append(versionBundles, v14.VersionBundle())
+	versionBundles = append(versionBundles, v15.VersionBundle())
 
 	return versionBundles
 }


### PR DESCRIPTION
I need to make v15 a k8s 1.10 release for the Ingress Controller migration. Reduces the version to a minor bump.