### PR TITLE
v14, v15: remove confusing logs from cloudformation resource

### DIFF
--- a/service/controller/v14/resource/cloudformation/create.go
+++ b/service/controller/v14/resource/cloudformation/create.go
@@ -205,20 +205,6 @@ func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1
 }
 
 func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha1.AWSConfig, guestMainStackState StackState) error {
-	// TODO introduced: aws-operator@v14; remove with: aws-operator@v13
-	// This output was introduced in v14 so it isn't accessible from CF
-	// stacks created by earlier versions. We need to handle that.
-	//
-	// Final version of the code:
-	//
-	//	// Just remove.
-	//
-	if guestMainStackState.HostedZoneNameServers == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not updated yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-	}
-	// TODO end
-
 	stackName := key.MainHostPostStackName(customObject)
 	mainTemplate, err := r.getMainHostPostTemplateBody(ctx, customObject, guestMainStackState)
 	if err != nil {

--- a/service/controller/v15/resource/cloudformation/create.go
+++ b/service/controller/v15/resource/cloudformation/create.go
@@ -205,20 +205,6 @@ func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1
 }
 
 func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha1.AWSConfig, guestMainStackState StackState) error {
-	// TODO introduced: aws-operator@v14; remove with: aws-operator@v13
-	// This output was introduced in v14 so it isn't accessible from CF
-	// stacks created by earlier versions. We need to handle that.
-	//
-	// Final version of the code:
-	//
-	//	// Just remove.
-	//
-	if guestMainStackState.HostedZoneNameServers == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not updated yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
-	}
-	// TODO end
-
 	stackName := key.MainHostPostStackName(customObject)
 	mainTemplate, err := r.getMainHostPostTemplateBody(ctx, customObject, guestMainStackState)
 	if err != nil {


### PR DESCRIPTION
Empty HostedZoneNameServers are handled in current.go. This one here
seems to be some leftover.