### PR TITLE
Monitoring/old cluster

### DIFF
--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -28,8 +28,9 @@ func (c Collector) getARNs() ([]string, error) {
 		arn, err := credential.GetARN(c.k8sClient, &awsConfig)
 		// Collect as many ARNs as possible in order to provide most metrics.
 		// Ignore old cluster which do not have credential.
-		if credential.IsCredentialNameEmptyError(err) ||
-			credential.IsCredentialNamespaceEmptyError(err) {
+		if credential.IsCredentialNameEmptyError(err) {
+			continue
+		} else if credential.IsCredentialNamespaceEmptyError(err) {
 			continue
 		} else if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -28,9 +28,14 @@ func (c Collector) getARNs() ([]string, error) {
 		arn, err := credential.GetARN(c.k8sClient, &awsConfig)
 		// Collect as many ARNs as possible in order to provide most metrics.
 		// Ignore old cluster which do not have credential.
-		if err == nil {
-			arnsMap[arn] = true
+		if credential.IsCredentialNameEmptyError(err) ||
+			credential.IsCredentialNamespaceEmptyError(err) {
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
 		}
+
+		arnsMap[arn] = true
 	}
 
 	// Ensure we check the default guest account for old cluster not having credential.

--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -24,8 +24,10 @@ func (c Collector) getARNs() ([]string, error) {
 	arnsMap := make(map[string]bool)
 	for _, awsConfig := range awsConfigs.Items {
 		arn, err := credential.GetARN(c.k8sClient, &awsConfig)
-		if err != nil {
-			return nil, microerror.Mask(err)
+		// Collect as many ARNs as possible in order to provide most metrics.
+		// Ignore old cluster which do not have credential.
+		if err == nil {
+			arnsMap[arn] = true
 		}
 		arnsMap[arn] = true
 	}

--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -92,8 +94,9 @@ func (c Collector) getAWSClients() ([]aws.Clients, error) {
 	}
 
 	// Convert map to slice.
-	for _, client := range clientsMap {
+	for accountID, client := range clientsMap {
 		clients = append(clients, client)
+		c.logger.Log("level", "debug", "message", fmt.Sprintf("collecting metrics in account: %s", accountID))
 	}
 
 	return clients, nil

--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -40,9 +40,10 @@ func (c Collector) getARNs() ([]string, error) {
 
 	// Ensure we check the default guest account for old cluster not having credential.
 	arn, err := credential.GetDefaultARN(c.k8sClient)
-	if err == nil {
-		arnsMap[arn] = true
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
+	arnsMap[arn] = true
 
 	for arn, _ := range arnsMap {
 		arns = append(arns, arn)

--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -29,6 +29,11 @@ func (c Collector) getARNs() ([]string, error) {
 		if err == nil {
 			arnsMap[arn] = true
 		}
+	}
+
+	// Ensure we check the default guest account for old cluster not having credential.
+	arn, err := credential.GetDefaultARN(c.k8sClient)
+	if err == nil {
 		arnsMap[arn] = true
 	}
 

--- a/service/controller/v15/credential/credential.go
+++ b/service/controller/v15/credential/credential.go
@@ -62,7 +62,14 @@ func readCredential(k8sClient kubernetes.Interface, obj interface{}) (*v1.Secret
 	}
 
 	credentialName := key.CredentialName(customObject)
+	if credentialName == "" {
+		return nil, microerror.Mask(credentialNameEmpty)
+	}
+
 	credentialNamespace := key.CredentialNamespace(customObject)
+	if credentialName == "" {
+		return nil, microerror.Mask(credentialNamespaceEmpty)
+	}
 
 	credential, err := k8sClient.CoreV1().Secrets(credentialNamespace).Get(credentialName, apismetav1.GetOptions{})
 	if err != nil {

--- a/service/controller/v15/credential/error.go
+++ b/service/controller/v15/credential/error.go
@@ -10,3 +10,21 @@ var arnNotFound = &microerror.Error{
 func IsArnNotFoundError(err error) bool {
 	return microerror.Cause(err) == arnNotFound
 }
+
+var credentialNameEmpty = &microerror.Error{
+	Kind: "credentialNameEmpty",
+}
+
+// IsArnNotFoundError asserts credentialNameEmpty.
+func IsCredentialNameEmptyError(err error) bool {
+	return microerror.Cause(err) == credentialNameEmpty
+}
+
+var credentialNamespaceEmpty = &microerror.Error{
+	Kind: "credentialNamespaceEmpty",
+}
+
+// IsArnNotFoundError asserts credentialNamespaceEmpty.
+func IsCredentialNamespaceEmptyError(err error) bool {
+	return microerror.Cause(err) == credentialNamespaceEmpty
+}


### PR DESCRIPTION
Fix for: https://github.com/giantswarm/aws-operator/pull/1105

Some old cluster do not have credential referenced in their AWSConfig, this causes the metrics collector to fails.
Fixed by ignoring those, and ensuring we always collect metrics for the default guest account in case none of the AWSConfig reference the `credential-default`.

Also added log for account id being scrapped
```
{"caller":"github.com/giantswarm/aws-operator/service/collector/collector.go:79","level":"debug","message":"collecting metrics","time":"2018-08-14T10:09:04.982613+00:00"}
{"caller":"github.com/giantswarm/aws-operator/service/collector/aws.go:99","level":"debug","message":"collecting metrics in account: 084190472784","time":"2018-08-14T10:09:05.274046+00:00"}
{"caller":"github.com/giantswarm/aws-operator/service/collector/aws.go:99","level":"debug","message":"collecting metrics in account: 270935918670","time":"2018-08-14T10:09:05.274085+00:00"}
{"caller":"github.com/giantswarm/aws-operator/service/collector/vpc.go:67","level":"debug","message":"collecting metrics for vpcs","time":"2018-08-14T10:09:05.274138+00:00"}
```