### PR TITLE
Check no vpc returned

### DIFF
--- a/service/controller/v15/adapter/host_post_route_tables.go
+++ b/service/controller/v15/adapter/host_post_route_tables.go
@@ -113,6 +113,8 @@ func waitForPeeringConnectionID(cfg Config) (string, error) {
 		}
 		if len(output.VpcPeeringConnections) > 1 {
 			return microerror.Maskf(tooManyResultsError, "peering connections")
+		} else if len(output.VpcPeeringConnections) == 0 {
+			return microerror.Maskf(notFoundError, "peering connections")
 		}
 		peeringID = *output.VpcPeeringConnections[0].VpcPeeringConnectionId
 		return nil


### PR DESCRIPTION
Aims to prevent errors like:
```
panic: runtime error: index out of range

goroutine 10 [running]:
github.com/giantswarm/aws-operator/service/controller/v15/adapter.waitForPeeringConnectionID.func1(0xc42003b6e0, 0xc42003b6e0)
    /go/src/github.com/giantswarm/aws-operator/service/controller/v15/adapter/host_post_route_tables.go:117 +0x14d
github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc420afbf00, 0x24304c0, 0xc42003b6e0, 0xc4208d1620, 0xc4208d1620, 0x0)
    /go/src/github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0x88
github.com/giantswarm/aws-operator/service/controller/v15/adapter.waitForPeeringConnectionID(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc420998254, 0xc, 0x0, ...)
    /go/src/github.com/giantswarm/aws-operator/service/controller/v15/adapter/host_post_route_tables.go:122 +0x493
github.com/giantswarm/aws-operator/service/controller/v15/adapter.(*HostPostRouteTablesAdapter).Adapt(0xc4200c16c8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc420998254, 0xc, ...)
    /go/src/github.com/giantswarm/aws-operator/service/controller/v15/adapter/host_post_route_tables.go:25 +0x60
github.com/giantswarm/aws-operator/service/controller/v15/adapter.(*HostPostRouteTablesAdapter).Adapt-fm(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc420998254, 0xc, 0x0, ...)
    /go/src/github.com/giantswarm/aws-operator/service/controller/v15/adapter/adapter.go:103 +0x50
github.com/giantswarm/aws-operator/service/controller/v15/adapter.NewHostPost(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc420998254, 0xc, 0x0, ...)
```
This started happeining on cluster-operator e2e tests see https://circleci.com/gh/giantswarm/cluster-operator/1647. Looks like the peering vpc can reach the `active` `status-code` later. The changes here prevent the panic and return an error inside the backoff, so that we can check for the active vpc in the next execution.