### PR TITLE
v14patch1: copy v14

### DIFF
--- a/service/controller/v14patch1/adapter/adapter.go
+++ b/service/controller/v14patch1/adapter/adapter.go
@@ -1,0 +1,141 @@
+// Package adapter contains the required logic for creating data structures used for
+// feeding CloudFormation templates.
+//
+// It follows the adapter pattern https://en.wikipedia.org/wiki/Adapter_pattern in the
+// sense that it has the knowledge to transform a aws custom object into a data structure
+// easily interpolable into the templates without any additional view logic.
+//
+// There's a base template in `service/templates/cloudformation/guest/main.yaml` which defines
+// the basic structure and includes the rest of templates that form the stack as nested
+// templates. Those subtemplates should use a `define` action with the name that will be
+// used to refer to them from the main template, as explained here
+// https://golang.org/pkg/text/template/#hdr-Nested_template_definitions
+//
+// Each adapter is related to one of these nested templates. It includes the data structure
+// with all the values needed to interpolate in the related template and the logic required
+// to obtain them, this logic is packed into functions called `hydraters`.
+//
+// When extending the stack we will just need to:
+// * Add the template file in `service/template/cloudformation/guest` and modify
+// `service/template/cloudformation/main.yaml` to include the new template.
+// * Add the adapter logic file in `service/resource/cloudformation/adapter` with the type
+// definition and the hydrater function to fill the fields (like asg.go or
+// launch_configuration.go).
+// * Add the new type to the Adapter type in `service/resource/cloudformation/adapter/adapter.go`
+// and include the hydrater function in the `hydraters` slice.
+package adapter
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+)
+
+type Config struct {
+	APIWhitelist      APIWhitelist
+	CustomObject      v1alpha1.AWSConfig
+	Clients           Clients
+	EncrypterBackend  string
+	GuestAccountID    string
+	HostAccountID     string
+	HostClients       Clients
+	InstallationName  string
+	PublicRouteTables string
+	Route53Enabled    bool
+	StackState        StackState
+}
+
+type Adapter struct {
+	Guest    GuestAdapter
+	HostPost HostPostAdapter
+	HostPre  HostPreAdapter
+}
+
+func NewGuest(cfg Config) (Adapter, error) {
+	a := Adapter{}
+
+	hydraters := []hydrater{
+		a.Guest.AutoScalingGroup.Adapt,
+		a.Guest.IAMPolicies.Adapt,
+		a.Guest.InternetGateway.Adapt,
+		a.Guest.Instance.Adapt,
+		a.Guest.LaunchConfiguration.Adapt,
+		a.Guest.LifecycleHooks.Adapt,
+		a.Guest.LoadBalancers.Adapt,
+		a.Guest.NATGateway.Adapt,
+		a.Guest.Outputs.Adapt,
+		a.Guest.RecordSets.Adapt,
+		a.Guest.RouteTables.Adapt,
+		a.Guest.SecurityGroups.Adapt,
+		a.Guest.Subnets.Adapt,
+		a.Guest.VPC.Adapt,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}
+
+func NewHostPre(cfg Config) (Adapter, error) {
+	a := Adapter{}
+
+	hydraters := []hydrater{
+		a.HostPre.IAMRoles.Adapt,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}
+
+func NewHostPost(cfg Config) (Adapter, error) {
+	a := Adapter{}
+
+	hydraters := []hydrater{
+		a.HostPost.RecordSets.Adapt,
+		a.HostPost.RouteTables.Adapt,
+	}
+
+	for _, h := range hydraters {
+		if err := h(cfg); err != nil {
+			return Adapter{}, microerror.Mask(err)
+		}
+	}
+
+	return a, nil
+}
+
+type GuestAdapter struct {
+	AutoScalingGroup    GuestAutoScalingGroupAdapter
+	IAMPolicies         GuestIAMPoliciesAdapter
+	InternetGateway     GuestInternetGatewayAdapter
+	Instance            GuestInstanceAdapter
+	LaunchConfiguration GuestLaunchConfigAdapter
+	LifecycleHooks      GuestLifecycleHooksAdapter
+	LoadBalancers       GuestLoadBalancersAdapter
+	NATGateway          GuestNATGatewayAdapter
+	Outputs             GuestOutputsAdapter
+	RecordSets          GuestRecordSetsAdapter
+	RouteTables         GuestRouteTablesAdapter
+	SecurityGroups      GuestSecurityGroupsAdapter
+	Subnets             GuestSubnetsAdapter
+	VPC                 GuestVPCAdapter
+}
+
+type HostPostAdapter struct {
+	RouteTables HostPostRouteTablesAdapter
+	RecordSets  HostPostRecordSetsAdapter
+}
+
+type HostPreAdapter struct {
+	IAMRoles HostPreIAMRolesAdapter
+}
+
+type hydrater func(Config) error

--- a/service/controller/v14patch1/adapter/adapter_key.go
+++ b/service/controller/v14patch1/adapter/adapter_key.go
@@ -1,0 +1,31 @@
+package adapter
+
+import "github.com/giantswarm/aws-operator/service/controller/v14/key"
+
+func asgType(config Config) string {
+	return prefixWorker
+}
+
+func baseDomain(config Config) string {
+	return key.BaseDomain(config.CustomObject)
+}
+
+func clusterID(config Config) string {
+	return key.ClusterID(config.CustomObject)
+}
+
+func hostedZoneNameServers(config Config) string {
+	return config.StackState.HostedZoneNameServers
+}
+
+func masterInstanceResourceName(config Config) string {
+	return config.StackState.MasterInstanceResourceName
+}
+
+func route53Enabled(config Config) bool {
+	return config.Route53Enabled
+}
+
+func workerImageID(config Config) string {
+	return config.StackState.WorkerImageID
+}

--- a/service/controller/v14patch1/adapter/adapter_test.go
+++ b/service/controller/v14patch1/adapter/adapter_test.go
@@ -1,0 +1,133 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+var (
+	defaultCluster = v1alpha1.Cluster{
+		ID: "test-cluster",
+		Kubernetes: v1alpha1.ClusterKubernetes{
+			API: v1alpha1.ClusterKubernetesAPI{
+				Domain: "api.domain",
+			},
+			IngressController: v1alpha1.ClusterKubernetesIngressController{
+				Domain: "ingress.domain",
+			},
+		},
+		Etcd: v1alpha1.ClusterEtcd{
+			Domain: "etcd.domain",
+		},
+	}
+)
+
+func TestAdapterGuestMain(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description              string
+		customObject             v1alpha1.AWSConfig
+		errorMatcher             func(error) bool
+		expectedASGType          string
+		expectedEC2ServiceDomain string
+		expectedMasterImageID    string
+		expectedWorkerImageID    string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:     "eu-central-1a",
+						Region: "eu-central-1",
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			errorMatcher:             nil,
+			expectedASGType:          "worker",
+			expectedEC2ServiceDomain: "ec2.amazonaws.com",
+			expectedMasterImageID:    "master-image-id",
+			expectedWorkerImageID:    "worker-image-id",
+		},
+		{
+			description: "china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:     "cn-north-1a",
+						Region: "cn-north-1",
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			errorMatcher:             nil,
+			expectedASGType:          "worker",
+			expectedEC2ServiceDomain: "ec2.amazonaws.com.cn",
+			expectedMasterImageID:    "master-image-id",
+			expectedWorkerImageID:    "worker-image-id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			config := Config{
+				CustomObject: tc.customObject,
+				Clients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					KMS: &KMSClientMock{},
+					ELB: &ELBClientMock{},
+					STS: &STSClientMock{},
+				},
+				HostClients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+				InstallationName: "myinstallation",
+				HostAccountID:    "myHostAccountID",
+				StackState: StackState{
+					MasterImageID: "master-image-id",
+					WorkerImageID: "worker-image-id",
+				},
+			}
+			a, err := NewGuest(config)
+			if tc.errorMatcher != nil && err == nil {
+				t.Fatal("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Fatal("expected", true, "got", false)
+			}
+
+			if tc.expectedASGType != a.Guest.AutoScalingGroup.ASGType {
+				t.Fatalf("unexpected ASG type, expected %q, got %q", tc.expectedASGType, a.Guest.AutoScalingGroup.ASGType)
+			}
+			if tc.expectedASGType != a.Guest.LaunchConfiguration.ASGType {
+				t.Fatalf("unexpected ASG type, expected %q, got %q", tc.expectedASGType, a.Guest.LaunchConfiguration.ASGType)
+			}
+
+			if tc.expectedEC2ServiceDomain != a.Guest.IAMPolicies.EC2ServiceDomain {
+				t.Fatalf("unexpected EC2 service domain, expected %q, got %q", tc.expectedEC2ServiceDomain, a.Guest.IAMPolicies.EC2ServiceDomain)
+			}
+
+			if tc.expectedWorkerImageID != a.Guest.LaunchConfiguration.WorkerImageID {
+				t.Fatalf("unexpected WorkerImageID, expected %q, got %q", tc.expectedWorkerImageID, a.Guest.LaunchConfiguration.WorkerImageID)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/error.go
+++ b/service/controller/v14patch1/adapter/error.go
@@ -1,0 +1,66 @@
+package adapter
+
+import "github.com/giantswarm/microerror"
+
+var emptyAmazonAccountIDError = &microerror.Error{
+	Kind: "emptyAmazonAccountIDError",
+}
+
+// IsEmptyAmazonAccountID asserts emptyAmazonAccountIDError.
+func IsEmptyAmazonAccountID(err error) bool {
+	return microerror.Cause(err) == emptyAmazonAccountIDError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var malformedAmazonAccountIDError = &microerror.Error{
+	Kind: "malformedAmazonAccountIDError",
+}
+
+// IsMalformedAmazonAccountID asserts malformedAmazonAccountIDError.
+func IsMalformedAmazonAccountID(err error) bool {
+	return microerror.Cause(err) == malformedAmazonAccountIDError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongAmazonAccountIDLengthError = &microerror.Error{
+	Kind: "wrongAmazonAccountIDLengthError",
+}
+
+// IsWrongAmazonAccountIDLength asserts wrongAmazonAccountIDLengthError.
+func IsWrongAmazonAccountIDLength(err error) bool {
+	return microerror.Cause(err) == wrongAmazonAccountIDLengthError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var tooManyResultsError = &microerror.Error{
+	Kind: "tooManyResultsError",
+}
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return microerror.Cause(err) == tooManyResultsError
+}

--- a/service/controller/v14patch1/adapter/guest_auto_scaling_group.go
+++ b/service/controller/v14patch1/adapter/guest_auto_scaling_group.go
@@ -1,0 +1,51 @@
+package adapter
+
+import (
+	"strconv"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestAutoScalingGroupAdapter struct {
+	ASGMaxSize             int
+	ASGMinSize             int
+	ASGType                string
+	ClusterID              string
+	HealthCheckGracePeriod int
+	MaxBatchSize           string
+	MinInstancesInService  string
+	RollingUpdatePauseTime string
+	WorkerAZ               string
+}
+
+func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
+	workers := key.WorkerCount(cfg.CustomObject)
+	if workers <= 0 {
+		return microerror.Maskf(invalidConfigError, "at least 1 worker required, found %d", workers)
+	}
+
+	a.WorkerAZ = key.AvailabilityZone(cfg.CustomObject)
+	a.ASGMaxSize = workers + 1
+	a.ASGMinSize = workers
+	a.ASGType = asgType(cfg)
+	a.ClusterID = clusterID(cfg)
+	a.MaxBatchSize = workerCountRatio(workers, asgMaxBatchSizeRatio)
+	a.MinInstancesInService = workerCountRatio(workers, asgMinInstancesRatio)
+	a.HealthCheckGracePeriod = gracePeriodSeconds
+	a.RollingUpdatePauseTime = rollingUpdatePauseTime
+
+	return nil
+}
+
+func workerCountRatio(workers int, ratio float32) string {
+	value := float32(workers) * ratio
+	rounded := int(value + 0.5)
+
+	if rounded == 0 {
+		rounded = 1
+	}
+
+	return strconv.Itoa(rounded)
+}

--- a/service/controller/v14patch1/adapter/guest_auto_scaling_group_test.go
+++ b/service/controller/v14patch1/adapter/guest_auto_scaling_group_test.go
@@ -1,0 +1,195 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                    string
+		customObject                   v1alpha1.AWSConfig
+		expectedError                  bool
+		expectedAZ                     string
+		expectedASGMaxSize             int
+		expectedASGMinSize             int
+		expectedHealthCheckGracePeriod int
+		expectedMaxBatchSize           string
+		expectedMinInstancesInService  string
+		expectedRollingUpdatePauseTime string
+	}{
+		{
+			description: "no worker nodes, return error",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ:      "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			description: "having one worker leaves 1 worker head room for updates",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             2, // headroom is +1
+			expectedASGMinSize:             1,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "1",
+			expectedMinInstancesInService:  "1",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             4,
+			expectedASGMinSize:             3,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "1",
+			expectedMinInstancesInService:  "2",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+		{
+			description: "7 node cluster, batch size and min instances are correct",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "myaz",
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+							{},
+							{},
+							{},
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			expectedError:                  false,
+			expectedAZ:                     "myaz",
+			expectedASGMaxSize:             8,
+			expectedASGMinSize:             7,
+			expectedHealthCheckGracePeriod: gracePeriodSeconds,
+			expectedMaxBatchSize:           "2",
+			expectedMinInstancesInService:  "5",
+			expectedRollingUpdatePauseTime: rollingUpdatePauseTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  Clients{},
+			}
+			err := a.Guest.AutoScalingGroup.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if !tc.expectedError {
+				if a.Guest.AutoScalingGroup.ASGMaxSize != tc.expectedASGMaxSize {
+					t.Errorf("unexpected output, got %d, want %d", a.Guest.AutoScalingGroup.ASGMaxSize, tc.expectedASGMaxSize)
+				}
+
+				if a.Guest.AutoScalingGroup.ASGMinSize != tc.expectedASGMinSize {
+					t.Errorf("unexpected output, got %d, want %d", a.Guest.AutoScalingGroup.ASGMinSize, tc.expectedASGMinSize)
+				}
+
+				if a.Guest.AutoScalingGroup.HealthCheckGracePeriod != tc.expectedHealthCheckGracePeriod {
+					t.Errorf("unexpected output, got %d, want %d", a.Guest.AutoScalingGroup.HealthCheckGracePeriod, tc.expectedHealthCheckGracePeriod)
+				}
+
+				if a.Guest.AutoScalingGroup.MaxBatchSize != tc.expectedMaxBatchSize {
+					t.Errorf("unexpected output, got %q, want %q", a.Guest.AutoScalingGroup.MaxBatchSize, tc.expectedMaxBatchSize)
+				}
+
+				if a.Guest.AutoScalingGroup.MinInstancesInService != tc.expectedMinInstancesInService {
+					t.Errorf("unexpected output, got %q, want %q", a.Guest.AutoScalingGroup.MinInstancesInService, tc.expectedMinInstancesInService)
+				}
+
+				if a.Guest.AutoScalingGroup.RollingUpdatePauseTime != tc.expectedRollingUpdatePauseTime {
+					t.Errorf("unexpected output, got %q, want %q", a.Guest.AutoScalingGroup.RollingUpdatePauseTime, tc.expectedRollingUpdatePauseTime)
+				}
+
+				if a.Guest.AutoScalingGroup.WorkerAZ != tc.expectedAZ {
+					t.Errorf("unexpected output, got %q, want %q", a.Guest.AutoScalingGroup.WorkerAZ, tc.expectedAZ)
+				}
+
+			}
+		})
+	}
+}
+
+func TestWorkerCountRatioMaxBatchSize(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		description   string
+		workers       int
+		expectedRatio string
+	}{
+		{
+			description:   "scaling down to one worker, one should be up",
+			workers:       1,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to two worker, one should be up",
+			workers:       2,
+			expectedRatio: "1",
+		},
+		{
+			description:   "scaling down to zero worker, ratio should be one, because it should never be zero",
+			workers:       0,
+			expectedRatio: "1",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := workerCountRatio(tc.workers, asgMaxBatchSizeRatio)
+
+			if tc.expectedRatio != actual {
+				t.Errorf("wrong worker count ratio, expected %q, actual %q", tc.expectedRatio, actual)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_iam_policies.go
+++ b/service/controller/v14patch1/adapter/guest_iam_policies.go
@@ -1,0 +1,60 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestIAMPoliciesAdapter struct {
+	EC2ServiceDomain  string
+	KMSKeyARN         string
+	MasterRoleName    string
+	MasterPolicyName  string
+	MasterProfileName string
+	RegionARN         string
+	S3Bucket          string
+	WorkerRoleName    string
+	WorkerPolicyName  string
+	WorkerProfileName string
+}
+
+func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
+	clusterID := key.ClusterID(cfg.CustomObject)
+
+	i.EC2ServiceDomain = key.EC2ServiceDomain(cfg.CustomObject)
+	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, prefixMaster)
+	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, prefixMaster)
+	i.MasterRoleName = key.RoleName(cfg.CustomObject, prefixMaster)
+	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, prefixWorker)
+	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, prefixWorker)
+	i.WorkerRoleName = key.RoleName(cfg.CustomObject, prefixWorker)
+	i.RegionARN = key.RegionARN(cfg.CustomObject)
+
+	// KMSKeyARN
+	if cfg.EncrypterBackend == encrypter.KMSBackend {
+		keyAlias := fmt.Sprintf("alias/%s", clusterID)
+		input := &kms.DescribeKeyInput{
+			KeyId: aws.String(keyAlias),
+		}
+		output, err := cfg.Clients.KMS.DescribeKey(input)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		i.KMSKeyARN = *output.KeyMetadata.Arn
+	}
+
+	// S3Bucket
+	accountID, err := AccountID(cfg.Clients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	i.S3Bucket = key.BucketName(cfg.CustomObject, accountID)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_iam_policies_test.go
+++ b/service/controller/v14patch1/adapter/guest_iam_policies_test.go
@@ -1,0 +1,215 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterIamPoliciesRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description               string
+		customObject              v1alpha1.AWSConfig
+		expectedMasterRoleName    string
+		expectedMasterPolicyName  string
+		expectedMasterProfileName string
+		expectedWorkerRoleName    string
+		expectedWorkerPolicyName  string
+		expectedWorkerProfileName string
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedMasterRoleName:    "test-cluster-master-EC2-K8S-Role",
+			expectedMasterPolicyName:  "test-cluster-master-EC2-K8S-Policy",
+			expectedMasterProfileName: "test-cluster-master-EC2-K8S-Role",
+			expectedWorkerRoleName:    "test-cluster-worker-EC2-K8S-Role",
+			expectedWorkerPolicyName:  "test-cluster-worker-EC2-K8S-Policy",
+			expectedWorkerProfileName: "test-cluster-worker-EC2-K8S-Role",
+		},
+	}
+
+	clients := Clients{
+		KMS: &KMSClientMock{},
+		IAM: &IAMClientMock{},
+		STS: &STSClientMock{},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.Guest.IAMPolicies.Adapt(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.IAMPolicies.MasterPolicyName != tc.expectedMasterPolicyName {
+				t.Errorf("unexpected MasterPolicyName, got %q, want %q", a.Guest.IAMPolicies.MasterPolicyName, tc.expectedMasterPolicyName)
+			}
+
+			if a.Guest.IAMPolicies.MasterRoleName != tc.expectedMasterRoleName {
+				t.Errorf("unexpected MasterRoleName, got %q, want %q", a.Guest.IAMPolicies.MasterRoleName, tc.expectedMasterRoleName)
+			}
+
+			if a.Guest.IAMPolicies.MasterProfileName != tc.expectedMasterProfileName {
+				t.Errorf("unexpected MasterProfileName, got %q, want %q", a.Guest.IAMPolicies.MasterProfileName, tc.expectedMasterProfileName)
+			}
+
+			if a.Guest.IAMPolicies.WorkerPolicyName != tc.expectedWorkerPolicyName {
+				t.Errorf("unexpected WorkerPolicyName, got %q, want %q", a.Guest.IAMPolicies.WorkerPolicyName, tc.expectedWorkerPolicyName)
+			}
+
+			if a.Guest.IAMPolicies.WorkerRoleName != tc.expectedWorkerRoleName {
+				t.Errorf("unexpected WorkerRoleName, got %q, want %q", a.Guest.IAMPolicies.WorkerRoleName, tc.expectedWorkerRoleName)
+			}
+
+			if a.Guest.IAMPolicies.WorkerProfileName != tc.expectedWorkerProfileName {
+				t.Errorf("unexpected WorkerProfileName, got %q, want %q", a.Guest.IAMPolicies.WorkerProfileName, tc.expectedWorkerProfileName)
+			}
+		})
+	}
+}
+
+func TestAdapterIamPoliciesKMSKeyARN(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		customObject      v1alpha1.AWSConfig
+		expectedKMSKeyARN string
+		expectedError     bool
+		encrypterBackend  string
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedKMSKeyARN: "alias/test-cluster",
+			encrypterBackend:  "kms",
+		},
+		{
+			description: "error check",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedError:    true,
+			encrypterBackend: "kms",
+		},
+		{
+			description: "vault backend",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedKMSKeyARN: "",
+			encrypterBackend:  "vault",
+		},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			clients := Clients{
+				IAM: &IAMClientMock{},
+				KMS: &KMSClientMock{
+					keyARN:  tc.expectedKMSKeyARN,
+					isError: tc.expectedError,
+				},
+				STS: &STSClientMock{},
+			}
+			cfg := Config{
+				EncrypterBackend: tc.encrypterBackend,
+				CustomObject:     tc.customObject,
+				Clients:          clients,
+			}
+			err := a.Guest.IAMPolicies.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if !tc.expectedError {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+
+				if a.Guest.IAMPolicies.KMSKeyARN != tc.expectedKMSKeyARN {
+					t.Errorf("unexpected KMSKeyARN, got %q, want %q", a.Guest.IAMPolicies.KMSKeyARN, tc.expectedKMSKeyARN)
+				}
+			}
+		})
+	}
+}
+
+func TestAdapterIamPoliciesS3Bucket(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description      string
+		customObject     v1alpha1.AWSConfig
+		accountID        string
+		expectedS3Bucket string
+		expectedError    bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			accountID:        "111111111111",
+			expectedS3Bucket: "111111111111-g8s-test-cluster",
+		},
+		{
+			description: "client error",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: defaultCluster,
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			clients := Clients{
+				KMS: &KMSClientMock{},
+				IAM: &IAMClientMock{},
+				STS: &STSClientMock{
+					accountID: tc.accountID,
+					isError:   tc.expectedError,
+				},
+			}
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.Guest.IAMPolicies.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+
+			if !tc.expectedError {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+
+				if a.Guest.IAMPolicies.S3Bucket != tc.expectedS3Bucket {
+					t.Errorf("unexpected S3Bucket, got %q, want %q", a.Guest.IAMPolicies.S3Bucket, tc.expectedS3Bucket)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_instance.go
+++ b/service/controller/v14patch1/adapter/guest_instance.go
@@ -1,0 +1,98 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates"
+)
+
+type GuestInstanceAdapter struct {
+	Cluster GuestInstanceAdapterCluster
+	Image   GuestInstanceAdapterImage
+	Master  GuestInstanceAdapterMaster
+}
+
+type GuestInstanceAdapterCluster struct {
+	ID string
+}
+
+type GuestInstanceAdapterImage struct {
+	ID string
+}
+
+type GuestInstanceAdapterMaster struct {
+	AZ               string
+	CloudConfig      string
+	EncrypterBackend string
+	DockerVolume     GuestInstanceAdapterMasterDockerVolume
+	EtcdVolume       GuestInstanceAdapterMasterEtcdVolume
+	Instance         GuestInstanceAdapterMasterInstance
+}
+
+type GuestInstanceAdapterMasterDockerVolume struct {
+	Name         string
+	ResourceName string
+}
+
+type GuestInstanceAdapterMasterEtcdVolume struct {
+	Name string
+}
+
+type GuestInstanceAdapterMasterInstance struct {
+	ResourceName string
+	Type         string
+	Monitoring   bool
+}
+
+func (i *GuestInstanceAdapter) Adapt(config Config) error {
+	{
+		i.Cluster.ID = key.ClusterID(config.CustomObject)
+	}
+
+	{
+		i.Image.ID = config.StackState.MasterImageID
+	}
+
+	{
+		i.Master.AZ = key.AvailabilityZone(config.CustomObject)
+
+		accountID, err := AccountID(config.Clients)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		c := SmallCloudconfigConfig{
+			MachineType:             prefixMaster,
+			Region:                  key.Region(config.CustomObject),
+			S3Domain:                key.S3ServiceDomain(config.CustomObject),
+			S3URI:                   fmt.Sprintf("%s-g8s-%s", accountID, i.Cluster.ID),
+			CloudConfigVersion:      config.StackState.MasterCloudConfigVersion,
+			AWSCliContainerRegistry: key.AWSCliContainerRegistry(config.CustomObject),
+		}
+		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		i.Master.CloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+		i.Master.EncrypterBackend = config.EncrypterBackend
+
+		i.Master.DockerVolume.Name = key.DockerVolumeName(config.CustomObject)
+
+		i.Master.DockerVolume.ResourceName = config.StackState.DockerVolumeResourceName
+
+		i.Master.EtcdVolume.Name = key.EtcdVolumeName(config.CustomObject)
+
+		i.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
+
+		i.Master.Instance.Type = config.StackState.MasterInstanceType
+
+		i.Master.Instance.Monitoring = config.StackState.MasterInstanceMonitoring
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_instance_test.go
+++ b/service/controller/v14patch1/adapter/guest_instance_test.go
@@ -1,0 +1,152 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func Test_Adapter_Instance_RegularFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Description              string
+		Config                   Config
+		ExpectedAZ               string
+		ExpectedEtcdVolumeName   string
+		ExpectedInstanceType     string
+		ExpectedEncrypterBackend string
+	}{
+		{
+			Description: "case 0 basic matching, all fields present",
+			Config: Config{
+				Clients: Clients{
+					EC2: &EC2ClientMock{},
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+				CustomObject: v1alpha1.AWSConfig{
+					Spec: v1alpha1.AWSConfigSpec{
+						Cluster: v1alpha1.Cluster{
+							ID: "test-cluster",
+						},
+						AWS: v1alpha1.AWSConfigSpecAWS{
+							AZ:     "eu-central-1a",
+							Region: "eu-west-1",
+						},
+					},
+				},
+				StackState: StackState{
+					MasterInstanceType: "m3.large",
+				},
+				EncrypterBackend: "my-encrypter-backend",
+			},
+			ExpectedAZ:               "eu-central-1a",
+			ExpectedEtcdVolumeName:   "test-cluster-etcd",
+			ExpectedInstanceType:     "m3.large",
+			ExpectedEncrypterBackend: "my-encrypter-backend",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &GuestInstanceAdapter{}
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			if a.Master.AZ != tc.ExpectedAZ {
+				t.Fatalf("unexpected a.Master.AZ, got %q, want %q", a.Master.AZ, tc.ExpectedAZ)
+			}
+
+			if a.Master.EtcdVolume.Name != tc.ExpectedEtcdVolumeName {
+				t.Fatalf("unexpected a.Master.EtcdVolume.Name, got %q, want %q", a.Master.EtcdVolume.Name, tc.ExpectedEtcdVolumeName)
+			}
+
+			if a.Master.Instance.Type != tc.ExpectedInstanceType {
+				t.Fatalf("unexpected a.Master.Instance.Type, got %q, want %q", a.Master.Instance.Type, tc.ExpectedInstanceType)
+			}
+
+			if a.Master.EncrypterBackend != tc.ExpectedEncrypterBackend {
+				t.Fatalf("unexpected a.Master.Instance.Type, got %q, want %q", a.Master.EncrypterBackend, tc.ExpectedEncrypterBackend)
+			}
+		})
+	}
+}
+
+func Test_Adapter_Instance_SmallCloudConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Description  string
+		ExpectedLine string
+		Region       string
+	}{
+		{
+			Description:  "case 0 userdata file",
+			ExpectedLine: "USERDATA_FILE=master",
+			Region:       "eu-west-1",
+		},
+		{
+			Description:  "scase 1 http URI",
+			ExpectedLine: "s3_http_uri=\"https://s3.eu-west-1.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/foo/$USERDATA_FILE\"",
+			Region:       "eu-west-1",
+		},
+		{
+			Description:  "scase 2 http URI different region",
+			ExpectedLine: "s3_http_uri=\"https://s3.eu-central-1.amazonaws.com/000000000000-g8s-test-cluster/cloudconfig/foo/$USERDATA_FILE\"",
+			Region:       "eu-central-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			clients := Clients{
+				EC2: &EC2ClientMock{},
+				IAM: &IAMClientMock{},
+				STS: &STSClientMock{accountID: "000000000000"},
+			}
+			customObject := v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-test",
+								InstanceType: "m3.large",
+							},
+						},
+						Region: tc.Region,
+					},
+				},
+			}
+			cfg := Config{
+				Clients:      clients,
+				CustomObject: customObject,
+				StackState: StackState{
+					MasterCloudConfigVersion: "foo",
+				},
+			}
+
+			a := &GuestInstanceAdapter{}
+			err := a.Adapt(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			data, err := base64.StdEncoding.DecodeString(a.Master.CloudConfig)
+			if err != nil {
+				t.Fatalf("unexpected error decoding a.Master.CloudConfig %v", err)
+			}
+
+			if !strings.Contains(string(data), tc.ExpectedLine) {
+				t.Fatalf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.ExpectedLine, string(data))
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_internet_gateway.go
+++ b/service/controller/v14patch1/adapter/guest_internet_gateway.go
@@ -1,0 +1,11 @@
+package adapter
+
+type GuestInternetGatewayAdapter struct {
+	ClusterID string
+}
+
+func (a *GuestInternetGatewayAdapter) Adapt(cfg Config) error {
+	a.ClusterID = clusterID(cfg)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_launch_configuration.go
+++ b/service/controller/v14patch1/adapter/guest_launch_configuration.go
@@ -1,0 +1,71 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates"
+)
+
+type GuestLaunchConfigAdapter struct {
+	ASGType                        string
+	WorkerAssociatePublicIPAddress bool
+	WorkerBlockDeviceMappings      []BlockDeviceMapping
+	WorkerInstanceMonitoring       bool
+	WorkerInstanceType             string
+	WorkerImageID                  string
+	WorkerSecurityGroupID          string
+	WorkerSmallCloudConfig         string
+}
+
+type BlockDeviceMapping struct {
+	DeleteOnTermination bool
+	DeviceName          string
+	VolumeSize          int
+	VolumeType          string
+}
+
+func (l *GuestLaunchConfigAdapter) Adapt(cfg Config) error {
+	l.ASGType = asgType(cfg)
+	l.WorkerInstanceType = key.WorkerInstanceType(cfg.CustomObject)
+	l.WorkerImageID = workerImageID(cfg)
+	l.WorkerAssociatePublicIPAddress = false
+
+	l.WorkerBlockDeviceMappings = []BlockDeviceMapping{
+		{
+			DeleteOnTermination: true,
+			DeviceName:          defaultEBSVolumeMountPoint,
+			VolumeSize:          defaultEBSVolumeSize,
+			VolumeType:          defaultEBSVolumeType,
+		},
+	}
+	l.WorkerInstanceMonitoring = cfg.StackState.WorkerInstanceMonitoring
+
+	// small cloud config field.
+	accountID, err := AccountID(cfg.Clients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	clusterID := key.ClusterID(cfg.CustomObject)
+	s3URI := fmt.Sprintf("%s-g8s-%s", accountID, clusterID)
+
+	c := SmallCloudconfigConfig{
+		MachineType:             prefixWorker,
+		Region:                  key.Region(cfg.CustomObject),
+		S3Domain:                key.S3ServiceDomain(cfg.CustomObject),
+		S3URI:                   s3URI,
+		CloudConfigVersion:      cloudconfig.CloudConfigVersion,
+		AWSCliContainerRegistry: key.AWSCliContainerRegistry(cfg.CustomObject),
+	}
+	rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	l.WorkerSmallCloudConfig = base64.StdEncoding.EncodeToString([]byte(rendered))
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_launch_configuration_test.go
+++ b/service/controller/v14patch1/adapter/guest_launch_configuration_test.go
@@ -1,0 +1,144 @@
+package adapter
+
+import (
+	"encoding/base64"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterLaunchConfigurationRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                      string
+		customObject                     v1alpha1.AWSConfig
+		expectedError                    bool
+		expectedInstanceType             string
+		expectedAssociatePublicIPAddress bool
+		expectedBlockDeviceMappings      []BlockDeviceMapping
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								InstanceType: "myinstancetype",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType:             "myinstancetype",
+			expectedAssociatePublicIPAddress: false,
+			expectedBlockDeviceMappings: []BlockDeviceMapping{
+				{
+					DeleteOnTermination: true,
+					DeviceName:          defaultEBSVolumeMountPoint,
+					VolumeSize:          defaultEBSVolumeSize,
+					VolumeType:          defaultEBSVolumeType,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		clients := Clients{
+			EC2: &EC2ClientMock{},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.Guest.LaunchConfiguration.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.LaunchConfiguration.ASGType != prefixWorker {
+				t.Errorf("unexpected ASGType, got %q, want %q", a.Guest.LaunchConfiguration.ASGType, prefixWorker)
+			}
+			if a.Guest.LaunchConfiguration.WorkerInstanceType != tc.expectedInstanceType {
+				t.Errorf("unexpected InstanceType, got %q, want %q", a.Guest.LaunchConfiguration.WorkerInstanceType, tc.expectedInstanceType)
+			}
+			if a.Guest.LaunchConfiguration.WorkerAssociatePublicIPAddress != tc.expectedAssociatePublicIPAddress {
+				t.Errorf("unexpected WorkerAssociatePublicIPAddress, got %t, want %t", a.Guest.LaunchConfiguration.WorkerAssociatePublicIPAddress, tc.expectedAssociatePublicIPAddress)
+			}
+			if !reflect.DeepEqual(a.Guest.LaunchConfiguration.WorkerBlockDeviceMappings, tc.expectedBlockDeviceMappings) {
+				t.Errorf("unexpected BlockDeviceMappings, got %v, want %v", a.Guest.LaunchConfiguration.WorkerBlockDeviceMappings, tc.expectedBlockDeviceMappings)
+			}
+		})
+	}
+}
+
+func TestAdapterLaunchConfigurationSmallCloudConfig(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description  string
+		expectedLine string
+	}{
+		{
+			description:  "userdata file",
+			expectedLine: "USERDATA_FILE=worker",
+		},
+	}
+
+	a := Adapter{}
+	clients := Clients{
+		EC2: &EC2ClientMock{},
+		IAM: &IAMClientMock{},
+		STS: &STSClientMock{accountID: "000000000000"},
+	}
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "myregion",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "myimageid",
+						InstanceType: "myinstancetype",
+					},
+				},
+			},
+		},
+	}
+	cfg := Config{
+		CustomObject: customObject,
+		Clients:      clients,
+	}
+	err := a.Guest.LaunchConfiguration.Adapt(cfg)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(a.Guest.LaunchConfiguration.WorkerSmallCloudConfig)
+	if err != nil {
+		t.Errorf("unexpected error decoding SmallCloudConfig %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if !strings.Contains(string(data), tc.expectedLine) {
+				t.Errorf("SmallCloudConfig didn't contain expected %q, complete: %q", tc.expectedLine, string(data))
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_lifecycle_hooks.go
+++ b/service/controller/v14patch1/adapter/guest_lifecycle_hooks.go
@@ -1,0 +1,27 @@
+package adapter
+
+import "github.com/giantswarm/aws-operator/service/controller/v14/key"
+
+type GuestLifecycleHooksAdapter struct {
+	Worker GuestLifecycleHooksAdapterWorker
+}
+
+type GuestLifecycleHooksAdapterWorker struct {
+	ASG           GuestLifecycleHooksAdapterASG
+	LifecycleHook GuestLifecycleHooksAdapterLifecycleHook
+}
+
+type GuestLifecycleHooksAdapterASG struct {
+	Ref string
+}
+
+type GuestLifecycleHooksAdapterLifecycleHook struct {
+	Name string
+}
+
+func (a *GuestLifecycleHooksAdapter) Adapt(config Config) error {
+	a.Worker.ASG.Ref = key.WorkerASGRef
+	a.Worker.LifecycleHook.Name = key.NodeDrainerLifecycleHookName
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_load_balancers.go
+++ b/service/controller/v14patch1/adapter/guest_load_balancers.go
@@ -1,0 +1,93 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	// Default values for health checks.
+	healthCheckHealthyThreshold   = 2
+	healthCheckInterval           = 5
+	healthCheckTimeout            = 3
+	healthCheckUnhealthyThreshold = 2
+)
+
+type GuestLoadBalancersAdapter struct {
+	APIElbHealthCheckTarget          string
+	APIElbName                       string
+	APIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
+	APIElbScheme                     string
+	APIElbSecurityGroupID            string
+	ELBHealthCheckHealthyThreshold   int
+	ELBHealthCheckInterval           int
+	ELBHealthCheckTimeout            int
+	ELBHealthCheckUnhealthyThreshold int
+	IngressElbHealthCheckTarget      string
+	IngressElbName                   string
+	IngressElbPortsToOpen            []GuestLoadBalancersAdapterPortPair
+	IngressElbScheme                 string
+	MasterInstanceResourceName       string
+}
+
+func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
+	// API load balancer settings.
+	apiElbName, err := key.LoadBalancerName(cfg.CustomObject.Spec.Cluster.Kubernetes.API.Domain, cfg.CustomObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	a.APIElbHealthCheckTarget = heathCheckTarget(cfg.CustomObject.Spec.Cluster.Kubernetes.API.SecurePort)
+	a.APIElbName = apiElbName
+	a.APIElbPortsToOpen = []GuestLoadBalancersAdapterPortPair{
+		{
+			PortELB:      key.KubernetesAPISecurePort(cfg.CustomObject),
+			PortInstance: key.KubernetesAPISecurePort(cfg.CustomObject),
+		},
+	}
+	a.APIElbScheme = externalELBScheme
+
+	// Ingress load balancer settings.
+	ingressElbName, err := key.LoadBalancerName(cfg.CustomObject.Spec.Cluster.Kubernetes.IngressController.Domain, cfg.CustomObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	a.IngressElbHealthCheckTarget = heathCheckTarget(key.IngressControllerSecurePort(cfg.CustomObject))
+	a.IngressElbName = ingressElbName
+	a.IngressElbPortsToOpen = []GuestLoadBalancersAdapterPortPair{
+		{
+			PortELB: httpsPort,
+
+			PortInstance: key.IngressControllerSecurePort(cfg.CustomObject),
+		},
+		{
+			PortELB:      httpPort,
+			PortInstance: key.IngressControllerInsecurePort(cfg.CustomObject),
+		},
+	}
+	a.IngressElbScheme = externalELBScheme
+
+	// Load balancer health check settings.
+	a.ELBHealthCheckHealthyThreshold = healthCheckHealthyThreshold
+	a.ELBHealthCheckInterval = healthCheckInterval
+	a.ELBHealthCheckTimeout = healthCheckTimeout
+	a.ELBHealthCheckUnhealthyThreshold = healthCheckUnhealthyThreshold
+	a.MasterInstanceResourceName = masterInstanceResourceName(cfg)
+
+	return nil
+}
+
+type GuestLoadBalancersAdapterPortPair struct {
+	// PortELB is the port the ELB should listen on.
+	PortELB int
+	// PortInstance is the port on the instance the ELB forwards traffic to.
+	PortInstance int
+}
+
+func heathCheckTarget(port int) string {
+	return fmt.Sprintf("TCP:%d", port)
+}

--- a/service/controller/v14patch1/adapter/guest_load_balancers_test.go
+++ b/service/controller/v14patch1/adapter/guest_load_balancers_test.go
@@ -1,0 +1,152 @@
+package adapter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func TestAdapterLoadBalancersRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                              string
+		customObject                             v1alpha1.AWSConfig
+		errorMatcher                             func(error) bool
+		expectedAPIElbName                       string
+		expectedAPIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
+		expectedAPIElbScheme                     string
+		expectedAPIElbSecurityGroupID            string
+		expectedAPIElbSubnetID                   string
+		expectedELBAZ                            string
+		expectedELBHealthCheckHealthyThreshold   int
+		expectedELBHealthCheckInterval           int
+		expectedELBHealthCheckTimeout            int
+		expectedELBHealthCheckUnhealthyThreshold int
+		expectedIngressElbName                   string
+		expectedIngressElbPortsToOpen            []GuestLoadBalancersAdapterPortPair
+		expectedIngressElbScheme                 string
+	}{
+		{
+			description:  "empty custom object",
+			customObject: v1alpha1.AWSConfig{},
+			errorMatcher: key.IsMissingCloudConfigKey,
+		},
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								Domain:     "api.test-cluster.aws.giantswarm.io",
+								SecurePort: 443,
+							},
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								Domain:       "ingress.test-cluster.aws.giantswarm.io",
+								InsecurePort: 30010,
+								SecurePort:   30011,
+							},
+						},
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "eu-central-1a",
+					},
+				},
+			},
+			errorMatcher:       nil,
+			expectedAPIElbName: "test-cluster-api",
+			expectedAPIElbPortsToOpen: []GuestLoadBalancersAdapterPortPair{
+				{
+					PortELB:      443,
+					PortInstance: 443,
+				},
+			},
+			expectedAPIElbScheme:                     "internet-facing",
+			expectedELBAZ:                            "eu-central-1a",
+			expectedELBHealthCheckHealthyThreshold:   2,
+			expectedELBHealthCheckInterval:           5,
+			expectedELBHealthCheckTimeout:            3,
+			expectedELBHealthCheckUnhealthyThreshold: 2,
+			expectedIngressElbName:                   "test-cluster-ingress",
+			expectedIngressElbPortsToOpen: []GuestLoadBalancersAdapterPortPair{
+				{
+					PortELB:      443,
+					PortInstance: 30011,
+				},
+				{
+					PortELB:      80,
+					PortInstance: 30010,
+				},
+			},
+			expectedIngressElbScheme: "internet-facing",
+		},
+	}
+
+	for _, tc := range testCases {
+		clients := Clients{
+			EC2: &EC2ClientMock{},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.Guest.LoadBalancers.Adapt(cfg)
+
+			if tc.errorMatcher != nil && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Error("expected", true, "got", false)
+			}
+
+			if tc.expectedAPIElbName != a.Guest.LoadBalancers.APIElbName {
+				t.Errorf("expected API ELB Name, got %q, want %q", a.Guest.LoadBalancers.APIElbName, tc.expectedAPIElbName)
+			}
+
+			if !reflect.DeepEqual(tc.expectedAPIElbPortsToOpen, a.Guest.LoadBalancers.APIElbPortsToOpen) {
+				t.Errorf("expected API ELB Ports To Open, got %q, want %q", a.Guest.LoadBalancers.APIElbPortsToOpen, tc.expectedAPIElbPortsToOpen)
+			}
+
+			if tc.expectedAPIElbScheme != a.Guest.LoadBalancers.APIElbScheme {
+				t.Errorf("expected API ELB Scheme, got %q, want %q", a.Guest.LoadBalancers.APIElbScheme, tc.expectedAPIElbScheme)
+			}
+
+			if tc.expectedELBHealthCheckHealthyThreshold != a.Guest.LoadBalancers.ELBHealthCheckHealthyThreshold {
+				t.Errorf("expected ELB health check healthy threshold, got %q, want %q", a.Guest.LoadBalancers.ELBHealthCheckHealthyThreshold, tc.expectedELBHealthCheckHealthyThreshold)
+			}
+
+			if tc.expectedELBHealthCheckInterval != a.Guest.LoadBalancers.ELBHealthCheckInterval {
+				t.Errorf("expected ELB health check interval, got %q, want %q", a.Guest.LoadBalancers.ELBHealthCheckInterval, tc.expectedELBHealthCheckInterval)
+			}
+
+			if tc.expectedELBHealthCheckTimeout != a.Guest.LoadBalancers.ELBHealthCheckTimeout {
+				t.Errorf("expected ELB health check timeout, got %q, want %q", a.Guest.LoadBalancers.ELBHealthCheckTimeout, tc.expectedELBHealthCheckTimeout)
+			}
+
+			if tc.expectedELBHealthCheckUnhealthyThreshold != a.Guest.LoadBalancers.ELBHealthCheckUnhealthyThreshold {
+				t.Errorf("expected ELB health check unhealthy threshold, got %q, want %q", a.Guest.LoadBalancers.ELBHealthCheckUnhealthyThreshold, tc.expectedELBHealthCheckUnhealthyThreshold)
+			}
+
+			if tc.expectedIngressElbName != a.Guest.LoadBalancers.IngressElbName {
+				t.Errorf("expected Ingress ELB Name, got %q, want %q", a.Guest.LoadBalancers.IngressElbName, tc.expectedIngressElbName)
+			}
+
+			if !reflect.DeepEqual(tc.expectedIngressElbPortsToOpen, a.Guest.LoadBalancers.IngressElbPortsToOpen) {
+				t.Errorf("expected Ingress ELB Ports To Open, got %v, want %v", a.Guest.LoadBalancers.IngressElbPortsToOpen, tc.expectedIngressElbPortsToOpen)
+			}
+
+			if tc.expectedIngressElbScheme != a.Guest.LoadBalancers.IngressElbScheme {
+				t.Errorf("expected Ingress ELB Scheme, got %q, want %q", a.Guest.LoadBalancers.IngressElbScheme, tc.expectedIngressElbScheme)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_nat_gateway.go
+++ b/service/controller/v14patch1/adapter/guest_nat_gateway.go
@@ -1,0 +1,11 @@
+package adapter
+
+type GuestNATGatewayAdapter struct {
+	ClusterID string
+}
+
+func (a *GuestNATGatewayAdapter) Adapt(cfg Config) error {
+	a.ClusterID = clusterID(cfg)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_outputs.go
+++ b/service/controller/v14patch1/adapter/guest_outputs.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestOutputsAdapter struct {
+	Master         GuestOutputsAdapterMaster
+	Worker         GuestOutputsAdapterWorker
+	Route53Enabled bool
+	VersionBundle  GuestOutputsAdapterVersionBundle
+}
+
+func (a *GuestOutputsAdapter) Adapt(config Config) error {
+	a.Route53Enabled = route53Enabled(config)
+	a.Master.DockerVolume.ResourceName = config.StackState.DockerVolumeResourceName
+	a.Master.ImageID = config.StackState.MasterImageID
+	a.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
+	a.Master.Instance.Type = config.StackState.MasterInstanceType
+	a.Master.CloudConfig.Version = config.StackState.MasterCloudConfigVersion
+
+	a.Worker.ASG.Key = key.WorkerASGKey
+	a.Worker.ASG.Ref = key.WorkerASGRef
+	a.Worker.Count = config.StackState.WorkerCount
+	a.Worker.ImageID = config.StackState.WorkerImageID
+	a.Worker.InstanceType = config.StackState.WorkerInstanceType
+	a.Worker.CloudConfig.Version = config.StackState.WorkerCloudConfigVersion
+
+	a.VersionBundle.Version = config.StackState.VersionBundleVersion
+
+	return nil
+}
+
+type GuestOutputsAdapterMaster struct {
+	ImageID      string
+	Instance     GuestOutputsAdapterMasterInstance
+	CloudConfig  GuestOutputsAdapterMasterCloudConfig
+	DockerVolume GuestOutputsAdapterMasterDockerVolume
+}
+
+type GuestOutputsAdapterMasterInstance struct {
+	ResourceName string
+	Type         string
+}
+
+type GuestOutputsAdapterMasterCloudConfig struct {
+	Version string
+}
+
+type GuestOutputsAdapterMasterDockerVolume struct {
+	ResourceName string
+}
+
+type GuestOutputsAdapterWorker struct {
+	ASG          GuestOutputsAdapterWorkerASG
+	Count        string
+	ImageID      string
+	InstanceType string
+	CloudConfig  GuestOutputsAdapterWorkerCloudConfig
+}
+
+type GuestOutputsAdapterWorkerASG struct {
+	Key string
+	Ref string
+}
+
+type GuestOutputsAdapterWorkerCloudConfig struct {
+	Version string
+}
+
+type GuestOutputsAdapterVersionBundle struct {
+	Version string
+}

--- a/service/controller/v14patch1/adapter/guest_outputs_test.go
+++ b/service/controller/v14patch1/adapter/guest_outputs_test.go
@@ -1,0 +1,127 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func Test_CloudFormation_Adapter_Outputs_MasterCloudConfigVersion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description                      string
+		Config                           Config
+		ExpectedMasterCloudConfigVersion string
+	}{
+		{
+			Description: "master CloudConfig version should match the hardcoded value",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					MasterCloudConfigVersion: "foo",
+				},
+			},
+			ExpectedMasterCloudConfigVersion: "foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &GuestOutputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Master.CloudConfig.Version != tc.ExpectedMasterCloudConfigVersion {
+				t.Fatalf("expected %s got %s", tc.ExpectedMasterCloudConfigVersion, a.Master.CloudConfig.Version)
+			}
+		})
+	}
+}
+
+func Test_CloudFormation_Adapter_Outputs_WorkerCloudConfigVersion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description                      string
+		Config                           Config
+		ExpectedWorkerCloudConfigVersion string
+	}{
+		{
+			Description: "worker CloudConfig version should match the hardcoded value",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCloudConfigVersion: "foo",
+				},
+			},
+			ExpectedWorkerCloudConfigVersion: "foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &GuestOutputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Worker.CloudConfig.Version != tc.ExpectedWorkerCloudConfigVersion {
+				t.Fatalf("expected %s got %s", tc.ExpectedWorkerCloudConfigVersion, a.Worker.CloudConfig.Version)
+			}
+		})
+	}
+}
+
+func Test_CloudFormation_Adapter_Outputs_WorkerCount(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Description         string
+		Config              Config
+		ExpectedWorkerCount string
+	}{
+		{
+			Description: "worker count should match the number of workers within the configured custom object when one worker is given",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCount: "1",
+				},
+			},
+			ExpectedWorkerCount: "1",
+		},
+
+		{
+			Description: "worker count should match the number of workers within the configured custom object when three workers are given",
+			Config: Config{
+				Clients:      Clients{},
+				CustomObject: v1alpha1.AWSConfig{},
+				StackState: StackState{
+					WorkerCount: "3",
+				},
+			},
+			ExpectedWorkerCount: "3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			a := &GuestOutputsAdapter{}
+
+			err := a.Adapt(tc.Config)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if a.Worker.Count != tc.ExpectedWorkerCount {
+				t.Fatalf("expected %s got %s", tc.ExpectedWorkerCount, a.Worker.Count)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_record_sets.go
+++ b/service/controller/v14patch1/adapter/guest_record_sets.go
@@ -1,0 +1,17 @@
+package adapter
+
+type GuestRecordSetsAdapter struct {
+	BaseDomain                 string
+	ClusterID                  string
+	MasterInstanceResourceName string
+	Route53Enabled             bool
+}
+
+func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
+	a.BaseDomain = baseDomain(config)
+	a.ClusterID = clusterID(config)
+	a.MasterInstanceResourceName = masterInstanceResourceName(config)
+	a.Route53Enabled = route53Enabled(config)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_record_sets_test.go
+++ b/service/controller/v14patch1/adapter/guest_record_sets_test.go
@@ -1,0 +1,79 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterRecordSetsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description            string
+		customObject           v1alpha1.AWSConfig
+		route53Enabled         bool
+		expectedBaseDomain     string
+		expectedClusterID      string
+		expectedRoute53Enabled bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								Domain: "api.domain",
+							},
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								Domain:         "ingress.domain",
+								WildcardDomain: "ingressWildcardDomain",
+							},
+						},
+						Etcd: v1alpha1.ClusterEtcd{
+							Domain: "etcd.domain",
+						},
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						HostedZones: v1alpha1.AWSConfigSpecAWSHostedZones{
+							API: v1alpha1.AWSConfigSpecAWSHostedZonesZone{
+								Name: "installation.aws.eu-central-1.gigantic.io",
+							},
+						},
+					},
+				},
+			},
+			route53Enabled:         true,
+			expectedRoute53Enabled: true,
+			expectedClusterID:      "test-cluster",
+			expectedBaseDomain:     "installation.aws.eu-central-1.gigantic.io",
+		},
+	}
+
+	clients := Clients{}
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:   tc.customObject,
+				Clients:        clients,
+				Route53Enabled: tc.route53Enabled,
+			}
+			err := a.Guest.RecordSets.Adapt(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.RecordSets.BaseDomain != tc.expectedBaseDomain {
+				t.Fatalf("BaseDomain == %q, want %q", a.Guest.RecordSets.BaseDomain, tc.expectedBaseDomain)
+			}
+			if a.Guest.RecordSets.ClusterID != tc.expectedClusterID {
+				t.Fatalf("ClusterID == %q, want %q", a.Guest.RecordSets.ClusterID, tc.expectedClusterID)
+			}
+			if a.Guest.RecordSets.Route53Enabled != tc.expectedRoute53Enabled {
+				t.Fatalf("Route53Enabled == %v, want %v", a.Guest.RecordSets.Route53Enabled, tc.expectedRoute53Enabled)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_route_tables.go
+++ b/service/controller/v14patch1/adapter/guest_route_tables.go
@@ -1,0 +1,26 @@
+package adapter
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestRouteTablesAdapter struct {
+	HostClusterCIDR       string
+	PublicRouteTableName  string
+	PrivateRouteTableName string
+}
+
+func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
+	hostClusterCIDR, err := VpcCIDR(cfg.HostClients, key.PeerID(cfg.CustomObject))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.HostClusterCIDR = hostClusterCIDR
+	r.PublicRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPublic)
+	r.PrivateRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPrivate)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_route_tables_test.go
+++ b/service/controller/v14patch1/adapter/guest_route_tables_test.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterRouteTablesRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                   string
+		customObject                  v1alpha1.AWSConfig
+		expectedError                 bool
+		expectedHostClusterCIDR       string
+		expectedPublicRouteTableName  string
+		expectedPrivateRouteTableName string
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedError:                 false,
+			expectedHostClusterCIDR:       "10.0.0.0/16",
+			expectedPublicRouteTableName:  "test-cluster-public",
+			expectedPrivateRouteTableName: "test-cluster-private",
+		},
+	}
+
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				vpcCIDR: tc.expectedHostClusterCIDR,
+			},
+			STS: &STSClientMock{},
+		}
+
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+			err := a.Guest.RouteTables.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.RouteTables.HostClusterCIDR != tc.expectedHostClusterCIDR {
+				t.Errorf("unexpected HostClusterCIDR, got %q, want %q", a.Guest.RouteTables.HostClusterCIDR, tc.expectedHostClusterCIDR)
+			}
+
+			if a.Guest.RouteTables.PublicRouteTableName != tc.expectedPublicRouteTableName {
+				t.Errorf("unexpected PublicRouteTableName, got %q, want %q", a.Guest.RouteTables.PublicRouteTableName, tc.expectedPrivateRouteTableName)
+			}
+
+			if a.Guest.RouteTables.PrivateRouteTableName != tc.expectedPrivateRouteTableName {
+				t.Errorf("unexpected PrivateRouteTableName, got %q, want %q", a.Guest.RouteTables.PrivateRouteTableName, tc.expectedPrivateRouteTableName)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_security_groups.go
+++ b/service/controller/v14patch1/adapter/guest_security_groups.go
@@ -1,0 +1,280 @@
+package adapter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	allPorts             = -1
+	cadvisorPort         = 4194
+	etcdPort             = 2379
+	kubeletPort          = 10250
+	nodeExporterPort     = 10300
+	kubeStateMetricsPort = 10301
+	sshPort              = 22
+
+	allProtocols = "-1"
+	tcpProtocol  = "tcp"
+
+	defaultCIDR = "0.0.0.0/0"
+
+	ingressSecurityGroupName = "IngressSecurityGroup"
+)
+
+type GuestSecurityGroupsAdapter struct {
+	APIWhitelistEnabled       bool
+	MasterSecurityGroupName   string
+	MasterSecurityGroupRules  []securityGroupRule
+	WorkerSecurityGroupName   string
+	WorkerSecurityGroupRules  []securityGroupRule
+	IngressSecurityGroupName  string
+	IngressSecurityGroupRules []securityGroupRule
+}
+
+func (s *GuestSecurityGroupsAdapter) Adapt(cfg Config) error {
+	hostClusterCIDR, err := VpcCIDR(cfg.HostClients, key.PeerID(cfg.CustomObject))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	masterRules, err := s.getMasterRules(cfg, hostClusterCIDR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	s.APIWhitelistEnabled = cfg.APIWhitelist.Enabled
+
+	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixMaster)
+	s.MasterSecurityGroupRules = masterRules
+
+	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixWorker)
+	s.WorkerSecurityGroupRules = s.getWorkerRules(cfg.CustomObject, hostClusterCIDR)
+
+	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixIngress)
+	s.IngressSecurityGroupRules = s.getIngressRules(cfg.CustomObject)
+
+	return nil
+}
+
+func (s *GuestSecurityGroupsAdapter) getMasterRules(cfg Config, hostClusterCIDR string) ([]securityGroupRule, error) {
+	// Allow traffic to the Kubernetes API server depending on the API
+	// whitelisting rules.
+	apiRules, err := getKubernetesAPIRules(cfg, hostClusterCIDR)
+	if err != nil {
+		return []securityGroupRule{}, microerror.Mask(err)
+	}
+
+	// Other security group rules for the master.
+	otherRules := []securityGroupRule{
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 2379 for etcd backup.
+		{
+			Port:       etcdPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10250 for kubelet scraping.
+		{
+			Port:       kubeletPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10300 for node-exporter scraping.
+		{
+			Port:       nodeExporterPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10301 for kube-state-metrics scraping.
+		{
+			Port:       kubeStateMetricsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Only allow ssh traffic from the host cluster.
+		{
+			Port:       sshPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+	}
+	return append(apiRules, otherRules...), nil
+}
+
+func (s *GuestSecurityGroupsAdapter) getWorkerRules(customObject v1alpha1.AWSConfig, hostClusterCIDR string) []securityGroupRule {
+	return []securityGroupRule{
+		// Allow traffic from the ingress security group to the ingress controller.
+		{
+			Port:                key.IngressControllerSecurePort(customObject),
+			Protocol:            tcpProtocol,
+			SourceSecurityGroup: ingressSecurityGroupName,
+		},
+		{
+			Port:                key.IngressControllerInsecurePort(customObject),
+			Protocol:            tcpProtocol,
+			SourceSecurityGroup: ingressSecurityGroupName,
+		},
+		// Allow traffic from host cluster to ingress controller secure port,
+		// for guest cluster scraping.
+		{
+			Port:       key.IngressControllerSecurePort(customObject),
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 4194 for cadvisor scraping.
+		{
+			Port:       cadvisorPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10250 for kubelet scraping.
+		{
+			Port:       kubeletPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10300 for node-exporter scraping.
+		{
+			Port:       nodeExporterPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Allow traffic from host cluster CIDR to 10301 for kube-state-metrics scraping.
+		{
+			Port:       kubeStateMetricsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+		// Only allow ssh traffic from the host cluster.
+		{
+			Port:       sshPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: hostClusterCIDR,
+		},
+	}
+}
+
+func (s *GuestSecurityGroupsAdapter) getIngressRules(customObject v1alpha1.AWSConfig) []securityGroupRule {
+	return []securityGroupRule{
+		// Allow all http and https traffic to the ingress load balancer.
+		{
+			Port:       httpPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: defaultCIDR,
+		},
+		{
+			Port:       httpsPort,
+			Protocol:   tcpProtocol,
+			SourceCIDR: defaultCIDR,
+		},
+	}
+}
+
+type securityGroupRule struct {
+	Port                int
+	Protocol            string
+	SourceCIDR          string
+	SourceSecurityGroup string
+}
+
+func getKubernetesAPIRules(cfg Config, hostClusterCIDR string) ([]securityGroupRule, error) {
+	// When API whitelisting is enabled, add separate security group rule per each subnet.
+	if cfg.APIWhitelist.Enabled {
+		rules := []securityGroupRule{
+			// Allow traffic from host cluster CIDR.
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: hostClusterCIDR,
+			},
+			// Allow traffic from guest cluster CIDR.
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: cfg.CustomObject.Spec.AWS.VPC.CIDR,
+			},
+		}
+
+		// Whitelist all configured subnets.
+		whitelistSubnets := strings.Split(cfg.APIWhitelist.SubnetList, ",")
+		for _, subnet := range whitelistSubnets {
+			if subnet != "" {
+				subnetRule := securityGroupRule{
+					Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+					Protocol:   tcpProtocol,
+					SourceCIDR: subnet,
+				}
+				rules = append(rules, subnetRule)
+			}
+		}
+
+		// Whitelist public EIPs of the host cluster NAT gateways.
+		hostClusterNATGatewayRules, err := getHostClusterNATGatewayRules(cfg)
+		if err != nil {
+			return []securityGroupRule{}, microerror.Mask(err)
+		}
+
+		for _, gatewayRule := range hostClusterNATGatewayRules {
+			rules = append(rules, gatewayRule)
+		}
+
+		return rules, nil
+	} else {
+		// When API whitelisting is disabled, allow all traffic.
+		allowAllRule := []securityGroupRule{
+			{
+				Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+				Protocol:   tcpProtocol,
+				SourceCIDR: defaultCIDR,
+			},
+		}
+
+		return allowAllRule, nil
+	}
+}
+
+func getHostClusterNATGatewayRules(cfg Config) ([]securityGroupRule, error) {
+	gatewayRules := []securityGroupRule{}
+
+	// Get all EIPs tagged with the host cluster installation tag.
+	// Each EIP is associated with a host cluster NAT gateway.
+	describeAddressesInput := &ec2.DescribeAddressesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:giantswarm.io/installation"),
+				Values: []*string{
+					aws.String(cfg.InstallationName),
+				},
+			},
+		},
+	}
+	output, err := cfg.HostClients.EC2.DescribeAddresses(describeAddressesInput)
+	if err != nil {
+		return gatewayRules, microerror.Mask(err)
+	}
+
+	for _, address := range output.Addresses {
+		gatewayRule := securityGroupRule{
+			Port:       key.KubernetesAPISecurePort(cfg.CustomObject),
+			Protocol:   tcpProtocol,
+			SourceCIDR: fmt.Sprintf("%s/32", *address.PublicIp),
+		}
+
+		gatewayRules = append(gatewayRules, gatewayRule)
+	}
+
+	return gatewayRules, nil
+}

--- a/service/controller/v14patch1/adapter/guest_security_groups_test.go
+++ b/service/controller/v14patch1/adapter/guest_security_groups_test.go
@@ -1,0 +1,494 @@
+package adapter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                       string
+		customObject                      v1alpha1.AWSConfig
+		expectedError                     bool
+		expectedMasterSecurityGroupName   string
+		expectedMasterSecurityGroupRules  []securityGroupRule
+		expectedWorkerSecurityGroupName   string
+		expectedWorkerSecurityGroupRules  []securityGroupRule
+		expectedIngressSecurityGroupName  string
+		expectedIngressSecurityGroupRules []securityGroupRule
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							PeerID: "vpc-1234",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							IngressController: v1alpha1.ClusterKubernetesIngressController{
+								SecurePort:   30010,
+								InsecurePort: 30011,
+							},
+						},
+					},
+				},
+			},
+			expectedError:                   false,
+			expectedMasterSecurityGroupName: "test-cluster-master",
+			expectedMasterSecurityGroupRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+				{
+					Port:       4194,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10250,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10300,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10301,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       22,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+			},
+			expectedWorkerSecurityGroupName: "test-cluster-worker",
+			expectedWorkerSecurityGroupRules: []securityGroupRule{
+				{
+					Port:                30010,
+					Protocol:            "tcp",
+					SourceSecurityGroup: "IngressSecurityGroup",
+				},
+				{
+					Port:                30011,
+					Protocol:            "tcp",
+					SourceSecurityGroup: "IngressSecurityGroup",
+				},
+				{
+					Port:       30010,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       4194,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10250,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10300,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       10301,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       22,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+			},
+			expectedIngressSecurityGroupName: "test-cluster-ingress",
+			expectedIngressSecurityGroupRules: []securityGroupRule{
+				{
+					Port:       80,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				vpcCIDR: "10.0.0.0/16",
+			},
+			IAM: &IAMClientMock{},
+			STS: &STSClientMock{},
+		}
+		a := Adapter{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+			err := a.Guest.SecurityGroups.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.SecurityGroups.MasterSecurityGroupName != tc.expectedMasterSecurityGroupName {
+				t.Errorf("unexpected MasterGroupName, got %q, want %q", a.Guest.SecurityGroups.MasterSecurityGroupName, tc.expectedMasterSecurityGroupName)
+			}
+
+			if a.Guest.SecurityGroups.WorkerSecurityGroupName != tc.expectedWorkerSecurityGroupName {
+				t.Errorf("unexpected WorkerGroupName, got %q, want %q", a.Guest.SecurityGroups.WorkerSecurityGroupName, tc.expectedWorkerSecurityGroupName)
+			}
+
+			if !reflect.DeepEqual(a.Guest.SecurityGroups.WorkerSecurityGroupRules, tc.expectedWorkerSecurityGroupRules) {
+				t.Errorf("unexpected Worker Security Group Rules, got %v, want %v", a.Guest.SecurityGroups.WorkerSecurityGroupRules, tc.expectedWorkerSecurityGroupRules)
+			}
+
+			if a.Guest.SecurityGroups.IngressSecurityGroupName != tc.expectedIngressSecurityGroupName {
+				t.Errorf("unexpected IngressGroupName, got %q, want %q", a.Guest.SecurityGroups.IngressSecurityGroupName, tc.expectedIngressSecurityGroupName)
+			}
+
+			if !reflect.DeepEqual(a.Guest.SecurityGroups.IngressSecurityGroupRules, tc.expectedIngressSecurityGroupRules) {
+				t.Errorf("unexpected Ingress Security Group Rules, got %v, want %v", a.Guest.SecurityGroups.IngressSecurityGroupRules, tc.expectedIngressSecurityGroupRules)
+			}
+		})
+	}
+}
+
+func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description            string
+		customObject           v1alpha1.AWSConfig
+		apiWhitelistingEnabled bool
+		apiWhitelistSubnets    string
+		elasticIPs             []string
+		hostClusterCIDR        string
+		expectedError          bool
+		expectedRules          []securityGroupRule
+	}{
+		{
+			description: "case 0: API whitelisting disabled",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: false,
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "0.0.0.0/0",
+				},
+			},
+		},
+		{
+			description: "case 1: API whitelisting enabled with default rules",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+			},
+		},
+		{
+			description: "case 2: API whitelisting enabled with single configured subnet",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32",
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+			},
+		},
+		{
+			description: "case 3: API whitelisting enabled with multiple configured subnets",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32,192.168.1.0/24,10.2.2.0/24",
+			hostClusterCIDR:        "10.0.0.0/16",
+			expectedError:          false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "192.168.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.2.2.0/24",
+				},
+			},
+		},
+		{
+			description: "case 4: API whitelisting enabled with NAT gateway EIPs",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			elasticIPs: []string{
+				"21.1.136.42",
+				"21.2.136.84",
+			},
+			hostClusterCIDR: "10.0.0.0/16",
+			expectedError:   false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.1.136.42/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.2.136.84/32",
+				},
+			},
+		},
+		{
+			description: "case 5: API whitelisting enabled with subnets and NAT gateway EIPs",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							CIDR: "10.1.1.0/24",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+						Kubernetes: v1alpha1.ClusterKubernetes{
+							API: v1alpha1.ClusterKubernetesAPI{
+								SecurePort: 443,
+							},
+						},
+					},
+				},
+			},
+			apiWhitelistingEnabled: true,
+			apiWhitelistSubnets:    "212.145.136.84/32,192.168.1.1/24",
+			elasticIPs: []string{
+				"21.1.136.42",
+				"21.2.136.84",
+			},
+			hostClusterCIDR: "10.0.0.0/16",
+			expectedError:   false,
+			expectedRules: []securityGroupRule{
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.0.0.0/16",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "10.1.1.0/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "212.145.136.84/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "192.168.1.1/24",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.1.136.42/32",
+				},
+				{
+					Port:       443,
+					Protocol:   "tcp",
+					SourceCIDR: "21.2.136.84/32",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		hostClients := Clients{
+			EC2: &EC2ClientMock{
+				elasticIPs: tc.elasticIPs,
+			},
+			STS: &STSClientMock{},
+		}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				APIWhitelist: APIWhitelist{
+					Enabled:    tc.apiWhitelistingEnabled,
+					SubnetList: tc.apiWhitelistSubnets,
+				},
+				CustomObject: tc.customObject,
+				Clients:      Clients{},
+				HostClients:  hostClients,
+			}
+
+			rules, err := getKubernetesAPIRules(cfg, tc.hostClusterCIDR)
+			if tc.expectedError && err == nil {
+				t.Fatalf("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			if len(tc.expectedRules) != len(rules) {
+				t.Fatalf("expected %d master rules got %d", len(tc.expectedRules), len(rules))
+			}
+
+			if !reflect.DeepEqual(tc.expectedRules, rules) {
+				t.Fatalf("expected master rules %v got %v", tc.expectedRules, rules)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_subnets.go
+++ b/service/controller/v14patch1/adapter/guest_subnets.go
@@ -1,0 +1,29 @@
+package adapter
+
+import (
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestSubnetsAdapter struct {
+	PublicSubnetAZ                   string
+	PublicSubnetCIDR                 string
+	PublicSubnetName                 string
+	PublicSubnetMapPublicIPOnLaunch  bool
+	PrivateSubnetAZ                  string
+	PrivateSubnetCIDR                string
+	PrivateSubnetName                string
+	PrivateSubnetMapPublicIPOnLaunch bool
+}
+
+func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
+	s.PublicSubnetAZ = key.AvailabilityZone(cfg.CustomObject)
+	s.PublicSubnetCIDR = cfg.CustomObject.Spec.AWS.VPC.PublicSubnetCIDR
+	s.PublicSubnetName = key.SubnetName(cfg.CustomObject, suffixPublic)
+	s.PublicSubnetMapPublicIPOnLaunch = false
+	s.PrivateSubnetAZ = key.AvailabilityZone(cfg.CustomObject)
+	s.PrivateSubnetCIDR = key.PrivateSubnetCIDR(cfg.CustomObject)
+	s.PrivateSubnetName = key.SubnetName(cfg.CustomObject, suffixPrivate)
+	s.PrivateSubnetMapPublicIPOnLaunch = false
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/guest_subnets_test.go
+++ b/service/controller/v14patch1/adapter/guest_subnets_test.go
@@ -1,0 +1,103 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterSubnetsRegularFields(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description                              string
+		customObject                             v1alpha1.AWSConfig
+		expectedError                            bool
+		expectedPublicSubnetAZ                   string
+		expectedPublicSubnetCIDR                 string
+		expectedPublicSubnetName                 string
+		expectedPublicSubnetMapPublicIPOnLaunch  bool
+		expectedPrivateSubnetAZ                  string
+		expectedPrivateSubnetCIDR                string
+		expectedPrivateSubnetName                string
+		expectedPrivateSubnetMapPublicIPOnLaunch bool
+	}{
+		{
+			description: "basic matching, all fields present",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						AZ: "eu-central-1a",
+						VPC: v1alpha1.AWSConfigSpecAWSVPC{
+							PublicSubnetCIDR:  "10.1.1.0/25",
+							PrivateSubnetCIDR: "10.1.2.0/25",
+						},
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedError:                            false,
+			expectedPublicSubnetAZ:                   "eu-central-1a",
+			expectedPublicSubnetCIDR:                 "10.1.1.0/25",
+			expectedPublicSubnetName:                 "test-cluster-public",
+			expectedPublicSubnetMapPublicIPOnLaunch:  false,
+			expectedPrivateSubnetAZ:                  "eu-central-1a",
+			expectedPrivateSubnetCIDR:                "10.1.2.0/25",
+			expectedPrivateSubnetName:                "test-cluster-private",
+			expectedPrivateSubnetMapPublicIPOnLaunch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		clients := Clients{}
+
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: tc.customObject,
+				Clients:      clients,
+			}
+			err := a.Guest.Subnets.Adapt(cfg)
+			if tc.expectedError && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.Subnets.PublicSubnetAZ != tc.expectedPublicSubnetAZ {
+				t.Errorf("unexpected PublicSubnetAZ, got %q, want %q", a.Guest.Subnets.PublicSubnetAZ, tc.expectedPublicSubnetAZ)
+			}
+
+			if a.Guest.Subnets.PublicSubnetCIDR != tc.expectedPublicSubnetCIDR {
+				t.Errorf("unexpected PublicSubnetCIDR, got %q, want %q", a.Guest.Subnets.PublicSubnetCIDR, tc.expectedPublicSubnetCIDR)
+			}
+
+			if a.Guest.Subnets.PublicSubnetName != tc.expectedPublicSubnetName {
+				t.Errorf("unexpected PublicSubnetName, got %q, want %q", a.Guest.Subnets.PublicSubnetName, tc.expectedPublicSubnetName)
+			}
+
+			if a.Guest.Subnets.PublicSubnetMapPublicIPOnLaunch != tc.expectedPublicSubnetMapPublicIPOnLaunch {
+				t.Errorf("unexpected PublicSubnetMapPublicIPOnLaunch, got %t, want %t", a.Guest.Subnets.PublicSubnetMapPublicIPOnLaunch, tc.expectedPublicSubnetMapPublicIPOnLaunch)
+			}
+
+			if a.Guest.Subnets.PrivateSubnetAZ != tc.expectedPrivateSubnetAZ {
+				t.Errorf("unexpected PrivateSubnetAZ, got %q, want %q", a.Guest.Subnets.PrivateSubnetAZ, tc.expectedPrivateSubnetAZ)
+			}
+
+			if a.Guest.Subnets.PrivateSubnetCIDR != tc.expectedPrivateSubnetCIDR {
+				t.Errorf("unexpected PrivateSubnetCIDR, got %q, want %q", a.Guest.Subnets.PrivateSubnetCIDR, tc.expectedPrivateSubnetCIDR)
+			}
+
+			if a.Guest.Subnets.PrivateSubnetName != tc.expectedPrivateSubnetName {
+				t.Errorf("unexpected PrivateSubnetName, got %q, want %q", a.Guest.Subnets.PrivateSubnetName, tc.expectedPrivateSubnetName)
+			}
+
+			if a.Guest.Subnets.PrivateSubnetMapPublicIPOnLaunch != tc.expectedPrivateSubnetMapPublicIPOnLaunch {
+				t.Errorf("unexpected PrivateSubnetMapPublicIPOnLaunch, got %t, want %t", a.Guest.Subnets.PrivateSubnetMapPublicIPOnLaunch, tc.expectedPrivateSubnetMapPublicIPOnLaunch)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/guest_vpc.go
+++ b/service/controller/v14patch1/adapter/guest_vpc.go
@@ -1,0 +1,62 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type GuestVPCAdapter struct {
+	CidrBlock        string
+	ClusterID        string
+	InstallationName string
+	HostAccountID    string
+	PeerVPCID        string
+	PeerRoleArn      string
+}
+
+func (v *GuestVPCAdapter) Adapt(cfg Config) error {
+	v.CidrBlock = cfg.CustomObject.Spec.AWS.VPC.CIDR
+	v.ClusterID = clusterID(cfg)
+	v.InstallationName = cfg.InstallationName
+	v.HostAccountID = cfg.HostAccountID
+	v.PeerVPCID = key.PeerID(cfg.CustomObject)
+
+	// PeerRoleArn.
+	roleName := key.PeerAccessRoleName(cfg.CustomObject)
+	input := &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	}
+	output, err := cfg.HostClients.IAM.GetRole(input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	v.PeerRoleArn = *output.Role.Arn
+
+	return nil
+}
+
+func VpcCIDR(clients Clients, vpcID string) (string, error) {
+	describeVpcInput := &ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(vpcID),
+				},
+			},
+		},
+	}
+	output, err := clients.EC2.DescribeVpcs(describeVpcInput)
+	if err != nil {
+		return "", microerror.Mask(err)
+	} else if len(output.Vpcs) == 0 {
+		return "", microerror.Maskf(notFoundError, "vpc: %s", vpcID)
+	} else if len(output.Vpcs) > 1 {
+		return "", microerror.Maskf(tooManyResultsError, "vpc: %s found %d vpcs", vpcID, len(output.Vpcs))
+	}
+	return *output.Vpcs[0].CidrBlock, nil
+}

--- a/service/controller/v14patch1/adapter/guest_vpc_test.go
+++ b/service/controller/v14patch1/adapter/guest_vpc_test.go
@@ -1,0 +1,122 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterVPCRegularFields(t *testing.T) {
+	t.Parallel()
+	cidr := "10.0.0.0/24"
+	peerID := "mypeerID"
+	installationName := "myinstallation"
+	hostAccountID := "myHostAccountID"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:   cidr,
+					PeerID: peerID,
+				},
+			},
+		},
+	}
+	testCases := []struct {
+		description              string
+		expectedCIDR             string
+		expectedPeerVPCID        string
+		expectedInstallationName string
+		expectedHostAccountID    string
+	}{
+		{
+			description:              "basic matching, all fields present",
+			expectedCIDR:             cidr,
+			expectedPeerVPCID:        peerID,
+			expectedInstallationName: installationName,
+			expectedHostAccountID:    hostAccountID,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:     customObject,
+				Clients:          Clients{},
+				InstallationName: installationName,
+				HostAccountID:    hostAccountID,
+				HostClients: Clients{
+					IAM: &IAMClientMock{},
+					STS: &STSClientMock{},
+				},
+			}
+			err := a.Guest.VPC.Adapt(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.VPC.CidrBlock != tc.expectedCIDR {
+				t.Errorf("unexpected CidrBlock, got %q, want %q", a.Guest.VPC.CidrBlock, tc.expectedCIDR)
+			}
+
+			if a.Guest.VPC.PeerVPCID != tc.expectedPeerVPCID {
+				t.Errorf("unexpected PeerVPCID, got %q, want %q", a.Guest.VPC.PeerVPCID, tc.expectedPeerVPCID)
+			}
+
+			if a.Guest.VPC.InstallationName != tc.expectedInstallationName {
+				t.Errorf("unexpected InstallationName, got %q, want %q", a.Guest.VPC.InstallationName, tc.expectedInstallationName)
+			}
+
+			if a.Guest.VPC.HostAccountID != tc.expectedHostAccountID {
+				t.Errorf("unexpected HostAccountID, got %q, want %q", a.Guest.VPC.HostAccountID, tc.expectedHostAccountID)
+			}
+		})
+	}
+}
+
+func TestAdapterVPCPeerRoleField(t *testing.T) {
+	t.Parallel()
+	peerRoleArn := "myPeerRoleArn"
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+	testCases := []struct {
+		description         string
+		expectedPeerRoleArn string
+	}{
+		{
+			description:         "basic matching, all fields present",
+			expectedPeerRoleArn: peerRoleArn,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject: customObject,
+				HostClients: Clients{
+					IAM: &IAMClientMock{peerRoleArn: peerRoleArn},
+					STS: &STSClientMock{},
+				},
+			}
+			err := a.Guest.VPC.Adapt(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.Guest.VPC.PeerRoleArn != tc.expectedPeerRoleArn {
+				t.Errorf("unexpected PeerRoleArn, got %q, want %q", a.Guest.VPC.PeerRoleArn, tc.expectedPeerRoleArn)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/host_post_record_sets.go
+++ b/service/controller/v14patch1/adapter/host_post_record_sets.go
@@ -1,0 +1,17 @@
+package adapter
+
+type HostPostRecordSetsAdapter struct {
+	BaseDomain                 string
+	ClusterID                  string
+	GuestHostedZoneNameServers string
+	Route53Enabled             bool
+}
+
+func (r *HostPostRecordSetsAdapter) Adapt(config Config) error {
+	r.BaseDomain = baseDomain(config)
+	r.ClusterID = clusterID(config)
+	r.Route53Enabled = route53Enabled(config)
+	r.GuestHostedZoneNameServers = hostedZoneNameServers(config)
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/host_post_route_tables.go
+++ b/service/controller/v14patch1/adapter/host_post_route_tables.go
@@ -1,0 +1,150 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type HostPostRouteTablesAdapter struct {
+	PrivateRouteTables []HostPostRouteTablesAdapterRouteTable
+	PublicRouteTables  []HostPostRouteTablesAdapterRouteTable
+}
+
+func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
+	peerConnectionID, err := waitForPeeringConnectionID(cfg)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// private routes.
+	for _, routeTableName := range cfg.CustomObject.Spec.AWS.VPC.RouteTableNames {
+		routeTableID, err := routeTableID(routeTableName, cfg)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		rt := HostPostRouteTablesAdapterRouteTable{
+			Name:         routeTableName,
+			RouteTableID: routeTableID,
+			// Requester CIDR block, we create the peering connection from the guest's private subnet.
+			CidrBlock:        key.PrivateSubnetCIDR(cfg.CustomObject),
+			PeerConnectionID: peerConnectionID,
+		}
+		i.PrivateRouteTables = append(i.PrivateRouteTables, rt)
+	}
+
+	// public routes for vault.
+	if cfg.EncrypterBackend == encrypter.VaultBackend {
+		publicRouteTables := strings.Split(cfg.PublicRouteTables, ",")
+		for _, routeTableName := range publicRouteTables {
+			routeTableID, err := routeTableID(routeTableName, cfg)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			rt := HostPostRouteTablesAdapterRouteTable{
+				Name:         routeTableName,
+				RouteTableID: routeTableID,
+				// Requester CIDR block, we create the peering connection from the
+				// guest's CIDR for being able to access Vault's ELB.
+				CidrBlock:        key.CIDR(cfg.CustomObject),
+				PeerConnectionID: peerConnectionID,
+			}
+			i.PublicRouteTables = append(i.PublicRouteTables, rt)
+		}
+	}
+	return nil
+}
+
+type HostPostRouteTablesAdapterRouteTable struct {
+	Name             string
+	RouteTableID     string
+	CidrBlock        string
+	PeerConnectionID string
+}
+
+// waitForPeeringConnectionID keeps asking for the peering connection ID until it is obtained or
+// a timeout expires. It is needed because the peering connection is created as part of the
+// guest stack, we need to wait until the required resources from the guest are in place.
+func waitForPeeringConnectionID(cfg Config) (string, error) {
+	clusterID := key.ClusterID(cfg.CustomObject)
+	input := &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("status-code"),
+				Values: []*string{
+					aws.String("active"),
+				},
+			},
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(clusterID),
+				},
+			},
+		},
+	}
+	var peeringID string
+	// TODO the logger should be injected and not magically made up in the depths
+	// of the code where nobody knows about it and nobody has control over it.
+	c := micrologger.Config{
+		Caller:             micrologger.DefaultCaller,
+		IOWriter:           micrologger.DefaultIOWriter,
+		TimestampFormatter: micrologger.DefaultTimestampFormatter,
+	}
+	logger, err := micrologger.New(c)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	o := func() error {
+		output, err := cfg.Clients.EC2.DescribeVpcPeeringConnections(input)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if len(output.VpcPeeringConnections) > 1 {
+			return microerror.Maskf(tooManyResultsError, "peering connections")
+		}
+		peeringID = *output.VpcPeeringConnections[0].VpcPeeringConnectionId
+		return nil
+	}
+	b := backoff.NewExponential(2*time.Minute, 10*time.Second)
+	n := backoff.NewNotifier(logger, context.Background())
+	err = backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return peeringID, nil
+}
+
+func routeTableID(name string, cfg Config) (string, error) {
+	input := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+				Values: []*string{
+					aws.String(name),
+				},
+			},
+		},
+	}
+	output, err := cfg.HostClients.EC2.DescribeRouteTables(input)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	if len(output.RouteTables) > 1 {
+		return "", microerror.Maskf(tooManyResultsError, "route tables: %s", name)
+	}
+
+	return *output.RouteTables[0].RouteTableId, nil
+}

--- a/service/controller/v14patch1/adapter/host_pre_iam_roles.go
+++ b/service/controller/v14patch1/adapter/host_pre_iam_roles.go
@@ -1,0 +1,15 @@
+package adapter
+
+import "github.com/giantswarm/aws-operator/service/controller/v14/key"
+
+type HostPreIAMRolesAdapter struct {
+	PeerAccessRoleName string
+	GuestAccountID     string
+}
+
+func (h *HostPreIAMRolesAdapter) Adapt(cfg Config) error {
+	h.PeerAccessRoleName = key.PeerAccessRoleName(cfg.CustomObject)
+	h.GuestAccountID = cfg.GuestAccountID
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/host_pre_iam_roles_test.go
+++ b/service/controller/v14patch1/adapter/host_pre_iam_roles_test.go
@@ -1,0 +1,63 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func TestAdapterHostIAMRolesRegularFields(t *testing.T) {
+	t.Parallel()
+	guestAccountID := "myGuestAccountID"
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					HostedZones: "apiHostedZones",
+				},
+				Etcd: v1alpha1.AWSConfigSpecAWSEtcd{
+					HostedZones: "etcdHostedZone",
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					HostedZones: "ingressHostedZone",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		description                string
+		expectedPeerAccessRoleName string
+		expectedGuestAccountID     string
+	}{
+		{
+			description:                "basic matching, all fields present",
+			expectedPeerAccessRoleName: "test-cluster-vpc-peer-access",
+			expectedGuestAccountID:     guestAccountID,
+		},
+	}
+
+	for _, tc := range testCases {
+		a := Adapter{}
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := Config{
+				CustomObject:   customObject,
+				GuestAccountID: guestAccountID,
+			}
+			err := a.HostPre.IAMRoles.Adapt(cfg)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if a.HostPre.IAMRoles.PeerAccessRoleName != tc.expectedPeerAccessRoleName {
+				t.Errorf("unexpected PeerAccessRoleName, got %q, want %q", a.HostPre.IAMRoles.PeerAccessRoleName, tc.expectedPeerAccessRoleName)
+			}
+			if a.HostPre.IAMRoles.GuestAccountID != tc.expectedGuestAccountID {
+				t.Errorf("unexpected GuestAccountID, got %q, want %q", a.HostPre.IAMRoles.GuestAccountID, tc.expectedGuestAccountID)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/adapter/mocks.go
+++ b/service/controller/v14patch1/adapter/mocks.go
@@ -1,0 +1,265 @@
+package adapter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+)
+
+type EC2ClientMock struct {
+	ec2iface.EC2API
+
+	unexistingSg        bool
+	sgID                string
+	unexistingSubnet    bool
+	subnetID            string
+	matchingRouteTables int
+	routeTableID        string
+	vpcID               string
+	vpcCIDR             string
+	unexistingVPC       bool
+	peeringID           string
+	elasticIPs          []string
+}
+
+func (e *EC2ClientMock) DescribeAddresses(input *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
+	addresses := make([]*ec2.Address, 0)
+
+	for _, eip := range e.elasticIPs {
+		address := &ec2.Address{
+			PublicIp: aws.String(eip),
+		}
+
+		addresses = append(addresses, address)
+	}
+
+	output := &ec2.DescribeAddressesOutput{
+		Addresses: addresses,
+	}
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	if !e.unexistingSg {
+		output := &ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String(e.sgID),
+				},
+			},
+		}
+		return output, nil
+	}
+
+	return nil, fmt.Errorf("security group not found")
+}
+
+func (e *EC2ClientMock) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	if e.subnetID == "" {
+		e.subnetID = "subnet-1234"
+	}
+
+	if e.unexistingSubnet {
+		return nil, fmt.Errorf("subnet not found")
+	}
+
+	output := &ec2.DescribeSubnetsOutput{
+		Subnets: []*ec2.Subnet{
+			{
+				SubnetId: aws.String(e.subnetID),
+			},
+		},
+	}
+	return output, nil
+}
+
+func (e *EC2ClientMock) SetMatchingRouteTables(value int) {
+	e.matchingRouteTables = value
+}
+
+func (e *EC2ClientMock) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	if e.matchingRouteTables == 0 {
+		return nil, fmt.Errorf("route table not found")
+	}
+
+	rts := []*ec2.RouteTable{}
+
+	for i := 0; i < e.matchingRouteTables; i++ {
+		rt := &ec2.RouteTable{
+			RouteTableId: aws.String(fmt.Sprintf("%s_%d", e.routeTableID, i)),
+		}
+		rts = append(rts, rt)
+	}
+
+	output := &ec2.DescribeRouteTablesOutput{
+		RouteTables: rts,
+	}
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	if e.unexistingVPC {
+		return nil, fmt.Errorf("vpc not found")
+	}
+
+	output := &ec2.DescribeVpcsOutput{
+		Vpcs: []*ec2.Vpc{
+			{
+				CidrBlock: aws.String(e.vpcCIDR),
+				VpcId:     aws.String(e.vpcID),
+			},
+		},
+	}
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	output := &ec2.DescribeVpcPeeringConnectionsOutput{
+		VpcPeeringConnections: []*ec2.VpcPeeringConnection{
+			{
+				VpcPeeringConnectionId: aws.String(e.peeringID),
+			},
+		},
+	}
+	return output, nil
+}
+
+type CFClientMock struct{}
+
+func (c *CFClientMock) CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error) {
+	return nil, nil
+}
+func (c *CFClientMock) UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error) {
+	return nil, nil
+}
+
+type IAMClientMock struct {
+	iamiface.IAMAPI
+
+	isError     bool
+	peerRoleArn string
+}
+
+func (i *IAMClientMock) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	if i.isError {
+		return nil, fmt.Errorf("error")
+	}
+	output := &iam.GetRoleOutput{
+		Role: &iam.Role{
+			Arn: aws.String(i.peerRoleArn),
+		},
+	}
+
+	return output, nil
+}
+
+type KMSClientMock struct {
+	kmsiface.KMSAPI
+
+	keyARN  string
+	isError bool
+}
+
+func (k *KMSClientMock) DescribeKey(input *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
+	if k.isError {
+		return nil, fmt.Errorf("error")
+	}
+
+	output := &kms.DescribeKeyOutput{
+		KeyMetadata: &kms.KeyMetadata{
+			Arn: aws.String(k.keyARN),
+		},
+	}
+	return output, nil
+}
+
+type ELBClientMock struct {
+	elbiface.ELBAPI
+
+	dns        string
+	hostedZone string
+	name       string
+	isError    bool
+}
+
+func (e *ELBClientMock) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	if e.isError {
+		return nil, fmt.Errorf("error")
+	}
+	output := &elb.DescribeLoadBalancersOutput{
+		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
+			{
+				DNSName:                   aws.String(e.dns),
+				CanonicalHostedZoneNameID: aws.String(e.hostedZone),
+			},
+		},
+	}
+	return output, nil
+}
+
+type CloudFormationMock struct{}
+
+func (c *CloudFormationMock) CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error) {
+	return nil, nil
+}
+func (c *CloudFormationMock) WaitUntilStackCreateComplete(*awscloudformation.DescribeStacksInput) error {
+	return nil
+}
+func (c *CloudFormationMock) WaitUntilStackCreateCompleteWithContext(ctx aws.Context, input *awscloudformation.DescribeStacksInput, opts ...request.WaiterOption) error {
+	return nil
+}
+
+type STSClientMock struct {
+	stsiface.STSAPI
+
+	accountID string
+	isError   bool
+}
+
+func (i *STSClientMock) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	if i.isError {
+		return nil, fmt.Errorf("error")
+	}
+	if i.accountID == "" {
+		i.accountID = "00"
+	}
+	// pad accountID to required length
+	toPad := accountIDLength - len(i.accountID)
+	for j := 0; j < toPad; j++ {
+		i.accountID += "0"
+	}
+	output := &sts.GetCallerIdentityOutput{
+		Arn: aws.String("::::" + i.accountID),
+	}
+
+	return output, nil
+}

--- a/service/controller/v14patch1/adapter/spec.go
+++ b/service/controller/v14patch1/adapter/spec.go
@@ -1,0 +1,155 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+const (
+	prefixMaster  = "master"
+	prefixWorker  = "worker"
+	prefixIngress = "ingress"
+
+	// asgMaxBatchSizeRatio is the % of instances to be updated during a
+	// rolling update.
+	asgMaxBatchSizeRatio = 0.3
+	// asgMinInstancesRatio is the % of instances to keep in service during a
+	// rolling update.
+	asgMinInstancesRatio = 0.7
+	// defaultEBSVolumeMountPoint is the path for mounting the EBS volume.
+	defaultEBSVolumeMountPoint = "/dev/xvdh"
+	// defaultEBSVolumeSize is expressed in GB.
+	defaultEBSVolumeSize = 100
+	// defaultEBSVolumeType is the EBS volume type.
+	defaultEBSVolumeType = "gp2"
+	// rollingUpdatePauseTime is how long to pause ASG operations after creating
+	// new instances. This allows time for new nodes to join the cluster.
+	rollingUpdatePauseTime = "PT15M"
+
+	// Subnet keys
+	subnetDescription = "description"
+	subnetGroupName   = "group-name"
+
+	// accountIDIndex represents the index in which we can find the account ID in the user ARN
+	// (splitting by colon)
+	accountIDIndex  = 4
+	accountIDLength = 12
+
+	// The number of seconds AWS will wait, before issuing a health check on
+	// instances in an Auto Scaling Group.
+	gracePeriodSeconds = 10
+
+	tagKeyName = "Name"
+
+	suffixPublic  = "public"
+	suffixPrivate = "private"
+
+	externalELBScheme = "internet-facing"
+	internalELBScheme = "internal"
+
+	httpPort  = 80
+	httpsPort = 443
+
+	// RootDirElement marks the directory that should be taken as root when evaluating
+	// template's relative paths.
+	RootDirElement = "aws-operator"
+)
+
+// APIWhitelist defines guest cluster k8s api whitelisting.
+type APIWhitelist struct {
+	Enabled    bool
+	SubnetList string
+}
+
+type Clients struct {
+	CloudFormation CFClient
+	EC2            EC2Client
+	IAM            IAMClient
+	KMS            KMSClient
+	ELB            ELBClient
+	STS            STSClient
+}
+
+// TODO we copy this because of a circular import issue with the cloudformation
+// resource. The way how the resource works with the adapter and how infromation
+// is passed has to be reworked at some point. Just hacking this now to keep
+// going and to keep the changes as minimal as possible.
+type StackState struct {
+	Name string
+
+	HostedZoneNameServers string
+
+	DockerVolumeResourceName   string
+	MasterImageID              string
+	MasterInstanceType         string
+	MasterInstanceResourceName string
+	MasterCloudConfigVersion   string
+	MasterInstanceMonitoring   bool
+
+	WorkerCount              string
+	WorkerImageID            string
+	WorkerInstanceMonitoring bool
+	WorkerInstanceType       string
+	WorkerCloudConfigVersion string
+
+	VersionBundleVersion string
+}
+
+// CFClient describes the methods required to be implemented by a CloudFormation
+// AWS client.
+type CFClient interface {
+	CreateStack(*awscloudformation.CreateStackInput) (*awscloudformation.CreateStackOutput, error)
+	DeleteStack(*awscloudformation.DeleteStackInput) (*awscloudformation.DeleteStackOutput, error)
+	DescribeStacks(*awscloudformation.DescribeStacksInput) (*awscloudformation.DescribeStacksOutput, error)
+	UpdateStack(*awscloudformation.UpdateStackInput) (*awscloudformation.UpdateStackOutput, error)
+	WaitUntilStackCreateComplete(*awscloudformation.DescribeStacksInput) error
+	WaitUntilStackCreateCompleteWithContext(ctx aws.Context, input *awscloudformation.DescribeStacksInput, opts ...request.WaiterOption) error
+}
+
+// EC2Client describes the methods required to be implemented by a EC2 AWS client.
+type EC2Client interface {
+	DescribeAddresses(*ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
+}
+
+// IAMClient describes the methods required to be implemented by a IAM AWS client.
+type IAMClient interface {
+	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
+	GetRole(*iam.GetRoleInput) (*iam.GetRoleOutput, error)
+}
+
+// KMSClient describes the methods required to be implemented by a KMS AWS client.
+type KMSClient interface {
+	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
+}
+
+// SmallCloudconfigConfig represents the data structure required for executing the
+// small cloudconfig template.
+type SmallCloudconfigConfig struct {
+	MachineType             string
+	Region                  string
+	S3Domain                string
+	S3URI                   string
+	CloudConfigVersion      string
+	AWSCliContainerRegistry string
+}
+
+// ELBClient describes the methods required to be implemented by a ELB AWS client.
+type ELBClient interface {
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+}
+
+// STSClient describes the methods required to be implemented by a STS AWS client.
+type STSClient interface {
+	GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+}

--- a/service/controller/v14patch1/adapter/sts.go
+++ b/service/controller/v14patch1/adapter/sts.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/giantswarm/microerror"
+)
+
+func AccountID(clients Clients) (string, error) {
+	resp, err := clients.STS.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	userArn := *resp.Arn
+	accountID := strings.Split(userArn, ":")[accountIDIndex]
+	if err := ValidateAccountID(accountID); err != nil {
+		return "", microerror.Mask(err)
+	}
+	return accountID, nil
+}
+
+func ValidateAccountID(accountID string) error {
+	r, _ := regexp.Compile("^[0-9]*$")
+
+	switch {
+	case accountID == "":
+		return microerror.Mask(emptyAmazonAccountIDError)
+	case len(accountID) != accountIDLength:
+		return microerror.Mask(wrongAmazonAccountIDLengthError)
+	case !r.MatchString(accountID):
+		return microerror.Mask(malformedAmazonAccountIDError)
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/adapter/sts_test.go
+++ b/service/controller/v14patch1/adapter/sts_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidAmazonAccountID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		amazonAccountID string
+		err             error
+	}{
+		{
+			name:            "ID has wrong length",
+			amazonAccountID: "foo",
+			err:             wrongAmazonAccountIDLengthError,
+		},
+		{
+			name:            "ID contains letters",
+			amazonAccountID: "123foo123foo",
+			err:             malformedAmazonAccountIDError,
+		},
+		{
+			name:            "ID is empty",
+			amazonAccountID: "",
+			err:             emptyAmazonAccountIDError,
+		},
+		{
+			name:            "ID has correct format",
+			amazonAccountID: "123456789012",
+			err:             nil,
+		},
+	}
+
+	for _, tc := range tests {
+		err := ValidateAccountID(tc.amazonAccountID)
+		assert.Equal(t, microerror.Cause(tc.err), microerror.Cause(err), fmt.Sprintf("[%s] The return value was not what we expected", tc.name))
+	}
+}

--- a/service/controller/v14patch1/cloudconfig/cloud_config.go
+++ b/service/controller/v14patch1/cloudconfig/cloud_config.go
@@ -1,0 +1,94 @@
+package cloudconfig
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+const (
+	FileOwner          = "root:root"
+	FilePermission     = 0700
+	GzipBase64Encoding = "gzip+base64"
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	Encrypter encrypter.Interface
+	Logger    micrologger.Logger
+
+	OIDC                   OIDCConfig
+	PodInfraContainerImage string
+	RegistryDomain         string
+	SSOPublicKey           string
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	encrypter encrypter.Interface
+	logger    micrologger.Logger
+
+	k8sAPIExtraArgs     []string
+	k8sKubeletExtraArgs []string
+	registryDomain      string
+	SSOPublicKey        string
+}
+
+// OIDCConfig represents the configuration of the OIDC authorization provider
+type OIDCConfig struct {
+	ClientID      string
+	IssuerURL     string
+	UsernameClaim string
+	GroupsClaim   string
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	if config.Encrypter == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Encrypter must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.RegistryDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
+	}
+
+	var k8sAPIExtraArgs []string
+	{
+		if config.OIDC.ClientID != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-client-id=%s", config.OIDC.ClientID))
+		}
+		if config.OIDC.IssuerURL != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-issuer-url=%s", config.OIDC.IssuerURL))
+		}
+		if config.OIDC.UsernameClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-username-claim=%s", config.OIDC.UsernameClaim))
+		}
+		if config.OIDC.GroupsClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-groups-claim=%s", config.OIDC.GroupsClaim))
+		}
+	}
+
+	var k8sKubeletExtraArgs []string
+	{
+		if config.PodInfraContainerImage != "" {
+			k8sKubeletExtraArgs = append(k8sKubeletExtraArgs, fmt.Sprintf("--pod-infra-container-image=%s", config.PodInfraContainerImage))
+		}
+	}
+
+	newCloudConfig := &CloudConfig{
+		encrypter: config.Encrypter,
+		logger:    config.Logger,
+
+		k8sAPIExtraArgs:     k8sAPIExtraArgs,
+		k8sKubeletExtraArgs: k8sKubeletExtraArgs,
+		registryDomain:      config.RegistryDomain,
+		SSOPublicKey:        config.SSOPublicKey,
+	}
+
+	return newCloudConfig, nil
+}

--- a/service/controller/v14patch1/cloudconfig/cloud_config_test.go
+++ b/service/controller/v14patch1/cloudconfig/cloud_config_test.go
@@ -1,0 +1,206 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_Service_CloudConfig_NewMasterTemplate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+		ClusterKeys  randomkeys.Cluster
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Etcd: v1alpha1.ClusterEtcd{
+							Port: 2379,
+						},
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+			ClusterKeys: randomkeys.Cluster{
+				APIServerEncryptionKey: randomkeys.RandomKey("fekhfiwoiqhoifhwqefoiqwefoikqhwef"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+		template, err := ccService.NewMasterTemplate(context.TODO(), tc.CustomObject, tc.Certs, tc.ClusterKeys)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerEncryptionKey", func(t *testing.T) {
+			if !strings.Contains(decoded, "H4sIAAAAAAAA/1SNMQ7CMAxF957CF+jQNSviCuwldYgVYTd2aBQh7o4CVREeLL33pf8T8eLgzF7bWkj4JBzoNswrXVCNhB1s06Bo8lCP5gaAEf6wC0OvWOxDq8pGC+oRzmj+6r/UL2GzH43A8x1dt9MhYW90EDDFQFUoR6EQa8YglGv/KceKYR+hBblQaQ6er3cAAAD//9QjGEbUAAAA") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain apiserver encryption config", "wrong config output")
+			}
+		})
+	}
+}
+
+func Test_Service_CloudConfig_NewWorkerTemplate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		CustomObject v1alpha1.AWSConfig
+		Certs        legacy.CompactTLSAssets
+	}{
+		{
+			CustomObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "123456789-super-magic-aws-region",
+					},
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			Certs: legacy.CompactTLSAssets{
+				CalicoClientCA:  "123456789-super-magic-calico-client-ca",
+				CalicoClientCrt: "123456789-super-magic-calico-client-crt",
+				CalicoClientKey: "123456789-super-magic-calico-client-key",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		ccService, err := testNewCloudConfigService()
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		template, err := ccService.NewWorkerTemplate(context.TODO(), tc.CustomObject, tc.Certs)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		decoded, err := testDecodeTemplate(template)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("VerifyAPIServerCA", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCA) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client CA", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerCrt", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientCrt) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Crt", "none")
+			}
+		})
+
+		t.Run("VerifyAPIServerKey", func(t *testing.T) {
+			if !strings.Contains(decoded, tc.Certs.CalicoClientKey) {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain Calico client Key", "none")
+			}
+		})
+
+		t.Run("VerifyTLSAssetsDecryptionUnit", func(t *testing.T) {
+			if !strings.Contains(decoded, "- name: decrypt-tls-assets.service") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain unit decrypt-tls-assets.service", "none")
+			}
+		})
+
+		t.Run("VerifyAWSRegion", func(t *testing.T) {
+			if !strings.Contains(decoded, "--region 123456789-super-magic-aws-region kms decrypt") {
+				t.Fatalf("expected %#v got %#v", "cloud config to contain AWS region", "none")
+			}
+		})
+	}
+}
+
+func testDecodeTemplate(template string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(template)
+	if err != nil {
+		return "", err
+	}
+	r, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	_, err = io.Copy(&b, r)
+	if err != nil {
+		return "", err
+	}
+	r.Close()
+
+	return b.String(), nil
+}
+
+func testNewCloudConfigService() (*CloudConfig, error) {
+	var err error
+
+	var ccService *CloudConfig
+	{
+		c := Config{
+			Encrypter:      &encrypter.EncrypterMock{},
+			Logger:         microloggertest.New(),
+			RegistryDomain: "quay.io",
+		}
+
+		ccService, err = New(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ccService, nil
+}

--- a/service/controller/v14patch1/cloudconfig/compact.go
+++ b/service/controller/v14patch1/cloudconfig/compact.go
@@ -1,0 +1,28 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+
+	"github.com/giantswarm/microerror"
+)
+
+func compactor(data []byte) (string, error) {
+	var err error
+
+	buf := &bytes.Buffer{}
+	gzw := gzip.NewWriter(buf)
+
+	_, err = gzw.Write(data)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	err = gzw.Close()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/service/controller/v14patch1/cloudconfig/error.go
+++ b/service/controller/v14patch1/cloudconfig/error.go
@@ -1,0 +1,21 @@
+package cloudconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/v14patch1/cloudconfig/interface.go
+++ b/service/controller/v14patch1/cloudconfig/interface.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/randomkeys"
+)
+
+type Interface interface {
+	NewMasterTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, clusterKeys randomkeys.Cluster) (string, error)
+	NewWorkerTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error)
+}

--- a/service/controller/v14patch1/cloudconfig/master_template.go
+++ b/service/controller/v14patch1/cloudconfig/master_template.go
@@ -1,0 +1,358 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_4_0"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter/vault"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudconfig"
+)
+
+// NewMasterTemplate generates a new master cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, clusterKeys randomkeys.Cluster) (string, error) {
+	var err error
+
+	encryptionKey, err := c.encrypter.EncryptionKey(ctx, customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	randomKeyTmplSet, err := renderRandomKeyTmplSet(ctx, c.encrypter, encryptionKey, clusterKeys)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var params k8scloudconfig.Params
+	{
+		be := baseExtension{
+			customObject:  customObject,
+			encrypter:     c.encrypter,
+			encryptionKey: encryptionKey,
+		}
+
+		params.Cluster = customObject.Spec.Cluster
+		params.DisableEncryptionAtREST = true
+		params.EtcdPort = customObject.Spec.Cluster.Etcd.Port
+		params.Extension = &MasterExtension{
+			certs:            certs,
+			baseExtension:    be,
+			RandomKeyTmplSet: randomKeyTmplSet,
+		}
+		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
+		params.Hyperkube.Kubelet.Docker.CommandExtraArgs = c.k8sKubeletExtraArgs
+		params.RegistryDomain = c.registryDomain
+		params.SSOPublicKey = c.SSOPublicKey
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.MasterTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+// RandomKeyTmplSet holds a collection of rendered templates for random key
+// encryption via KMS.
+type RandomKeyTmplSet struct {
+	APIServerEncryptionKey string
+}
+
+type MasterExtension struct {
+	baseExtension
+
+	certs            legacy.CompactTLSAssets
+	RandomKeyTmplSet RandomKeyTmplSet
+}
+
+func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsScript,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCrt,
+			Path:         "/etc/kubernetes/ssl/apiserver-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerCA,
+			Path:         "/etc/kubernetes/ssl/apiserver-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.APIServerKey,
+			Path:         "/etc/kubernetes/ssl/apiserver-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCrt,
+			Path:         "/etc/kubernetes/ssl/service-account-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountCA,
+			Path:         "/etc/kubernetes/ssl/service-account-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.ServiceAccountKey,
+			Path:         "/etc/kubernetes/ssl/service-account-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/server-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/server-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/server-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		// Add second copy of files for etcd client certs. Will be replaced by
+		// a separate client cert.
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: e.RandomKeyTmplSet.APIServerEncryptionKey,
+			Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",
+			Owner:        FileOwner,
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0644,
+		},
+		{
+			AssetContent: cloudconfig.WaitDockerConf,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: cloudconfig.DecryptKeysAssetsScript,
+			Path:         "/opt/bin/decrypt-keys-assets",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Add use-proxy-protocol to ingress-controller ConfigMap, this doesn't work
+		// on KVM because of dependencies on hardware LB configuration.
+		{
+			AssetContent: cloudconfig.IngressControllerConfigMap,
+			Path:         "/srv/ingress-controller-cm.yml",
+			Owner:        FileOwner,
+			Permissions:  0644,
+		},
+		// NVME disks udev rules and script.
+		// Workaround for https://github.com/coreos/bugs/issues/2399
+		{
+			AssetContent: cloudconfig.NVMEUdevRule,
+			Path:         "/etc/udev/rules.d/10-ebs-nvme-mapping.rules",
+			Owner:        FileOwner,
+			Permissions:  0644,
+		},
+		{
+			AssetContent: cloudconfig.NVMEUdevScript,
+			Path:         "/opt/ebs-nvme-mapping",
+			Owner:        FileOwner,
+			Permissions:  0766,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		data := e.templateData()
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, data)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		// Create symlinks for nvme disks.
+		// This service should be started only on first boot.
+		{
+			AssetContent: cloudconfig.NVMEUdevTriggerUnit,
+			Name:         "ebs-nvme-udev-trigger.service",
+			Enable:       false,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsService,
+			Name:         "decrypt-tls-assets.service",
+			// Do not enable TLS assets decrypt unit so that it won't get automatically
+			// executed on master reboot. This will prevent eventual races with the
+			// asset files creation.
+			Enable:  false,
+			Command: "start",
+		},
+		{
+			AssetContent: cloudconfig.MasterFormatVarLibDockerService,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.EphemeralVarLibDockerMount,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.DecryptKeysAssetsService,
+			Name:         "decrypt-keys-assets.service",
+			// Do not enable key decrypt unit so that it won't get automatically
+			// executed on master reboot. This will prevent eventual races with the
+			// key files creation.
+			Enable:  false,
+			Command: "start",
+		},
+		// Format etcd EBS volume.
+		{
+			AssetContent: cloudconfig.FormatEtcdVolume,
+			Name:         "format-etcd-ebs.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		// Mount etcd EBS volume.
+		{
+			AssetContent: cloudconfig.MountEtcdVolume,
+			Name:         "var-lib-etcd.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *MasterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	var storageClasss string
+	_, ok := e.encrypter.(*vault.Encrypter)
+	if ok {
+		storageClasss = cloudconfig.InstanceStorageClass
+	} else {
+		storageClasss = cloudconfig.InstanceStorageClassEncrypted
+	}
+
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storage",
+			Content: cloudconfig.InstanceStorage,
+		},
+		{
+			Name:    "storageclass",
+			Content: storageClasss,
+		},
+	}
+	return newSections
+}

--- a/service/controller/v14patch1/cloudconfig/randomkeys.go
+++ b/service/controller/v14patch1/cloudconfig/randomkeys.go
@@ -1,0 +1,46 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudconfig"
+)
+
+func renderRandomKeyTmplSet(ctx context.Context, encrypter encrypter.Interface, key string, clusterKeys randomkeys.Cluster) (RandomKeyTmplSet, error) {
+	var randomKeyTmplSet RandomKeyTmplSet
+	{
+		tmpl, err := template.New("encryption-config").Parse(cloudconfig.EncryptionConfig)
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+		buf := new(bytes.Buffer)
+		err = tmpl.Execute(buf, struct {
+			EncryptionKey string
+		}{
+			EncryptionKey: string(clusterKeys.APIServerEncryptionKey),
+		})
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		enc, err := encrypter.Encrypt(ctx, key, buf.String())
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		com, err := compactor([]byte(enc))
+		if err != nil {
+			return RandomKeyTmplSet{}, microerror.Mask(err)
+		}
+
+		randomKeyTmplSet.APIServerEncryptionKey = com
+	}
+
+	return randomKeyTmplSet, nil
+}

--- a/service/controller/v14patch1/cloudconfig/spec.go
+++ b/service/controller/v14patch1/cloudconfig/spec.go
@@ -1,0 +1,53 @@
+package cloudconfig
+
+import (
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter/vault"
+)
+
+const (
+	// CloudConfigVersion defines the version of k8scloudconfig in use.
+	// It is used in the main stack output and S3 object paths.
+	CloudConfigVersion = "v_3_4_0"
+)
+
+// TemplateData is a composed data type that adds encrypter type info to
+// AWSConfigSpec.
+type TemplateData struct {
+	v1alpha1.AWSConfigSpec
+	EncrypterType string
+	VaultAddress  string
+	EncryptionKey string
+}
+
+type baseExtension struct {
+	customObject  v1alpha1.AWSConfig
+	encrypter     encrypter.Interface
+	encryptionKey string
+}
+
+func (e *baseExtension) templateData() TemplateData {
+	var encrypterType string
+	var vaultAddress string
+	v, ok := e.encrypter.(*vault.Encrypter)
+	if ok {
+		encrypterType = encrypter.VaultBackend
+		vaultAddress = v.Address()
+	} else {
+		encrypterType = encrypter.KMSBackend
+	}
+	data := TemplateData{
+		AWSConfigSpec: e.customObject.Spec,
+		EncrypterType: encrypterType,
+		VaultAddress:  vaultAddress,
+		EncryptionKey: e.encryptionKey,
+	}
+
+	return data
+}
+
+type KMSClient interface {
+	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
+}

--- a/service/controller/v14patch1/cloudconfig/worker_template.go
+++ b/service/controller/v14patch1/cloudconfig/worker_template.go
@@ -1,0 +1,216 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_4_0"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudconfig"
+)
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error) {
+	var err error
+
+	encryptionKey, err := c.encrypter.EncryptionKey(ctx, customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var params k8scloudconfig.Params
+	{
+		be := baseExtension{
+			customObject:  customObject,
+			encrypter:     c.encrypter,
+			encryptionKey: encryptionKey,
+		}
+
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &WorkerExtension{
+			baseExtension: be,
+			certs:         certs,
+		}
+		params.Hyperkube.Kubelet.Docker.CommandExtraArgs = c.k8sKubeletExtraArgs
+		params.RegistryDomain = c.registryDomain
+		params.SSOPublicKey = c.SSOPublicKey
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.WorkerTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type WorkerExtension struct {
+	baseExtension
+	certs legacy.CompactTLSAssets
+}
+
+func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsScript,
+			Path:         "/opt/bin/decrypt-tls-assets",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCrt,
+			Path:         "/etc/kubernetes/ssl/worker-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerCA,
+			Path:         "/etc/kubernetes/ssl/worker-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.WorkerKey,
+			Path:         "/etc/kubernetes/ssl/worker-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCrt,
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientCA,
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.CalicoClientKey,
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCrt,
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerCA,
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: e.certs.EtcdServerKey,
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem.enc",
+			Owner:        "root:root",
+			Encoding:     GzipBase64Encoding,
+			Permissions:  0700,
+		},
+		{
+			AssetContent: cloudconfig.WaitDockerConf,
+			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
+			Owner:        "root:root",
+			Permissions:  0700,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, m := range filesMeta {
+		data := e.templateData()
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, data)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *WorkerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			AssetContent: cloudconfig.DecryptTLSAssetsService,
+			Name:         "decrypt-tls-assets.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.WorkerFormatVarLibDockerService,
+			Name:         "format-var-lib-docker.service",
+			Enable:       true,
+			Command:      "start",
+		},
+		{
+			AssetContent: cloudconfig.PersistentVarLibDockerMount,
+			Name:         "var-lib-docker.mount",
+			Enable:       true,
+			Command:      "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, m := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(m.AssetContent, e.customObject.Spec)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: m,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *WorkerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	newSections := []k8scloudconfig.VerbatimSection{
+		{
+			Name:    "storageclass",
+			Content: cloudconfig.InstanceStorageClass,
+		},
+	}
+
+	return newSections
+}

--- a/service/controller/v14patch1/cloudformation/cloud_formation.go
+++ b/service/controller/v14patch1/cloudformation/cloud_formation.go
@@ -1,0 +1,84 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+type Config struct {
+	Client CloudFormationInterface
+}
+
+type CloudFormation struct {
+	client CloudFormationInterface
+}
+
+func New(config Config) (*CloudFormation, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+
+	c := &CloudFormation{
+		client: config.Client,
+	}
+
+	return c, nil
+}
+
+func (c *CloudFormation) DescribeOutputsAndStatus(stackName string) ([]*cloudformation.Output, string, error) {
+	// At first we fetch the CF stack state by describing it via the AWS golang
+	// SDK. We are interested in the stack outputs and the stack status, since
+	// this tells us if we are able to access outputs at all.
+	var stackOutputs []*cloudformation.Output
+	var stackStatus string
+	{
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(stackName),
+		}
+
+		o, err := c.client.DescribeStacks(i)
+		if IsStackNotFound(err) {
+			return nil, "", microerror.Maskf(stackNotFoundError, "stack name '%s'", stackName)
+		} else if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+
+		if len(o.Stacks) > 1 {
+			return nil, "", microerror.Maskf(tooManyStacksError, "expected 1 stack, got %d", len(o.Stacks))
+		}
+
+		stackOutputs = o.Stacks[0].Outputs
+		stackStatus = *o.Stacks[0].StackStatus
+	}
+
+	// We call DescribeOutputsAndStatus in certain GetCurrentState
+	// implementations. If the stack creation failed, the outputs can be
+	// unaccessible. This can lead to a stack that cannot be deleted. it can also
+	// be called during creation, while the outputs are still not accessible.
+	{
+		errorStatuses := []string{
+			cloudformation.StackStatusRollbackInProgress,
+			cloudformation.StackStatusRollbackComplete,
+			cloudformation.StackStatusCreateInProgress,
+		}
+
+		for _, s := range errorStatuses {
+			if stackStatus == s {
+				return nil, "", microerror.Maskf(outputsNotAccessibleError, "due to stack state '%s'", stackStatus)
+			}
+		}
+	}
+
+	return stackOutputs, stackStatus, nil
+}
+
+func (c *CloudFormation) GetOutputValue(outputs []*cloudformation.Output, key string) (string, error) {
+	for _, o := range outputs {
+		if *o.OutputKey == key {
+			return *o.OutputValue, nil
+		}
+	}
+
+	return "", microerror.Maskf(outputNotFoundError, "stack output value for key '%s'", key)
+}

--- a/service/controller/v14patch1/cloudformation/error.go
+++ b/service/controller/v14patch1/cloudformation/error.go
@@ -1,0 +1,70 @@
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var outputNotFoundError = &microerror.Error{
+	Kind: "outputNotFoundError",
+}
+
+// IsOutputNotFound asserts outputNotFoundError.
+func IsOutputNotFound(err error) bool {
+	return microerror.Cause(err) == outputNotFoundError
+}
+
+var outputsNotAccessibleError = &microerror.Error{
+	Kind: "outputsNotAccessibleError",
+}
+
+// IsOutputsNotAccessible asserts outputsNotAccessibleError.
+func IsOutputsNotAccessible(err error) bool {
+	return microerror.Cause(err) == outputsNotAccessibleError
+}
+
+var stackNotFoundError = &microerror.Error{
+	Kind: "stackNotFoundError",
+}
+
+// IsStackNotFound asserts stackNotFoundError and stack not found errors from
+// the upstream's API message.
+//
+// FIXME: The validation error returned by the CloudFormation API doesn't make
+// things easy to check, other than looking for the returned string. There's no
+// constant in the AWS golang SDK for defining this string, it comes from the
+// service.
+func IsStackNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if strings.Contains(microerror.Cause(err).Error(), "does not exist") {
+		return true
+	}
+
+	if microerror.Cause(err) == stackNotFoundError {
+		return true
+	}
+
+	return false
+}
+
+var tooManyStacksError = &microerror.Error{
+	Kind: "tooManyStacksError",
+}
+
+// IsTooManyStacks asserts tooManyStacksError.
+func IsTooManyStacks(err error) bool {
+	return microerror.Cause(err) == tooManyStacksError
+}

--- a/service/controller/v14patch1/cloudformation/types.go
+++ b/service/controller/v14patch1/cloudformation/types.go
@@ -1,0 +1,10 @@
+package cloudformation
+
+import "github.com/aws/aws-sdk-go/service/cloudformation"
+
+// CloudFormationInterface provides a set of methods to work with
+// CloudFormation stacks. *CloudFormation struct from
+// "github.com/aws/aws-sdk-go/service/cloudformation" fulfils this interface.
+type CloudFormationInterface interface {
+	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+}

--- a/service/controller/v14patch1/cluster_resource_set.go
+++ b/service/controller/v14patch1/cluster_resource_set.go
@@ -1,0 +1,594 @@
+package v14
+
+import (
+	"context"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/guestcluster"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/giantswarm/randomkeys"
+	"github.com/giantswarm/statusresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v14/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/credential"
+	"github.com/giantswarm/aws-operator/service/controller/v14/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter/kms"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter/vault"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/bridgezone"
+	cloudformationresource "github.com/giantswarm/aws-operator/service/controller/v14/resource/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/ebsvolume"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/encryptionkey"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/endpoints"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/hostedzone"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/loadbalancer"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/migration"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/namespace"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/s3bucket"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/s3object"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/service"
+)
+
+type ClusterResourceSetConfig struct {
+	CertsSearcher      legacy.Searcher
+	G8sClient          versioned.Interface
+	HostAWSConfig      aws.Config
+	HostAWSClients     aws.Clients
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	RandomkeysSearcher randomkeys.Interface
+
+	AccessLogsExpiration   int
+	AdvancedMonitoringEC2  bool
+	APIWhitelist           adapter.APIWhitelist
+	EncrypterBackend       string
+	GuestUpdateEnabled     bool
+	IncludeTags            bool
+	InstallationName       string
+	DeleteLoggingBucket    bool
+	OIDC                   cloudconfig.OIDCConfig
+	ProjectName            string
+	PublicRouteTables      string
+	Route53Enabled         bool
+	PodInfraContainerImage string
+	RegistryDomain         string
+	SSOPublicKey           string
+	VaultAddress           string
+}
+
+func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CertsSearcher must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.HostAWSConfig.AccessKeyID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.AccessKeyID must not be empty", config)
+	}
+	if config.HostAWSConfig.AccessKeySecret == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.AccessKeySecret must not be empty", config)
+	}
+	if config.HostAWSConfig.Region == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.Region must not be empty", config)
+	}
+	if config.HostAWSClients.CloudFormation == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSClients.CloudFormation must not be empty", config)
+	}
+	if config.HostAWSClients.EC2 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSClients.EC2 must not be empty", config)
+	}
+	if config.HostAWSClients.IAM == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSClients.IAM must not be empty", config)
+	}
+	if config.HostAWSClients.Route53 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSClients.Route53 must not be empty", config)
+	}
+
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.RandomkeysSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RandomkeysSearcher must not be empty", config)
+	}
+
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+	if config.APIWhitelist.Enabled && config.APIWhitelist.SubnetList == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.APIWhitelist.SubnetList must not be empty when %T.APIWhitelist is enabled", config)
+	}
+	if config.SSOPublicKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.SSOPublicKey must not be empty", config)
+	}
+
+	var encrypterObject encrypter.Interface
+	var encrypterRoleManager encrypter.RoleManager
+	switch config.EncrypterBackend {
+	case encrypter.VaultBackend:
+		c := &vault.EncrypterConfig{
+			Logger: config.Logger,
+
+			Address: config.VaultAddress,
+		}
+
+		encrypterObject, err = vault.NewEncrypter(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		encrypterRoleManager = encrypterObject.(encrypter.RoleManager)
+	case encrypter.KMSBackend:
+		c := &kms.EncrypterConfig{
+			Logger: config.Logger,
+
+			InstallationName: config.InstallationName,
+		}
+
+		encrypterObject, err = kms.NewEncrypter(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	default:
+		return nil, microerror.Maskf(invalidConfigError, "unknown encrypter backend %q", config.EncrypterBackend)
+	}
+
+	var encryptionKeyResource controller.Resource
+	{
+		c := encryptionkey.Config{
+			Encrypter: encrypterObject,
+			Logger:    config.Logger,
+
+			InstallationName: config.InstallationName,
+		}
+
+		ops, err := encryptionkey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		encryptionKeyResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var migrationResource controller.Resource
+	{
+		c := migration.Config{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		migrationResource, err = migration.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var hostedZoneResource controller.Resource
+	{
+		c := hostedzone.Config{
+			HostRoute53: config.HostAWSClients.Route53,
+			Logger:      config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+		}
+
+		hostedZoneResource, err = hostedzone.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var bridgeZoneResource controller.Resource
+	{
+		c := bridgezone.Config{
+			HostAWSConfig: config.HostAWSConfig,
+			HostRoute53:   config.HostAWSClients.Route53,
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+		}
+
+		bridgeZoneResource, err = bridgezone.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var s3BucketResource controller.Resource
+	{
+		c := s3bucket.Config{
+			Logger: config.Logger,
+
+			AccessLogsExpiration: config.AccessLogsExpiration,
+			DeleteLoggingBucket:  config.DeleteLoggingBucket,
+			IncludeTags:          config.IncludeTags,
+			InstallationName:     config.InstallationName,
+		}
+
+		ops, err := s3bucket.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		s3BucketResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var s3BucketObjectResource controller.Resource
+	{
+		c := s3object.Config{
+			CertWatcher:       config.CertsSearcher,
+			Encrypter:         encrypterObject,
+			Logger:            config.Logger,
+			RandomKeySearcher: config.RandomkeysSearcher,
+		}
+
+		ops, err := s3object.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		s3BucketObjectResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var loadBalancerResource controller.Resource
+	{
+		c := loadbalancer.Config{
+			Logger: config.Logger,
+		}
+
+		loadBalancerResource, err = loadbalancer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ebsVolumeResource controller.Resource
+	{
+		c := ebsvolume.Config{
+			Logger: config.Logger,
+		}
+
+		ebsVolumeResource, err = ebsvolume.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cloudformationResource controller.Resource
+	{
+		c := cloudformationresource.Config{
+			HostClients: &adapter.Clients{
+				EC2:            config.HostAWSClients.EC2,
+				IAM:            config.HostAWSClients.IAM,
+				STS:            config.HostAWSClients.STS,
+				CloudFormation: config.HostAWSClients.CloudFormation,
+			},
+			Logger: config.Logger,
+			APIWhitelist: adapter.APIWhitelist{
+				Enabled:    config.APIWhitelist.Enabled,
+				SubnetList: config.APIWhitelist.SubnetList,
+			},
+
+			AdvancedMonitoringEC2: config.AdvancedMonitoringEC2,
+			EncrypterBackend:      config.EncrypterBackend,
+			EncrypterRoleManager:  encrypterRoleManager,
+			InstallationName:      config.InstallationName,
+			PublicRouteTables:     config.PublicRouteTables,
+			Route53Enabled:        config.Route53Enabled,
+		}
+
+		ops, err := cloudformationresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		cloudformationResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource controller.Resource
+	{
+		c := namespace.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource controller.Resource
+	{
+		c := service.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var endpointsResource controller.Resource
+	{
+		c := endpoints.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := endpoints.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		endpointsResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var certsSearcher certs.Interface
+	{
+		c := certs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
+		}
+
+		certsSearcher, err = certs.NewSearcher(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var guestCluster guestcluster.Interface
+	{
+		c := guestcluster.Config{
+			CertsSearcher: certsSearcher,
+			Logger:        config.Logger,
+
+			CertID: certs.APICert,
+		}
+
+		guestCluster, err = guestcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var statusResource controller.Resource
+	{
+		c := statusresource.ResourceConfig{
+			ClusterEndpointFunc:      key.ToClusterEndpoint,
+			ClusterIDFunc:            key.ToClusterID,
+			ClusterStatusFunc:        key.ToClusterStatus,
+			GuestCluster:             guestCluster,
+			NodeCountFunc:            key.ToNodeCount,
+			Logger:                   config.Logger,
+			RESTClient:               config.G8sClient.ProviderV1alpha1().RESTClient(),
+			VersionBundleVersionFunc: key.ToVersionBundleVersion,
+		}
+
+		statusResource, err = statusresource.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		statusResource,
+		migrationResource,
+		hostedZoneResource,
+		bridgeZoneResource,
+		encryptionKeyResource,
+		s3BucketResource,
+		s3BucketObjectResource,
+		loadBalancerResource,
+		ebsVolumeResource,
+		cloudformationResource,
+		namespaceResource,
+		serviceResource,
+		endpointsResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(customObject) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		var awsClient aws.Clients
+		{
+			arn, err := credential.GetARN(config.K8sClient, obj)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			c := config.HostAWSConfig
+			c.RoleARN = arn
+
+			awsClient = aws.NewClients(c)
+		}
+
+		var awsService *awsservice.Service
+		{
+			c := awsservice.Config{
+				Clients: awsservice.Clients{
+					KMS: awsClient.KMS,
+					STS: awsClient.STS,
+				},
+				Logger: config.Logger,
+			}
+
+			awsService, err = awsservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var cloudConfig *cloudconfig.CloudConfig
+		{
+			c := cloudconfig.Config{
+				Encrypter: encrypterObject,
+				Logger:    config.Logger,
+
+				OIDC: config.OIDC,
+				PodInfraContainerImage: config.PodInfraContainerImage,
+				RegistryDomain:         config.RegistryDomain,
+				SSOPublicKey:           config.SSOPublicKey,
+			}
+
+			cloudConfig, err = cloudconfig.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var ebsService ebs.Interface
+		{
+			c := ebs.Config{
+				Client: awsClient.EC2,
+				Logger: config.Logger,
+			}
+			ebsService, err = ebs.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		var cloudFormationService *cloudformationservice.CloudFormation
+		{
+			c := cloudformationservice.Config{
+				Client: awsClient.CloudFormation,
+			}
+
+			cloudFormationService, err = cloudformationservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		c := controllercontext.Context{
+			AWSClient:      awsClient,
+			AWSService:     awsService,
+			CloudConfig:    cloudConfig,
+			CloudFormation: *cloudFormationService,
+			EBSService:     ebsService,
+		}
+		ctx = controllercontext.NewContext(ctx, c)
+
+		return ctx, nil
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/v14patch1/controllercontext/context.go
+++ b/service/controller/v14patch1/controllercontext/context.go
@@ -1,0 +1,43 @@
+package controllercontext
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v14/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/ebs"
+)
+
+type contextKey string
+
+const controllerKey contextKey = "controller"
+
+type Context struct {
+	AWSClient      awsclient.Clients
+	AWSService     awsservice.Interface
+	CloudConfig    cloudconfig.Interface
+	CloudFormation cloudformationservice.CloudFormation
+	EBSService     ebs.Interface
+
+	// Status holds the data used to communicate between controller's
+	// resources. It can be edited in place as Context is stored as
+	// a pointer within context.Context.
+	Status Status
+}
+
+func NewContext(ctx context.Context, c Context) context.Context {
+	return context.WithValue(ctx, controllerKey, &c)
+}
+
+func FromContext(ctx context.Context) (*Context, error) {
+	c, ok := ctx.Value(controllerKey).(*Context)
+	if !ok {
+		return nil, microerror.Maskf(notFoundError, "context key %q of type %T", controllerKey, controllerKey)
+	}
+
+	return c, nil
+}

--- a/service/controller/v14patch1/controllercontext/error.go
+++ b/service/controller/v14patch1/controllercontext/error.go
@@ -1,0 +1,14 @@
+package controllercontext
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/v14patch1/controllercontext/status.go
+++ b/service/controller/v14patch1/controllercontext/status.go
@@ -1,0 +1,29 @@
+package controllercontext
+
+type Status struct {
+	// Cluster carries information between cluster controller resource.
+	Cluster Cluster
+	// Drainer carries information between drainer controller resource.
+	Drainer Drainer
+}
+
+type Cluster struct {
+	// HostedZones is filled by the hostedzone resource. This information
+	// is used when creating CloudFormation templates.
+	HostedZones ClusterHostedZones
+}
+
+type ClusterHostedZones struct {
+	API     ClusterHostedZonesZone
+	Etcd    ClusterHostedZonesZone
+	Ingress ClusterHostedZonesZone
+}
+
+type ClusterHostedZonesZone struct {
+	ID string
+}
+
+type Drainer struct {
+	// WorkerASGName is filled by the workerasgname resource.
+	WorkerASGName string
+}

--- a/service/controller/v14patch1/credential/credential.go
+++ b/service/controller/v14patch1/credential/credential.go
@@ -1,0 +1,73 @@
+package credential
+
+import (
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	// awsOperatorArnKey is the key in the Secret under which the ARN for the aws-operator role is held.
+	awsOperatorArnKey = "aws.awsoperator.arn"
+)
+
+func GetARN(k8sClient kubernetes.Interface, obj interface{}) (string, error) {
+	credential, err := readCredential(k8sClient, obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	arn, err := getARN(credential)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return arn, nil
+}
+
+// GetDefaultARN is used only by the bridgezone resource. It should be removed
+// when the resource is removed.
+func GetDefaultARN(k8sClient kubernetes.Interface) (string, error) {
+	ns := "giantswarm"
+	name := "credential-default"
+	credential, err := k8sClient.CoreV1().Secrets(ns).Get(name, apismetav1.GetOptions{})
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	arn, err := getARN(credential)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return arn, nil
+}
+
+func getARN(credential *v1.Secret) (string, error) {
+	arn, ok := credential.Data[awsOperatorArnKey]
+	if !ok {
+		return "", microerror.Maskf(arnNotFound, awsOperatorArnKey)
+	}
+
+	return string(arn), nil
+}
+
+func readCredential(k8sClient kubernetes.Interface, obj interface{}) (*v1.Secret, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	credentialName := key.CredentialName(customObject)
+	credentialNamespace := key.CredentialNamespace(customObject)
+
+	credential, err := k8sClient.CoreV1().Secrets(credentialNamespace).Get(credentialName, apismetav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return credential, nil
+}

--- a/service/controller/v14patch1/credential/error.go
+++ b/service/controller/v14patch1/credential/error.go
@@ -1,0 +1,12 @@
+package credential
+
+import "github.com/giantswarm/microerror"
+
+var arnNotFound = &microerror.Error{
+	Kind: "arnNotFound",
+}
+
+// IsArnNotFoundError asserts arnNotFound.
+func IsArnNotFoundError(err error) bool {
+	return microerror.Cause(err) == arnNotFound
+}

--- a/service/controller/v14patch1/drainer_resource_set.go
+++ b/service/controller/v14patch1/drainer_resource_set.go
@@ -1,0 +1,171 @@
+package v14
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v14/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/credential"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/drainer"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/drainfinisher"
+	"github.com/giantswarm/aws-operator/service/controller/v14/resource/workerasgname"
+)
+
+type DrainerResourceSetConfig struct {
+	G8sClient     versioned.Interface
+	HostAWSConfig aws.Config
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+
+	GuestUpdateEnabled bool
+	ProjectName        string
+}
+
+func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	var drainerResource controller.Resource
+	{
+		c := drainer.ResourceConfig{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		drainerResource, err = drainer.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var drainFinisherResource controller.Resource
+	{
+		c := drainfinisher.ResourceConfig{
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+		}
+
+		drainFinisherResource, err = drainfinisher.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var workerASGNameResource controller.Resource
+	{
+		c := workerasgname.ResourceConfig{
+			Logger: config.Logger,
+		}
+
+		workerASGNameResource, err = workerasgname.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		workerASGNameResource,
+		drainerResource,
+		drainFinisherResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(customObject) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		var awsClient aws.Clients
+		{
+			arn, err := credential.GetARN(config.K8sClient, obj)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			c := config.HostAWSConfig
+			c.RoleARN = arn
+
+			awsClient = aws.NewClients(c)
+		}
+
+		var cloudFormationService *cloudformationservice.CloudFormation
+		{
+			c := cloudformationservice.Config{
+				Client: awsClient.CloudFormation,
+			}
+
+			cloudFormationService, err = cloudformationservice.New(c)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		c := controllercontext.Context{
+			AWSClient:      awsClient,
+			CloudFormation: *cloudFormationService,
+		}
+		ctx = controllercontext.NewContext(ctx, c)
+
+		return ctx, nil
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/service/controller/v14patch1/ebs/ebs.go
+++ b/service/controller/v14patch1/ebs/ebs.go
@@ -1,0 +1,177 @@
+package ebs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	cloudProviderClusterTagValue = "owned"
+)
+
+type Config struct {
+	Client EC2Client
+	Logger micrologger.Logger
+}
+
+type EBS struct {
+	client EC2Client
+	logger micrologger.Logger
+}
+
+func New(config Config) (*EBS, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	e := &EBS{
+		client: config.Client,
+		logger: config.Logger,
+	}
+
+	return e, nil
+}
+
+// DeleteVolume deletes an EBS volume with retry logic.
+func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting EBS volume %s", volumeID))
+
+	o := func() error {
+		_, err := e.client.DeleteVolume(&ec2.DeleteVolumeInput{
+			VolumeId: aws.String(volumeID),
+		})
+		if IsVolumeNotFound(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+	n := backoff.NewNotifier(e.logger, context.Background())
+	err := backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted EBS volume %s", volumeID))
+
+	return nil
+}
+
+// DetachVolume detaches an EBS volume. If force is specified data loss may occur. If shutdown is
+// specified the instance will be stopped first.
+func (e *EBS) DetachVolume(ctx context.Context, volumeID string, attachment VolumeAttachment, force bool, shutdown bool, wait bool) error {
+	if shutdown {
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("stopping instance %s", attachment.InstanceID))
+
+		i := &ec2.StopInstancesInput{
+			InstanceIds: []*string{
+				aws.String(attachment.InstanceID),
+			},
+		}
+		_, err := e.client.StopInstances(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if wait {
+			e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for instance %s being stopped", attachment.InstanceID))
+
+			i := &ec2.DescribeInstancesInput{
+				InstanceIds: []*string{
+					aws.String(attachment.InstanceID),
+				},
+			}
+			err := e.client.WaitUntilInstanceStopped(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for instance %s being stopped", attachment.InstanceID))
+		}
+
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("stopped instance %s", attachment.InstanceID))
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detaching EBS volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	_, err := e.client.DetachVolume(&ec2.DetachVolumeInput{
+		Device:     aws.String(attachment.Device),
+		InstanceId: aws.String(attachment.InstanceID),
+		VolumeId:   aws.String(volumeID),
+		Force:      aws.Bool(force),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detached EBS volume %s from instance %s", volumeID, attachment.InstanceID))
+
+	return nil
+}
+
+// ListVolumes lists EBS volumes for a guest cluster. If etcdVolume is true
+// the Etcd volume for the master instance will be returned. If persistentVolume
+// is set then any Persistent Volumes associated with the cluster will be
+// returned.
+func (e *EBS) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error) {
+	var volumes []Volume
+
+	// We filter to only select clusters with the cluster cloud provider tag.
+	i := &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", key.ClusterCloudProviderTag(customObject))),
+				Values: []*string{
+					aws.String(cloudProviderClusterTagValue),
+				},
+			},
+		},
+	}
+	o, err := e.client.DescribeVolumes(i)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, v := range o.Volumes {
+		if !IsFiltered(v, filterFuncs) {
+			continue
+		}
+
+		attachments := []VolumeAttachment{}
+
+		if len(v.Attachments) > 0 {
+			for _, a := range v.Attachments {
+				attachments = append(attachments, VolumeAttachment{
+					Device:     *a.Device,
+					InstanceID: *a.InstanceId,
+				})
+			}
+		}
+
+		volume := Volume{
+			VolumeID:    *v.VolumeId,
+			Attachments: attachments,
+		}
+
+		volumes = append(volumes, volume)
+	}
+
+	return volumes, nil
+}

--- a/service/controller/v14patch1/ebs/ebs_test.go
+++ b/service/controller/v14patch1/ebs/ebs_test.go
@@ -1,0 +1,352 @@
+package ebs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_ListVolumes(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description     string
+		obj             v1alpha1.AWSConfig
+		filterFuncs     []func(t *ec2.Tag) bool
+		expectedVolumes []Volume
+		ebsVolumes      []ebsVolumeMock
+	}{
+		{
+			description: "case 0: basic match with no volumes",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+		},
+		{
+			description: "case 1: basic match with pv volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 2: basic match with etcd and multiple pv volumes",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-5678",
+				},
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-6789",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-5678",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-5678"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 3: no match due to cluster tag",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/other-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 4: no match due to missing pv tag",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: nil,
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 5: multiple ebs volumes with attachments",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{
+						{
+							InstanceID: "i-12345",
+							Device:     "/dev/sdh",
+						},
+					},
+					VolumeID: "vol-1234",
+				},
+				{
+					Attachments: []VolumeAttachment{
+						{
+							InstanceID: "i-56789",
+							Device:     "/dev/sdh",
+						},
+					},
+					VolumeID: "vol-5678",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					attachments: []*ec2.VolumeAttachment{
+						{
+							Device:     aws.String("/dev/sdh"),
+							InstanceId: aws.String("i-12345"),
+						},
+					},
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-5678",
+					attachments: []*ec2.VolumeAttachment{
+						{
+							Device:     aws.String("/dev/sdh"),
+							InstanceId: aws.String("i-56789"),
+						},
+					},
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-5678"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 6: only etcd volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewEtcdVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-6789",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "case 7: only pv volume",
+			obj:         customObject,
+			filterFuncs: []func(t *ec2.Tag) bool{
+				NewPersistentVolumeFilter(customObject),
+			},
+			expectedVolumes: []Volume{
+				{
+					Attachments: []VolumeAttachment{},
+					VolumeID:    "vol-1234",
+				},
+			},
+			ebsVolumes: []ebsVolumeMock{
+				{
+					volumeID: "vol-1234",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/created-for/pv/name"),
+							Value: aws.String("pvc-1234"),
+						},
+					},
+				},
+				{
+					volumeID: "vol-6789",
+					tags: []*ec2.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String("test-cluster-etcd"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				Client: &EC2ClientMock{
+					customObject: tc.obj,
+					ebsVolumes:   tc.ebsVolumes,
+				},
+				Logger: microloggertest.New(),
+			}
+			e, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			result, err := e.ListVolumes(tc.obj, tc.filterFuncs...)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedVolumes) {
+				t.Fatalf("expected volumes '%#v', got '%#v'", tc.expectedVolumes, result)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/ebs/error.go
+++ b/service/controller/v14patch1/ebs/error.go
@@ -1,0 +1,42 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var volumeNotFoundError = &microerror.Error{
+	Kind: "volumeNotFoundError",
+}
+
+// IsVolumeNotFound asserts volume not found error from upstream's API code.
+func IsVolumeNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+	if c == volumeNotFoundError {
+		return true
+	}
+
+	aerr, ok := c.(awserr.Error)
+	if !ok {
+		return false
+	}
+	// TODO Find constant in the Go SDK for the error code.
+	if aerr.Code() == "NotFound" {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/ebs/filter.go
+++ b/service/controller/v14patch1/ebs/filter.go
@@ -1,0 +1,52 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	cloudProviderPersistentVolumeTagKey = "kubernetes.io/created-for/pv/name"
+	nameTagKey                          = "Name"
+)
+
+func IsFiltered(vol *ec2.Volume, filterFuncs []func(t *ec2.Tag) bool) bool {
+	for _, f := range filterFuncs {
+		for _, t := range vol.Tags {
+			if f(t) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func NewDockerVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.DockerVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewEtcdVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == nameTagKey && *t.Value == key.EtcdVolumeName(customObject) {
+			return true
+		}
+		return false
+	}
+}
+
+func NewPersistentVolumeFilter(customObject v1alpha1.AWSConfig) func(t *ec2.Tag) bool {
+	return func(t *ec2.Tag) bool {
+		if *t.Key == cloudProviderPersistentVolumeTagKey {
+			return true
+		}
+		return false
+	}
+}

--- a/service/controller/v14patch1/ebs/mock_test.go
+++ b/service/controller/v14patch1/ebs/mock_test.go
@@ -1,0 +1,61 @@
+package ebs
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type EC2ClientMock struct {
+	customObject v1alpha1.AWSConfig
+	ebsVolumes   []ebsVolumeMock
+}
+
+type ebsVolumeMock struct {
+	volumeID    string
+	attachments []*ec2.VolumeAttachment
+	tags        []*ec2.Tag
+}
+
+func (e *EC2ClientMock) DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
+	output := &ec2.DescribeVolumesOutput{}
+	volumes := []*ec2.Volume{}
+
+	clusterTag := key.ClusterCloudProviderTag(e.customObject)
+
+	for _, mock := range e.ebsVolumes {
+		vol := &ec2.Volume{
+			VolumeId:    aws.String(mock.volumeID),
+			Attachments: mock.attachments,
+			Tags:        mock.tags,
+		}
+
+		for _, tag := range mock.tags {
+			if *tag.Key == clusterTag && *tag.Value == "owned" {
+				volumes = append(volumes, vol)
+			}
+		}
+	}
+
+	output.SetVolumes(volumes)
+
+	return output, nil
+}
+
+func (e *EC2ClientMock) DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
+	return nil, nil
+}
+
+func (e *EC2ClientMock) WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error {
+	return nil
+}

--- a/service/controller/v14patch1/ebs/spec.go
+++ b/service/controller/v14patch1/ebs/spec.go
@@ -1,0 +1,43 @@
+package ebs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+// Interface describes the methods provided by the helm client.
+type Interface interface {
+	// DeleteVolume deletes an EBS volume with retry logic.
+	DeleteVolume(ctx context.Context, volumeID string) error
+	// DetachVolume detaches an EBS volume. If force is specified data loss may
+	// occur. If shutdown is specified the instance will be stopped first.
+	DetachVolume(ctx context.Context, volumeID string, attachment VolumeAttachment, force bool, shutdown bool, wait bool) error
+	// ListVolumes lists EBS volumes for a guest cluster. If etcdVolume is true
+	// the Etcd volume for the master instance will be returned. If
+	// persistentVolume is true then any Persistent Volumes associated with the
+	// cluster will be returned.
+	ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]Volume, error)
+}
+
+// EC2Client describes the methods required to be implemented by an EC2 AWS client.
+type EC2Client interface {
+	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
+	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
+	DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
+	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
+	WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error
+}
+
+// Volume is an EBS volume and its attachments.
+type Volume struct {
+	VolumeID    string
+	Attachments []VolumeAttachment
+}
+
+// VolumeAttachment is an EBS volume attached to an EC2 instance.
+type VolumeAttachment struct {
+	Device     string
+	InstanceID string
+}

--- a/service/controller/v14patch1/encrypter/kms/certs.go
+++ b/service/controller/v14patch1/encrypter/kms/certs.go
@@ -1,0 +1,37 @@
+package kms
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (k *Encrypter) EncryptTLSAssets(ctx context.Context, customObject v1alpha1.AWSConfig, assets legacy.AssetsBundle) (*legacy.CompactTLSAssets, error) {
+	rawTLS := encrypter.CreateRawTLSAssets(assets)
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+	kmsKeyARN, err := sc.AWSService.GetKeyArn(clusterID)
+
+	encTLS, err := rawTLS.Encrypt(ctx, k, kmsKeyARN)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	compTLS, err := encTLS.Compact()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return compTLS, nil
+}

--- a/service/controller/v14patch1/encrypter/kms/error.go
+++ b/service/controller/v14patch1/encrypter/kms/error.go
@@ -1,0 +1,40 @@
+package kms
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var keyNotFoundError = &microerror.Error{
+	Kind: "keyNotFoundError",
+}
+
+// IsKeyNotFound asserts keyNotFoundError.
+func IsKeyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	aerr, ok := c.(awserr.Error)
+	if ok && aerr.Code() == kms.ErrCodeNotFoundException {
+		return true
+	}
+
+	if c == keyNotFoundError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/encrypter/kms/kms.go
+++ b/service/controller/v14patch1/encrypter/kms/kms.go
@@ -1,0 +1,220 @@
+package kms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Encrypter struct {
+	logger micrologger.Logger
+
+	installationName string
+}
+
+type EncrypterConfig struct {
+	Logger micrologger.Logger
+
+	InstallationName string
+}
+
+func NewEncrypter(c *EncrypterConfig) (*Encrypter, error) {
+	if c.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", c)
+	}
+
+	if c.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", c)
+	}
+
+	kms := &Encrypter{
+		logger: c.Logger,
+
+		installationName: c.InstallationName,
+	}
+
+	return kms, nil
+}
+
+func (k *Encrypter) CreateKey(ctx context.Context, customObject v1alpha1.AWSConfig, keyAlias string) error {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	key, err := sc.AWSClient.KMS.CreateKey(&kms.CreateKeyInput{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = sc.AWSClient.KMS.CreateAlias(&kms.CreateAliasInput{
+		AliasName:   aws.String(keyAlias),
+		TargetKeyId: key.KeyMetadata.Arn,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = sc.AWSClient.KMS.EnableKeyRotation(&kms.EnableKeyRotationInput{
+		KeyId: key.KeyMetadata.KeyId,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = sc.AWSClient.KMS.TagResource(&kms.TagResourceInput{
+		KeyId: key.KeyMetadata.KeyId,
+		Tags:  k.getKMSTags(customObject),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (k *Encrypter) DeleteKey(ctx context.Context, keyAlias string) error {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Get the KMS key ID using the key alias.
+	key, err := sc.AWSClient.KMS.DescribeKey(&kms.DescribeKeyInput{
+		KeyId: aws.String(keyAlias),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Delete the key alias.
+	_, err = sc.AWSClient.KMS.DeleteAlias(&kms.DeleteAliasInput{
+		AliasName: aws.String(keyAlias),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// AWS API doesn't allow to delete the KMS key immediately, but we can schedule its deletion.
+	_, err = sc.AWSClient.KMS.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyId:               key.KeyMetadata.KeyId,
+		PendingWindowInDays: aws.Int64(pendingDeletionWindow),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (k *Encrypter) CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	var currentState encrypter.EncryptionKeyState
+
+	clusterID := key.ClusterID(customObject)
+	alias := toAlias(clusterID)
+
+	output, err := k.describeKey(ctx, customObject)
+	if IsKeyNotFound(err) {
+		// Fall through.
+		return currentState, nil
+	}
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
+	currentState.KeyID = *output.KeyMetadata.KeyId
+	currentState.KeyName = alias
+
+	return currentState, nil
+}
+
+func (k *Encrypter) DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	desiredState := encrypter.EncryptionKeyState{}
+
+	clusterID := key.ClusterID(customObject)
+	desiredState.KeyName = toAlias(clusterID)
+
+	return desiredState, nil
+}
+
+func (k *Encrypter) EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	output, err := k.describeKey(ctx, customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return *output.KeyMetadata.Arn, nil
+}
+
+func (k *Encrypter) Encrypt(ctx context.Context, key, plaintext string) (string, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	encryptInput := &kms.EncryptInput{
+		KeyId:     aws.String(key),
+		Plaintext: []byte(plaintext),
+	}
+
+	encryptOutput, err := sc.AWSClient.KMS.Encrypt(encryptInput)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(encryptOutput.CiphertextBlob), nil
+}
+
+func (e *Encrypter) IsKeyNotFound(err error) bool {
+	return IsKeyNotFound(err)
+}
+
+func (k *Encrypter) getKMSTags(customObject v1alpha1.AWSConfig) []*kms.Tag {
+	clusterTags := key.ClusterTags(customObject, k.installationName)
+	kmsTags := []*kms.Tag{}
+
+	for k, v := range clusterTags {
+		tag := &kms.Tag{
+			TagKey:   aws.String(k),
+			TagValue: aws.String(v),
+		}
+
+		kmsTags = append(kmsTags, tag)
+	}
+
+	return kmsTags
+}
+
+func (k *Encrypter) describeKey(ctx context.Context, customObject v1alpha1.AWSConfig) (*kms.DescribeKeyOutput, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+	alias := toAlias(clusterID)
+	input := &kms.DescribeKeyInput{
+		KeyId: aws.String(alias),
+	}
+
+	output, err := sc.AWSClient.KMS.DescribeKey(input)
+	if IsKeyNotFound(err) {
+		return nil, microerror.Mask(keyNotFoundError)
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return output, nil
+}
+
+func toAlias(keyID string) string {
+	return fmt.Sprintf("alias/%s", keyID)
+}

--- a/service/controller/v14patch1/encrypter/kms/spec.go
+++ b/service/controller/v14patch1/encrypter/kms/spec.go
@@ -1,0 +1,13 @@
+package kms
+
+import "github.com/aws/aws-sdk-go/service/kms"
+
+const (
+	// pendingDeletionWindow is the number of days to keep a key on pending
+	// deletion state.
+	pendingDeletionWindow = 7
+)
+
+type KMSClient interface {
+	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
+}

--- a/service/controller/v14patch1/encrypter/mock.go
+++ b/service/controller/v14patch1/encrypter/mock.go
@@ -1,0 +1,61 @@
+package encrypter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+)
+
+type EncrypterMock struct {
+	IsError bool
+	KeyID   string
+	KeyName string
+}
+
+func (e *EncrypterMock) CreateKey(ctx context.Context, customObject v1alpha1.AWSConfig, keyName string) error {
+	return nil
+}
+
+func (e *EncrypterMock) DeleteKey(ctx context.Context, keyName string) error {
+	return nil
+}
+
+func (e *EncrypterMock) CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (EncryptionKeyState, error) {
+	if e.IsError {
+		return EncryptionKeyState{}, fmt.Errorf("could not get current state")
+	}
+
+	return EncryptionKeyState{
+		KeyID:   e.KeyID,
+		KeyName: e.KeyName,
+	}, nil
+}
+
+func (e *EncrypterMock) DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (EncryptionKeyState, error) {
+	if e.IsError {
+		return EncryptionKeyState{}, fmt.Errorf("could not get current state")
+	}
+
+	return EncryptionKeyState{
+		KeyID:   e.KeyID,
+		KeyName: e.KeyName,
+	}, nil
+}
+
+func (e *EncrypterMock) EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	return "", nil
+}
+
+func (e *EncrypterMock) Encrypt(ctx context.Context, key, plaintext string) (string, error) {
+	return plaintext, nil
+}
+
+func (e *EncrypterMock) EncryptTLSAssets(ctx context.Context, customObject v1alpha1.AWSConfig, assets legacy.AssetsBundle) (*legacy.CompactTLSAssets, error) {
+	return &legacy.CompactTLSAssets{}, nil
+}
+
+func (e *EncrypterMock) IsKeyNotFound(err error) bool {
+	return false
+}

--- a/service/controller/v14patch1/encrypter/spec.go
+++ b/service/controller/v14patch1/encrypter/spec.go
@@ -1,0 +1,51 @@
+package encrypter
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+)
+
+const (
+	KMSBackend         = "kms"
+	VaultBackend       = "vault"
+	DecrypterVaultRole = "decrypter"
+)
+
+type EncryptionKeyState struct {
+	KeyID   string
+	KeyName string
+}
+
+type Interface interface {
+	KeyManager
+	StateManager
+	TLSManager
+	Encrypter
+}
+
+type KeyManager interface {
+	CreateKey(ctx context.Context, customObject v1alpha1.AWSConfig, keyName string) error
+	DeleteKey(ctx context.Context, keyName string) error
+}
+
+type StateManager interface {
+	CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (EncryptionKeyState, error)
+	DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (EncryptionKeyState, error)
+}
+
+type TLSManager interface {
+	EncryptTLSAssets(ctx context.Context, customObject v1alpha1.AWSConfig, assets legacy.AssetsBundle) (*legacy.CompactTLSAssets, error)
+}
+
+type Encrypter interface {
+	EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error)
+	Encrypt(ctx context.Context, key, plaintext string) (string, error)
+	IsKeyNotFound(error) bool
+}
+
+type RoleManager interface {
+	AddIAMRoleToAuth(vaultRoleName string, iamRoleARNs ...string) error
+	RemoveIAMRoleFromAuth(vaultRoleName string, iamRoleARNs ...string) error
+}

--- a/service/controller/v14patch1/encrypter/tls.go
+++ b/service/controller/v14patch1/encrypter/tls.go
@@ -1,0 +1,151 @@
+package encrypter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+)
+
+type TLSassets struct {
+	APIServerCA       []byte
+	APIServerKey      []byte
+	APIServerCrt      []byte
+	WorkerCA          []byte
+	WorkerKey         []byte
+	WorkerCrt         []byte
+	ServiceAccountCA  []byte
+	ServiceAccountKey []byte
+	ServiceAccountCrt []byte
+	CalicoClientCA    []byte
+	CalicoClientKey   []byte
+	CalicoClientCrt   []byte
+	EtcdServerCA      []byte
+	EtcdServerKey     []byte
+	EtcdServerCrt     []byte
+}
+
+// PEM encoded TLS assets.
+type RawTLSAssets TLSassets
+
+// Encrypted PEM encoded TLS assets
+type EncryptedTLSAssets TLSassets
+
+func CreateRawTLSAssets(assets legacy.AssetsBundle) *RawTLSAssets {
+	// TODO refactor this with a for loop iterating over components and asset types
+	return &RawTLSAssets{
+		APIServerCA:       assets[assetsBundleKey(legacy.APIComponent, legacy.CA)],
+		APIServerCrt:      assets[assetsBundleKey(legacy.APIComponent, legacy.Crt)],
+		APIServerKey:      assets[assetsBundleKey(legacy.APIComponent, legacy.Key)],
+		WorkerCA:          assets[assetsBundleKey(legacy.WorkerComponent, legacy.CA)],
+		WorkerCrt:         assets[assetsBundleKey(legacy.WorkerComponent, legacy.Crt)],
+		WorkerKey:         assets[assetsBundleKey(legacy.WorkerComponent, legacy.Key)],
+		ServiceAccountCA:  assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.CA)],
+		ServiceAccountCrt: assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.Crt)],
+		ServiceAccountKey: assets[assetsBundleKey(legacy.ServiceAccountComponent, legacy.Key)],
+		EtcdServerCA:      assets[assetsBundleKey(legacy.EtcdComponent, legacy.CA)],
+		EtcdServerCrt:     assets[assetsBundleKey(legacy.EtcdComponent, legacy.Crt)],
+		EtcdServerKey:     assets[assetsBundleKey(legacy.EtcdComponent, legacy.Key)],
+		CalicoClientCA:    assets[assetsBundleKey(legacy.CalicoComponent, legacy.CA)],
+		CalicoClientCrt:   assets[assetsBundleKey(legacy.CalicoComponent, legacy.Crt)],
+		CalicoClientKey:   assets[assetsBundleKey(legacy.CalicoComponent, legacy.Key)],
+	}
+}
+
+func (r *RawTLSAssets) Encrypt(ctx context.Context, e Encrypter, key string) (*EncryptedTLSAssets, error) {
+	var err error
+	encrypt := func(data []byte) (b []byte) {
+		if err != nil {
+			return []byte{}
+		}
+
+		bs, err := e.Encrypt(ctx, key, string(data))
+
+		if err != nil {
+			return []byte{}
+		}
+		return []byte(bs)
+	}
+	encryptedAssets := EncryptedTLSAssets{
+		APIServerCA:       encrypt(r.APIServerCA),
+		APIServerKey:      encrypt(r.APIServerKey),
+		APIServerCrt:      encrypt(r.APIServerCrt),
+		WorkerCA:          encrypt(r.WorkerCA),
+		WorkerCrt:         encrypt(r.WorkerCrt),
+		WorkerKey:         encrypt(r.WorkerKey),
+		ServiceAccountCA:  encrypt(r.ServiceAccountCA),
+		ServiceAccountCrt: encrypt(r.ServiceAccountCrt),
+		ServiceAccountKey: encrypt(r.ServiceAccountKey),
+		CalicoClientCA:    encrypt(r.CalicoClientCA),
+		CalicoClientKey:   encrypt(r.CalicoClientKey),
+		CalicoClientCrt:   encrypt(r.CalicoClientCrt),
+		EtcdServerCA:      encrypt(r.EtcdServerCA),
+		EtcdServerKey:     encrypt(r.EtcdServerKey),
+		EtcdServerCrt:     encrypt(r.EtcdServerCrt),
+	}
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &encryptedAssets, nil
+}
+
+func (r *EncryptedTLSAssets) Compact() (*legacy.CompactTLSAssets, error) {
+	var err error
+	compact := func(data []byte) (r string) {
+		if err != nil {
+			return ""
+		}
+
+		r, err = compactor(data)
+		if err != nil {
+			return ""
+		}
+
+		return r
+	}
+
+	compactAssets := legacy.CompactTLSAssets{
+		APIServerCA:       compact(r.APIServerCA),
+		APIServerKey:      compact(r.APIServerKey),
+		APIServerCrt:      compact(r.APIServerCrt),
+		WorkerCA:          compact(r.WorkerCA),
+		WorkerKey:         compact(r.WorkerKey),
+		WorkerCrt:         compact(r.WorkerCrt),
+		ServiceAccountCA:  compact(r.ServiceAccountCA),
+		ServiceAccountKey: compact(r.ServiceAccountKey),
+		ServiceAccountCrt: compact(r.ServiceAccountCrt),
+		CalicoClientCA:    compact(r.CalicoClientCA),
+		CalicoClientKey:   compact(r.CalicoClientKey),
+		CalicoClientCrt:   compact(r.CalicoClientCrt),
+		EtcdServerCA:      compact(r.EtcdServerCA),
+		EtcdServerKey:     compact(r.EtcdServerKey),
+		EtcdServerCrt:     compact(r.EtcdServerCrt),
+	}
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return &compactAssets, nil
+}
+
+func assetsBundleKey(c legacy.ClusterComponent, t legacy.TLSAssetType) legacy.AssetsBundleKey {
+	return legacy.AssetsBundleKey{
+		Component: c,
+		Type:      t,
+	}
+}
+
+func compactor(data []byte) (string, error) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if _, err := gzw.Write(data); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/service/controller/v14patch1/encrypter/vault/certs.go
+++ b/service/controller/v14patch1/encrypter/vault/certs.go
@@ -1,0 +1,32 @@
+package vault
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func (k *Encrypter) EncryptTLSAssets(ctx context.Context, customObject v1alpha1.AWSConfig, assets legacy.AssetsBundle) (*legacy.CompactTLSAssets, error) {
+	rawTLS := encrypter.CreateRawTLSAssets(assets)
+
+	key, err := k.EncryptionKey(ctx, customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	encTLS, err := rawTLS.Encrypt(ctx, k, key)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	compTLS, err := encTLS.Compact()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return compTLS, nil
+}

--- a/service/controller/v14patch1/encrypter/vault/error.go
+++ b/service/controller/v14patch1/encrypter/vault/error.go
@@ -1,0 +1,32 @@
+package vault
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var keyNotFoundError = &microerror.Error{
+	Kind: "keyNotFoundError",
+}
+
+// IsKeyNotFound asserts keyNotFoundError.
+func IsKeyNotFound(err error) bool {
+	return microerror.Cause(err) == keyNotFoundError
+}
+
+var invalidHTTPStatusCodeError = &microerror.Error{
+	Kind: "invalidHTTPStatusCodeError",
+}
+
+// IsInvalidHTTPStatus asserts invalidHTTPStatusCodeError.
+func IsInvalidHTTPStatus(err error) bool {
+	return microerror.Cause(err) == invalidHTTPStatusCodeError
+}

--- a/service/controller/v14patch1/encrypter/vault/spec.go
+++ b/service/controller/v14patch1/encrypter/vault/spec.go
@@ -1,0 +1,72 @@
+package vault
+
+const (
+	httpClientTimeout = 5
+
+	// instanceIdentityPKCS7Endpoint contains the fixed AWS endpoint to get an ec2
+	// instance identity PKCS7 signature.
+	instanceIdentityPKCS7Endpoint = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
+
+	defaultRole = "encrypter"
+	// fixed nonce, see https://www.vaultproject.io/api/auth/aws/index.html#nonce.
+	defaultNonce = "aws-operator"
+)
+
+type LoginPayload struct {
+	Role  string `json:"role"`
+	PKCS7 string `json:"pkcs7"`
+	Nonce string `json:"nonce,omitempty"`
+}
+
+type LoginResponse struct {
+	Auth LoginAuthResponse `json:"auth"`
+}
+
+type LoginAuthResponse struct {
+	Metadata    LoginAuthMetadataResponse `json:"metadata"`
+	ClientToken string                    `json:"client_token"`
+}
+
+type LoginAuthMetadataResponse struct {
+	Nonce string `json:"nonce"`
+}
+
+type ErrorResponse struct {
+	Errors []string `json:"errors"`
+}
+
+type EncryptPayload struct {
+	Plaintext string `json:"plaintext"`
+}
+
+type EncryptResponse struct {
+	Data EncryptResponseData `json:"data"`
+}
+
+type EncryptResponseData struct {
+	Ciphertext string `json:"ciphertext"`
+}
+
+type DecryptPayload struct {
+	Ciphertext string `json:"ciphertext"`
+}
+
+type DecryptResponse struct {
+	Data DecryptResponseData `json:"data"`
+}
+
+type DecryptResponseData struct {
+	Plaintext string `json:"plaintext"`
+}
+
+type AWSAuthRoleResponse struct {
+	Data AWSAuthRole `json:"data"`
+}
+
+type AWSAuthRole struct {
+	BoundIAMRoleARN []string `json:"bound_iam_role_arn"`
+}
+
+type KeyConfigPayload struct {
+	DeletionAllowed bool `json:"deletion_allowed"`
+}

--- a/service/controller/v14patch1/encrypter/vault/vault.go
+++ b/service/controller/v14patch1/encrypter/vault/vault.go
@@ -1,0 +1,572 @@
+package vault
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type Encrypter struct {
+	httpClient *http.Client
+	logger     micrologger.Logger
+
+	address string
+	base    *url.URL
+	nonce   string
+	token   string
+}
+
+type EncrypterConfig struct {
+	Logger micrologger.Logger
+
+	Address string
+}
+
+func NewEncrypter(c *EncrypterConfig) (*Encrypter, error) {
+	if c.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", c)
+	}
+	if c.Address == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Address must not be empty", c)
+	}
+
+	base, err := url.Parse(c.Address + "/v1/")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// set client timeout to prevent leakages.
+	httpClient := &http.Client{
+		Timeout: time.Second * httpClientTimeout,
+	}
+
+	e := &Encrypter{
+		httpClient: httpClient,
+		logger:     c.Logger,
+
+		address: c.Address,
+		base:    base,
+		// fixed nonce, so that we can reauthenticate from the same host.
+		nonce: defaultNonce,
+	}
+
+	return e, nil
+}
+
+func (e *Encrypter) CreateKey(ctx context.Context, customObject v1alpha1.AWSConfig, _ string) error {
+	err := e.ensureToken()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	keyName := e.keyName(customObject)
+
+	payload := &struct{}{}
+
+	p := path.Join("transit", "keys", keyName)
+
+	req, err := e.newPayloadRequest(p, payload)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return microerror.Mask(invalidHTTPStatusCodeError)
+	}
+
+	// We need to make the key deletable.
+	keyConfigPayload := &KeyConfigPayload{
+		DeletionAllowed: true,
+	}
+
+	p = path.Join("transit", "keys", keyName, "config")
+
+	req, err = e.newPayloadRequest(p, keyConfigPayload)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	resp, err = e.httpClient.Do(req)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return microerror.Mask(invalidHTTPStatusCodeError)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) DeleteKey(ctx context.Context, keyName string) error {
+	err := e.ensureToken()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	p := path.Join("transit", "keys", keyName)
+
+	req, err := e.newRequest("DELETE", p)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusBadRequest {
+		// key not found, fallthrough
+		return nil
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return microerror.Maskf(invalidHTTPStatusCodeError, "want 204, got %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	state := encrypter.EncryptionKeyState{}
+
+	err := e.ensureToken()
+	if err != nil {
+		return state, microerror.Mask(err)
+	}
+
+	keyName := e.keyName(customObject)
+
+	p := path.Join("transit", "keys", keyName)
+
+	req, err := e.newRequest("GET", p)
+	if err != nil {
+		return state, microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return state, microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// fallthrough
+		return state, nil
+	} else if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return state, microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	state.KeyName = keyName
+
+	return state, nil
+}
+
+func (e *Encrypter) DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	state := encrypter.EncryptionKeyState{}
+
+	keyName := e.keyName(customObject)
+
+	state.KeyName = keyName
+
+	return state, nil
+}
+
+func (e *Encrypter) EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	err := e.ensureToken()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	keyName := e.keyName(customObject)
+
+	p := path.Join("transit", "keys", keyName)
+
+	req, err := e.newRequest("GET", p)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", microerror.Mask(keyNotFoundError)
+	} else if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return "", microerror.Maskf(invalidHTTPStatusCodeError, "want %d, got %d, response body: %q", http.StatusOK, resp.StatusCode, body)
+	}
+
+	return keyName, nil
+}
+
+func (e *Encrypter) Encrypt(ctx context.Context, key, plaintext string) (string, error) {
+	err := e.ensureToken()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(plaintext))
+
+	payload := &EncryptPayload{
+		Plaintext: encoded,
+	}
+
+	p := path.Join("transit", "encrypt", key)
+
+	req, err := e.newPayloadRequest(p, payload)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return "", microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	encryptResp := &EncryptResponse{}
+	err = json.NewDecoder(resp.Body).Decode(encryptResp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	ciphertext := encryptResp.Data.Ciphertext
+
+	return ciphertext, nil
+}
+
+func (e *Encrypter) IsKeyNotFound(err error) bool {
+	return IsKeyNotFound(err)
+}
+
+func (e *Encrypter) Decrypt(key, ciphertext string) (string, error) {
+	err := e.ensureToken()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	payload := &DecryptPayload{
+		Ciphertext: ciphertext,
+	}
+
+	p := path.Join("transit", "decrypt", key)
+
+	req, err := e.newPayloadRequest(p, payload)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return "", microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	decryptResp := &DecryptResponse{}
+	err = json.NewDecoder(resp.Body).Decode(decryptResp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	encoded := decryptResp.Data.Plaintext
+
+	plaintext, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(plaintext), nil
+}
+
+func (e *Encrypter) AddIAMRoleToAuth(vaultRoleName string, iamRoleARNs ...string) error {
+	err := e.ensureToken()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	p := path.Join("auth", "aws", "role", vaultRoleName)
+
+	role, err := e.getAWSAuthRole(p)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(role.BoundIAMRoleARN) == 0 {
+		role.BoundIAMRoleARN = iamRoleARNs
+	} else {
+		joinedBoundIAMRoleARN := strings.Join(role.BoundIAMRoleARN, ",")
+		for _, iamRoleARN := range iamRoleARNs {
+			if !strings.Contains(joinedBoundIAMRoleARN, iamRoleARN) {
+				role.BoundIAMRoleARN = append(role.BoundIAMRoleARN, iamRoleARN)
+			}
+		}
+	}
+
+	err = e.postAWSAuthRole(p, role)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) RemoveIAMRoleFromAuth(vaultRoleName string, iamRoleARNs ...string) error {
+	err := e.ensureToken()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	p := path.Join("auth", "aws", "role", vaultRoleName)
+
+	role, err := e.getAWSAuthRole(p)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	wantedIamRoles := []string{}
+	toRemoveIamRoleARNs := strings.Join(iamRoleARNs, ",")
+	for _, iamRole := range role.BoundIAMRoleARN {
+		if !strings.Contains(toRemoveIamRoleARNs, iamRole) {
+			wantedIamRoles = append(wantedIamRoles, iamRole)
+		}
+	}
+	role.BoundIAMRoleARN = wantedIamRoles
+
+	err = e.postAWSAuthRole(p, role)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) Address() string {
+	return e.address
+}
+
+func (e *Encrypter) ensureToken() error {
+	if e.isTokenValid() {
+		return nil
+	}
+
+	err := e.login()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) isTokenValid() bool {
+	p := path.Join("auth", "token", "lookup-self")
+
+	req, err := e.newRequest("GET", p)
+	if err != nil {
+		e.logger.Log("level", "error", "message", fmt.Sprintf("could not create GET request for %q: %#v", p, err))
+		return false
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		e.logger.Log("level", "error", "message", fmt.Sprintf("could not do %q request for %q: %#v", req.Method, req.URL, err))
+		return false
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		e.logger.Log("level", "error", "message", fmt.Sprintf("invalid HTTP status code, want 200, got %d, response body: %q", resp.StatusCode, body))
+		return false
+	}
+	return true
+}
+
+func (e *Encrypter) login() error {
+	pkcs7, err := e.getPKCS7()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	payload := &LoginPayload{
+		Role:  defaultRole,
+		PKCS7: pkcs7,
+		Nonce: e.nonce,
+	}
+	p := path.Join("auth", "aws", "login")
+
+	req, err := e.newPayloadRequest(p, payload)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	loginResp := &LoginResponse{}
+	err = json.NewDecoder(resp.Body).Decode(loginResp)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	e.token = loginResp.Auth.ClientToken
+	e.nonce = loginResp.Auth.Metadata.Nonce
+
+	return nil
+}
+
+func (e *Encrypter) newRequest(method, path string) (*http.Request, error) {
+	u := &url.URL{Path: path}
+	dest := e.base.ResolveReference(u)
+
+	var buf io.Reader
+
+	req, err := http.NewRequest(method, dest.String(), buf)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if e.token != "" {
+		req.Header.Set("X-Vault-Token", e.token)
+	}
+
+	return req, nil
+}
+
+func (e *Encrypter) newPayloadRequest(path string, payload interface{}) (*http.Request, error) {
+	u := &url.URL{Path: path}
+	dest := e.base.ResolveReference(u)
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	buf := bytes.NewReader(b)
+
+	req, err := http.NewRequest("POST", dest.String(), buf)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if e.token != "" {
+		req.Header.Set("X-Vault-Token", e.token)
+	}
+
+	return req, nil
+}
+
+func (e *Encrypter) getPKCS7() (string, error) {
+	response, err := http.Get(instanceIdentityPKCS7Endpoint)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer response.Body.Close()
+
+	responseData, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return strings.Replace(string(responseData), "\n", "", -1), nil
+}
+
+func (e *Encrypter) getAWSAuthRole(path string) (*AWSAuthRole, error) {
+	req, err := e.newRequest("GET", path)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return nil, microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	roleResponse := &AWSAuthRoleResponse{}
+	err = json.NewDecoder(resp.Body).Decode(roleResponse)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return &roleResponse.Data, nil
+}
+
+func (e *Encrypter) postAWSAuthRole(path string, role *AWSAuthRole) error {
+	req, err := e.newPayloadRequest(path, role)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return microerror.Maskf(invalidHTTPStatusCodeError, "want 200, got %d, response body: %q", resp.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (e *Encrypter) keyName(customObject v1alpha1.AWSConfig) string {
+	return key.ClusterID(customObject)
+}

--- a/service/controller/v14patch1/error.go
+++ b/service/controller/v14patch1/error.go
@@ -1,0 +1,12 @@
+package v14
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/key/error.go
+++ b/service/controller/v14patch1/key/error.go
@@ -1,0 +1,48 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var malformedCloudConfigKeyError = &microerror.Error{
+	Kind: "malformedCloudConfigKeyError",
+}
+
+// IsMalformedCloudConfigKey asserts malformedCloudConfigKeyError.
+func IsMalformedCloudConfigKey(err error) bool {
+	return microerror.Cause(err) == malformedCloudConfigKeyError
+}
+
+var missingCloudConfigKeyError = &microerror.Error{
+	Kind: "missingCloudConfigKeyError",
+}
+
+// IsMissingCloudConfigKey asserts missingCloudConfigKeyError.
+func IsMissingCloudConfigKey(err error) bool {
+	return microerror.Cause(err) == missingCloudConfigKeyError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/key/key.go
+++ b/service/controller/v14patch1/key/key.go
@@ -1,0 +1,571 @@
+package key
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudformation/guest"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudformation/hostpost"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates/cloudformation/hostpre"
+)
+
+const (
+	// CloudProviderTagName is used to add Cloud Provider tags to AWS resources.
+	CloudProviderTagName = "kubernetes.io/cluster/%s"
+
+	// Cluster tag name for tagging all resources helping cost analysis in AWS.
+	ClusterTagName = "giantswarm.io/cluster"
+
+	// CloudProviderTagOwnedValue is used to indicate an AWS resource is owned
+	// and managed by a cluster.
+	CloudProviderTagOwnedValue = "owned"
+
+	// InstallationTagName is used for AWS resource tagging.
+	InstallationTagName = "giantswarm.io/installation"
+
+	// OrganizationTagName is used for AWS resource tagging.
+	OrganizationTagName = "giantswarm.io/organization"
+
+	// ProfileNameTemplate will be included in the IAM instance profile name.
+	ProfileNameTemplate = "EC2-K8S-Role"
+	// RoleNameTemplate will be included in the IAM role name.
+	RoleNameTemplate = "EC2-K8S-Role"
+	// PolicyNameTemplate will be included in the IAM policy name.
+	PolicyNameTemplate = "EC2-K8S-Policy"
+	// LogDeliveryURI is used for setting the correct ACL in the access log bucket
+	LogDeliveryURI = "uri=http://acs.amazonaws.com/groups/s3/LogDelivery"
+
+	InstanceIDAnnotation = "aws-operator.giantswarm.io/instance"
+
+	defaultAWSCliContainerRegistry = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
+	chinaAWSCliContainerRegistry   = "docker://registry-intl.cn-shanghai.aliyuncs.com/giantswarm/awscli:latest"
+)
+
+const (
+	DockerVolumeResourceNameKey   = "DockerVolumeResourceName"
+	HostedZoneNameServers         = "HostedZoneNameServers"
+	MasterImageIDKey              = "MasterImageID"
+	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
+	MasterInstanceTypeKey         = "MasterInstanceType"
+	MasterInstanceMonitoring      = "Monitoring"
+	MasterCloudConfigVersionKey   = "MasterCloudConfigVersion"
+	WorkerASGKey                  = "WorkerASGName"
+	WorkerCountKey                = "WorkerCount"
+	WorkerImageIDKey              = "WorkerImageID"
+	WorkerInstanceMonitoring      = "Monitoring"
+	WorkerInstanceTypeKey         = "WorkerInstanceType"
+	WorkerCloudConfigVersionKey   = "WorkerCloudConfigVersion"
+	VersionBundleVersionKey       = "VersionBundleVersion"
+)
+
+const (
+	ClusterIDLabel = "giantswarm.io/cluster"
+
+	AnnotationEtcdDomain        = "giantswarm.io/etcd-domain"
+	AnnotationPrometheusCluster = "giantswarm.io/prometheus-cluster"
+
+	LabelApp           = "app"
+	LabelCluster       = "giantswarm.io/cluster"
+	LabelCustomer      = "customer"
+	LabelOrganization  = "giantswarm.io/organization"
+	LabelVersionBundle = "giantswarm.io/version-bundle"
+
+	LegacyLabelCluster = "cluster"
+)
+
+const (
+	NodeDrainerLifecycleHookName = "NodeDrainer"
+	WorkerASGRef                 = "workerAutoScalingGroup"
+)
+
+func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Kubernetes.API.Domain
+}
+
+func AutoScalingGroupName(customObject v1alpha1.AWSConfig, groupName string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), groupName)
+}
+
+func AvailabilityZone(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.AZ
+}
+
+func AWSCliContainerRegistry(customObject v1alpha1.AWSConfig) string {
+	if IsChinaRegion(customObject) {
+		return chinaAWSCliContainerRegistry
+	}
+	return defaultAWSCliContainerRegistry
+}
+
+func BucketName(customObject v1alpha1.AWSConfig, accountID string) string {
+	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(customObject))
+}
+
+func BucketObjectName(templateVersion string, prefix string) string {
+	return fmt.Sprintf("cloudconfig/%s/%s", templateVersion, prefix)
+}
+
+func CredentialName(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.CredentialSecret.Name
+}
+
+func CredentialNamespace(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.CredentialSecret.Namespace
+}
+
+func CloudConfigSmallTemplates() []string {
+	return []string{
+		cloudconfig.Small,
+	}
+}
+
+func CloudFormationGuestTemplates() []string {
+	return []string{
+		guest.AutoScalingGroup,
+		guest.IAMPolicies,
+		guest.Instance,
+		guest.InternetGateway,
+		guest.LaunchConfiguration,
+		guest.LoadBalancers,
+		guest.Main,
+		guest.NatGateway,
+		guest.LifecycleHooks,
+		guest.Outputs,
+		guest.RecordSets,
+		guest.RouteTables,
+		guest.SecurityGroups,
+		guest.Subnets,
+		guest.VPC,
+	}
+}
+
+func CloudFormationHostPostTemplates() []string {
+	return []string{
+		hostpost.Main,
+		hostpost.RecordSets,
+		hostpost.RouteTables,
+	}
+}
+
+func CloudFormationHostPreTemplates() []string {
+	return []string{
+		hostpre.IAMRoles,
+		hostpre.Main,
+	}
+}
+
+func ClusterCloudProviderTag(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf(CloudProviderTagName, ClusterID(customObject))
+}
+
+func ClusterCustomer(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func ClusterEtcdDomain(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s:%d", customObject.Spec.Cluster.Etcd.Domain, customObject.Spec.Cluster.Etcd.Port)
+}
+
+func ClusterID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.ID
+}
+
+func ClusterNamespace(customObject v1alpha1.AWSConfig) string {
+	return ClusterID(customObject)
+}
+
+// ClusterOrganization returns the org name from the custom object.
+// It uses ClusterCustomer until this field is renamed in the custom object.
+func ClusterOrganization(customObject v1alpha1.AWSConfig) string {
+	return ClusterCustomer(customObject)
+}
+
+func ClusterTags(customObject v1alpha1.AWSConfig, installationName string) map[string]string {
+	cloudProviderTag := ClusterCloudProviderTag(customObject)
+	tags := map[string]string{
+		cloudProviderTag:    CloudProviderTagOwnedValue,
+		ClusterTagName:      ClusterID(customObject),
+		InstallationTagName: installationName,
+		OrganizationTagName: ClusterOrganization(customObject),
+	}
+
+	return tags
+}
+
+func ClusterVersion(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Version
+}
+
+func CustomerID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func DockerVolumeResourceName(customObject v1alpha1.AWSConfig) string {
+	return getResourcenameWithTimeHash("DockerVolume", customObject)
+}
+
+func DockerVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-docker", ClusterID(customObject))
+}
+
+func EtcdVolumeName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-etcd", ClusterID(customObject))
+}
+
+func EC2ServiceDomain(customObject v1alpha1.AWSConfig) string {
+	domain := "ec2.amazonaws.com"
+
+	if IsChinaRegion(customObject) {
+		domain += ".cn"
+	}
+
+	return domain
+}
+
+func BaseDomain(customObject v1alpha1.AWSConfig) string {
+	// TODO remove other zones and make it a BaseDomain in the CR.
+	// CloudFormation creates a separate HostedZone with the same name.
+	// Probably the easiest way for now is to just allow single domain for
+	// everything which we do now.
+	return customObject.Spec.AWS.HostedZones.API.Name
+}
+
+func HostedZoneNameAPI(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.HostedZones.API.Name
+}
+
+func HostedZoneNameEtcd(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.HostedZones.Etcd.Name
+}
+
+func HostedZoneNameIngress(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.HostedZones.Ingress.Name
+}
+
+func IngressControllerInsecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.IngressController.InsecurePort
+}
+
+func IngressControllerSecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.IngressController.SecurePort
+}
+
+func InstanceProfileName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, ProfileNameTemplate)
+}
+
+func IsChinaRegion(customObject v1alpha1.AWSConfig) bool {
+	return strings.HasPrefix(Region(customObject), "cn-")
+}
+
+func KubernetesAPISecurePort(customObject v1alpha1.AWSConfig) int {
+	return customObject.Spec.Cluster.Kubernetes.API.SecurePort
+}
+
+// LoadBalancerName produces a unique name for the load balancer.
+// It takes the domain name, extracts the first subdomain, and combines it with the cluster name.
+func LoadBalancerName(domainName string, cluster v1alpha1.AWSConfig) (string, error) {
+	if ClusterID(cluster) == "" {
+		return "", microerror.Maskf(missingCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	componentName, err := componentName(domainName)
+	if err != nil {
+		return "", microerror.Maskf(malformedCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	lbName := fmt.Sprintf("%s-%s", ClusterID(cluster), componentName)
+
+	return lbName, nil
+}
+
+func MainGuestStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-guest-main", clusterID)
+}
+
+func MainHostPreStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-host-setup", clusterID)
+}
+
+func MainHostPostStackName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("cluster-%s-host-main", clusterID)
+}
+
+func MasterCount(customObject v1alpha1.AWSConfig) int {
+	return len(customObject.Spec.AWS.Masters)
+}
+
+func MasterImageID(customObject v1alpha1.AWSConfig) string {
+	var imageID string
+
+	if len(customObject.Spec.AWS.Masters) > 0 {
+		imageID = customObject.Spec.AWS.Masters[0].ImageID
+	}
+
+	return imageID
+}
+
+func MasterInstanceResourceName(customObject v1alpha1.AWSConfig) string {
+	return getResourcenameWithTimeHash("MasterInstance", customObject)
+}
+
+func MasterInstanceName(customObject v1alpha1.AWSConfig) string {
+	clusterID := ClusterID(customObject)
+
+	return fmt.Sprintf("%s-master", clusterID)
+}
+
+func MasterInstanceType(customObject v1alpha1.AWSConfig) string {
+	var instanceType string
+
+	if len(customObject.Spec.AWS.Masters) > 0 {
+		instanceType = customObject.Spec.AWS.Masters[0].InstanceType
+	}
+
+	return instanceType
+}
+
+func MasterRoleARN(customObject v1alpha1.AWSConfig, accountID string) string {
+	return baseRoleARN(customObject, accountID, "master")
+}
+
+func PeerAccessRoleName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-vpc-peer-access", ClusterID(customObject))
+}
+
+func PeerID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.PeerID
+}
+
+func PolicyName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, PolicyNameTemplate)
+}
+
+func PrivateSubnetCIDR(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.PrivateSubnetCIDR
+}
+
+func CIDR(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.CIDR
+}
+
+func Region(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.Region
+}
+
+func RegionARN(customObject v1alpha1.AWSConfig) string {
+	regionARN := "aws"
+
+	if IsChinaRegion(customObject) {
+		regionARN += "-cn"
+	}
+
+	return regionARN
+}
+
+func RoleName(customObject v1alpha1.AWSConfig, profileType string) string {
+	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, RoleNameTemplate)
+}
+
+func RouteTableName(customObject v1alpha1.AWSConfig, suffix string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), suffix)
+}
+
+func S3ServiceDomain(customObject v1alpha1.AWSConfig) string {
+	s3Domain := fmt.Sprintf("s3.%s.amazonaws.com", Region(customObject))
+
+	if IsChinaRegion(customObject) {
+		s3Domain += ".cn"
+	}
+
+	return s3Domain
+}
+
+func SecurityGroupName(customObject v1alpha1.AWSConfig, groupName string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), groupName)
+}
+
+func SubnetName(customObject v1alpha1.AWSConfig, suffix string) string {
+	return fmt.Sprintf("%s-%s", ClusterID(customObject), suffix)
+}
+
+func TargetLogBucketName(customObject v1alpha1.AWSConfig) string {
+	return fmt.Sprintf("%s-g8s-access-logs", ClusterID(customObject))
+}
+
+func ToClusterEndpoint(v interface{}) (string, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return ClusterAPIEndpoint(customObject), nil
+}
+
+func ToClusterID(v interface{}) (string, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return ClusterID(customObject), nil
+}
+
+func ToClusterStatus(v interface{}) (v1alpha1.StatusCluster, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return v1alpha1.StatusCluster{}, microerror.Mask(err)
+	}
+
+	return customObject.Status.Cluster, nil
+}
+
+func ToCustomObject(v interface{}) (v1alpha1.AWSConfig, error) {
+	if v == nil {
+		return v1alpha1.AWSConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSConfig{}, v)
+	}
+
+	customObjectPointer, ok := v.(*v1alpha1.AWSConfig)
+	if !ok {
+		return v1alpha1.AWSConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.AWSConfig{}, v)
+	}
+	customObject := *customObjectPointer
+
+	customObject = *customObject.DeepCopy()
+
+	return customObject, nil
+}
+
+func ToNodeCount(v interface{}) (int, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return 0, microerror.Mask(err)
+	}
+
+	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+
+	return nodeCount, nil
+}
+
+func ToVersionBundleVersion(v interface{}) (string, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return VersionBundleVersion(customObject), nil
+}
+
+// VersionBundleVersion returns the version contained in the Version Bundle.
+func VersionBundleVersion(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.VersionBundle.Version
+}
+
+func WorkerCount(customObject v1alpha1.AWSConfig) int {
+	return len(customObject.Spec.AWS.Workers)
+}
+
+func WorkerImageID(customObject v1alpha1.AWSConfig) string {
+	var imageID string
+
+	if len(customObject.Spec.AWS.Workers) > 0 {
+		imageID = customObject.Spec.AWS.Workers[0].ImageID
+	}
+
+	return imageID
+}
+
+func WorkerInstanceType(customObject v1alpha1.AWSConfig) string {
+	var instanceType string
+
+	if len(customObject.Spec.AWS.Workers) > 0 {
+		instanceType = customObject.Spec.AWS.Workers[0].InstanceType
+
+	}
+
+	return instanceType
+}
+
+func WorkerRoleARN(customObject v1alpha1.AWSConfig, accountID string) string {
+	return baseRoleARN(customObject, accountID, "worker")
+}
+
+func baseRoleARN(customObject v1alpha1.AWSConfig, accountID string, kind string) string {
+	clusterID := ClusterID(customObject)
+	partition := RegionARN(customObject)
+
+	return fmt.Sprintf("arn:%s:iam::%s:role/%s-%s-%s", partition, accountID, clusterID, kind, RoleNameTemplate)
+}
+
+// componentName returns the first component of a domain name.
+// e.g. apiserver.example.customer.cloud.com -> apiserver
+func componentName(domainName string) (string, error) {
+	splits := strings.SplitN(domainName, ".", 2)
+
+	if len(splits) != 2 {
+		return "", microerror.Mask(malformedCloudConfigKeyError)
+	}
+
+	return splits[0], nil
+}
+
+// ImageID returns the EC2 AMI for the configured region.
+func ImageID(customObject v1alpha1.AWSConfig) (string, error) {
+	region := Region(customObject)
+
+	/*
+		Container Linux AMIs for each active AWS region.
+		From: https://coreos.com/os/docs/latest/booting-on-ec2.html
+
+		NOTE 1: AMIs should always be for HVM virtualisation and not PV.
+		NOTE 2: You also need to update the tests.
+
+		service/controller/v14/key/key_test.go
+		service/controller/v14/adapter/adapter_test.go
+		service/controller/v14/resource/cloudformation/main_stack_test.go
+
+		Current Release: CoreOS Container Linux stable 1745.4.0 (HVM)
+	*/
+	imageIDs := map[string]string{
+		"ap-southeast-1": "ami-73b28f0f",
+		"cn-north-1":     "ami-2a875e47",
+		"eu-central-1":   "ami-32042fd9",
+		"eu-west-1":      "ami-82645dfb",
+		"us-west-2":      "ami-574f362f",
+	}
+
+	imageID, ok := imageIDs[region]
+	if !ok {
+		return "", microerror.Maskf(invalidConfigError, "no image id for region '%s'", region)
+	}
+
+	return imageID, nil
+}
+
+// getResourcenameWithTimeHash returns the string compared from specific prefix,
+// time hash and cluster ID.
+func getResourcenameWithTimeHash(prefix string, customObject v1alpha1.AWSConfig) string {
+	clusterID := strings.Replace(ClusterID(customObject), "-", "", -1)
+
+	h := sha1.New()
+	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
+	timeHash := fmt.Sprintf("%x", h.Sum(nil))[0:5]
+
+	upperTimeHash := strings.ToUpper(timeHash)
+	upperClusterID := strings.ToUpper(clusterID)
+
+	return fmt.Sprintf("%s%s%s", prefix, upperClusterID, upperTimeHash)
+}

--- a/service/controller/v14patch1/key/key_test.go
+++ b/service/controller/v14patch1/key/key_test.go
@@ -1,0 +1,1480 @@
+package key
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AutoScalingGroupName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker"
+	groupName := "worker"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if AutoScalingGroupName(customObject, groupName) != expectedName {
+		t.Fatalf("Expected auto scaling group name %s but was %s", expectedName, AutoScalingGroupName(customObject, groupName))
+	}
+}
+
+func Test_AvailabilityZone(t *testing.T) {
+	t.Parallel()
+	expectedAZ := "eu-central-1a"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+			},
+		},
+	}
+
+	if AvailabilityZone(customObject) != expectedAZ {
+		t.Fatalf("Expected availability zone %s but was %s", expectedAZ, AvailabilityZone(customObject))
+	}
+}
+
+func Test_BaseDomain(t *testing.T) {
+	t.Parallel()
+	expectedBaseDomain := "installtion.eu-central-1.aws.gigantic.io"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				HostedZones: v1alpha1.AWSConfigSpecAWSHostedZones{
+					API: v1alpha1.AWSConfigSpecAWSHostedZonesZone{
+						Name: "installtion.eu-central-1.aws.gigantic.io",
+					},
+				},
+			},
+		},
+	}
+
+	baseDomain := BaseDomain(customObject)
+	if baseDomain != expectedBaseDomain {
+		t.Fatalf("BaseDomain == %q, want %q", baseDomain, expectedBaseDomain)
+	}
+}
+
+func Test_BucketName(t *testing.T) {
+	t.Parallel()
+	accountID := "1234567890"
+	expectedName := "1234567890-g8s-test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	if BucketName(customObject, accountID) != expectedName {
+		t.Fatalf("Expected bucket name %s but was %s", expectedName, BucketName(customObject, accountID))
+	}
+}
+
+func Test_ClusterID(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+
+	cluster := v1alpha1.Cluster{
+		ID: expectedID,
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterID(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterID(customObject))
+	}
+}
+
+func Test_ClusterCustomer(t *testing.T) {
+	t.Parallel()
+	expectedCustomer := "test-customer"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if ClusterCustomer(customObject) != expectedCustomer {
+		t.Fatalf("Expected customer ID %s but was %s", expectedCustomer, ClusterCustomer(customObject))
+	}
+}
+
+func Test_ClusterCloudProviderTag(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+	expectedTag := "kubernetes.io/cluster/test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+			},
+		},
+	}
+
+	if ClusterCloudProviderTag(customObject) != expectedTag {
+		t.Fatalf("Expected cloud provider tag %s but was %s", expectedTag, ClusterCloudProviderTag(customObject))
+	}
+}
+
+func Test_ClusterNamespace(t *testing.T) {
+	t.Parallel()
+	expectedID := "test-cluster"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+			},
+		},
+	}
+
+	if ClusterNamespace(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterNamespace(customObject))
+	}
+}
+
+func Test_ClusterOrganization(t *testing.T) {
+	t.Parallel()
+	expectedOrg := "test-org"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-org",
+				},
+			},
+		},
+	}
+
+	if ClusterOrganization(customObject) != expectedOrg {
+		t.Fatalf("Expected organization ID %s but was %s", expectedOrg, ClusterOrganization(customObject))
+	}
+}
+
+func Test_ClusterTags(t *testing.T) {
+	t.Parallel()
+	installName := "test-install"
+
+	expectedID := "test-cluster"
+	expectedTags := map[string]string{
+		"kubernetes.io/cluster/test-cluster": "owned",
+		"giantswarm.io/cluster":              "test-cluster",
+		"giantswarm.io/installation":         "test-install",
+		"giantswarm.io/organization":         "test-org",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+				// Organization uses Customer until its renamed in the CRD.
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-org",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject, installName)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject, installName))
+	}
+}
+
+func Test_ClusterVersion(t *testing.T) {
+	t.Parallel()
+	expectedVersion := "v_0_1_0"
+
+	cluster := v1alpha1.Cluster{
+		Version: expectedVersion,
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterVersion(customObject) != expectedVersion {
+		t.Fatalf("Expected cluster version %s but was %s", expectedVersion, ClusterVersion(customObject))
+	}
+}
+
+func Test_EC2ServiceDomain(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description              string
+		customObject             v1alpha1.AWSConfig
+		expectedEC2ServiceDomain string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			expectedEC2ServiceDomain: "ec2.amazonaws.com",
+		},
+		{
+			description: "different region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "us-west-2",
+					},
+				},
+			},
+			expectedEC2ServiceDomain: "ec2.amazonaws.com",
+		},
+		{
+			description: "china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			expectedEC2ServiceDomain: "ec2.amazonaws.com.cn",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ec2ServiceDomain := EC2ServiceDomain(tc.customObject)
+
+			if tc.expectedEC2ServiceDomain != ec2ServiceDomain {
+				t.Errorf("unexpected EC2 service domain, expecting %q, want %q", tc.expectedEC2ServiceDomain, ec2ServiceDomain)
+			}
+		})
+	}
+}
+
+func Test_DockerVolumeResourceName_Format(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n := DockerVolumeResourceName(customObject)
+
+	prefix := "DockerVolume"
+
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
+	}
+}
+
+func Test_DockerVolumeResourceName_Inequivalence(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := DockerVolumeResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := DockerVolumeResourceName(customObject)
+
+	if n1 == n2 {
+		t.Fatalf("expected %s to differ from %s", n1, n2)
+	}
+}
+
+func Test_EtcdVolumeName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-etcd"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if EtcdVolumeName(customObject) != expectedName {
+		t.Fatalf("Expected Etcd volume name %s but was %s", expectedName, EtcdVolumeName(customObject))
+	}
+}
+
+func Test_IngressControllerInsecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 30010
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						InsecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if IngressControllerInsecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected ingress controller insecure port %d but was %d", expectedPort, IngressControllerInsecurePort(customObject))
+	}
+}
+
+func Test_IngressControllerSecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 30011
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						SecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if IngressControllerSecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected ingress controller secure port %d but was %d", expectedPort, IngressControllerSecurePort(customObject))
+	}
+}
+
+func Test_IsChinaRegion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description    string
+		customObject   v1alpha1.AWSConfig
+		expectedResult bool
+	}{
+		{
+			description: "non china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			description: "different non china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "us-west-2",
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			description: "china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			description: "different china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-northwest-1",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.expectedResult != IsChinaRegion(tc.customObject) {
+				t.Errorf("unexpected result, expecting %t, want %t", tc.expectedResult, IsChinaRegion(tc.customObject))
+			}
+		})
+	}
+}
+
+func Test_KubernetesAPISecurePort(t *testing.T) {
+	t.Parallel()
+	expectedPort := 443
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						SecurePort: expectedPort,
+					},
+				},
+			},
+		},
+	}
+
+	if KubernetesAPISecurePort(customObject) != expectedPort {
+		t.Fatalf("Expected kubernetes api secure port %d but was %d", expectedPort, KubernetesAPISecurePort(customObject))
+	}
+}
+
+func Test_MasterImageID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject    v1alpha1.AWSConfig
+		expectedImageID string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedImageID: "ami-d60ad6b9",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{},
+			},
+			expectedImageID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterImageID(tc.customObject) != tc.expectedImageID {
+			t.Fatalf("Expected master image ID %s but was %s", tc.expectedImageID, MasterImageID(tc.customObject))
+		}
+	}
+}
+
+func Test_MasterInstanceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceName string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "test-cluster",
+					},
+				},
+			},
+			expectedInstanceName: "test-cluster-master",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterInstanceName(tc.customObject) != tc.expectedInstanceName {
+			t.Fatalf("Expected master instance name %s but was %s", tc.expectedInstanceName, MasterInstanceName(tc.customObject))
+		}
+	}
+}
+
+func Test_MasterInstanceResourceName_Format(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n := MasterInstanceResourceName(customObject)
+
+	prefix := "MasterInstance"
+
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
+	}
+}
+
+func Test_MasterInstanceResourceName_Inequivalence(t *testing.T) {
+	t.Parallel()
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	n1 := MasterInstanceResourceName(customObject)
+	time.Sleep(1 * time.Millisecond)
+	n2 := MasterInstanceResourceName(customObject)
+
+	if n1 == n2 {
+		t.Fatalf("expected %s to differ from %s", n1, n2)
+	}
+}
+
+func Test_MasterInstanceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceType string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "m3.medium",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Masters: []v1alpha1.AWSConfigSpecAWSNode{
+							{},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if MasterInstanceType(tc.customObject) != tc.expectedInstanceType {
+			t.Fatalf("Expected master instance type %s but was %s", tc.expectedInstanceType, MasterInstanceType(tc.customObject))
+		}
+	}
+}
+
+func Test_Region(t *testing.T) {
+	t.Parallel()
+	expectedRegion := "eu-central-1"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "eu-central-1",
+			},
+		},
+	}
+
+	if Region(customObject) != expectedRegion {
+		t.Fatalf("Expected region %s but was %s", expectedRegion, Region(customObject))
+	}
+}
+
+func Test_RouteTableName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-private"
+	suffix := "private"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if RouteTableName(customObject, suffix) != expectedName {
+		t.Fatalf("Expected route table name %s but was %s", expectedName, RouteTableName(customObject, suffix))
+	}
+
+}
+
+func Test_S3ServiceDomain(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description      string
+		customObject     v1alpha1.AWSConfig
+		expectedS3Domain string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			expectedS3Domain: "s3.eu-central-1.amazonaws.com",
+		},
+		{
+			description: "different region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "us-west-2",
+					},
+				},
+			},
+			expectedS3Domain: "s3.us-west-2.amazonaws.com",
+		},
+		{
+			description: "china region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			expectedS3Domain: "s3.cn-north-1.amazonaws.com.cn",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			s3Domain := S3ServiceDomain(tc.customObject)
+
+			if tc.expectedS3Domain != s3Domain {
+				t.Errorf("unexpected S3 service domain, expecting %q, want %q", tc.expectedS3Domain, s3Domain)
+			}
+		})
+	}
+}
+
+func Test_SecurityGroupName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker"
+	groupName := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+		Customer: v1alpha1.ClusterCustomer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if SecurityGroupName(customObject, groupName) != expectedName {
+		t.Fatalf("Expected security group name %s but was %s", expectedName, SecurityGroupName(customObject, groupName))
+	}
+}
+
+func Test_SubnetName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-private"
+	suffix := "private"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if SubnetName(customObject, suffix) != expectedName {
+		t.Fatalf("Expected subnet name %s but was %s", expectedName, SubnetName(customObject, suffix))
+	}
+
+}
+
+func Test_WorkerCount(t *testing.T) {
+	t.Parallel()
+	expectedCount := 2
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						InstanceType: "m3.medium",
+					},
+					{
+						InstanceType: "m3.medium",
+					},
+				},
+			},
+		},
+	}
+
+	if WorkerCount(customObject) != expectedCount {
+		t.Fatalf("Expected worker count %d but was %d", expectedCount, WorkerCount(customObject))
+	}
+}
+
+func Test_WorkerImageID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject    v1alpha1.AWSConfig
+		expectedImageID string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedImageID: "ami-d60ad6b9",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedImageID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if WorkerImageID(tc.customObject) != tc.expectedImageID {
+			t.Fatalf("Expected worker image ID %s but was %s", tc.expectedImageID, WorkerImageID(tc.customObject))
+		}
+	}
+}
+
+func Test_WorkerInstanceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		customObject         v1alpha1.AWSConfig
+		expectedInstanceType string
+	}{
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{
+							{
+								ImageID:      "ami-d60ad6b9",
+								InstanceType: "m3.medium",
+							},
+						},
+					},
+				},
+			},
+			expectedInstanceType: "m3.medium",
+		},
+		{
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Workers: []v1alpha1.AWSConfigSpecAWSNode{},
+					},
+				},
+			},
+			expectedInstanceType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		if WorkerInstanceType(tc.customObject) != tc.expectedInstanceType {
+			t.Fatalf("Expected worker instance type %s but was %s", tc.expectedInstanceType, WorkerInstanceType(tc.customObject))
+		}
+	}
+}
+
+func Test_MainGuestStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-guest-main"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainGuestStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_MainHostPreStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-host-setup"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainHostPreStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_MainHostPostStackName(t *testing.T) {
+	t.Parallel()
+	expected := "cluster-xyz-host-main"
+
+	cluster := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "xyz",
+			},
+		},
+	}
+
+	actual := MainHostPostStackName(cluster)
+	if actual != expected {
+		t.Fatalf("Expected main stack name %s but was %s", expected, actual)
+	}
+}
+
+func Test_InstanceProfileName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Role"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	if InstanceProfileName(customObject, profileType) != expectedName {
+		t.Fatalf("Expected instance profile name '%s' but was '%s'", expectedName, InstanceProfileName(customObject, profileType))
+	}
+}
+
+func TestLoadBalancerName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc       string
+		domainName string
+		tpo        v1alpha1.AWSConfig
+		res        string
+		err        error
+	}{
+		{
+			desc:       "works",
+			domainName: "component.foo.bar.example.com",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "foo-customer-component",
+		},
+		{
+			desc:       "also works",
+			domainName: "component.of.a.well.formed.domain",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "quux-the-customer",
+					},
+				},
+			},
+			res: "quux-the-customer-component",
+		},
+		{
+			desc:       "missing ID key in cloudconfig",
+			domainName: "component.foo.bar.example.com",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "",
+					},
+				},
+			},
+			res: "",
+			err: missingCloudConfigKeyError,
+		},
+		{
+			desc:       "malformed domain name",
+			domainName: "not a domain name",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "missing domain name",
+			domainName: "",
+			tpo: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foo-customer",
+					},
+				},
+			},
+			res: "",
+			err: malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := LoadBalancerName(tc.domainName, tc.tpo)
+
+		if err != nil {
+			underlying := microerror.Cause(err)
+			assert.Equal(t, tc.err, underlying, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}
+
+func TestComponentName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc       string
+		domainName string
+		res        string
+		err        error
+	}{
+		{
+			desc:       "one level of subdomains",
+			domainName: "foo.bar.com",
+			res:        "foo",
+		},
+		{
+			desc:       "two levels of subdomains",
+			domainName: "foo.bar.quux.com",
+			res:        "foo",
+		},
+		{
+			desc:       "malformed domain",
+			domainName: "not a domain name",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+		{
+			desc:       "empty domain",
+			domainName: "",
+			res:        "",
+			err:        malformedCloudConfigKeyError,
+		},
+	}
+
+	for _, tc := range tests {
+		res, err := componentName(tc.domainName)
+
+		if err != nil {
+			assert.True(t, IsMalformedCloudConfigKey(err), fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+		}
+
+		assert.Equal(t, tc.res, res, fmt.Sprintf("[%s] The input values didn't produce the expected output", tc.desc))
+	}
+}
+
+func Test_VersionBundleVersion(t *testing.T) {
+	t.Parallel()
+	expectedVersion := "0.1.0"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			VersionBundle: v1alpha1.AWSConfigSpecVersionBundle{
+				Version: "0.1.0",
+			},
+		},
+	}
+
+	if VersionBundleVersion(customObject) != expectedVersion {
+		t.Fatalf("Expected version in version bundle to be %s but was %s", expectedVersion, VersionBundleVersion(customObject))
+	}
+}
+
+func Test_BucketObjectName(t *testing.T) {
+	t.Parallel()
+	version := "v_0_1_0"
+	suffix := "mysuffix"
+
+	expectedBucketObjectName := "cloudconfig/v_0_1_0/mysuffix"
+	actualBucketObjectName := BucketObjectName(version, suffix)
+	if expectedBucketObjectName != actualBucketObjectName {
+		t.Fatalf("Expected bucket object name %q but was %q", expectedBucketObjectName, actualBucketObjectName)
+	}
+}
+
+func Test_RoleName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Role"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := RoleName(customObject, profileType)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_PolicyName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-worker-EC2-K8S-Policy"
+	profileType := "worker"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := PolicyName(customObject, profileType)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_PeerAccessRoleName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-vpc-peer-access"
+
+	cluster := v1alpha1.Cluster{
+		ID: "test-cluster",
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: cluster,
+		},
+	}
+
+	actual := PeerAccessRoleName(customObject)
+	if actual != expectedName {
+		t.Fatalf("Expected  name '%s' but was '%s'", expectedName, actual)
+	}
+}
+
+func Test_MasterCount(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						InstanceType: "m3.medium",
+					},
+					{
+						InstanceType: "m3.medium",
+					},
+				},
+			},
+		},
+	}
+
+	expected := 2
+	actual := MasterCount(customObject)
+	if actual != expected {
+		t.Fatalf("Expected master count %d but was %d", expected, actual)
+	}
+}
+
+func Test_PrivateSubnetCIDR(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PrivateSubnetCIDR: "172.31.0.0/16",
+				},
+			},
+		},
+	}
+	expected := "172.31.0.0/16"
+	actual := PrivateSubnetCIDR(customObject)
+
+	if actual != expected {
+		t.Fatalf("Expected PrivateSubnetCIDR %s but was %s", expected, actual)
+	}
+}
+
+func Test_CIDR(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR: "172.31.0.0/16",
+				},
+			},
+		},
+	}
+	expected := "172.31.0.0/16"
+	actual := CIDR(customObject)
+
+	if actual != expected {
+		t.Fatalf("Expected CIDR %s but was %s", expected, actual)
+	}
+}
+
+func Test_PeerID(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PeerID: "vpc-abcd",
+				},
+			},
+		},
+	}
+	expected := "vpc-abcd"
+	actual := PeerID(customObject)
+
+	if actual != expected {
+		t.Fatalf("Expected PeerID %s but was %s", expected, actual)
+	}
+}
+
+func Test_ImageID(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		customObject    v1alpha1.AWSConfig
+		errorMatcher    func(error) bool
+		expectedImageID string
+	}{
+		{
+			description: "basic match",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			errorMatcher:    nil,
+			expectedImageID: "ami-32042fd9",
+		},
+		{
+			description: "different region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-west-1",
+					},
+				},
+			},
+			errorMatcher:    nil,
+			expectedImageID: "ami-82645dfb",
+		},
+		{
+			description: "invalid region",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "invalid-1",
+					},
+				},
+			},
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			imageID, err := ImageID(tc.customObject)
+			if tc.errorMatcher != nil && err == nil {
+				t.Error("expected error didn't happen")
+			}
+
+			if tc.errorMatcher != nil && !tc.errorMatcher(err) {
+				t.Error("expected", true, "got", false)
+			}
+
+			if tc.expectedImageID != imageID {
+				t.Errorf("unexpected imageID, expecting %q, want %q", tc.expectedImageID, imageID)
+			}
+		})
+	}
+}
+
+func Test_TargetLogBucketName(t *testing.T) {
+	t.Parallel()
+	expectedName := "test-cluster-g8s-access-logs"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	if TargetLogBucketName(customObject) != expectedName {
+		t.Fatalf("Expected target bucket name %s but was %s", expectedName, TargetLogBucketName(customObject))
+	}
+}
+
+func Test_RegionARN(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		region            string
+		expectedRegionARN string
+		description       string
+	}{
+		{
+			description:       "eu region",
+			region:            "eu-central-1",
+			expectedRegionARN: "aws",
+		},
+		{
+			description:       "china region",
+			region:            "cn-north-1",
+			expectedRegionARN: "aws-cn",
+		},
+		{
+			description:       "unknown region",
+			region:            "unknown-region-1",
+			expectedRegionARN: "aws",
+		},
+	}
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				Region: "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			customObject.Spec.AWS.Region = tc.region
+
+			actual := RegionARN(customObject)
+
+			if actual != tc.expectedRegionARN {
+				t.Fatalf("Expected region ARN %q but was %q", tc.expectedRegionARN, actual)
+			}
+		})
+	}
+}
+
+func Test_MasterRoleARN(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		customObject    v1alpha1.AWSConfig
+		accountID       string
+		expectedRoleARN string
+	}{
+		{
+			description: "common partition",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "myclusterid",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			accountID:       "myaccountid",
+			expectedRoleARN: "arn:aws:iam::myaccountid:role/myclusterid-master-EC2-K8S-Role",
+		},
+		{
+			description: "china partition",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "myclusterid",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			accountID:       "myaccountid",
+			expectedRoleARN: "arn:aws-cn:iam::myaccountid:role/myclusterid-master-EC2-K8S-Role",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			roleARN := MasterRoleARN(tc.customObject, tc.accountID)
+			if tc.expectedRoleARN != roleARN {
+				t.Errorf("unexpected Master role ARN, expecting %q, want %q", tc.expectedRoleARN, roleARN)
+			}
+		})
+	}
+}
+
+func Test_WorkerRoleARN(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		customObject    v1alpha1.AWSConfig
+		accountID       string
+		expectedRoleARN string
+	}{
+		{
+			description: "common partition",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "myclusterid",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+				},
+			},
+			accountID:       "myaccountid",
+			expectedRoleARN: "arn:aws:iam::myaccountid:role/myclusterid-worker-EC2-K8S-Role",
+		},
+		{
+			description: "china partition",
+			customObject: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "myclusterid",
+					},
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "cn-north-1",
+					},
+				},
+			},
+			accountID:       "myaccountid",
+			expectedRoleARN: "arn:aws-cn:iam::myaccountid:role/myclusterid-worker-EC2-K8S-Role",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			roleARN := WorkerRoleARN(tc.customObject, tc.accountID)
+			if tc.expectedRoleARN != roleARN {
+				t.Errorf("unexpected Worker role ARN, expecting %q, want %q", tc.expectedRoleARN, roleARN)
+			}
+		})
+	}
+}
+
+func Test_getResourcenameWithTimeHash_Format(t *testing.T) {
+	t.Parallel()
+
+	clusterID := "test-cluster"
+	prefix := "FooResource"
+
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: clusterID,
+			},
+		},
+	}
+
+	n := getResourcenameWithTimeHash(prefix, customObject)
+
+	if !strings.HasPrefix(n, prefix) {
+		t.Fatalf("expected %s to have prefix %s", n, prefix)
+	}
+	if strings.Contains(n, "-") {
+		t.Fatalf("expected %s to not contain dashes", n)
+	}
+}

--- a/service/controller/v14patch1/resource/bridgezone/error.go
+++ b/service/controller/v14patch1/resource/bridgezone/error.go
@@ -1,0 +1,30 @@
+package bridgezone
+
+import "github.com/giantswarm/microerror"
+
+var executionError = &microerror.Error{
+	Kind: "executionError",
+}
+
+// IsExecution asserts executionError.
+func IsExecution(err error) bool {
+	return microerror.Cause(err) == executionError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/v14patch1/resource/bridgezone/resource.go
+++ b/service/controller/v14patch1/resource/bridgezone/resource.go
@@ -1,0 +1,425 @@
+package bridgezone
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/credential"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	name = "bridgezonev14"
+)
+
+type Config struct {
+	HostAWSConfig aws.Config
+	HostRoute53   *route53.Route53
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+
+	Route53Enabled bool
+}
+
+// Resource is bridgezone resource making sure we have fallback delegation in
+// old DNS structure. This is only for the migration period. When we delete the
+// "intermediate" zone this resource becomes noop and we do not need it
+// anymore.
+//
+// Old structure looks like:
+//
+//	installation.eu-central-1.aws.gigantic.io (host account)
+//	└── NS k8s.installation.eu-central-1.aws.gigantic.io (default guest account)
+//	    ├── A api.old_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	    └── A ingress.old_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//
+// New structure looks like:
+//
+//	installation.eu-central-1.aws.gigantic.io (host account)
+//	└── NS new_cluster.k8s.installation.eu-central-1.aws.gigantic.io (byoc guest account)
+//	    ├── A api.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	    └── A ingress.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//
+// For the migration period for new clusters we need also to add delegation to
+// k8s.installation.eu-central-1.aws.gigantic.io because of the AWS DNS caching issues.
+//
+//	installation.eu-central-1.aws.gigantic.io (host account)
+//	├── NS k8s.installation.eu-central-1.aws.gigantic.io (default guest account)
+//	│   ├── NS new_cluster.k8s.installation.eu-central-1.aws.gigantic.io (byoc guest account)
+//	│   ├── A api.old_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	│   └── A ingress.old_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	└── NS new_cluster.k8s.installation.eu-central-1.aws.gigantic.io (byoc guest account)
+//	    ├── A api.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	    └── A ingress.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//
+// NOTE: In the code below k8s.installation.eu-central-1.aws.gigantic.io zone is called
+// "intermediate" and new_cluster.k8s.installation.eu-central-1.aws.gigantic.io zone is
+// called "final". This resource *only* ensures we have delegation from the
+// intermediate zone to the final zone, but only if the intermediate zone
+// exists.
+//
+// After we have guest clusters managed by this resource set (v14) and newer
+// the DNS layout should look like:
+//
+//	installation.eu-central-1.aws.gigantic.io (host account)
+//	├── NS k8s.installation.eu-central-1.aws.gigantic.io (default guest account)
+//	│   └── NS new_cluster.k8s.installation.eu-central-1.aws.gigantic.io (byoc guest account)
+//	└── NS new_cluster.k8s.installation.eu-central-1.aws.gigantic.io (byoc guest account)
+//	    ├── A api.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//	    └── A ingress.new_cluster.k8s.installation.eu-central-1.aws.gigantic.io
+//
+// At this point we should be fine with removing
+// k8s.installation.eu-central-1.aws.gigantic.io NS record from
+// installation.eu-central-1.aws.gigantic.io zone. Then after a couple of days
+// when delegation propagates and DNS caches are refreshed we can delete
+// k8s.installation.eu-central-1.aws.gigantic.io zone from the default guest
+// account.
+type Resource struct {
+	hostAWSConfig aws.Config
+	hostRoute53   *route53.Route53
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+
+	route53Enabled bool
+}
+
+func New(config Config) (*Resource, error) {
+	if reflect.DeepEqual(aws.Config{}, config.HostAWSConfig) {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig must not be empty", config)
+	}
+	if config.HostRoute53 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostRoute53 must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		hostAWSConfig: config.HostAWSConfig,
+		hostRoute53:   config.HostRoute53,
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+
+		route53Enabled: config.Route53Enabled,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return name
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !r.route53Enabled {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "route53 disabled")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		return nil
+	}
+
+	baseDomain := key.BaseDomain(customObject)
+	intermediateZone := "k8s." + baseDomain
+	finalZone := key.ClusterID(customObject) + ".k8s." + baseDomain
+
+	guest, defaultGuest, err := r.route53Clients(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var intermediateZoneID string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "getting intermediate zone ID")
+
+		intermediateZoneID, err = r.findHostedZoneID(ctx, defaultGuest, intermediateZone)
+		if IsNotFound(err) {
+			// If the intermeidate zone is not found we are after
+			// the migraiton period and this resource becomes noop.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "intermediate zone not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "got intermediate zone ID")
+	}
+
+	var finalZoneID string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "getting final zone ID")
+
+		finalZoneID, err = r.findHostedZoneID(ctx, guest, finalZone)
+		if IsNotFound(err) {
+			// The final zone is not yet created. Retry in the next
+			// reconciliation loop.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "final zone not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "got final zone ID")
+	}
+
+	var finalZoneRecords []*route53.ResourceRecord
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "getting final zone name servers")
+
+		nameServers, _, err := r.getNameServersAndTTL(ctx, guest, finalZoneID, finalZone)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, ns := range nameServers {
+			copy := ns
+			v := &route53.ResourceRecord{
+				Value: &copy,
+			}
+			finalZoneRecords = append(finalZoneRecords, v)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "got final zone name servers")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring final zone delegation from intermediate zone")
+
+		upsert := route53.ChangeActionUpsert
+		ns := route53.RRTypeNs
+		ttl := int64(900)
+
+		in := &route53.ChangeResourceRecordSetsInput{
+			ChangeBatch: &route53.ChangeBatch{
+				Changes: []*route53.Change{
+					{
+						Action: &upsert,
+						ResourceRecordSet: &route53.ResourceRecordSet{
+							Name:            &finalZone,
+							Type:            &ns,
+							TTL:             &ttl,
+							ResourceRecords: finalZoneRecords,
+						},
+					},
+				},
+			},
+			HostedZoneId: &intermediateZoneID,
+		}
+		_, err := defaultGuest.ChangeResourceRecordSetsWithContext(ctx, in)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured final zone delegation from intermediate zone")
+	}
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !r.route53Enabled {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "route53 disabled")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+		return nil
+	}
+
+	baseDomain := key.BaseDomain(customObject)
+	intermediateZone := "k8s." + baseDomain
+	finalZone := key.ClusterID(customObject) + ".k8s." + baseDomain
+
+	_, defaultGuest, err := r.route53Clients(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var intermediateZoneID string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "getting intermediate zone ID")
+
+		intermediateZoneID, err = r.findHostedZoneID(ctx, defaultGuest, intermediateZone)
+		if IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "intermediate zone not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "got intermediate zone ID")
+	}
+
+	var finalZoneTTL int64
+	var finalZoneRecords []*route53.ResourceRecord
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "getting final zone delegation name servers and TTL from intermediate zone")
+
+		nameServers, ttl, err := r.getNameServersAndTTL(ctx, defaultGuest, intermediateZoneID, finalZone)
+		if IsNotFound(err) {
+			// Delegation may be already deleted. It must be handled.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "final zone delegation not found in intermediate zone")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		finalZoneTTL = ttl
+
+		for _, ns := range nameServers {
+			copy := ns
+			v := &route53.ResourceRecord{
+				Value: &copy,
+			}
+			finalZoneRecords = append(finalZoneRecords, v)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "got final zone delegation name servers and TTL from intermediate zone")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring deletion of final zone delegation from intermediate zone")
+
+		delete := route53.ChangeActionDelete
+		ns := route53.RRTypeNs
+
+		in := &route53.ChangeResourceRecordSetsInput{
+			ChangeBatch: &route53.ChangeBatch{
+				Changes: []*route53.Change{
+					{
+						Action: &delete,
+						ResourceRecordSet: &route53.ResourceRecordSet{
+							Name:            &finalZone,
+							Type:            &ns,
+							TTL:             &finalZoneTTL,
+							ResourceRecords: finalZoneRecords,
+						},
+					},
+				},
+			},
+			HostedZoneId: &intermediateZoneID,
+		}
+		_, err := defaultGuest.ChangeResourceRecordSetsWithContext(ctx, in)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured deletion of final zone delegation from intermediate zone")
+	}
+
+	return nil
+}
+
+func (r *Resource) findHostedZoneID(ctx context.Context, client *route53.Route53, name string) (string, error) {
+	var marker *string
+	for {
+		in := &route53.ListHostedZonesInput{
+			Marker: marker,
+		}
+
+		out, err := client.ListHostedZones(in)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		for _, hz := range out.HostedZones {
+			if hz.Name == nil || hz.Id == nil {
+				continue
+			}
+
+			hzName := *hz.Name
+			hzName = strings.TrimSuffix(hzName, ".")
+			hzID := *hz.Id
+
+			if hzName == name {
+				return hzID, nil
+			}
+		}
+
+		// If not all IDs are found, try to search next page.
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			return "", microerror.Maskf(notFoundError, "HostedZone with name %q not found", name)
+		}
+		marker = out.Marker
+	}
+}
+
+func (r *Resource) getNameServersAndTTL(ctx context.Context, client *route53.Route53, zoneID, name string) (nameServers []string, ttl int64, err error) {
+	one := "1"
+	ns := route53.RRTypeNs
+	in := &route53.ListResourceRecordSetsInput{
+		HostedZoneId:    &zoneID,
+		MaxItems:        &one,
+		StartRecordName: &name,
+		StartRecordType: &ns,
+	}
+	out, err := client.ListResourceRecordSetsWithContext(ctx, in)
+	if err != nil {
+		return nil, 0, microerror.Mask(err)
+	}
+
+	if len(out.ResourceRecordSets) == 0 {
+		return nil, 0, microerror.Maskf(notFoundError, "NS record %q for HostedZone %q not found", name, zoneID)
+	}
+	if len(out.ResourceRecordSets) != 1 {
+		return nil, 0, microerror.Maskf(executionError, "expected single NS record %q for HostedZone %q, found %#v", name, zoneID, out.ResourceRecordSets)
+	}
+
+	rs := *out.ResourceRecordSets[0]
+
+	if strings.TrimSuffix(*rs.Name, ".") != name {
+		return nil, 0, microerror.Maskf(notFoundError, "NS record %q for HostedZone %q not found", name, zoneID)
+	}
+
+	var servers []string
+	for _, r := range rs.ResourceRecords {
+		servers = append(servers, *r.Value)
+	}
+
+	return servers, *rs.TTL, nil
+}
+
+func (r *Resource) route53Clients(ctx context.Context) (guest, defaultGuest *route53.Route53, err error) {
+	// guest
+	{
+		controllerCtx, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return nil, nil, microerror.Mask(err)
+		}
+		guest = controllerCtx.AWSClient.Route53
+	}
+
+	// defaultGuest
+	{
+		arn, err := credential.GetDefaultARN(r.k8sClient)
+		if err != nil {
+			return nil, nil, microerror.Mask(err)
+		}
+
+		c := r.hostAWSConfig
+		c.RoleARN = arn
+		defaultGuest = aws.NewClients(c).Route53
+	}
+
+	return guest, defaultGuest, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/create.go
+++ b/service/controller/v14patch1/resource/cloudformation/create.go
@@ -1,0 +1,237 @@
+package cloudformation
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	stackInput, err := toCreateStackInput(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackInput.StackName != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the guest cluster main stack")
+
+		sc, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if r.encrypterBackend == encrypter.VaultBackend {
+			customObject, err := key.ToCustomObject(obj)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			err = r.addRoleAccess(sc, customObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		stackInput.Parameters = []*cloudformation.Parameter{
+			{
+				ParameterKey:   aws.String(versionBundleVersionParameterKey),
+				ParameterValue: aws.String(key.VersionBundleVersion(customObject)),
+			},
+		}
+
+		_, err = sc.AWSClient.CloudFormation.CreateStack(&stackInput)
+		if IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		err = sc.AWSClient.CloudFormation.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
+			StackName: stackInput.StackName,
+		})
+		if ctx.Err() == context.DeadlineExceeded {
+			// We waited longer than we wanted to get a reasonable result and be sure
+			// the stack got properly created. We skip here and try again on the next
+			// resync.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster main stack creation is not complete")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+			return nil
+		} else if IsResourceNotReady(err) {
+			// There might be cases in which AWS is not fast enough to create the
+			// resources we want to watch. We skip here and try again on the next
+			// resync.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster main stack creation is not complete")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+			return nil
+		} else if ctx.Err() != nil {
+			return microerror.Mask(ctx.Err())
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not creating the guest cluster main stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return cloudformation.CreateStackInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be created")
+
+	createState := cloudformation.CreateStackInput{}
+
+	if currentStackState.Name == "" || desiredStackState.Name != currentStackState.Name {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be created")
+
+		if err := r.validateCluster(customObject); err != nil {
+			return cloudformation.CreateStackInput{}, microerror.Mask(err)
+		}
+
+		// We need to create the required peering resources in the host account before
+		// getting the guest main stack template body, it requires id values from host
+		// resources.
+		err = r.createHostPreStack(ctx, customObject)
+		if err != nil {
+			return cloudformation.CreateStackInput{}, microerror.Mask(err)
+		}
+
+		var mainTemplate string
+		mainTemplate, err := r.getMainGuestTemplateBody(ctx, customObject, desiredStackState)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		createState.StackName = aws.String(desiredStackState.Name)
+		createState.TemplateBody = aws.String(mainTemplate)
+		createState.TimeoutInMinutes = aws.Int64(defaultCreationTimeout)
+		// CAPABILITY_NAMED_IAM is required for creating IAM roles (worker policy)
+		createState.Capabilities = []*string{
+			aws.String(namedIAMCapability),
+		}
+
+		createState.SetTags(r.getCloudFormationTags(customObject))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be created")
+
+		// Create host post-main stack once the guest main stack got created. This
+		// here usually happens on the second or third attempt dependening on the
+		// resnyc period. It includes the peering routes, which need resources from
+		// the guest stack to be in place before it can be created.
+		err = r.createHostPostStack(ctx, customObject, currentStackState)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return createState, nil
+}
+
+func (r *Resource) createHostPreStack(ctx context.Context, customObject v1alpha1.AWSConfig) error {
+	stackName := key.MainHostPreStackName(customObject)
+	mainTemplate, err := r.getMainHostPreTemplateBody(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	createStack := &cloudformation.CreateStackInput{
+		StackName:    aws.String(stackName),
+		TemplateBody: aws.String(mainTemplate),
+		// CAPABILITY_NAMED_IAM is required for creating IAM roles (worker policy)
+		Capabilities: []*string{
+			aws.String(namedIAMCapability),
+		},
+	}
+	createStack.SetTags(r.getCloudFormationTags(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster pre cloud formation stack")
+
+	_, err = r.hostClients.CloudFormation.CreateStack(createStack)
+	if IsAlreadyExists(err) {
+		// TODO this here indicates we should have dedicated resources for the pre,
+		// main and post stacks. The workflow would be more straight forward and
+		// easy to manage. Right now we hack around this and add conditionals to
+		// make it work somehow while bypassing the framework primitives.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the host cluster pre cloud formation stack is already created")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.hostClients.CloudFormation.WaitUntilStackCreateComplete(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created the host cluster pre cloud formation stack")
+
+	return nil
+}
+
+func (r *Resource) createHostPostStack(ctx context.Context, customObject v1alpha1.AWSConfig, guestMainStackState StackState) error {
+	stackName := key.MainHostPostStackName(customObject)
+	mainTemplate, err := r.getMainHostPostTemplateBody(ctx, customObject, guestMainStackState)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	createStack := &cloudformation.CreateStackInput{
+		StackName:    aws.String(stackName),
+		TemplateBody: aws.String(mainTemplate),
+	}
+	createStack.SetTags(r.getCloudFormationTags(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating the host cluster post cloud formation stack")
+
+	_, err = r.hostClients.CloudFormation.CreateStack(createStack)
+	if IsAlreadyExists(err) {
+		// TODO this here indicates we should have dedicated resources for the pre,
+		// main and post stacks. The workflow would be more straight forward and
+		// easy to manage. Right now we hack around this and add conditionals to
+		// make it work somehow while bypassing the framework primitives.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the host cluster post cloud formation stack is already created")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created the host cluster post cloud formation stack")
+
+	return nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/create_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/create_test.go
@@ -1,0 +1,129 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func Test_Resource_Cloudformation_newCreate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID: "myimageid",
+					},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID: "myimageid",
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj               interface{}
+		currentState      interface{}
+		desiredState      interface{}
+		expectedStackName string
+		description       string
+	}{
+		{
+			description:       "current and desired state empty, expected empty",
+			obj:               clusterTpo,
+			currentState:      StackState{},
+			desiredState:      StackState{},
+			expectedStackName: "",
+		},
+		{
+			description:  "current state empty, desired state not empty, expected desired state",
+			obj:          clusterTpo,
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj:         clusterTpo,
+			currentState: StackState{
+				Name: "current",
+			},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			EC2:            &adapter.EC2ClientMock{},
+			CloudFormation: &adapter.CloudFormationMock{},
+			IAM:            &adapter.IAMClientMock{},
+			STS:            &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+		c.EncrypterBackend = "kms"
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			createChange, ok := result.(awscloudformation.CreateStackInput)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", createChange, result)
+			}
+			if createChange.StackName != nil && *createChange.StackName != tc.expectedStackName {
+				t.Fatalf("expected %s, got %s", tc.expectedStackName, *createChange.StackName)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/cloudformation/current.go
+++ b/service/controller/v14patch1/resource/cloudformation/current.go
@@ -1,0 +1,183 @@
+package cloudformation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v14/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the guest cluster main stack in the AWS API")
+
+	stackName := key.MainGuestStackName(customObject)
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// In order to compute the current state of the guest cluster's cloud
+	// formation stack we have to describe the CF stacks and lookup the right
+	// stack. We dispatch our custom StackState structure and enrich it with all
+	// information necessary to reconcile the cloudformation resource.
+	var stackOutputs []*cloudformation.Output
+	var stackStatus string
+	{
+		stackOutputs, stackStatus, err = sc.CloudFormation.DescribeOutputsAndStatus(stackName)
+		if cloudformationservice.IsStackNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster main stack in the AWS API")
+			return StackState{}, nil
+
+		} else if cloudformationservice.IsOutputsNotAccessible(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack output values are not accessible due to stack state transition")
+			return StackState{}, nil
+
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster main stack in the AWS API")
+
+	// In case the current guest cluster is already being updated, we cancel the
+	// reconciliation until the current update is done in order to reduce
+	// unnecessary friction.
+	if stackStatus == cloudformation.ResourceStatusUpdateInProgress {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("guest cluster main stack is in state '%s'", cloudformation.ResourceStatusUpdateInProgress))
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return StackState{}, nil
+	}
+
+	var currentState StackState
+	{
+		var hostedZoneNameServers string
+		if r.route53Enabled {
+			hostedZoneNameServers, err = sc.CloudFormation.GetOutputValue(stackOutputs, key.HostedZoneNameServers)
+			// TODO introduced: aws-operator@v14; remove with: aws-operator@v13
+			// This output was introduced in v14 so it isn't accessible from CF
+			// stacks created by earlier versions. We need to handle that.
+			//
+			// Final version of the code:
+			//
+			//	if err != nil {
+			//		return StackState{}, microerror.Mask(err)
+			//	}
+			//
+			if cloudformationservice.IsOutputNotFound(err) {
+				// Fall trough. Empty string is handled in host post stack creation.
+			} else if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+			// TODO end
+		}
+		dockerVolumeResourceName, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.DockerVolumeResourceNameKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the docker
+			// volume resource name in the CF stack outputs. We ignore this problem
+			// for now and move on regardless. On the next resync period the output
+			// value will be there, once the cluster got updated.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a docker volume resource.
+			dockerVolumeResourceName = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterImageID, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterImageIDKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterInstanceResourceName, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterInstanceResourceNameKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the master
+			// instance resource name in the CF stack outputs. We ignore this problem
+			// for now and move on regardless. On the next resync period the output
+			// value will be there, once the cluster got updated.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a master instance resource.
+			masterInstanceResourceName = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterInstanceType, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterInstanceTypeKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		masterCloudConfigVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.MasterCloudConfigVersionKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		workerCount, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerCountKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerImageID, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerImageIDKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerInstanceType, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerInstanceTypeKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+		workerCloudConfigVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerCloudConfigVersionKey)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		versionBundleVersion, err := sc.CloudFormation.GetOutputValue(stackOutputs, key.VersionBundleVersionKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the version
+			// bundle version in the CF stack outputs. We ignore this problem for now
+			// and move on regardless. The reconciliation will detect the guest cluster
+			// needs to be updated and once this is done, we should be fine again.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a version bundle version.
+			versionBundleVersion = ""
+		} else if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		currentState = StackState{
+			Name: stackName,
+
+			HostedZoneNameServers: hostedZoneNameServers,
+
+			DockerVolumeResourceName:   dockerVolumeResourceName,
+			MasterImageID:              masterImageID,
+			MasterInstanceResourceName: masterInstanceResourceName,
+			MasterInstanceType:         masterInstanceType,
+			MasterCloudConfigVersion:   masterCloudConfigVersion,
+
+			Status: stackStatus,
+
+			WorkerCount:              workerCount,
+			WorkerImageID:            workerImageID,
+			WorkerInstanceType:       workerInstanceType,
+			WorkerCloudConfigVersion: workerCloudConfigVersion,
+
+			VersionBundleVersion: versionBundleVersion,
+		}
+	}
+
+	return currentState, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/delete.go
+++ b/service/controller/v14patch1/resource/cloudformation/delete.go
@@ -1,0 +1,134 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	stackStateToDelete, err := toStackState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackStateToDelete.Status == cloudformation.ResourceStatusUpdateInProgress {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cannot delete CF stacks due to stack state transitioning")
+
+		// TODO control flow via more proper mechanism via something like the
+		// context like it is done for cancelation already.
+		return microerror.Maskf(deletionMustBeRetriedError, "stack state is transitioning")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the guest cluster main stack")
+
+		sc, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainGuestStackName(customObject)),
+		}
+		_, err = sc.AWSClient.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if r.encrypterBackend == encrypter.VaultBackend {
+			err = r.removeRoleAccess(sc, customObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the guest cluster main stack")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster pre stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPreStackName(customObject)),
+		}
+		_, err = r.hostClients.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the host cluster pre stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the host cluster pre stack")
+	}
+
+	if stackStateToDelete.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster post stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPostStackName(customObject)),
+		}
+		_, err = r.hostClients.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the host cluster post stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the host cluster post stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(deleteChange)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// For deletion we need the current and desired state in order to process it
+	// reliable. There are cases in which the current state does not contain a
+	// name because of stack state transitions but provides the stack status
+	// itself. The desired state never provides the current stack state in return.
+	// This is why we have to compute the delete state using both entities. Note
+	// that for deletion some properties of the stack state are omitted due to
+	// unimportance to the process.
+	deleteState := StackState{
+		Name:   desiredStackState.Name,
+		Status: currentStackState.Status,
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster main stack that has to be deleted")
+
+	return deleteState, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/delete_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/delete_test.go
@@ -1,0 +1,118 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+)
+
+func Test_Resource_Cloudformation_newDelete(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj               interface{}
+		currentState      interface{}
+		desiredState      interface{}
+		expectedStackName string
+		description       string
+	}{
+		{
+			description: "case 0: current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:      StackState{},
+			desiredState:      StackState{},
+			expectedStackName: "",
+		},
+		{
+			description: "case 1: current state empty, desired state not empty, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "case 2: current state not empty, desired state not empty but different, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{
+				Name: "current",
+			},
+			desiredState: StackState{
+				Name: "desired",
+			},
+			expectedStackName: "desired",
+		},
+		{
+			description: "case 3: current state not empty, desired state not empty but equal, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: StackState{
+				Name: "equal",
+			},
+			desiredState: StackState{
+				Name: "equal",
+			},
+			expectedStackName: "equal",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{}
+		c.Logger = microloggertest.New()
+		c.EncrypterBackend = "kms"
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			result, err := newResource.newDeleteChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			deleteChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", deleteChange, result)
+			}
+			if deleteChange.Name != tc.expectedStackName {
+				t.Fatalf("expected %s, got %s", tc.expectedStackName, deleteChange.Name)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/cloudformation/desired.go
+++ b/service/controller/v14patch1/resource/cloudformation/desired.go
@@ -1,0 +1,63 @@
+package cloudformation
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var mainStack StackState
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computing desired state for the guest cluster main stack")
+
+		imageID, err := key.ImageID(customObject)
+		if err != nil {
+			return StackState{}, microerror.Mask(err)
+		}
+
+		// FIXME: the instance type should not depend on the number of workers.
+		// issue: https://github.com/giantswarm/awstpr/issues/47
+		var workerInstanceType string
+		if key.WorkerCount(customObject) > 0 {
+			workerInstanceType = key.WorkerInstanceType(customObject)
+		}
+
+		var masterInstanceType string
+		if len(customObject.Spec.AWS.Masters) > 0 {
+			masterInstanceType = key.MasterInstanceType(customObject)
+		}
+
+		mainStack = StackState{
+			Name: key.MainGuestStackName(customObject),
+
+			DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
+			MasterImageID:              imageID,
+			MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+			MasterInstanceType:         masterInstanceType,
+			MasterCloudConfigVersion:   cloudconfig.CloudConfigVersion,
+			MasterInstanceMonitoring:   r.monitoring,
+
+			WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+			WorkerImageID:            imageID,
+			WorkerInstanceMonitoring: r.monitoring,
+			WorkerInstanceType:       workerInstanceType,
+			WorkerCloudConfigVersion: cloudconfig.CloudConfigVersion,
+
+			VersionBundleVersion: key.VersionBundleVersion(customObject),
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computed desired state for the guest cluster main stack")
+	}
+
+	return mainStack, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/desired_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/desired_test.go
@@ -1,0 +1,71 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+)
+
+func Test_Resource_Cloudformation_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj          interface{}
+		expectedName string
+		description  string
+	}{
+		{
+			description: "CloudFormation gets name from custom object",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					AWS: v1alpha1.AWSConfigSpecAWS{
+						Region: "eu-central-1",
+					},
+					Cluster: v1alpha1.Cluster{
+						ID:      "5xchu",
+						Version: "cloud-formation",
+					},
+				},
+			},
+			expectedName: "cluster-5xchu-guest-main",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{}
+		c.Logger = microloggertest.New()
+		c.EncrypterBackend = "kms"
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			desiredStack, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredStack, result)
+			}
+
+			if tc.expectedName != desiredStack.Name {
+				t.Fatalf("expected cloudformation name '%s' got '%s'", tc.expectedName, desiredStack.Name)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/cloudformation/error.go
+++ b/service/controller/v14patch1/resource/cloudformation/error.go
@@ -1,0 +1,99 @@
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+var alreadyExistsError = &microerror.Error{
+	Kind: "alreadyExistsError",
+}
+
+// IsAlreadyExists asserts alreadyExistsError.
+func IsAlreadyExists(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ErrCodeAlreadyExistsException) {
+		return true
+	}
+
+	if c == alreadyExistsError {
+		return true
+	}
+
+	return false
+}
+
+var deletionMustBeRetriedError = &microerror.Error{
+	Kind: "deletionMustBeRetriedError",
+}
+
+// IsDeletionMustBeRetried asserts deletionMustBeRetriedError.
+func IsDeletionMustBeRetried(err error) bool {
+	return microerror.Cause(err) == deletionMustBeRetriedError
+}
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var resourceNotReadyError = &microerror.Error{
+	Kind: "resourceNotReadyError",
+}
+
+// IsResourceNotReady asserts resourceNotReadyError.
+func IsResourceNotReady(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "ResourceNotReady") {
+		return true
+	}
+
+	if c == resourceNotReadyError {
+		return true
+	}
+
+	return false
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/cloudformation/main_stack.go
+++ b/service/controller/v14patch1/resource/cloudformation/main_stack.go
@@ -1,0 +1,155 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates"
+)
+
+func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig, stackState StackState) (string, error) {
+	hostAccountID, err := adapter.AccountID(*r.hostClients)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	cfg := adapter.Config{
+		APIWhitelist: adapter.APIWhitelist{
+			Enabled:    r.apiWhiteList.Enabled,
+			SubnetList: r.apiWhiteList.SubnetList,
+		},
+		CustomObject:      customObject,
+		Clients:           adapterClients,
+		EncrypterBackend:  r.encrypterBackend,
+		HostClients:       *r.hostClients,
+		InstallationName:  r.installationName,
+		HostAccountID:     hostAccountID,
+		PublicRouteTables: r.publicRouteTables,
+		Route53Enabled:    r.route53Enabled,
+		StackState: adapter.StackState{
+			Name: stackState.Name,
+
+			DockerVolumeResourceName:   stackState.DockerVolumeResourceName,
+			MasterImageID:              stackState.MasterImageID,
+			MasterInstanceResourceName: stackState.MasterInstanceResourceName,
+			MasterInstanceType:         stackState.MasterInstanceType,
+			MasterCloudConfigVersion:   stackState.MasterCloudConfigVersion,
+			MasterInstanceMonitoring:   stackState.MasterInstanceMonitoring,
+
+			WorkerCount:              stackState.WorkerCount,
+			WorkerImageID:            stackState.WorkerImageID,
+			WorkerInstanceMonitoring: stackState.WorkerInstanceMonitoring,
+			WorkerInstanceType:       stackState.WorkerInstanceType,
+			WorkerCloudConfigVersion: stackState.WorkerCloudConfigVersion,
+
+			VersionBundleVersion: stackState.VersionBundleVersion,
+		},
+	}
+
+	adp, err := adapter.NewGuest(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationGuestTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}
+
+func (r *Resource) getMainHostPreTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	guestAccountID, err := adapter.AccountID(adapterClients)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	cfg := adapter.Config{
+		CustomObject:   customObject,
+		GuestAccountID: guestAccountID,
+		Route53Enabled: r.route53Enabled,
+	}
+	adp, err := adapter.NewHostPre(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationHostPreTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}
+
+func (r *Resource) getMainHostPostTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig, guestMainStackState StackState) (string, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	adapterClients := adapter.Clients{
+		CloudFormation: sc.AWSClient.CloudFormation,
+		EC2:            sc.AWSClient.EC2,
+		IAM:            sc.AWSClient.IAM,
+		KMS:            sc.AWSClient.KMS,
+		ELB:            sc.AWSClient.ELB,
+		STS:            sc.AWSClient.STS,
+	}
+
+	cfg := adapter.Config{
+		CustomObject:      customObject,
+		Clients:           adapterClients,
+		HostClients:       *r.hostClients,
+		EncrypterBackend:  r.encrypterBackend,
+		PublicRouteTables: r.publicRouteTables,
+		Route53Enabled:    r.route53Enabled,
+		StackState: adapter.StackState{
+			HostedZoneNameServers: guestMainStackState.HostedZoneNameServers,
+		},
+	}
+	adp, err := adapter.NewHostPost(cfg)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	rendered, err := templates.Render(key.CloudFormationHostPostTemplates(), adp)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return rendered, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/main_stack_test.go
@@ -1,0 +1,702 @@
+package cloudformation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func testConfig() Config {
+	c := Config{}
+
+	c.HostClients = &adapter.Clients{}
+	c.Logger = microloggertest.New()
+	c.EncrypterBackend = "kms"
+	c.InstallationName = "myinstallation"
+
+	return c
+}
+
+func TestMainGuestTemplateGetEmptyBody(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{}
+
+	c := testConfig()
+	c.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(c)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	_, err = newResource.getMainGuestTemplateBody(ctx, customObject, StackState{})
+	if err == nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+}
+
+func TestMainGuestTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "eu-central-1",
+				AZ:     "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.CloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.CloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.AdvancedMonitoringEC2 = true
+	cfg.Route53Enabled = true
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Guest CloudFormation stack.") {
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  workerLaunchConfiguration:") {
+		t.Fatal("launch configuration header not found")
+	}
+
+	if !strings.Contains(body, "  workerAutoScalingGroup:") {
+		t.Fatal("asg header not found")
+	}
+
+	if !strings.Contains(body, "InstanceType: m3.large") {
+		t.Fatal("launch configuration element not found")
+	}
+
+	if !strings.Contains(body, "AvailabilityZones: [eu-central-1a]") {
+		fmt.Println(body)
+		t.Fatal("asg element not found")
+	}
+
+	if !strings.Contains(body, "Outputs:") {
+		fmt.Println(body)
+		t.Fatal("outputs header not found")
+	}
+
+	if !strings.Contains(body, key.MasterImageIDKey+":") {
+		fmt.Println(body)
+		t.Fatal("MasterImageID output element not found")
+	}
+	if !strings.Contains(body, key.MasterInstanceMonitoring+": true") {
+		fmt.Println(body)
+		t.Fatal("MasterInstanceMonitoring output element not found")
+	}
+	if !strings.Contains(body, key.MasterInstanceTypeKey+":") {
+		fmt.Println(body)
+		t.Fatal("MasterInstanceType output element not found")
+	}
+	if !strings.Contains(body, key.MasterCloudConfigVersionKey+":") {
+		fmt.Println(body)
+		t.Fatal("master CloudConfig version output element not found")
+	}
+	if !strings.Contains(body, key.WorkerCountKey+":") {
+		fmt.Println(body)
+		t.Fatal("workers output element not found")
+	}
+	if !strings.Contains(body, key.WorkerImageIDKey+":") {
+		fmt.Println(body)
+		t.Fatal("WorkerImageID output element not found")
+	}
+	if !strings.Contains(body, key.WorkerInstanceTypeKey+":") {
+		fmt.Println(body)
+		t.Fatal("WorkerInstanceType output element not found")
+	}
+	if !strings.Contains(body, key.WorkerCloudConfigVersionKey+":") {
+		fmt.Println(body)
+		t.Fatal("worker CloudConfig version output element not found")
+	}
+	if !strings.Contains(body, key.WorkerInstanceMonitoring+": true") {
+		fmt.Println(body)
+		t.Fatal("WorkerInstanceMonitoring output element not found")
+	}
+
+	if !strings.Contains(body, "Value: "+cloudconfig.CloudConfigVersion) {
+		fmt.Println(body)
+		t.Fatal("output element not found")
+	}
+
+	if !strings.Contains(body, workerRoleKey+":") {
+		fmt.Println(body)
+		t.Fatal("workerRole output element not found")
+	}
+	if !strings.Contains(body, "PolicyName: test-cluster-master") {
+		fmt.Println(body)
+		t.Fatal("PolicyName output element not found")
+	}
+	if !strings.Contains(body, "PolicyName: test-cluster-worker") {
+		fmt.Println(body)
+		t.Fatal("PolicyName output element not found")
+	}
+	if !strings.Contains(body, "ApiRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ApiRecordSet element not found")
+	}
+	if !strings.Contains(body, "EtcdRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("EtcdRecordSet element not found")
+	}
+	if !strings.Contains(body, "IngressRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("IngressRecordSet element not found")
+	}
+	if !strings.Contains(body, "IngressWildcardRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ingressWildcardRecordSet element not found")
+	}
+	if !strings.Contains(body, "MasterInstance") {
+		fmt.Println(body)
+		t.Fatal("MasterInstance element not found")
+	}
+	if !strings.Contains(body, "ApiLoadBalancer:") {
+		fmt.Println(body)
+		t.Fatal("ApiLoadBalancer element not found")
+	}
+	if !strings.Contains(body, "IngressLoadBalancer:") {
+		fmt.Println(body)
+		t.Fatal("IngressLoadBalancer element not found")
+	}
+	if !strings.Contains(body, "InternetGateway:") {
+		fmt.Println(body)
+		t.Fatal("InternetGateway element not found")
+	}
+	if !strings.Contains(body, "NATGateway:") {
+		fmt.Println(body)
+		t.Fatal("NATGateway element not found")
+	}
+	if !strings.Contains(body, "PublicRouteTable:") {
+		fmt.Println(body)
+		t.Fatal("PublicRouteTable element not found")
+	}
+	if !strings.Contains(body, "PublicSubnet:") {
+		fmt.Println(body)
+		t.Fatal("PublicSubnet element not found")
+	}
+	if !strings.Contains(body, "PrivateRouteTable:") {
+		fmt.Println(body)
+		t.Fatal("PrivateRouteTable element not found")
+	}
+	if !strings.Contains(body, "PrivateSubnet:") {
+		fmt.Println(body)
+		t.Fatal("PrivateSubnet element not found")
+	}
+	if !strings.Contains(body, "MasterSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("MasterSecurityGroup element not found")
+	}
+	if !strings.Contains(body, "WorkerSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("WorkerSecurityGroup element not found")
+	}
+	if !strings.Contains(body, "IngressSecurityGroup:") {
+		fmt.Println(body)
+		t.Fatal("IngressSecurityGroup element not found")
+	}
+	if !strings.Contains(body, " VPC:") {
+		fmt.Println(body)
+		t.Fatal("VPC element not found")
+	}
+	if !strings.Contains(body, "CidrBlock: 10.1.1.0/24") {
+		fmt.Println(body)
+		t.Fatal("CidrBlock element not found")
+	}
+
+	// arn depends on region
+	if !strings.Contains(body, `Resource: "arn:aws:s3:::`) {
+		fmt.Println(body)
+		t.Fatal("ARN region dependent element not found")
+	}
+
+	// image ids should be fixed despite the values in the custom object
+	if !strings.Contains(body, "ImageId: ami-32042fd9") {
+		fmt.Println(body)
+		t.Fatal("Fixed image ID not found")
+	}
+}
+
+func TestMainHostPreTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainHostPreTemplateBody(ctx, customObject)
+
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Host Pre-Guest CloudFormation stack.") {
+		fmt.Println(body)
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  PeerRole:") {
+		fmt.Println(body)
+		t.Fatal("peer role header not found")
+	}
+
+	if !strings.Contains(body, "  RoleName: test-cluster-vpc-peer-access") {
+		fmt.Println(body)
+		t.Fatal("role name not found")
+	}
+}
+
+func TestMainHostPostTemplateExistingFields(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					RouteTableNames: []string{
+						"route_table_1",
+						"route_table_2",
+					},
+					PeerID: "mypeerid",
+				},
+			},
+		},
+	}
+
+	cfg := testConfig()
+	cfg.Route53Enabled = true
+	ec2Mock := &adapter.EC2ClientMock{}
+	ec2Mock.SetMatchingRouteTables(1)
+	cfg.HostClients = &adapter.Clients{
+		EC2: ec2Mock,
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	stackState := StackState{
+		HostedZoneNameServers: "a.com.,b.com.",
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainHostPostTemplateBody(ctx, customObject, stackState)
+
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !strings.Contains(body, "Description: Main Host Post-Guest CloudFormation stack.") {
+		fmt.Println(body)
+		t.Fatal("stack header not found")
+	}
+
+	if !strings.Contains(body, "  PrivateRoute1:") {
+		fmt.Println(body)
+		t.Fatal("route header not found")
+	}
+
+	if !strings.Contains(body, "  GuestNSRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("GuestNSRecordSet resource not found")
+	} else if !strings.Contains(body, "ResourceRecords: !Split [ ',', 'a.com.,b.com.' ]") {
+		t.Fatal("GuestNSRecordSet.ResourceRecords resource not found")
+	}
+}
+
+func TestMainGuestTemplateRoute53Disabled(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "eu-central-1",
+				AZ:     "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.CloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.CloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.Route53Enabled = false
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if strings.Contains(body, "ApiRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ApiRecordSet element found")
+	}
+	if strings.Contains(body, "EtcdRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("EtcdRecordSet element found")
+	}
+	if strings.Contains(body, "IngressRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("IngressRecordSet element found")
+	}
+	if strings.Contains(body, "IngressWildcardRecordSet:") {
+		fmt.Println(body)
+		t.Fatal("ingressWildcardRecordSet element found")
+	}
+}
+
+func TestMainGuestTemplateChinaRegion(t *testing.T) {
+	t.Parallel()
+	// customObject with example fields for both asg and launch config
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain:     "api.domain",
+						SecurePort: 443,
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain:       "ingress.domain",
+						InsecurePort: 30010,
+						SecurePort:   30011,
+					},
+				},
+				Etcd: v1alpha1.ClusterEtcd{
+					Domain: "etcd.domain",
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				API: v1alpha1.AWSConfigSpecAWSAPI{
+					ELB: v1alpha1.AWSConfigSpecAWSAPIELB{
+						IdleTimeoutSeconds: 3600,
+					},
+				},
+				Region: "cn-north-1",
+				AZ:     "cn-north-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-master",
+						InstanceType: "m3.large",
+					},
+				},
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{
+						ImageID:      "ami-1234-worker",
+						InstanceType: "m3.large",
+					},
+				},
+				Ingress: v1alpha1.AWSConfigSpecAWSIngress{
+					ELB: v1alpha1.AWSConfigSpecAWSIngressELB{
+						IdleTimeoutSeconds: 60,
+					},
+				},
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					CIDR:              "10.1.1.0/24",
+					PublicSubnetCIDR:  "10.1.1.0/25",
+					PrivateSubnetCIDR: "10.1.2.0/25",
+				},
+			},
+		},
+	}
+
+	imageID, err := key.ImageID(customObject)
+	if err != nil {
+		t.Fatalf("expected %#v got %#v", nil, err)
+	}
+
+	stackState := StackState{
+		Name: key.MainGuestStackName(customObject),
+
+		DockerVolumeResourceName:   key.DockerVolumeResourceName(customObject),
+		MasterImageID:              imageID,
+		MasterInstanceResourceName: key.MasterInstanceResourceName(customObject),
+		MasterInstanceType:         key.MasterInstanceType(customObject),
+		MasterCloudConfigVersion:   cloudconfig.CloudConfigVersion,
+		MasterInstanceMonitoring:   false,
+
+		WorkerCount:              strconv.Itoa(key.WorkerCount(customObject)),
+		WorkerImageID:            imageID,
+		WorkerInstanceMonitoring: true,
+		WorkerInstanceType:       key.WorkerInstanceType(customObject),
+		WorkerCloudConfigVersion: cloudconfig.CloudConfigVersion,
+
+		VersionBundleVersion: key.VersionBundleVersion(customObject),
+	}
+
+	cfg := testConfig()
+	cfg.HostClients = &adapter.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+	cfg.Route53Enabled = false
+	newResource, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	awsClients := aws.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		ELB: &adapter.ELBClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	ctx := context.TODO()
+	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// arn depends on region
+	if !strings.Contains(body, `Resource: "arn:aws-cn:s3:::`) {
+		fmt.Println(body)
+		t.Fatal("ARN region dependent element not found")
+	}
+}

--- a/service/controller/v14patch1/resource/cloudformation/mock_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/mock_test.go
@@ -1,0 +1,27 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/ebs"
+)
+
+type EBSServiceMock struct {
+}
+
+func (e *EBSServiceMock) DeleteVolume(ctx context.Context, volumeID string) error {
+	return nil
+}
+
+func (e *EBSServiceMock) DetachVolume(ctx context.Context, volumeID string, attachment ebs.VolumeAttachment, force bool, shutdown bool, wait bool) error {
+	return nil
+}
+
+// ListVolumes always returns a list containing one volume because this is what
+// the update process of the cloudformation resource needs.
+func (e *EBSServiceMock) ListVolumes(customObject v1alpha1.AWSConfig, filterFuncs ...func(t *ec2.Tag) bool) ([]ebs.Volume, error) {
+	return []ebs.Volume{{}}, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/resource.go
+++ b/service/controller/v14patch1/resource/cloudformation/resource.go
@@ -1,0 +1,188 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cloudformationv14"
+)
+
+type AWSConfig struct {
+	AccessKeyID     string
+	AccessKeySecret string
+	SessionToken    string
+	Region          string
+	accountID       string
+}
+
+// Config represents the configuration used to create a new cloudformation
+// resource.
+type Config struct {
+	APIWhitelist         adapter.APIWhitelist
+	HostClients          *adapter.Clients
+	Logger               micrologger.Logger
+	EncrypterRoleManager encrypter.RoleManager
+
+	AdvancedMonitoringEC2 bool
+	EncrypterBackend      string
+	InstallationName      string
+	PublicRouteTables     string
+	Route53Enabled        bool
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	apiWhiteList         adapter.APIWhitelist
+	encrypterRoleManager encrypter.RoleManager
+	hostClients          *adapter.Clients
+	logger               micrologger.Logger
+
+	encrypterBackend  string
+	installationName  string
+	monitoring        bool
+	publicRouteTables string
+	route53Enabled    bool
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	if config.HostClients == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostClients must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.EncrypterBackend == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.EncrypterBackend must not be empty")
+	}
+
+	newService := &Resource{
+		apiWhiteList:         config.APIWhitelist,
+		hostClients:          config.HostClients,
+		logger:               config.Logger,
+		encrypterRoleManager: config.EncrypterRoleManager,
+
+		encrypterBackend:  config.EncrypterBackend,
+		installationName:  config.InstallationName,
+		monitoring:        config.AdvancedMonitoringEC2,
+		publicRouteTables: config.PublicRouteTables,
+		route53Enabled:    config.Route53Enabled,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) getCloudFormationTags(customObject v1alpha1.AWSConfig) []*awscloudformation.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
+	stackTags := []*awscloudformation.Tag{}
+
+	for k, v := range clusterTags {
+		tag := &awscloudformation.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		stackTags = append(stackTags, tag)
+	}
+
+	return stackTags
+}
+
+func (r *Resource) addRoleAccess(sc *controllercontext.Context, customObject v1alpha1.AWSConfig) error {
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	masterRoleARN := key.MasterRoleARN(customObject, accountID)
+	workerRoleARN := key.WorkerRoleARN(customObject, accountID)
+
+	err = r.encrypterRoleManager.AddIAMRoleToAuth(encrypter.DecrypterVaultRole, masterRoleARN, workerRoleARN)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func (r *Resource) removeRoleAccess(sc *controllercontext.Context, customObject v1alpha1.AWSConfig) error {
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	masterRoleARN := key.MasterRoleARN(customObject, accountID)
+	workerRoleARN := key.WorkerRoleARN(customObject, accountID)
+
+	err = r.encrypterRoleManager.RemoveIAMRoleFromAuth(encrypter.DecrypterVaultRole, masterRoleARN, workerRoleARN)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func toCreateStackInput(v interface{}) (awscloudformation.CreateStackInput, error) {
+	if v == nil {
+		return awscloudformation.CreateStackInput{}, nil
+	}
+
+	createStackInput, ok := v.(awscloudformation.CreateStackInput)
+	if !ok {
+		return awscloudformation.CreateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", createStackInput, v)
+	}
+
+	return createStackInput, nil
+}
+
+func toDeleteStackInput(v interface{}) (awscloudformation.DeleteStackInput, error) {
+	if v == nil {
+		return awscloudformation.DeleteStackInput{}, nil
+	}
+
+	deleteStackInput, ok := v.(awscloudformation.DeleteStackInput)
+	if !ok {
+		return awscloudformation.DeleteStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", deleteStackInput, v)
+	}
+
+	return deleteStackInput, nil
+}
+
+func toStackState(v interface{}) (StackState, error) {
+	if v == nil {
+		return StackState{}, nil
+	}
+
+	stackState, ok := v.(StackState)
+	if !ok {
+		return StackState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", stackState, v)
+	}
+
+	return stackState, nil
+}
+
+func toUpdateStackInput(v interface{}) (awscloudformation.UpdateStackInput, error) {
+	if v == nil {
+		return awscloudformation.UpdateStackInput{}, nil
+	}
+
+	updateStackInput, ok := v.(awscloudformation.UpdateStackInput)
+	if !ok {
+		return awscloudformation.UpdateStackInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", updateStackInput, v)
+	}
+
+	return updateStackInput, nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/resource_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/resource_test.go
@@ -1,0 +1,97 @@
+package cloudformation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Cloudformation_GetCloudFormationTags(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description  string
+		installation string
+		obj          v1alpha1.AWSConfig
+		expectedTags []*awscloudformation.Tag
+	}{
+		{
+			description:  "basic match",
+			installation: "test-install",
+			obj: v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+						Customer: v1alpha1.ClusterCustomer{
+							ID: "giantswarm",
+						},
+					},
+				},
+			},
+			expectedTags: []*awscloudformation.Tag{
+				{
+					Key:   aws.String("kubernetes.io/cluster/5xchu"),
+					Value: aws.String("owned"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/cluster"),
+					Value: aws.String("5xchu"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/organization"),
+					Value: aws.String("giantswarm"),
+				},
+				{
+					Key:   aws.String("giantswarm.io/installation"),
+					Value: aws.String("test-install"),
+				},
+			},
+		},
+	}
+
+	c := Config{}
+
+	c.HostClients = &adapter.Clients{
+		EC2:            &adapter.EC2ClientMock{},
+		CloudFormation: &adapter.CloudFormationMock{},
+		IAM:            &adapter.IAMClientMock{},
+		STS:            &adapter.STSClientMock{},
+	}
+	c.Logger = microloggertest.New()
+	c.EncrypterBackend = "kms"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.InstallationName = tc.installation
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			tags := r.getCloudFormationTags(tc.obj)
+
+			if len(tags) != len(tc.expectedTags) {
+				t.Fatalf("Expected %d tags, found %d", len(tc.expectedTags), len(tags))
+			}
+
+			for _, tag := range tc.expectedTags {
+				if !containsTag(tag, tags) {
+					t.Fatalf("Expected cloud formation contains tag %v in the slice %v", tag, tags)
+				}
+			}
+		})
+	}
+}
+
+func containsTag(tag *awscloudformation.Tag, tags []*awscloudformation.Tag) bool {
+	for _, inTag := range tags {
+		if reflect.DeepEqual(tag, inTag) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/cloudformation/spec.go
+++ b/service/controller/v14patch1/resource/cloudformation/spec.go
@@ -1,0 +1,46 @@
+package cloudformation
+
+import "github.com/aws/aws-sdk-go/service/cloudformation"
+
+const (
+	// defaultCreationTimeout is the timeout in minutes for the creation of the
+	// stack.
+	defaultCreationTimeout = 10
+
+	workerRoleKey = "WorkerRole"
+
+	namedIAMCapability = "CAPABILITY_NAMED_IAM"
+
+	// versionBundleVersionParameterKey is the key name of the Cloud Formation
+	// parameter that sets the version bundle version.
+	versionBundleVersionParameterKey = "VersionBundleVersionParameter"
+)
+
+// StackState is the state representation on which the resource methods work.
+type StackState struct {
+	Name string
+
+	HostedZoneNameServers string
+
+	DockerVolumeResourceName   string
+	MasterImageID              string
+	MasterInstanceType         string
+	MasterInstanceResourceName string
+	MasterCloudConfigVersion   string
+	MasterInstanceMonitoring   bool
+
+	ShouldScale  bool
+	ShouldUpdate bool
+
+	Status string
+
+	WorkerCount              string
+	WorkerImageID            string
+	WorkerInstanceMonitoring bool
+	WorkerInstanceType       string
+	WorkerCloudConfigVersion string
+
+	UpdateStackInput cloudformation.UpdateStackInput
+
+	VersionBundleVersion string
+}

--- a/service/controller/v14patch1/resource/cloudformation/update.go
+++ b/service/controller/v14patch1/resource/cloudformation/update.go
@@ -1,0 +1,270 @@
+package cloudformation
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	stackStateToUpdate, err := toStackState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if stackStateToUpdate.Name != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the guest cluster main stack")
+
+		sc, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if stackStateToUpdate.ShouldUpdate && !stackStateToUpdate.ShouldScale {
+			// Fetch the etcd volume information.
+			filterFuncs := []func(t *ec2.Tag) bool{
+				ebs.NewDockerVolumeFilter(customObject),
+				ebs.NewEtcdVolumeFilter(customObject),
+			}
+			volumes, err := sc.EBSService.ListVolumes(customObject, filterFuncs...)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			// First shutdown the instances and wait for it to be stopped. Then detach
+			// the etcd and docker volume without forcing.
+			force := false
+			shutdown := true
+			wait := true
+			for _, v := range volumes {
+				for _, a := range v.Attachments {
+					err := sc.EBSService.DetachVolume(ctx, v.VolumeID, a, force, shutdown, wait)
+					if err != nil {
+						return microerror.Mask(err)
+					}
+				}
+			}
+		}
+
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		updateStackInput := stackStateToUpdate.UpdateStackInput
+		updateStackInput.Parameters = []*cloudformation.Parameter{
+			{
+				ParameterKey:   aws.String(versionBundleVersionParameterKey),
+				ParameterValue: aws.String(key.VersionBundleVersion(customObject)),
+			},
+		}
+
+		// Once the etcd volume is cleaned up and the master instance is down we can
+		// go ahead to let CloudFormation do its job.
+		_, err = sc.AWSClient.CloudFormation.UpdateStack(&updateStackInput)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the guest cluster main stack")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not updating the guest cluster main stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) computeUpdateState(ctx context.Context, customObject v1alpha1.AWSConfig, stackState StackState) (cloudformation.UpdateStackInput, error) {
+	mainTemplate, err := r.getMainGuestTemplateBody(ctx, customObject, stackState)
+	if err != nil {
+		return cloudformation.UpdateStackInput{}, microerror.Mask(err)
+	}
+
+	updateStackInput := cloudformation.UpdateStackInput{
+		Capabilities: []*string{
+			// CAPABILITY_NAMED_IAM is required for updating IAM roles (worker
+			// policy).
+			aws.String(namedIAMCapability),
+		},
+		StackName:    aws.String(stackState.Name),
+		TemplateBody: aws.String(mainTemplate),
+	}
+
+	return updateStackInput, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	currentStackState, err := toStackState(currentState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+	desiredStackState, err := toStackState(desiredState)
+	if err != nil {
+		return StackState{}, microerror.Mask(err)
+	}
+
+	// We enable/disable updates in order to enable them our test installations
+	// but disable them in production installations. That is useful until we have
+	// full confidence in updating guest clusters. Note that updates also manage
+	// scaling at the same time to be more efficient.
+	if updateallowedcontext.IsUpdateAllowed(ctx) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be updated")
+
+		if shouldUpdate(currentStackState, desiredStackState) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be updated")
+
+			updateStackInput, err := r.computeUpdateState(ctx, customObject, desiredStackState)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+
+			updateState := StackState{
+				Name:             desiredStackState.Name,
+				ShouldScale:      false,
+				ShouldUpdate:     true,
+				UpdateStackInput: updateStackInput,
+			}
+
+			return updateState, nil
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be updated")
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not computing update state of the guest cluster main stack because updates are not allowed")
+	}
+
+	// We manage scaling separately because the impact and implications of scaling
+	// is different compared to updates. We can just process scaling any time. We
+	// cannot just process updates at any time and thus have to separate the
+	// management of both primitives. Note that updates also manage scaling at the
+	// same time for more efficiency. Note that we have to preserve the master
+	// instance resource name when scaling worker nodes to prevent updating the
+	// master node. This is why we set the desired state of the master instance
+	// resource name to the current state below.
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the guest cluster main stack has to be scaled")
+
+		if r.shouldScale(ctx, currentStackState, desiredStackState) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack has to be scaled")
+
+			desiredStackState.MasterInstanceResourceName = currentStackState.MasterInstanceResourceName
+			desiredStackState.DockerVolumeResourceName = currentStackState.DockerVolumeResourceName
+
+			updateStackInput, err := r.computeUpdateState(ctx, customObject, desiredStackState)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+
+			updateState := StackState{
+				Name:             desiredStackState.Name,
+				ShouldScale:      true,
+				ShouldUpdate:     false,
+				UpdateStackInput: updateStackInput,
+			}
+
+			return updateState, nil
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack does not have to be scaled")
+		}
+	}
+
+	return StackState{}, nil
+}
+
+// shouldScale determines whether the reconciled guest cluster should be scaled.
+// A guest cluster is only allowed to scale in case nothing but the worker count
+// changes. In case anything else changes as well, scaling is not allowed, since
+// any other changes should be covered by general updates, which is a separate
+// step.
+func (r *Resource) shouldScale(ctx context.Context, currentState, desiredState StackState) bool {
+	if currentState.MasterImageID != desiredState.MasterImageID {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master image id")
+		return false
+	}
+	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master instance type")
+		return false
+	}
+	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master cloudconfig version")
+		return false
+	}
+	if currentState.WorkerImageID != desiredState.WorkerImageID {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to worker image id")
+		return false
+	}
+	if currentState.WorkerInstanceType != desiredState.WorkerInstanceType {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to worker instance type")
+		return false
+	}
+	if currentState.WorkerCloudConfigVersion != desiredState.WorkerCloudConfigVersion {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to worker cloudconfig version")
+		return false
+	}
+	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to version bundle version")
+		return false
+	}
+
+	if currentState.WorkerCount != desiredState.WorkerCount {
+		return true
+	}
+
+	return false
+}
+
+// shouldUpdate determines whether the reconciled guest cluster should be
+// updated. A guest cluster is only allowed to update in the following cases.
+//
+//     The instance type of master nodes changes (indicates updates).
+//     The instance type of worker nodes changes (indicates updates).
+//     The version bundle version changes (indicates updates).
+//
+func shouldUpdate(currentState, desiredState StackState) bool {
+	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+		return true
+	}
+	if currentState.WorkerInstanceType != desiredState.WorkerInstanceType {
+		return true
+	}
+	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/cloudformation/update_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/update_test.go
@@ -1,0 +1,885 @@
+package cloudformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   interface{}
+		desiredState   interface{}
+		expectedChange awscloudformation.UpdateStackInput
+		description    string
+	}{
+		{
+			description:  "case 0, current state empty, desired state empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description:  "case 1, current state empty, desired state not empty, expected desired state",
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 2, current state not empty, equal desired state, expected empty",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 3, current state not empty, desired state not empty, different master image, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "CHANGED",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 4, current state not empty, desired state not empty, different master CloudConfig version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 5, current state not empty, desired state not empty, different number of workers, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "CHANGED",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 6, current state not empty, desired state not empty, different worker image, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "CHANGED",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 7, current state not empty, desired state not empty, different worker CloudConfig version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 8, current state not empty, desired state not empty, different master instance type, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "CHANGED",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 9, current state not empty, desired state not empty, different worker instance type, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "CHANGED",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 10, current state not empty, desired state not empty, different version bundle version, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			IAM: &adapter.IAMClientMock{},
+			EC2: &adapter.EC2ClientMock{},
+			STS: &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+		c.EncrypterBackend = "kms"
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := awsclient.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := updateallowedcontext.NewContext(context.Background(), make(chan struct{}))
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+			updateallowedcontext.SetUpdateAllowed(ctx)
+
+			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			updateChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", updateChange, result)
+			}
+			if updateChange.UpdateStackInput.StackName != nil && *updateChange.UpdateStackInput.StackName != *tc.expectedChange.StackName {
+				t.Fatalf("expected %v, got %v", *tc.expectedChange.StackName, *updateChange.UpdateStackInput.StackName)
+			}
+		})
+	}
+}
+
+func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+				Kubernetes: v1alpha1.ClusterKubernetes{
+					API: v1alpha1.ClusterKubernetesAPI{
+						Domain: "mysubdomain.mydomain.com",
+					},
+					IngressController: v1alpha1.ClusterKubernetesIngressController{
+						Domain: "mysubdomain.mydomain.com",
+					},
+				},
+			},
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				AZ: "eu-central-1a",
+				Masters: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+				Region: "eu-central-1",
+				Workers: []v1alpha1.AWSConfigSpecAWSNode{
+					{},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   interface{}
+		desiredState   interface{}
+		expectedChange awscloudformation.UpdateStackInput
+		description    string
+	}{
+		{
+			description:  "case 0, current state empty, desired state empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description:  "case 1, current state empty, desired state not empty, expected empty state",
+			currentState: StackState{},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 2, current state not empty, equal desired state, expected empty",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 3, current state not empty, desired state not empty, different master image, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "CHANGED",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 4, current state not empty, desired state not empty, different master CloudConfig version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 5, current state not empty, desired state not empty, different number of workers, expected desired state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "CHANGED",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String("desired"),
+			},
+		},
+		{
+			description: "case 6, current state not empty, desired state not empty, different worker image, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "CHANGED",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 7, current state not empty, desired state not empty, different worker CloudConfig version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "CHANGED",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 8, current state not empty, desired state not empty, different master instance type, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "CHANGED",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 9, current state not empty, desired state not empty, different worker instance type, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "CHANGED",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 10, current state not empty, desired state not empty, different master version bundle version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+		{
+			description: "case 11, current state not empty, desired state not empty, different worker version bundle version, expected empty state",
+			currentState: StackState{
+				Name: "current",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "1.0.0",
+			},
+			desiredState: StackState{
+				Name: "desired",
+
+				MasterCloudConfigVersion: "1.0.0",
+				MasterImageID:            "ami-123",
+				MasterInstanceType:       "m3.large",
+
+				WorkerCloudConfigVersion: "1.0.0",
+				WorkerCount:              "4",
+				WorkerImageID:            "ami-123",
+				WorkerInstanceType:       "m3.large",
+
+				VersionBundleVersion: "CHANGED",
+			},
+			expectedChange: awscloudformation.UpdateStackInput{
+				StackName: aws.String(""),
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+
+		c.HostClients = &adapter.Clients{
+			IAM: &adapter.IAMClientMock{},
+			EC2: &adapter.EC2ClientMock{},
+			STS: &adapter.STSClientMock{},
+		}
+		c.Logger = microloggertest.New()
+		c.EncrypterBackend = "kms"
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	awsClients := awsclient.Clients{
+		EC2: &adapter.EC2ClientMock{},
+		IAM: &adapter.IAMClientMock{},
+		KMS: &adapter.KMSClientMock{},
+		STS: &adapter.STSClientMock{},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			updateChange, ok := result.(StackState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", updateChange, result)
+			}
+			if updateChange.UpdateStackInput.StackName != nil && *updateChange.UpdateStackInput.StackName != *tc.expectedChange.StackName {
+				t.Fatalf("expected %v, got %v", *tc.expectedChange.StackName, *updateChange.UpdateStackInput.StackName)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/cloudformation/validate.go
+++ b/service/controller/v14patch1/resource/cloudformation/validate.go
@@ -1,0 +1,51 @@
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+type validator func(v1alpha1.AWSConfig) error
+
+func (r *Resource) validateCluster(cluster v1alpha1.AWSConfig) error {
+	validators := []validator{
+		r.validateHostPeeringRoutes,
+	}
+
+	for _, v := range validators {
+		if err := v(cluster); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) validateHostPeeringRoutes(cluster v1alpha1.AWSConfig) error {
+	input := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("route.destination-cidr-block"),
+				Values: []*string{
+					aws.String(key.PrivateSubnetCIDR(cluster)),
+				},
+			},
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(key.PeerID(cluster)),
+				},
+			},
+		},
+	}
+	output, err := r.hostClients.EC2.DescribeRouteTables(input)
+	if err == nil && len(output.RouteTables) > 0 {
+		return microerror.Maskf(alreadyExistsError, "route: %s", key.PrivateSubnetCIDR(cluster))
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/resource/cloudformation/validate_test.go
+++ b/service/controller/v14patch1/resource/cloudformation/validate_test.go
@@ -1,0 +1,80 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/adapter"
+)
+
+func Test_validateHostPeeringRoutes(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			AWS: v1alpha1.AWSConfigSpecAWS{
+				VPC: v1alpha1.AWSConfigSpecAWSVPC{
+					PrivateSubnetCIDR: "172.31.0.0/16",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		description         string
+		matchingRouteTables int
+		expectedError       bool
+	}{
+		{
+			description:         "route table doesn't exist, do not expect error",
+			matchingRouteTables: 0,
+			expectedError:       false,
+		},
+		{
+			description:         "route table exists, expect error",
+			matchingRouteTables: 1,
+			expectedError:       true,
+		},
+		{
+			description:         "two route table exist, expect error",
+			matchingRouteTables: 2,
+			expectedError:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		var err error
+		var newResource *Resource
+		{
+			ec2Mock := &adapter.EC2ClientMock{}
+			ec2Mock.SetMatchingRouteTables(tc.matchingRouteTables)
+
+			c := Config{}
+
+			c.HostClients = &adapter.Clients{
+				EC2:            ec2Mock,
+				CloudFormation: &adapter.CloudFormationMock{},
+				IAM:            &adapter.IAMClientMock{},
+				STS:            &adapter.STSClientMock{},
+			}
+			c.Logger = microloggertest.New()
+			c.EncrypterBackend = "kms"
+
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		t.Run(tc.description, func(t *testing.T) {
+			err := newResource.validateHostPeeringRoutes(customObject)
+			if tc.expectedError && err == nil {
+				t.Fatalf("expected error didn't happen")
+			}
+			if !tc.expectedError && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/drainer/create.go
+++ b/service/controller/v14patch1/resource/drainer/create.go
@@ -1,0 +1,177 @@
+package drainer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+// EnsureCreated creates DrainerConfigs for ASG instances in terminating/wait
+// state then lets node-operator to do its job.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	controllerCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	workerASGName := controllerCtx.Status.Drainer.WorkerASGName
+	if workerASGName == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	var instances []*autoscaling.Instance
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding the guest cluster nodes being in state '%s'", autoscaling.LifecycleStateTerminatingWait))
+
+		i := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{
+				aws.String(workerASGName),
+			},
+		}
+
+		o, err := controllerCtx.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, g := range o.AutoScalingGroups {
+			for _, i := range g.Instances {
+				if *i.LifecycleState == autoscaling.LifecycleStateTerminatingWait {
+					instances = append(instances, i)
+				}
+			}
+		}
+
+		if len(instances) == 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find the guest cluster nodes being in state '%s'", autoscaling.LifecycleStateTerminatingWait))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d guest cluster nodes being in state '%s'", len(instances), autoscaling.LifecycleStateTerminatingWait))
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring drainer configs for %d guest cluster nodes being in state '%s'", len(instances), autoscaling.LifecycleStateTerminatingWait)
+
+		for _, instance := range instances {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding drainer config for guest cluster nodes '%s'", *instance.InstanceId))
+
+			privateDNS, err := r.privateDNSForInstance(ctx, *instance.InstanceId)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			n := customObject.GetNamespace()
+			o := metav1.GetOptions{}
+
+			_, err = r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Get(privateDNS, o)
+			if errors.IsNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find drainer config for guest cluster node '%s'", *instance.InstanceId))
+
+				err := r.createDrainerConfig(ctx, customObject, *instance.InstanceId, privateDNS)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found drainer config for guest cluster node '%s'", *instance.InstanceId))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured drainer configs for %d guest cluster nodes being in state '%s'", len(instances), autoscaling.LifecycleStateTerminatingWait)
+	}
+
+	return nil
+}
+
+func (r *Resource) createDrainerConfig(ctx context.Context, customObject providerv1alpha1.AWSConfig, instanceID, privateDNS string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating drainer config for guest cluster nodes '%s'", instanceID))
+
+	n := customObject.GetNamespace()
+	c := &corev1alpha1.DrainerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				key.InstanceIDAnnotation: instanceID,
+			},
+			Labels: map[string]string{
+				key.ClusterIDLabel: key.ClusterID(customObject),
+			},
+			Name: privateDNS,
+		},
+		Spec: corev1alpha1.DrainerConfigSpec{
+			Guest: corev1alpha1.DrainerConfigSpecGuest{
+				Cluster: corev1alpha1.DrainerConfigSpecGuestCluster{
+					API: corev1alpha1.DrainerConfigSpecGuestClusterAPI{
+						Endpoint: key.ClusterAPIEndpoint(customObject),
+					},
+					ID: key.ClusterID(customObject),
+				},
+				Node: corev1alpha1.DrainerConfigSpecGuestNode{
+					Name: privateDNS,
+				},
+			},
+			VersionBundle: corev1alpha1.DrainerConfigSpecVersionBundle{
+				Version: "0.1.0",
+			},
+		},
+	}
+
+	_, err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Create(c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created drainer config for guest cluster node '%s'", instanceID))
+	return nil
+}
+
+func (r *Resource) privateDNSForInstance(ctx context.Context, instanceID string) (string, error) {
+	i := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{
+			aws.String(instanceID),
+		},
+	}
+
+	controllerCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	o, err := controllerCtx.AWSClient.EC2.DescribeInstances(i)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if len(o.Reservations) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected 1 reservation, got %d", len(o.Reservations))
+	}
+	if len(o.Reservations[0].Instances) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected 1 node, got %d", len(o.Reservations[0].Instances))
+	}
+
+	privateDNS := *o.Reservations[0].Instances[0].PrivateDnsName
+
+	return privateDNS, nil
+}

--- a/service/controller/v14patch1/resource/drainer/delete.go
+++ b/service/controller/v14patch1/resource/drainer/delete.go
@@ -1,0 +1,11 @@
+package drainer
+
+import (
+	"context"
+)
+
+// EnsureDeleted is a no-op, because the lifecycle resource only has to act on
+// create and update events in order to drain guest cluster nodes.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/drainer/error.go
+++ b/service/controller/v14patch1/resource/drainer/error.go
@@ -1,0 +1,23 @@
+package drainer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/resource/drainer/resource.go
+++ b/service/controller/v14patch1/resource/drainer/resource.go
@@ -1,0 +1,41 @@
+package drainer
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "drainerv14"
+)
+
+type ResourceConfig struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func NewResource(config ResourceConfig) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/drainer/spec.go
+++ b/service/controller/v14patch1/resource/drainer/spec.go
@@ -1,0 +1,8 @@
+package drainer
+
+import "github.com/aws/aws-sdk-go/service/autoscaling"
+
+type StackState struct {
+	Instances     []*autoscaling.Instance
+	WorkerASGName string
+}

--- a/service/controller/v14patch1/resource/drainfinisher/create.go
+++ b/service/controller/v14patch1/resource/drainfinisher/create.go
@@ -1,0 +1,157 @@
+package drainfinisher
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+// EnsureCreated completes ASG lifecycle hooks for nodes drained by
+// node-operator, and then deletes drained DrainerConfigs.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	controllerCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	workerASGName := controllerCtx.Status.Drainer.WorkerASGName
+	if workerASGName == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	var drainedDrainerConfigs []corev1alpha1.DrainerConfig
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding drained drainer configs for the guest cluster")
+
+		n := v1.NamespaceAll
+		o := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", key.ClusterIDLabel, key.ClusterID(customObject)),
+		}
+
+		drainerConfigs, err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).List(o)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, drainerConfig := range drainerConfigs.Items {
+			if drainerConfig.Status.HasDrainedCondition() {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("drainer config '%s' of guest cluster has drained condition", drainerConfig.GetName()))
+				drainedDrainerConfigs = append(drainedDrainerConfigs, drainerConfig)
+			}
+
+			if drainerConfig.Status.HasTimeoutCondition() {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("drainer config '%s' of guest cluster has timeout condition", drainerConfig.GetName()))
+				drainedDrainerConfigs = append(drainedDrainerConfigs, drainerConfig)
+			}
+		}
+
+		if len(drainedDrainerConfigs) == 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find drained drainer configs for the guest cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d drained drainer configs for the guest cluster", len(drainedDrainerConfigs)))
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring finised draining for drained nodes")
+
+		for _, drainerConfig := range drainedDrainerConfigs {
+			// This is a special thing for AWS. We use annotations to transport EC2
+			// instance IDs. Otherwise the lookups of all necessary information
+			// again would be quite a ball ache. Se we take the shortcut leveraging
+			// the k8s API.
+			instanceID, err := instanceIDFromAnnotations(drainerConfig.GetAnnotations())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			err = r.completeLifecycleHook(ctx, instanceID, workerASGName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			err = r.deleteDrainerConfig(ctx, drainerConfig)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensured finised draining for drained nodes")
+	}
+
+	return nil
+}
+
+func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, workerASGName string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completing lifecycle hook action for guest cluster node '%s'", instanceID))
+	i := &autoscaling.CompleteLifecycleActionInput{
+		AutoScalingGroupName:  aws.String(workerASGName),
+		InstanceId:            aws.String(instanceID),
+		LifecycleActionResult: aws.String("CONTINUE"),
+		LifecycleHookName:     aws.String(key.NodeDrainerLifecycleHookName),
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = sc.AWSClient.AutoScaling.CompleteLifecycleAction(i)
+	if IsNoActiveLifecycleAction(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not found lifecycle hook action for guest cluster node '%s'", instanceID))
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster node '%s'", instanceID))
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("completed lifecycle hook action for guest cluster node '%s'", instanceID))
+	return nil
+}
+
+func (r *Resource) deleteDrainerConfig(ctx context.Context, drainerConfig corev1alpha1.DrainerConfig) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting drainer config for guest cluster node '%s'", drainerConfig.Name))
+
+	n := drainerConfig.GetNamespace()
+	i := drainerConfig.GetName()
+	o := &metav1.DeleteOptions{}
+
+	err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Delete(i, o)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted drainer config for guest cluster node '%s'", drainerConfig.Name))
+	return nil
+}
+
+func instanceIDFromAnnotations(annotations map[string]string) (string, error) {
+	instanceID, ok := annotations[key.InstanceIDAnnotation]
+	if !ok {
+		return "", microerror.Maskf(missingAnnotationError, key.InstanceIDAnnotation)
+	}
+	if instanceID == "" {
+		return "", microerror.Maskf(missingAnnotationError, key.InstanceIDAnnotation)
+	}
+
+	return instanceID, nil
+}

--- a/service/controller/v14patch1/resource/drainfinisher/delete.go
+++ b/service/controller/v14patch1/resource/drainfinisher/delete.go
@@ -1,0 +1,11 @@
+package drainfinisher
+
+import (
+	"context"
+)
+
+// EnsureDeleted is a no-op, because the lifecycle resource only has to act on
+// create and update events in order to drain guest cluster nodes.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/drainfinisher/error.go
+++ b/service/controller/v14patch1/resource/drainfinisher/error.go
@@ -1,0 +1,58 @@
+package drainfinisher
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var missingAnnotationError = &microerror.Error{
+	Kind: "missingAnnotationError",
+}
+
+func IsMissingAnnotationError(err error) bool {
+	return microerror.Cause(err) == missingAnnotationError
+}
+
+var noActiveLifecycleActionError = &microerror.Error{
+	Kind: "noActiveLifecycleActionError",
+}
+
+// IsNoActiveLifecycleAction asserts noActiveLifecycleActionError. It also
+// checks for some string matching in the error message to figure if the AWS API
+// gives the error we expect.
+func IsNoActiveLifecycleAction(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "No active Lifecycle Action found") {
+		return true
+	}
+
+	if c == noActiveLifecycleActionError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/drainfinisher/resource.go
+++ b/service/controller/v14patch1/resource/drainfinisher/resource.go
@@ -1,0 +1,41 @@
+package drainfinisher
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "drainfinisherv14"
+)
+
+type ResourceConfig struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func NewResource(config ResourceConfig) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/drainfinisher/spec.go
+++ b/service/controller/v14patch1/resource/drainfinisher/spec.go
@@ -1,0 +1,8 @@
+package drainfinisher
+
+import "github.com/aws/aws-sdk-go/service/autoscaling"
+
+type StackState struct {
+	Instances     []*autoscaling.Instance
+	WorkerASGName string
+}

--- a/service/controller/v14patch1/resource/ebsvolume/create.go
+++ b/service/controller/v14patch1/resource/ebsvolume/create.go
@@ -1,0 +1,11 @@
+package ebsvolume
+
+import (
+	"context"
+)
+
+// EnsureCreated is a no-op, because the ebsvolume resource is only
+// interested in delete events.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/ebsvolume/delete.go
+++ b/service/controller/v14patch1/resource/ebsvolume/delete.go
@@ -1,0 +1,84 @@
+package ebsvolume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/ebs"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+// EnsureDeleted detaches and deletes the EBS volumes. We don't return
+// errors so deletion logic in following resources is executed.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Get all etcd, docker and persistent volumes.
+	filterFuncs := []func(t *ec2.Tag) bool{
+		ebs.NewDockerVolumeFilter(customObject),
+		ebs.NewEtcdVolumeFilter(customObject),
+		ebs.NewPersistentVolumeFilter(customObject),
+	}
+	volumes, err := sc.EBSService.ListVolumes(customObject, filterFuncs...)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(volumes) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d EBS volumes", len(volumes)))
+
+		// First detach any attached volumes without forcing but shutdown the
+		// instances.
+		for _, vol := range volumes {
+			for _, a := range vol.Attachments {
+				force := false
+				shutdown := true
+				wait := false
+				err := sc.EBSService.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
+				if err != nil {
+					r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to detach EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+				}
+			}
+		}
+
+		// Now force detach so the volumes can be deleted cleanly. Instances
+		// are already shutdown.
+		for _, vol := range volumes {
+			for _, a := range vol.Attachments {
+				force := true
+				shutdown := false
+				wait := false
+				err := sc.EBSService.DetachVolume(ctx, vol.VolumeID, a, force, shutdown, wait)
+				if err != nil {
+					r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to force detach EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+				}
+			}
+		}
+
+		// Now delete the volumes.
+		for _, vol := range volumes {
+			err := sc.EBSService.DeleteVolume(ctx, vol.VolumeID)
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("failed to delete EBS volume %s", vol.VolumeID), "stack", fmt.Sprintf("%#v", err))
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d EBS volumes", len(volumes)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting EBS volumes because there aren't any")
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/resource/ebsvolume/error.go
+++ b/service/controller/v14patch1/resource/ebsvolume/error.go
@@ -1,0 +1,14 @@
+package ebsvolume
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/resource/ebsvolume/resource.go
+++ b/service/controller/v14patch1/resource/ebsvolume/resource.go
@@ -1,0 +1,39 @@
+package ebsvolume
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "ebsvolumev14"
+)
+
+// Config represents the configuration used to create a new ebsvolume resource.
+type Config struct {
+	Logger micrologger.Logger
+}
+
+// Resource implements the ebsvolume resource.
+type Resource struct {
+	logger micrologger.Logger
+}
+
+// New creates a new configured ebsvolume resource.
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/encryptionkey/create.go
+++ b/service/controller/v14patch1/resource/encryptionkey/create.go
@@ -1,0 +1,52 @@
+package encryptionkey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	createInput, err := toEncryptionKeyState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if createInput.KeyName != "" {
+		err := r.encrypter.CreateKey(ctx, customObject, createInput.KeyName)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating encryption key: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating encryption key: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentKeyState, err := toEncryptionKeyState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredKeyState, err := toEncryptionKeyState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if currentKeyState.KeyName == "" || desiredKeyState.KeyName != currentKeyState.KeyName {
+		return desiredKeyState, nil
+	}
+
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/create_test.go
+++ b/service/controller/v14patch1/resource/encryptionkey/create_test.go
@@ -1,0 +1,136 @@
+package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_Resource_EncryptionKey_newCreate(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState   encrypter.EncryptionKeyState
+		desiredState   encrypter.EncryptionKeyState
+		expectedChange encrypter.EncryptionKeyState
+		description    string
+	}{
+		{
+			description:    "current state empty, desired state empty, empty create change",
+			currentState:   encrypter.EncryptionKeyState{},
+			desiredState:   encrypter.EncryptionKeyState{},
+			expectedChange: encrypter.EncryptionKeyState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, create change == desired state",
+			currentState: encrypter.EncryptionKeyState{},
+			desiredState: encrypter.EncryptionKeyState{
+				KeyName: "mykeyid",
+			},
+			expectedChange: encrypter.EncryptionKeyState{
+				KeyName: "mykeyid",
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty, create change == desired state",
+			currentState: encrypter.EncryptionKeyState{
+				KeyName: "currentkeyid",
+			},
+			desiredState: encrypter.EncryptionKeyState{
+				KeyName: "mykeyid",
+			},
+			expectedChange: encrypter.EncryptionKeyState{
+				KeyName: "mykeyid",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.Encrypter = &encrypter.EncrypterMock{}
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			result, err := newResource.newCreateChange(ctx, customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChange, ok := result.(encrypter.EncryptionKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChange, result)
+			}
+			if createChange.KeyName != tc.expectedChange.KeyName {
+				t.Errorf("expected %s, got %s", tc.expectedChange.KeyName, createChange.KeyName)
+			}
+		})
+	}
+}
+
+func Test_ApplyCreateChange(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		createChange encrypter.EncryptionKeyState
+		description  string
+	}{
+		{
+			description: "basic case, create",
+			createChange: encrypter.EncryptionKeyState{
+				KeyName: "alias/test-cluster",
+			},
+		},
+		{
+			description:  "empty create change, not create",
+			createChange: encrypter.EncryptionKeyState{},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.Encrypter = &encrypter.EncrypterMock{}
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		ctx := context.TODO()
+		err := newResource.ApplyCreateChange(ctx, customObject, tc.createChange)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/encryptionkey/current.go
+++ b/service/controller/v14patch1/resource/encryptionkey/current.go
@@ -1,0 +1,23 @@
+package encryptionkey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	currentState, err := r.encrypter.CurrentState(ctx, customObject)
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
+	return currentState, nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/current_test.go
+++ b/service/controller/v14patch1/resource/encryptionkey/current_test.go
@@ -1,0 +1,74 @@
+package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_CurrentState(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description             string
+		expectedKeyID           string
+		expectedEncryptionError bool
+	}{
+		{
+			description:   "basic match",
+			expectedKeyID: "mykeyid",
+		},
+		{
+			description:             "Encryption error",
+			expectedEncryptionError: true,
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			resourceConfig.Encrypter = &encrypter.EncrypterMock{
+				IsError: tc.expectedEncryptionError,
+				KeyID:   tc.expectedKeyID,
+			}
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			ctx := context.TODO()
+			result, err := newResource.GetCurrentState(ctx, customObject)
+			if err != nil && !tc.expectedEncryptionError {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(encrypter.EncryptionKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if err == nil && tc.expectedEncryptionError {
+				t.Error("expected encryption error didn't happen")
+			}
+
+			if currentState.KeyID != tc.expectedKeyID {
+				t.Errorf("expected keyID %q, got %q", tc.expectedKeyID, currentState.KeyID)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/encryptionkey/delete.go
+++ b/service/controller/v14patch1/resource/encryptionkey/delete.go
@@ -1,0 +1,63 @@
+package encryptionkey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	deleteInput, err := toEncryptionKeyState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if deleteInput.KeyName != "" {
+		err := r.encrypter.DeleteKey(ctx, deleteInput.KeyName)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryption Key: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryption Key: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentKeyState, err := toEncryptionKeyState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredKeyState, err := toEncryptionKeyState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the encryption key should be deleted")
+
+	var keyToDelete encrypter.EncryptionKeyState
+	if currentKeyState.KeyName != "" {
+		keyToDelete = desiredKeyState
+	}
+
+	return keyToDelete, nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/delete_test.go
+++ b/service/controller/v14patch1/resource/encryptionkey/delete_test.go
@@ -1,0 +1,130 @@
+package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_newDelete(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		currentState  encrypter.EncryptionKeyState
+		desiredState  encrypter.EncryptionKeyState
+		expectedAlias string
+		description   string
+	}{
+		{
+			description:   "current and desired state empty, expected empty",
+			currentState:  encrypter.EncryptionKeyState{},
+			desiredState:  encrypter.EncryptionKeyState{},
+			expectedAlias: "",
+		},
+		{
+			description:  "current state empty, desired state not empty, expected empty",
+			currentState: encrypter.EncryptionKeyState{},
+			desiredState: encrypter.EncryptionKeyState{
+				KeyName: "desired",
+			},
+			expectedAlias: "",
+		},
+		{
+			description: "current state not empty, desired state not empty but equal, expected current state",
+			currentState: encrypter.EncryptionKeyState{
+				KeyName: "current",
+			},
+			desiredState: encrypter.EncryptionKeyState{
+				KeyName: "current",
+			},
+			expectedAlias: "current",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.Encrypter = &encrypter.EncrypterMock{}
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Error("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), customObject, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			deleteChange, ok := result.(encrypter.EncryptionKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", deleteChange, result)
+			}
+			if deleteChange.KeyName != tc.expectedAlias {
+				t.Errorf("expected %s, got %s", tc.expectedAlias, deleteChange.KeyName)
+			}
+		})
+	}
+}
+
+func Test_ApplyDeleteChange(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		deleteChange encrypter.EncryptionKeyState
+		description  string
+	}{
+		{
+			description: "basic case, create",
+			deleteChange: encrypter.EncryptionKeyState{
+				KeyName: "alias/test-cluster",
+			},
+		},
+		{
+			description:  "empty create change, not create",
+			deleteChange: encrypter.EncryptionKeyState{},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.Encrypter = &encrypter.EncrypterMock{}
+	resourceConfig.InstallationName = "test-install"
+
+	newResource, err = New(resourceConfig)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	for _, tc := range testCases {
+		ctx := context.TODO()
+		err := newResource.ApplyDeleteChange(ctx, &customObject, tc.deleteChange)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/encryptionkey/desired.go
+++ b/service/controller/v14patch1/resource/encryptionkey/desired.go
@@ -1,0 +1,23 @@
+package encryptionkey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredState, err := r.encrypter.DesiredState(ctx, customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return desiredState, nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/desired_test.go
+++ b/service/controller/v14patch1/resource/encryptionkey/desired_test.go
@@ -1,0 +1,64 @@
+package encryptionkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_DesiredState(t *testing.T) {
+	t.Parallel()
+	customObject := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description     string
+		expectedKeyName string
+	}{
+		{
+			description:     "basic match",
+			expectedKeyName: "alias/test-cluster",
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	resourceConfig := DefaultConfig()
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.InstallationName = "test-install"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			resourceConfig.Encrypter = &encrypter.EncrypterMock{
+				KeyName: tc.expectedKeyName,
+			}
+
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			result, err := newResource.GetDesiredState(context.TODO(), customObject)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(encrypter.EncryptionKeyState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if currentState.KeyName != tc.expectedKeyName {
+				t.Errorf("expected keyName %q, got %q", tc.expectedKeyName, currentState.KeyName)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/encryptionkey/error.go
+++ b/service/controller/v14patch1/resource/encryptionkey/error.go
@@ -1,0 +1,34 @@
+package encryptionkey
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+func IsKeyNotFound(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if ok && aerr.Code() == kms.ErrCodeNotFoundException {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/encryptionkey/mock.go
+++ b/service/controller/v14patch1/resource/encryptionkey/mock.go
@@ -1,0 +1,50 @@
+package encryptionkey
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+type EncrypterMock struct {
+	isError bool
+	keyID   string
+	keyName string
+}
+
+func (e *EncrypterMock) CreateKey(ctx context.Context, customObject v1alpha1.AWSConfig, keyName string) error {
+	return nil
+}
+
+func (e *EncrypterMock) DeleteKey(ctx context.Context, keyName string) error {
+	return nil
+}
+
+func (e *EncrypterMock) CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	if e.isError {
+		return encrypter.EncryptionKeyState{}, fmt.Errorf("could not get current state")
+	}
+
+	return encrypter.EncryptionKeyState{
+		KeyID:   e.keyID,
+		KeyName: e.keyName,
+	}, nil
+}
+
+func (e *EncrypterMock) DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
+	if e.isError {
+		return encrypter.EncryptionKeyState{}, fmt.Errorf("could not get current state")
+	}
+
+	return encrypter.EncryptionKeyState{
+		KeyID:   e.keyID,
+		KeyName: e.keyName,
+	}, nil
+}
+
+func (e *EncrypterMock) EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
+	return "", nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/resource.go
+++ b/service/controller/v14patch1/resource/encryptionkey/resource.go
@@ -1,0 +1,88 @@
+package encryptionkey
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "encryptionkeyv14"
+)
+
+// Config represents the configuration used to create a new cloudformation resource.
+type Config struct {
+	// Dependencies.
+	Encrypter encrypter.Interface
+	Logger    micrologger.Logger
+
+	// Settings.
+	InstallationName string
+}
+
+// DefaultConfig provides a default configuration to create a new cloudformation
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Encrypter: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	// Dependencies.
+	encrypter encrypter.Interface
+	logger    micrologger.Logger
+
+	// Settings.
+	installationName string
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Encrypter == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Encrypter must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
+
+	// Settings.
+	newService := &Resource{
+		// Dependencies.
+		encrypter: config.Encrypter,
+		logger:    config.Logger,
+
+		// Settings.
+		installationName: config.InstallationName,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toEncryptionKeyState(v interface{}) (encrypter.EncryptionKeyState, error) {
+	if v == nil {
+		return encrypter.EncryptionKeyState{}, nil
+	}
+
+	keyState, ok := v.(encrypter.EncryptionKeyState)
+	if !ok {
+		return encrypter.EncryptionKeyState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", keyState, v)
+	}
+
+	return keyState, nil
+}

--- a/service/controller/v14patch1/resource/encryptionkey/update.go
+++ b/service/controller/v14patch1/resource/encryptionkey/update.go
@@ -1,0 +1,35 @@
+package encryptionkey
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because encryption keys are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/create.go
+++ b/service/controller/v14patch1/resource/endpoints/create.go
@@ -1,0 +1,58 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToCreate, err := toEndpoints(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err = r.k8sClient.CoreV1().Endpoints(namespace).Create(endpointsToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes endpoints: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var endpointsToCreate *apiv1.Endpoints
+	if currentEndpoints == nil || desiredEndpoints.Name != currentEndpoints.Name {
+		endpointsToCreate = desiredEndpoints
+	}
+
+	return endpointsToCreate, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/create_test.go
+++ b/service/controller/v14patch1/resource/endpoints/create_test.go
@@ -1,0 +1,117 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current state matches desired state, desired state is empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: nil,
+		},
+		{
+			description: "current state is empty, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToCreate, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToCreate, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToCreate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToCreate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/endpoints/current.go
+++ b/service/controller/v14patch1/resource/endpoints/current.go
@@ -1,0 +1,40 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master endpoints in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+
+	// Lookup the current state of the endpoints.
+	var endpoints *apiv1.Endpoints
+	{
+		manifest, err := r.k8sClient.CoreV1().Endpoints(namespace).Get(masterEndpointsName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master endpoints in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master endpoints in the Kubernetes API")
+			endpoints = manifest
+		}
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/delete.go
+++ b/service/controller/v14patch1/resource/endpoints/delete.go
@@ -1,0 +1,76 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToDelete, err := toEndpoints(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().Endpoints(namespace).Delete(endpointsToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes endpoints: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the endpoints has to be deleted")
+
+	var endpointsToDelete *apiv1.Endpoints
+	if currentEndpoints != nil && desiredEndpoints.Name == currentEndpoints.Name {
+		endpointsToDelete = desiredEndpoints
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the endpoints has to be deleted")
+
+	return endpointsToDelete, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/delete_test.go
+++ b/service/controller/v14patch1/resource/endpoints/delete_test.go
@@ -1,0 +1,117 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current state matches desired state, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedEndpoints: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToDelete, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToDelete, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToDelete.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToDelete.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/endpoints/desired.go
+++ b/service/controller/v14patch1/resource/endpoints/desired.go
@@ -1,0 +1,68 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	instanceName := key.MasterInstanceName(customObject)
+	masterInstance, err := r.findMasterInstance(ctx, instanceName)
+	if IsNotFound(err) {
+		// During updates the master instance is shut down and thus cannot be found.
+		// In such cases we cancel the reconciliation for the endpoint resource.
+		// This should be ok since all endpoints should be created and up to date
+		// already. In case we miss an update it will be done on the next resync
+		// period once the master instance is up again.
+		//
+		// TODO we might want to alert at some point when the master instance was
+		// not seen for too long. Like we should be able to find it again after
+		// three resync periods max or something.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "master instance not found")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	endpoints := &v1.Endpoints{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      masterEndpointsName,
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				"app":      masterEndpointsName,
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.CustomerID(customObject),
+			},
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: *masterInstance.PrivateIpAddress,
+					},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Port: httpsPort,
+					},
+				},
+			},
+		},
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/desired_test.go
+++ b/service/controller/v14patch1/resource/endpoints/desired_test.go
@@ -1,0 +1,91 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func Test_Resource_Endpoints_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		expectedNamespace string
+		expectedName      string
+		expectedIPAddress string
+		expectedPort      int
+	}{
+		{
+			description: "basic match",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			expectedNamespace: "al9qy",
+			expectedName:      "master",
+			expectedIPAddress: "10.1.1.1",
+			expectedPort:      443,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				K8sClient: fake.NewSimpleClientset(),
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			awsClients := aws.Clients{
+				EC2: EC2ClientMock{
+					privateIPAddress: tc.expectedIPAddress,
+				},
+			}
+
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatalf("expected '%v' got '%#v'", nil, err)
+			}
+			desiredEndpoints, ok := result.(*apiv1.Endpoints)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredEndpoints, result)
+			}
+
+			if tc.expectedNamespace != desiredEndpoints.ObjectMeta.Namespace {
+				t.Fatalf("expected namespace %q got %q", tc.expectedNamespace, desiredEndpoints.ObjectMeta.Namespace)
+			}
+
+			if tc.expectedName != desiredEndpoints.ObjectMeta.Name {
+				t.Fatalf("expected name %q got %q", tc.expectedName, desiredEndpoints.ObjectMeta.Name)
+			}
+
+			if int32(tc.expectedPort) != desiredEndpoints.Subsets[0].Ports[0].Port {
+				t.Fatalf("expected port %q got %q", int32(tc.expectedPort), desiredEndpoints.Subsets[0].Ports[0].Port)
+			}
+
+			if tc.expectedIPAddress != desiredEndpoints.Subsets[0].Addresses[0].IP {
+				t.Fatalf("expected ip address %s got %s", tc.expectedIPAddress, desiredEndpoints.Subsets[0].Addresses[0].IP)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/endpoints/error.go
+++ b/service/controller/v14patch1/resource/endpoints/error.go
@@ -1,0 +1,39 @@
+package endpoints
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var tooManyResultsError = &microerror.Error{
+	Kind: "tooManyResultsError",
+}
+
+// IsTooManyResults asserts tooManyResultsError.
+func IsTooManyResults(err error) bool {
+	return microerror.Cause(err) == tooManyResultsError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/endpoints/instance.go
+++ b/service/controller/v14patch1/resource/endpoints/instance.go
@@ -1,0 +1,62 @@
+package endpoints
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+const (
+	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#InstanceState
+	ec2RunningState = 16
+	tagKeyName      = "Name"
+)
+
+func (r Resource) findMasterInstance(ctx context.Context, instanceName string) (*ec2.Instance, error) {
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	filters := []*ec2.Filter{
+		{
+			Name: aws.String(fmt.Sprintf("tag:%s", tagKeyName)),
+			Values: []*string{
+				aws.String(instanceName),
+			},
+		},
+	}
+
+	output, err := sc.AWSClient.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
+		Filters: filters,
+	})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var masterInstance *ec2.Instance
+	var instancesFound int
+	for _, reservation := range output.Reservations {
+		for _, instance := range reservation.Instances {
+			if *instance.State.Code == ec2RunningState {
+				masterInstance = instance
+				instancesFound++
+			}
+		}
+	}
+
+	if instancesFound < 1 {
+		return nil, microerror.Maskf(notFoundError, "instance: %s", instanceName)
+	}
+	if instancesFound > 1 {
+		return nil, microerror.Maskf(tooManyResultsError, "instances: %s", instanceName)
+	}
+
+	return masterInstance, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/mock.go
+++ b/service/controller/v14patch1/resource/endpoints/mock.go
@@ -1,0 +1,39 @@
+package endpoints
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+type EC2ClientMock struct {
+	ec2iface.EC2API
+
+	isError          bool
+	privateIPAddress string
+}
+
+func (e EC2ClientMock) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	if e.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						PrivateIpAddress: aws.String(e.privateIPAddress),
+						State: &ec2.InstanceState{
+							Code: aws.Int64(ec2RunningState),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return output, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/resource.go
+++ b/service/controller/v14patch1/resource/endpoints/resource.go
@@ -1,0 +1,66 @@
+package endpoints
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "endpointsv14"
+
+	httpsPort           = 443
+	masterEndpointsName = "master"
+)
+
+// Config represents the configuration used to create a new endpoints resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the endpoints resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured endpoints resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toEndpoints(v interface{}) (*apiv1.Endpoints, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	endpoints, ok := v.(*apiv1.Endpoints)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Endpoints{}, v)
+	}
+
+	return endpoints, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/spec.go
+++ b/service/controller/v14patch1/resource/endpoints/spec.go
@@ -1,0 +1,14 @@
+package endpoints
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type Clients struct {
+	EC2 EC2Client
+}
+
+// EC2Client describes the methods required to be implemented by a EC2 AWS client.
+type EC2Client interface {
+	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+}

--- a/service/controller/v14patch1/resource/endpoints/update.go
+++ b/service/controller/v14patch1/resource/endpoints/update.go
@@ -1,0 +1,84 @@
+package endpoints
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	endpointsToUpdate, err := toEndpoints(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if endpointsToUpdate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating Kubernetes endpoints")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err := r.k8sClient.CoreV1().Endpoints(namespace).Update(endpointsToUpdate)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated Kubernetes endpoints")
+
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "Kubernetes endpoints do not need to be updated")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentEndpoints, err := toEndpoints(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoints, err := toEndpoints(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the endpoints has to be updated")
+
+	var endpointsToUpdate *apiv1.Endpoints
+
+	// The subsets can change if the private IP of the master node has changed.
+	// We then need to update the endpoints resource.
+	if currentEndpoints != nil && desiredEndpoints != nil {
+		if !reflect.DeepEqual(desiredEndpoints.Subsets, currentEndpoints.Subsets) {
+			endpointsToUpdate = desiredEndpoints
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the endpoints has to be deleted")
+
+	return endpointsToUpdate, nil
+}

--- a/service/controller/v14patch1/resource/endpoints/update_test.go
+++ b/service/controller/v14patch1/resource/endpoints/update_test.go
@@ -1,0 +1,200 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoints_newUpdateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description       string
+		obj               interface{}
+		cur               interface{}
+		des               interface{}
+		expectedEndpoints *apiv1.Endpoints
+	}{
+		{
+			description: "current and desired states are different, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: nil,
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Endpoints{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Endpoints",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+				Subsets: []apiv1.EndpointSubset{
+					{
+						Addresses: []apiv1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newUpdateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedEndpoints == nil {
+				if tc.expectedEndpoints != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedEndpoints, result)
+				}
+			} else {
+				endpointsToUpdate, ok := result.(*apiv1.Endpoints)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", endpointsToUpdate, result)
+				}
+				if tc.expectedEndpoints.Name != endpointsToUpdate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedEndpoints.Name, endpointsToUpdate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/hostedzone/error.go
+++ b/service/controller/v14patch1/resource/hostedzone/error.go
@@ -1,0 +1,21 @@
+package hostedzone
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var hostedZoneNotFoundError = &microerror.Error{
+	Kind: "hostedZoneNotFoundError",
+}
+
+// IsHostedZoneNotFound asserts hostedZoneNotFoundError.
+func IsHostedZoneNotFound(err error) bool {
+	return microerror.Cause(err) == hostedZoneNotFoundError
+}

--- a/service/controller/v14patch1/resource/hostedzone/resource.go
+++ b/service/controller/v14patch1/resource/hostedzone/resource.go
@@ -1,0 +1,166 @@
+package hostedzone
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	name = "hostedzonev14"
+)
+
+type Config struct {
+	HostRoute53 *route53.Route53
+	Logger      micrologger.Logger
+
+	Route53Enabled bool
+}
+
+type Resource struct {
+	hostRoute53 *route53.Route53
+	logger      micrologger.Logger
+
+	route53Enabled bool
+}
+
+func New(config Config) (*Resource, error) {
+	if config.HostRoute53 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostRoute53 must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		hostRoute53: config.HostRoute53,
+		logger:      config.Logger,
+
+		route53Enabled: config.Route53Enabled,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return name
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.setStatus(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := r.setStatus(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// setStatus searches for HostedZone in AWS API by name for their IDs. Those
+// IDs are set in controller context status for further use.
+func (r *Resource) setStatus(ctx context.Context, obj interface{}) error {
+	if !r.route53Enabled {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "route53 disabled, skipping execution")
+		return nil
+	}
+
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	controllerCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for host cluster hosted zone IDs in AWS API")
+
+	var (
+		apiFound     = false
+		etcdFound    = false
+		ingressFound = false
+
+		apiZone     = strings.TrimSuffix(key.HostedZoneNameAPI(customObject), ".")
+		etcdZone    = strings.TrimSuffix(key.HostedZoneNameEtcd(customObject), ".")
+		ingressZone = strings.TrimSuffix(key.HostedZoneNameIngress(customObject), ".")
+	)
+
+	var marker *string
+	for {
+		in := &route53.ListHostedZonesInput{
+			Marker: marker,
+		}
+
+		out, err := r.hostRoute53.ListHostedZones(in)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, hz := range out.HostedZones {
+			if hz.Name == nil || hz.Id == nil {
+				continue
+			}
+
+			hzName := *hz.Name
+			hzName = strings.TrimSuffix(hzName, ".")
+			hzID := *hz.Id
+
+			if hzName == apiZone {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found api hosted zone ID %q for domain %q", hzID, hzName))
+				controllerCtx.Status.Cluster.HostedZones.API.ID = hzID
+				apiFound = true
+			}
+			if hzName == etcdZone {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found etcd hosted zone ID %q for domain %q", hzID, hzName))
+				controllerCtx.Status.Cluster.HostedZones.Etcd.ID = hzID
+				etcdFound = true
+			}
+			if hzName == ingressZone {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ingress hosted zone ID %q for domain %q", hzID, hzName))
+				controllerCtx.Status.Cluster.HostedZones.Ingress.ID = hzID
+				ingressFound = true
+			}
+		}
+
+		// If all IDs are found stop here.
+		allFound := apiFound && etcdFound && ingressFound
+		if allFound {
+			break
+		}
+
+		// If not all IDs are found, try to search next page.
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			break
+		}
+		marker = out.Marker
+	}
+
+	if !apiFound {
+		return microerror.Maskf(hostedZoneNotFoundError, "zone = %q", apiZone)
+	}
+	if !etcdFound {
+		return microerror.Maskf(hostedZoneNotFoundError, "zone = %q", etcdZone)
+	}
+	if !ingressFound {
+		return microerror.Maskf(hostedZoneNotFoundError, "zone = %q", ingressZone)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found all host cluster hosted zone IDs")
+	return nil
+}

--- a/service/controller/v14patch1/resource/loadbalancer/create.go
+++ b/service/controller/v14patch1/resource/loadbalancer/create.go
@@ -1,0 +1,11 @@
+package loadbalancer
+
+import (
+	"context"
+)
+
+// EnsureCreated is a no-op, because the loadbalancer resource is only
+// interested in delete events.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/loadbalancer/delete.go
+++ b/service/controller/v14patch1/resource/loadbalancer/delete.go
@@ -1,0 +1,51 @@
+package loadbalancer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+// EnsureDeleted ensures that any ELBs from Kubernetes LoadBalancer services
+// are deleted. This is needed because the use the VPC public subnet.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	lbState, err := r.clusterLoadBalancers(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if lbState != nil && len(lbState.LoadBalancerNames) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d load balancers", len(lbState.LoadBalancerNames)))
+
+		sc, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, lbName := range lbState.LoadBalancerNames {
+			_, err := sc.AWSClient.ELB.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{
+				LoadBalancerName: aws.String(lbName),
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d load balancers", len(lbState.LoadBalancerNames)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting load balancers because there aren't any")
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/resource/loadbalancer/elb.go
+++ b/service/controller/v14patch1/resource/loadbalancer/elb.go
@@ -1,0 +1,100 @@
+package loadbalancer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	cloudProviderClusterTagValue = "owned"
+	cloudProviderServiceTagKey   = "kubernetes.io/service-name"
+	loadBalancerTagChunkSize     = 20
+)
+
+func (r *Resource) clusterLoadBalancers(ctx context.Context, customObject v1alpha1.AWSConfig) (*LoadBalancerState, error) {
+	lbState := &LoadBalancerState{}
+	clusterLBNames := []string{}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get all load balancers because the API does not allow tag filters.
+	output, err := sc.AWSClient.ELB.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	allLBNames := []*string{}
+	for _, lb := range output.LoadBalancerDescriptions {
+		allLBNames = append(allLBNames, lb.LoadBalancerName)
+	}
+
+	lbChunks := splitLoadBalancers(allLBNames, loadBalancerTagChunkSize)
+
+	for _, lbNames := range lbChunks {
+		tagsInput := &elb.DescribeTagsInput{
+			LoadBalancerNames: lbNames,
+		}
+		tagsOutput, err := sc.AWSClient.ELB.DescribeTags(tagsInput)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		// We filter based on the AWS cloud provider tags to find load balancers
+		// associated with the cluster being processed.
+		for _, lb := range tagsOutput.TagDescriptions {
+			if containsClusterTag(lb.Tags, customObject) && containsServiceTag(lb.Tags) {
+				clusterLBNames = append(clusterLBNames, *lb.LoadBalancerName)
+			}
+		}
+	}
+
+	lbState.LoadBalancerNames = clusterLBNames
+
+	return lbState, nil
+}
+
+func splitLoadBalancers(loadBalancerNames []*string, chunkSize int) [][]*string {
+	chunks := make([][]*string, 0)
+
+	for i := 0; i < len(loadBalancerNames); i += chunkSize {
+		endPos := i + chunkSize
+
+		if endPos > len(loadBalancerNames) {
+			endPos = len(loadBalancerNames)
+		}
+
+		chunks = append(chunks, loadBalancerNames[i:endPos])
+	}
+
+	return chunks
+}
+
+func containsClusterTag(tags []*elb.Tag, customObject v1alpha1.AWSConfig) bool {
+	tagKey := key.ClusterCloudProviderTag(customObject)
+
+	for _, tag := range tags {
+		if *tag.Key == tagKey && *tag.Value == cloudProviderClusterTagValue {
+			return true
+		}
+	}
+	return false
+}
+
+func containsServiceTag(tags []*elb.Tag) bool {
+	for _, tag := range tags {
+		if *tag.Key == cloudProviderServiceTagKey {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/loadbalancer/elb_test.go
+++ b/service/controller/v14patch1/resource/loadbalancer/elb_test.go
@@ -1,0 +1,318 @@
+package loadbalancer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsclient "github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func Test_clusterLoadBalancers(t *testing.T) {
+	t.Parallel()
+	customObject := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		expectedState *LoadBalancerState
+		loadBalancers []LoadBalancerMock
+	}{
+		{
+			description: "basic match with no load balancers",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+		},
+		{
+			description: "basic match with load balancer",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "no matching load balancer",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/other-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "multiple load balancers",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+					"test-elb-2",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-2",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "multiple load balancers some not matching",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{
+					"test-elb",
+					"test-elb-2",
+				},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-2",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+				{
+					loadBalancerName: "test-elb-3",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/another-cluster"),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String("kubernetes.io/service-name"),
+							Value: aws.String("hello-world-2"),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "missing service tag",
+			obj:         customObject,
+			expectedState: &LoadBalancerState{
+				LoadBalancerNames: []string{},
+			},
+			loadBalancers: []LoadBalancerMock{
+				{
+					loadBalancerName: "test-elb",
+					loadBalancerTags: []*elb.Tag{
+						{
+							Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+							Value: aws.String("owned"),
+						},
+					},
+				},
+			},
+		},
+	}
+	var err error
+	var newResource *Resource
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Config{
+				Logger: microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Error("expected", nil, "got", err)
+			}
+
+			awsClients := awsclient.Clients{
+				ELB: &ELBClientMock{
+					loadBalancers: tc.loadBalancers,
+				},
+			}
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+
+			result, err := newResource.clusterLoadBalancers(ctx, tc.obj)
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedState) {
+				t.Errorf("expected current state '%#v', got '%#v'", tc.expectedState, result)
+			}
+		})
+	}
+}
+
+func Test_splitLoadBalancers(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name              string
+		loadBalancerNames []*string
+		chunkSize         int
+		expectedChunks    [][]*string
+	}{
+		{
+			name:              "case 0: empty lb names returns empty chunks",
+			loadBalancerNames: []*string{},
+			chunkSize:         20,
+			expectedChunks:    [][]*string{},
+		},
+		{
+			name: "case 1: single batch",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+			},
+			chunkSize: 20,
+			expectedChunks: [][]*string{{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+			}},
+		},
+		{
+			name: "case 2: multiple even chunks",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+				aws.String("lb-3"),
+				aws.String("lb-4"),
+				aws.String("lb-5"),
+				aws.String("lb-6"),
+			},
+			chunkSize: 2,
+			expectedChunks: [][]*string{
+				{
+					aws.String("lb-1"),
+					aws.String("lb-2"),
+				},
+				{
+					aws.String("lb-3"),
+					aws.String("lb-4"),
+				},
+				{
+					aws.String("lb-5"),
+					aws.String("lb-6"),
+				},
+			},
+		},
+		{
+			name: "case 3: multiple chunks of different sizes",
+			loadBalancerNames: []*string{
+				aws.String("lb-1"),
+				aws.String("lb-2"),
+				aws.String("lb-3"),
+				aws.String("lb-4"),
+				aws.String("lb-5"),
+				aws.String("lb-6"),
+				aws.String("lb-7"),
+			},
+			chunkSize: 3,
+			expectedChunks: [][]*string{
+				{
+					aws.String("lb-1"),
+					aws.String("lb-2"),
+					aws.String("lb-3"),
+				},
+				{
+					aws.String("lb-4"),
+					aws.String("lb-5"),
+					aws.String("lb-6"),
+				},
+				{
+					aws.String("lb-7"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitLoadBalancers(tc.loadBalancerNames, tc.chunkSize)
+
+			if !reflect.DeepEqual(result, tc.expectedChunks) {
+				t.Fatalf("chunks == %q, want %q", result, tc.expectedChunks)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/loadbalancer/error.go
+++ b/service/controller/v14patch1/resource/loadbalancer/error.go
@@ -1,0 +1,23 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/loadbalancer/mocks_test.go
+++ b/service/controller/v14patch1/resource/loadbalancer/mocks_test.go
@@ -1,0 +1,53 @@
+package loadbalancer
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+)
+
+type ELBClientMock struct {
+	elbiface.ELBAPI
+
+	loadBalancers []LoadBalancerMock
+}
+
+type LoadBalancerMock struct {
+	loadBalancerName string
+	loadBalancerTags []*elb.Tag
+}
+
+func (e *ELBClientMock) DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error) {
+	return nil, nil
+}
+
+func (e *ELBClientMock) DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	output := &elb.DescribeLoadBalancersOutput{}
+	lbDescs := []*elb.LoadBalancerDescription{}
+
+	for _, lb := range e.loadBalancers {
+		lbDesc := &elb.LoadBalancerDescription{
+			LoadBalancerName: aws.String(lb.loadBalancerName),
+		}
+		lbDescs = append(lbDescs, lbDesc)
+	}
+	output.SetLoadBalancerDescriptions(lbDescs)
+
+	return output, nil
+}
+
+func (e *ELBClientMock) DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {
+	output := &elb.DescribeTagsOutput{}
+	tagDescs := []*elb.TagDescription{}
+
+	for _, lb := range e.loadBalancers {
+		tagDesc := &elb.TagDescription{
+			LoadBalancerName: aws.String(lb.loadBalancerName),
+			Tags:             lb.loadBalancerTags,
+		}
+		tagDescs = append(tagDescs, tagDesc)
+	}
+	output.SetTagDescriptions(tagDescs)
+
+	return output, nil
+}

--- a/service/controller/v14patch1/resource/loadbalancer/resource.go
+++ b/service/controller/v14patch1/resource/loadbalancer/resource.go
@@ -1,0 +1,42 @@
+package loadbalancer
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "loadbalancerv14"
+)
+
+// Config represents the configuration used to create a new loadbalancer resource.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+// Resource implements the loadbalancer resource.
+type Resource struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+// New creates a new configured loadbalancer resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/loadbalancer/spec.go
+++ b/service/controller/v14patch1/resource/loadbalancer/spec.go
@@ -1,0 +1,21 @@
+package loadbalancer
+
+import (
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+type Clients struct {
+	ELB ELBClient
+}
+
+// ELBClient describes the methods required to be implemented by an ELB AWS
+// client. The ELB API provides support for classic ELBs.
+type ELBClient interface {
+	DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
+	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+	DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error)
+}
+
+type LoadBalancerState struct {
+	LoadBalancerNames []string
+}

--- a/service/controller/v14patch1/resource/migration/error.go
+++ b/service/controller/v14patch1/resource/migration/error.go
@@ -1,0 +1,23 @@
+package migration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var malformedDomainError = &microerror.Error{
+	Kind: "malformedDomainError",
+}
+
+// IsMalformedDomain asserts malformedDomainError.
+func IsMalformedDomain(err error) bool {
+	return microerror.Cause(err) == malformedDomainError
+}

--- a/service/controller/v14patch1/resource/migration/resource.go
+++ b/service/controller/v14patch1/resource/migration/resource.go
@@ -1,0 +1,125 @@
+// Package migration provides an operatorkit resource that migrates awsconfig CRs
+// to reference the default credential secret if they do not already.
+// It can be safely removed once all awsconfig CRs reference a credential secret.
+package migration
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	name = "migrationv14"
+
+	awsConfigNamespace               = "default"
+	credentialSecretDefaultNamespace = "giantswarm"
+	credentialSecretDefaultName      = "credential-default"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return name
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	customObject = *customObject.DeepCopy()
+
+	oldSpec := *customObject.Spec.DeepCopy()
+
+	r.migrateSpec(ctx, &customObject.Spec)
+
+	if reflect.DeepEqual(customObject.Spec, oldSpec) {
+		return nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "updating CR")
+
+	_, err = r.g8sClient.ProviderV1alpha1().AWSConfigs(awsConfigNamespace).Update(&customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "CR updated, canceling reconciliation")
+	reconciliationcanceledcontext.SetCanceled(ctx)
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+func (r *Resource) migrateSpec(ctx context.Context, spec *providerv1alpha1.AWSConfigSpec) error {
+	if spec.AWS.CredentialSecret.Name == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing credential, setting the default")
+
+		spec.AWS.CredentialSecret.Namespace = credentialSecretDefaultNamespace
+		spec.AWS.CredentialSecret.Name = credentialSecretDefaultName
+	}
+
+	if reflect.DeepEqual(providerv1alpha1.AWSConfigSpecAWSHostedZones{}, spec.AWS.HostedZones) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing hosted zone names")
+
+		apiDomain := spec.Cluster.Kubernetes.API.Domain
+		zone, err := zoneFromAPIDomain(apiDomain)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("settings all zones to %q", zone))
+
+		spec.AWS.HostedZones.API.Name = zone
+		spec.AWS.HostedZones.Etcd.Name = zone
+		spec.AWS.HostedZones.Ingress.Name = zone
+	}
+
+	return nil
+}
+
+func zoneFromAPIDomain(apiDomain string) (string, error) {
+	parts := strings.Split(apiDomain, ".")
+	if len(parts) < 5 {
+		return "", microerror.Maskf(malformedDomainError, "API domain must have at least 5 parts, got %d for domain %q", len(parts), apiDomain)
+	}
+
+	return strings.Join(parts[3:], "."), nil
+}

--- a/service/controller/v14patch1/resource/migration/resource_test.go
+++ b/service/controller/v14patch1/resource/migration/resource_test.go
@@ -1,0 +1,194 @@
+package migration
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_migrateSpec(t *testing.T) {
+	testCases := []struct {
+		name         string
+		spec         providerv1alpha1.AWSConfigSpec
+		expectedSpec providerv1alpha1.AWSConfigSpec
+		errorMatcher func(err error) bool
+	}{
+		{
+			name: "case 0: fill missing fields",
+			spec: providerv1alpha1.AWSConfigSpec{
+				Cluster: providerv1alpha1.Cluster{
+					Kubernetes: providerv1alpha1.ClusterKubernetes{
+						API: providerv1alpha1.ClusterKubernetesAPI{
+							Domain: "api.eggs2.k8s.gauss.eu-central-1.aws.gigantic.io",
+						},
+					},
+				},
+			},
+			expectedSpec: providerv1alpha1.AWSConfigSpec{
+				AWS: providerv1alpha1.AWSConfigSpecAWS{
+					CredentialSecret: providerv1alpha1.CredentialSecret{
+						Name:      "credential-default",
+						Namespace: "giantswarm",
+					},
+					HostedZones: providerv1alpha1.AWSConfigSpecAWSHostedZones{
+						API: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "gauss.eu-central-1.aws.gigantic.io",
+						},
+						Etcd: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "gauss.eu-central-1.aws.gigantic.io",
+						},
+						Ingress: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "gauss.eu-central-1.aws.gigantic.io",
+						},
+					},
+				},
+				Cluster: providerv1alpha1.Cluster{
+					Kubernetes: providerv1alpha1.ClusterKubernetes{
+						API: providerv1alpha1.ClusterKubernetesAPI{
+							Domain: "api.eggs2.k8s.gauss.eu-central-1.aws.gigantic.io",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 1: not mess with fields already set",
+			spec: providerv1alpha1.AWSConfigSpec{
+				AWS: providerv1alpha1.AWSConfigSpecAWS{
+					CredentialSecret: providerv1alpha1.CredentialSecret{
+						Name:      "test-credential",
+						Namespace: "test-credential-namespace",
+					},
+					HostedZones: providerv1alpha1.AWSConfigSpecAWSHostedZones{
+						API: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-api.gigantic.io",
+						},
+						Etcd: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-etcd.gigantic.io",
+						},
+						Ingress: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-ingress.gigantic.io",
+						},
+					},
+				},
+				Cluster: providerv1alpha1.Cluster{
+					Kubernetes: providerv1alpha1.ClusterKubernetes{
+						API: providerv1alpha1.ClusterKubernetesAPI{
+							Domain: "api.eggs5.k8s.gauss.eu-central-1.aws.gigantic.io",
+						},
+					},
+				},
+			},
+			expectedSpec: providerv1alpha1.AWSConfigSpec{
+				AWS: providerv1alpha1.AWSConfigSpecAWS{
+					CredentialSecret: providerv1alpha1.CredentialSecret{
+						Name:      "test-credential",
+						Namespace: "test-credential-namespace",
+					},
+					HostedZones: providerv1alpha1.AWSConfigSpecAWSHostedZones{
+						API: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-api.gigantic.io",
+						},
+						Etcd: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-etcd.gigantic.io",
+						},
+						Ingress: providerv1alpha1.AWSConfigSpecAWSHostedZonesZone{
+							Name: "test-ingress.gigantic.io",
+						},
+					},
+				},
+				Cluster: providerv1alpha1.Cluster{
+					Kubernetes: providerv1alpha1.ClusterKubernetes{
+						API: providerv1alpha1.ClusterKubernetesAPI{
+							Domain: "api.eggs5.k8s.gauss.eu-central-1.aws.gigantic.io",
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Resource{
+				logger: microloggertest.New(),
+			}
+
+			err := r.migrateSpec(context.Background(), &tc.spec)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			if !reflect.DeepEqual(tc.spec, tc.expectedSpec) {
+				t.Errorf("spec == %q, want %q", tc.spec, tc.expectedSpec)
+			}
+		})
+	}
+}
+
+func Test_zoneFromAPIDomain(t *testing.T) {
+	testCases := []struct {
+		name         string
+		apiDomain    string
+		expectedZone string
+		errorMatcher func(err error) bool
+	}{
+		{
+			name:         "case 0: normal case",
+			apiDomain:    "api.eggs2.k8s.gauss.eu-central-1.aws.gigantic.io",
+			expectedZone: "gauss.eu-central-1.aws.gigantic.io",
+		},
+		{
+			name:         "case 1: domain too short",
+			apiDomain:    "api.eggs2.k8s.gigantic",
+			errorMatcher: IsMalformedDomain,
+		},
+		{
+			name:         "case 1: minimal length domain",
+			apiDomain:    "api.eggs2.k8s.gigantic.io",
+			expectedZone: "gigantic.io",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			zone, err := zoneFromAPIDomain(tc.apiDomain)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			if zone != tc.expectedZone {
+				t.Fatalf("zone == %q, want %q", zone, tc.expectedZone)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/create.go
+++ b/service/controller/v14patch1/resource/namespace/create.go
@@ -1,0 +1,51 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	namespaceToCreate, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace")
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes namespace: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var namespaceToCreate *apiv1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	return namespaceToCreate, nil
+}

--- a/service/controller/v14patch1/resource/namespace/create_test.go
+++ b/service/controller/v14patch1/resource/namespace/create_test.go
@@ -1,0 +1,126 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/current.go
+++ b/service/controller/v14patch1/resource/namespace/current.go
@@ -1,0 +1,50 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the Kubernetes API")
+
+	// Lookup the current state of the namespace.
+	var namespace *apiv1.Namespace
+	{
+		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the Kubernetes API")
+			namespace = manifest
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. Then we cancel the reconciliation to prevent the current and
+	// any further resource from being processed.
+	if namespace != nil && namespace.Status.Phase == "Terminating" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "namespace is in state 'Terminating'")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource reconciliation for custom object")
+
+		return nil, nil
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/current_test.go
+++ b/service/controller/v14patch1/resource/namespace/current_test.go
@@ -1,0 +1,54 @@
+package namespace
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetCurrentState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetCurrentState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedNamespace, result) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedNamespace, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/delete.go
+++ b/service/controller/v14patch1/resource/namespace/delete.go
@@ -1,0 +1,69 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	namespaceToDelete, err := toNamespace(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace")
+
+		err = r.k8sClient.CoreV1().Namespaces().Delete(namespaceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes namespace: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the namespace has to be deleted")
+
+	var namespaceToDelete *apiv1.Namespace
+	if currentNamespace != nil {
+		namespaceToDelete = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the namespace has to be deleted")
+
+	return namespaceToDelete, nil
+}

--- a/service/controller/v14patch1/resource/namespace/delete_test.go
+++ b/service/controller/v14patch1/resource/namespace/delete_test.go
@@ -1,0 +1,126 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/desired.go
+++ b/service/controller/v14patch1/resource/namespace/desired.go
@@ -1,0 +1,36 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Compute the desired state of the namespace to have a reference of how
+	// the data should be.
+	namespace := &apiv1.Namespace{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterNamespace(customObject),
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/desired_test.go
+++ b/service/controller/v14patch1/resource/namespace/desired_test.go
@@ -1,0 +1,64 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			ExpectedName: "foobar",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.Namespace).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/error.go
+++ b/service/controller/v14patch1/resource/namespace/error.go
@@ -1,0 +1,30 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/namespace/resource.go
+++ b/service/controller/v14patch1/resource/namespace/resource.go
@@ -1,0 +1,63 @@
+package namespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "namespacev14"
+)
+
+// Config represents the configuration used to create a new namespace resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the namespace resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured namespace resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toNamespace(v interface{}) (*apiv1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*apiv1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Namespace{}, v)
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/update.go
+++ b/service/controller/v14patch1/resource/namespace/update.go
@@ -1,0 +1,35 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because Kubernetes namespaces are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/s3bucket/create.go
+++ b/service/controller/v14patch1/resource/s3bucket/create.go
@@ -1,0 +1,126 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	createBucketsState, err := toBucketState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, bucketInput := range createBucketsState {
+		if bucketInput.Name == "" {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 bucket %q", bucketInput.Name))
+
+		_, err = sc.AWSClient.S3.CreateBucket(&s3.CreateBucketInput{
+			Bucket: aws.String(bucketInput.Name),
+		})
+		if IsBucketAlreadyExists(err) || IsBucketAlreadyOwnedByYou(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		_, err = sc.AWSClient.S3.PutBucketTagging(&s3.PutBucketTaggingInput{
+			Bucket: aws.String(bucketInput.Name),
+			Tagging: &s3.Tagging{
+				TagSet: r.getS3BucketTags(customObject),
+			},
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if bucketInput.IsLoggingBucket {
+			_, err = sc.AWSClient.S3.PutBucketAcl(&s3.PutBucketAclInput{
+				Bucket:       aws.String(key.TargetLogBucketName(customObject)),
+				GrantReadACP: aws.String(key.LogDeliveryURI),
+				GrantWrite:   aws.String(key.LogDeliveryURI),
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutBucketLifecycleConfiguration(&s3.PutBucketLifecycleConfigurationInput{
+				Bucket: aws.String(key.TargetLogBucketName(customObject)),
+				LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+					Rules: []*s3.LifecycleRule{
+						{
+							Expiration: &s3.LifecycleExpiration{
+								Days: aws.Int64(int64(r.accessLogsExpiration)),
+							},
+							Filter: &s3.LifecycleRuleFilter{},
+							ID:     aws.String(LifecycleLoggingBucketID),
+							Status: aws.String("Enabled"),
+						},
+					},
+				},
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		if bucketInput.LoggingEnabled {
+			_, err = sc.AWSClient.S3.PutBucketLogging(&s3.PutBucketLoggingInput{
+				Bucket: aws.String(bucketInput.Name),
+				BucketLoggingStatus: &s3.BucketLoggingStatus{
+					LoggingEnabled: &s3.LoggingEnabled{
+						TargetBucket: aws.String(key.TargetLogBucketName(customObject)),
+						TargetPrefix: aws.String(bucketInput.Name + "/"),
+					},
+				},
+			})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 bucket %q: created", bucketInput.Name))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBuckets, err := toBucketState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredBuckets, err := toBucketState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var createState []BucketState
+	for _, bucket := range desiredBuckets {
+		if !containsBucketState(bucket.Name, currentBuckets) {
+			createState = append(createState, bucket)
+		}
+	}
+
+	return createState, nil
+}

--- a/service/controller/v14patch1/resource/s3bucket/create_test.go
+++ b/service/controller/v14patch1/resource/s3bucket/create_test.go
@@ -1,0 +1,111 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_S3Bucket_newCreate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj                  interface{}
+		currentState         interface{}
+		desiredState         interface{}
+		expectedBucketsState []BucketState
+		description          string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:         []BucketState{},
+			desiredState:         []BucketState{},
+			expectedBucketsState: []BucketState{},
+		},
+		{
+			description: "current state empty, desired state not empty, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketsState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty but different, expected desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{
+				{
+					Name: "current",
+				},
+			},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketsState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChanges, ok := result.([]BucketState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChanges, result)
+			}
+			for _, expectedBucketState := range tc.expectedBucketsState {
+				if !containsBucketState(expectedBucketState.Name, createChanges) {
+					t.Errorf("expected %v, got %v", expectedBucketState, createChanges)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3bucket/current.go
+++ b/service/controller/v14patch1/resource/s3bucket/current.go
@@ -1,0 +1,121 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the S3 buckets")
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bucketStateNames := []string{
+		key.TargetLogBucketName(customObject),
+		key.BucketName(customObject, accountID),
+	}
+
+	var currentBucketState []BucketState
+	for _, inputBucketName := range bucketStateNames {
+		inputBucket := BucketState{
+			Name: inputBucketName,
+		}
+
+		isCreated, err := r.isBucketCreated(ctx, inputBucketName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if !isCreated {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("find the S3 bucket %q", inputBucketName))
+
+		lc, err := r.getLoggingConfiguration(ctx, inputBucketName)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		inputBucket.LoggingEnabled = isLoggingEnabled(lc)
+		inputBucket.IsLoggingBucket = isLoggingBucket(inputBucketName, lc)
+
+		currentBucketState = append(currentBucketState, inputBucket)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the S3 buckets")
+
+	return currentBucketState, nil
+}
+
+func (r *Resource) isBucketCreated(ctx context.Context, name string) (bool, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	headInput := &s3.HeadBucketInput{
+		Bucket: aws.String(name),
+	}
+	_, err = sc.AWSClient.S3.HeadBucket(headInput)
+	if IsBucketNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func (r *Resource) getLoggingConfiguration(ctx context.Context, name string) (*s3.GetBucketLoggingOutput, error) {
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bucketLoggingInput := &s3.GetBucketLoggingInput{
+		Bucket: aws.String(name),
+	}
+	bucketLoggingOutput, err := sc.AWSClient.S3.GetBucketLogging(bucketLoggingInput)
+	if err != nil {
+		return bucketLoggingOutput, microerror.Mask(err)
+	}
+
+	return bucketLoggingOutput, nil
+}
+
+func isLoggingEnabled(lc *s3.GetBucketLoggingOutput) bool {
+	if lc.LoggingEnabled != nil {
+		return true
+	}
+
+	return false
+}
+
+func isLoggingBucket(name string, lc *s3.GetBucketLoggingOutput) bool {
+	if lc.LoggingEnabled != nil {
+		if *lc.LoggingEnabled.TargetBucket == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/s3bucket/delete.go
+++ b/service/controller/v14patch1/resource/s3bucket/delete.go
@@ -1,0 +1,113 @@
+package s3bucket
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	bucketsInput, err := toBucketState(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, bucketInput := range bucketsInput {
+		if bucketInput.Name == "" {
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting S3 bucket %q", bucketInput.Name))
+
+		var repeat bool
+		for {
+			i := &s3.ListObjectsV2Input{
+				Bucket: aws.String(bucketInput.Name),
+			}
+			o, err := sc.AWSClient.S3.ListObjectsV2(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if o.IsTruncated != nil && *o.IsTruncated {
+				repeat = true
+			}
+			if len(o.Contents) == 0 {
+				break
+			}
+
+			for _, o := range o.Contents {
+				i := &s3.DeleteObjectInput{
+					Bucket: aws.String(bucketInput.Name),
+					Key:    o.Key,
+				}
+				_, err := sc.AWSClient.S3.DeleteObject(i)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+
+			if !repeat {
+				break
+			}
+		}
+
+		_, err = sc.AWSClient.S3.DeleteBucket(&s3.DeleteBucketInput{
+			Bucket: aws.String(bucketInput.Name),
+		})
+		if IsBucketNotFound(err) {
+			// Fall through.
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting S3 bucket %q: deleted", bucketInput.Name))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBuckets, err := toBucketState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredBuckets, err := toBucketState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var bucketsToDelete []BucketState
+	for _, bucket := range currentBuckets {
+		// Destination Logs Bucket should not be deleted because it has to keep logs
+		// even when cluster is removed (rotation of these logs are managed externally).
+		if r.canBeDeleted(bucket) && containsBucketState(bucket.Name, desiredBuckets) {
+			bucketsToDelete = append(bucketsToDelete, bucket)
+		}
+	}
+
+	return bucketsToDelete, nil
+}

--- a/service/controller/v14patch1/resource/s3bucket/delete_test.go
+++ b/service/controller/v14patch1/resource/s3bucket/delete_test.go
@@ -1,0 +1,113 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_S3Bucket_newDelete(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj                interface{}
+		currentState       []BucketState
+		desiredState       []BucketState
+		expectedBucketName string
+		description        string
+	}{
+		{
+			description: "current and desired state empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState:       []BucketState{},
+			desiredState:       []BucketState{},
+			expectedBucketName: "",
+		},
+		{
+			description: "current state empty, desired state not empty, expected empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{},
+			desiredState: []BucketState{
+				{
+					Name: "desired",
+				},
+			},
+			expectedBucketName: "",
+		},
+		{
+			description: "current state not empty, desired state not empty but equal, expected desired state avoiding delivery log bucket",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			currentState: []BucketState{
+				{
+					Name: "current",
+				},
+				{
+					Name:            "log-bucket",
+					IsLoggingBucket: true,
+				},
+			},
+			desiredState: []BucketState{
+				{
+					Name: "current",
+				},
+				{
+					Name:            "log-bucket",
+					IsLoggingBucket: true,
+				},
+			},
+			expectedBucketName: "current",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Error("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+
+			deleteChanges, ok := result.([]BucketState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", deleteChanges, result)
+			}
+
+			for _, deleteChange := range deleteChanges {
+				if deleteChange.Name != tc.expectedBucketName {
+					t.Errorf("expected %s, got %s", tc.expectedBucketName, deleteChange.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3bucket/desired.go
+++ b/service/controller/v14patch1/resource/s3bucket/desired.go
@@ -1,0 +1,44 @@
+package s3bucket
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// First bucket must be the delivery log bucket because otherwise
+	// other buckets can not forward logs to it
+	bucketsState := []BucketState{
+		{
+			Name:            key.TargetLogBucketName(customObject),
+			IsLoggingBucket: true,
+			LoggingEnabled:  true,
+		},
+		{
+			Name:            key.BucketName(customObject, accountID),
+			IsLoggingBucket: false,
+			LoggingEnabled:  true,
+		},
+	}
+
+	return bucketsState, nil
+}

--- a/service/controller/v14patch1/resource/s3bucket/desired_test.go
+++ b/service/controller/v14patch1/resource/s3bucket/desired_test.go
@@ -1,0 +1,86 @@
+package s3bucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		obj           interface{}
+		expectedNames []string
+		description   string
+	}{
+		{
+			description: "Get bucket name from custom object.",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "5xchu",
+					},
+				},
+			},
+			expectedNames: []string{
+				"5xchu-g8s-access-logs",
+				"000000000000-g8s-5xchu",
+			},
+		},
+	}
+
+	var err error
+	var awsService *awsservice.Service
+	{
+		awsConfig := awsservice.DefaultConfig()
+		awsConfig.Clients = awsservice.Clients{
+			STS: &awsservice.STSClientMock{},
+		}
+		awsConfig.Logger = microloggertest.New()
+		awsService, err = awsservice.New(awsConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.InstallationName = "test-install"
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSService: awsService})
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatalf("expected '%v' got '%#v'", nil, err)
+			}
+
+			desiredBuckets, ok := result.([]BucketState)
+			if !ok {
+				t.Fatalf("case expected '%T', got '%T'", desiredBuckets, result)
+			}
+
+			// Order should be respected in the slice returned (always delivery log bucket first)
+			for key, desiredBucket := range desiredBuckets {
+				if tc.expectedNames[key] != desiredBucket.Name {
+					t.Fatalf("expected bucket name %q got %q", tc.expectedNames[key], desiredBucket.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3bucket/error.go
+++ b/service/controller/v14patch1/resource/s3bucket/error.go
@@ -1,0 +1,87 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var bucketNotFoundError = &microerror.Error{
+	Kind: "bucketNotFoundError",
+}
+
+// IsBucketNotFound asserts bucket not found error from upstream's API code.
+func IsBucketNotFound(err error) bool {
+	c := microerror.Cause(err)
+	aerr, ok := c.(awserr.Error)
+	if !ok {
+		return false
+	}
+	// hack for HeadBucket request that returns a wrong error code
+	if aerr.Code() == "NotFound" {
+		return true
+	}
+	if aerr.Code() == s3.ErrCodeNoSuchBucket {
+		return true
+	}
+	if c == bucketNotFoundError {
+		return true
+	}
+
+	return false
+}
+
+// IsBucketAlreadyExists asserts bucket already exists error from upstream's
+// API code.
+func IsBucketAlreadyExists(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	if aerr.Code() == s3.ErrCodeBucketAlreadyExists {
+		return true
+	}
+
+	return false
+}
+
+// IsBucketAlreadyOwnedByYou asserts bucket already owned by you error from
+// upstream's API code.
+func IsBucketAlreadyOwnedByYou(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	if aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou {
+		return true
+	}
+
+	return false
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/s3bucket/resource.go
+++ b/service/controller/v14patch1/resource/s3bucket/resource.go
@@ -1,0 +1,129 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "s3bucketv14"
+	// LifecycleLoggingBucketID is the Lifecycle ID for the logging bucket
+	LifecycleLoggingBucketID = "ExpirationLogs"
+)
+
+// Config represents the configuration used to create a new s3bucket resource.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	AccessLogsExpiration int
+	DeleteLoggingBucket  bool
+	IncludeTags          bool
+	InstallationName     string
+}
+
+// DefaultConfig provides a default configuration to create a new s3bucket
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// Resource implements the s3bucket resource.
+type Resource struct {
+	// Dependencies.
+	logger micrologger.Logger
+
+	// Settings.
+	accessLogsExpiration int
+	deleteLoggingBucket  bool
+	includeTags          bool
+	installationName     string
+}
+
+// New creates a new configured s3bucket resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	// Settings.
+	if config.AccessLogsExpiration < 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.AccessLogsExpiration must not be lower than 0", config)
+	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		logger: config.Logger,
+
+		// Settings.
+		accessLogsExpiration: config.AccessLogsExpiration,
+		deleteLoggingBucket:  config.DeleteLoggingBucket,
+		includeTags:          config.IncludeTags,
+		installationName:     config.InstallationName,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toBucketState(v interface{}) ([]BucketState, error) {
+	if v == nil {
+		return []BucketState{}, nil
+	}
+
+	bucketsState, ok := v.([]BucketState)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []BucketState{}, v)
+	}
+
+	return bucketsState, nil
+}
+
+func containsBucketState(bucketStateName string, bucketStateList []BucketState) bool {
+	for _, b := range bucketStateList {
+		if b.Name == bucketStateName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Resource) getS3BucketTags(customObject v1alpha1.AWSConfig) []*s3.Tag {
+	clusterTags := key.ClusterTags(customObject, r.installationName)
+	s3Tags := []*s3.Tag{}
+
+	if r.includeTags {
+		for k, v := range clusterTags {
+			tag := &s3.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			}
+
+			s3Tags = append(s3Tags, tag)
+		}
+	}
+
+	return s3Tags
+}
+
+func (r *Resource) canBeDeleted(bucket BucketState) bool {
+	return !bucket.IsLoggingBucket || bucket.IsLoggingBucket && r.deleteLoggingBucket
+}

--- a/service/controller/v14patch1/resource/s3bucket/resource_test.go
+++ b/service/controller/v14patch1/resource/s3bucket/resource_test.go
@@ -1,0 +1,154 @@
+package s3bucket
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_ContainsBucketState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description      string
+		installation     string
+		bucketNameToFind string
+		bucketStateList  []BucketState
+		expectedValue    bool
+	}{
+		{
+			description:      "basic match",
+			installation:     "test-install",
+			bucketNameToFind: "bck1",
+			bucketStateList:  []BucketState{},
+			expectedValue:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := containsBucketState(tc.bucketNameToFind, tc.bucketStateList)
+
+			if result != tc.expectedValue {
+				t.Fatalf("Expected %t tags, found %t", tc.expectedValue, result)
+			}
+		})
+	}
+}
+func Test_BucketCanBeDeleted(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description         string
+		installation        string
+		deleteLoggingBucket bool
+		bucketState         BucketState
+		expectedValue       bool
+	}{
+		{
+			description:         "test env true",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env false",
+			installation:        "test-install",
+			deleteLoggingBucket: false,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env true no logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env true logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState: BucketState{
+				IsLoggingBucket: true,
+			},
+			expectedValue: true,
+		},
+		{
+			description:         "test env false no logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: true,
+			bucketState:         BucketState{},
+			expectedValue:       true,
+		},
+		{
+			description:         "test env false logging bucket",
+			installation:        "test-install",
+			deleteLoggingBucket: false,
+			bucketState: BucketState{
+				IsLoggingBucket: true,
+			},
+			expectedValue: false,
+		},
+	}
+
+	c := Config{}
+
+	c.Logger = microloggertest.New()
+	c.AccessLogsExpiration = 0
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.DeleteLoggingBucket = tc.deleteLoggingBucket
+			c.InstallationName = tc.installation
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+			result := r.canBeDeleted(tc.bucketState)
+
+			if result != tc.expectedValue {
+				t.Fatalf("Expected %t, found %t", tc.expectedValue, result)
+			}
+		})
+	}
+}
+
+func Test_getS3BucketTags(t *testing.T) {
+	testCases := []struct {
+		obj          v1alpha1.AWSConfig
+		includeTags  bool
+		expectedTags []*s3.Tag
+		description  string
+	}{
+		{
+			description:  "do not include tags",
+			obj:          v1alpha1.AWSConfig{},
+			includeTags:  false,
+			expectedTags: []*s3.Tag{},
+		},
+	}
+
+	c := Config{}
+
+	c.Logger = microloggertest.New()
+	c.InstallationName = "installation-name"
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c.IncludeTags = tc.includeTags
+
+			r, err := New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+
+			actual := r.getS3BucketTags(tc.obj)
+			if !reflect.DeepEqual(actual, tc.expectedTags) {
+				t.Errorf("tags don't match, want %#v, got %#v", tc.expectedTags, actual)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3bucket/spec.go
+++ b/service/controller/v14patch1/resource/s3bucket/spec.go
@@ -1,0 +1,31 @@
+package s3bucket
+
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// BucketState is the state representation on which the resource methods work.
+type BucketState struct {
+	Name            string
+	IsLoggingBucket bool
+	LoggingEnabled  bool
+}
+
+type Clients struct {
+	S3 S3Client
+}
+
+// S3Client describes the methods required to be implemented by a S3 AWS client.
+type S3Client interface {
+	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
+	DeleteBucket(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
+	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
+	DeleteObjects(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
+	GetBucketLogging(*s3.GetBucketLoggingInput) (*s3.GetBucketLoggingOutput, error)
+	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
+	ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
+	PutBucketAcl(*s3.PutBucketAclInput) (*s3.PutBucketAclOutput, error)
+	PutBucketLifecycleConfiguration(*s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
+	PutBucketLogging(*s3.PutBucketLoggingInput) (*s3.PutBucketLoggingOutput, error)
+	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
+}

--- a/service/controller/v14patch1/resource/s3bucket/update.go
+++ b/service/controller/v14patch1/resource/s3bucket/update.go
@@ -1,0 +1,35 @@
+package s3bucket
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// newUpdateChange is a no-op because S3 buckets are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/s3object/create.go
+++ b/service/controller/v14patch1/resource/s3object/create.go
@@ -1,0 +1,69 @@
+package s3object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	createBucketState, err := toBucketObjectState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for key, bucketObject := range createBucketState {
+		if bucketObject.Key != "" {
+			s3PutInput, err := toPutObjectInput(bucketObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutObject(&s3PutInput)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 object '%s': created", key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating S3 object '%s': already created", key))
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBucketState, err := toBucketObjectState(currentState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	desiredBucketState, err := toBucketObjectState(desiredState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the s3 objects should be created")
+
+	createState := map[string]BucketObjectState{}
+
+	for key, bucketObject := range desiredBucketState {
+		if _, ok := currentBucketState[key]; !ok {
+			createState[key] = bucketObject
+		} else {
+			createState[key] = BucketObjectState{}
+		}
+	}
+
+	return createState, nil
+}

--- a/service/controller/v14patch1/resource/s3object/create_test.go
+++ b/service/controller/v14patch1/resource/s3object/create_test.go
@@ -1,0 +1,198 @@
+package s3object
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_Resource_S3Object_newCreate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		currentState  map[string]BucketObjectState
+		desiredState  map[string]BucketObjectState
+		expectedState map[string]BucketObjectState
+	}{
+		{
+			description:   "current state empty, desired state empty, empty create change",
+			obj:           clusterTpo,
+			currentState:  map[string]BucketObjectState{},
+			desiredState:  map[string]BucketObjectState{},
+			expectedState: map[string]BucketObjectState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, create change == desired state",
+			obj:          clusterTpo,
+			currentState: map[string]BucketObjectState{},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state not empty, desired state not empty, create change == desired state",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"mykey": {
+					Body:   "mykey",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state has 1 object, desired state has 2 objects, create change == missing object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, empty create change",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+				"worker": {},
+			},
+		},
+	}
+
+	awsClients := aws.Clients{
+		S3: &S3ClientMock{},
+	}
+
+	awsService := awsservice.AwsServiceMock{}
+	cloudconfig := &CloudConfigMock{}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{}
+		c.CertWatcher = legacytest.NewService()
+		c.Encrypter = &encrypter.EncrypterMock{}
+		c.Logger = microloggertest.New()
+		c.RandomKeySearcher = randomkeystest.NewSearcher()
+
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			c := controllercontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, c)
+
+			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			createChange, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", createChange, result)
+			}
+
+			if !reflect.DeepEqual(tc.expectedState, createChange) {
+				t.Error("expected", tc.expectedState, "got", createChange)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3object/current.go
+++ b/service/controller/v14patch1/resource/s3object/current.go
@@ -1,0 +1,95 @@
+package s3object
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	output := map[string]BucketObjectState{}
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for S3 objects")
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	bucketName := key.BucketName(customObject, accountID)
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	}
+	result, err := sc.AWSClient.S3.ListObjectsV2(input)
+	// the bucket can be already deleted with all the objects in it, it is ok if so.
+	if IsBucketNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "S3 object's bucket not found, no current objects present")
+		return output, nil
+	}
+	// we don't expect other errors.
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found the S3 objects")
+
+	for _, object := range result.Contents {
+		body, err := r.getBucketObjectBody(ctx, bucketName, *object.Key)
+		if err != nil {
+			return output, microerror.Mask(err)
+		}
+
+		output[*object.Key] = BucketObjectState{
+			Body:   body,
+			Bucket: bucketName,
+			Key:    *object.Key,
+		}
+	}
+
+	return output, nil
+}
+
+func (r *Resource) getBucketObjectBody(ctx context.Context, bucketName string, keyName string) (string, error) {
+	var body string
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return body, microerror.Mask(err)
+	}
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(keyName),
+	}
+	result, err := sc.AWSClient.S3.GetObject(input)
+	if IsObjectNotFound(err) || IsBucketNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("did not find S3 object '%s'", keyName))
+
+		// fall through
+		return body, nil
+	}
+	if err != nil {
+		return body, microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(result.Body)
+	body = buf.String()
+
+	return body, nil
+}

--- a/service/controller/v14patch1/resource/s3object/current_test.go
+++ b/service/controller/v14patch1/resource/s3object/current_test.go
@@ -1,0 +1,134 @@
+package s3object
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_CurrentState(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID:      "test-cluster",
+				Version: "myversion",
+			},
+		},
+	}
+
+	testCases := []struct {
+		obj              *v1alpha1.AWSConfig
+		description      string
+		expectedIAMError bool
+		expectedS3Error  bool
+		expectedKey      string
+		expectedBucket   string
+		expectedBody     string
+	}{
+		{
+			description:    "basic match",
+			obj:            clusterTpo,
+			expectedKey:    "cloudconfig/myversion/worker",
+			expectedBucket: "myaccountid-g8s-test-cluster",
+			expectedBody:   "mybody",
+		},
+		{
+			description:      "IAM error",
+			obj:              clusterTpo,
+			expectedIAMError: true,
+		},
+
+		{
+			description:     "S3 error",
+			obj:             clusterTpo,
+			expectedS3Error: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				S3: &S3ClientMock{
+					isError: tc.expectedS3Error,
+					body:    tc.expectedBody,
+				},
+			}
+
+			awsService := awsservice.AwsServiceMock{
+				AccountID: "myaccountid",
+				IsError:   tc.expectedIAMError,
+			}
+
+			cloudconfig := &CloudConfigMock{}
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{}
+				c.CertWatcher = legacytest.NewService()
+				c.Encrypter = &encrypter.EncrypterMock{}
+				c.Logger = microloggertest.New()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+				newResource, err = New(c)
+				if err != nil {
+					t.Error("expected", nil, "got", err)
+				}
+			}
+
+			c := controllercontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, c)
+
+			result, err := newResource.GetCurrentState(ctx, tc.obj)
+			if err != nil && !tc.expectedIAMError && !tc.expectedS3Error {
+				t.Errorf("unexpected error %v", err)
+			}
+			currentState, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", currentState, result)
+			}
+
+			if err == nil && tc.expectedIAMError {
+				t.Error("expected IAM error didn't happen")
+			}
+
+			if err == nil && tc.expectedS3Error {
+				t.Error("expected S3 error didn't happen")
+			}
+
+			if !tc.expectedIAMError && !tc.expectedS3Error {
+				var bucketObject BucketObjectState
+
+				if bucketObject, ok = currentState[tc.expectedKey]; !ok {
+					t.Errorf("expected S3 key %q not found", tc.expectedKey)
+				}
+
+				if bucketObject.Body != tc.expectedBody {
+					t.Errorf("expected body %q, got %q", tc.expectedBody, bucketObject.Body)
+				}
+
+				if bucketObject.Bucket != tc.expectedBucket {
+					t.Errorf("expected bucket %q, got %q", tc.expectedBucket, bucketObject.Bucket)
+				}
+
+				if bucketObject.Key != tc.expectedKey {
+					t.Errorf("expected key %q, got %q", tc.expectedKey, bucketObject.Key)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3object/desired.go
+++ b/service/controller/v14patch1/resource/s3object/desired.go
@@ -1,0 +1,83 @@
+package s3object
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	output := map[string]BucketObjectState{}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	accountID, err := sc.AWSService.GetAccountID()
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+
+	_, err = r.encrypter.EncryptionKey(ctx, customObject)
+	if r.encrypter.IsKeyNotFound(err) {
+		// we can get here during deletion, if the key is already deleted we can safely exit.
+		return output, nil
+	}
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	certs, err := r.certWatcher.SearchCerts(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	tlsAssets, err := r.encrypter.EncryptTLSAssets(ctx, customObject, certs)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	clusterKeys, err := r.randomKeySearcher.SearchCluster(clusterID)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	masterBody, err := sc.CloudConfig.NewMasterTemplate(ctx, customObject, *tlsAssets, clusterKeys)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	masterObjectName := key.BucketObjectName(cloudconfig.CloudConfigVersion, prefixMaster)
+	masterCloudConfig := BucketObjectState{
+		Bucket: key.BucketName(customObject, accountID),
+		Body:   masterBody,
+		Key:    masterObjectName,
+	}
+	output[masterObjectName] = masterCloudConfig
+
+	workerBody, err := sc.CloudConfig.NewWorkerTemplate(ctx, customObject, *tlsAssets)
+	if err != nil {
+		return output, microerror.Mask(err)
+	}
+
+	workerObjectName := key.BucketObjectName(cloudconfig.CloudConfigVersion, prefixWorker)
+	workerCloudConfig := BucketObjectState{
+		Bucket: key.BucketName(customObject, accountID),
+		Body:   workerBody,
+		Key:    workerObjectName,
+	}
+	output[workerObjectName] = workerCloudConfig
+
+	return output, nil
+}

--- a/service/controller/v14patch1/resource/s3object/desired_test.go
+++ b/service/controller/v14patch1/resource/s3object/desired_test.go
@@ -1,0 +1,124 @@
+package s3object
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_DesiredState(t *testing.T) {
+	t.Parallel()
+	clusterTpo := &v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	masterKeyPattern := "cloudconfig/v[\\d_]+/master"
+	workerKeyPattern := "cloudconfig/v[\\d_]+/worker"
+
+	masterKeyRegexp := regexp.MustCompile(masterKeyPattern)
+	workerKeyRegexp := regexp.MustCompile(workerKeyPattern)
+
+	testCases := []struct {
+		obj            *v1alpha1.AWSConfig
+		description    string
+		expectedBucket string
+		expectedBody   string
+	}{
+		{
+			description:    "basic match",
+			obj:            clusterTpo,
+			expectedBody:   "mybody-",
+			expectedBucket: "myaccountid-g8s-test-cluster",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				KMS: &KMSClientMock{},
+			}
+
+			awsService := awsservice.AwsServiceMock{
+				AccountID: "myaccountid",
+				KeyArn:    "mykeyarn",
+			}
+
+			cloudconfig := &CloudConfigMock{
+				template: tc.expectedBody,
+			}
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{}
+				c.Logger = microloggertest.New()
+				c.Encrypter = &encrypter.EncrypterMock{}
+				c.CertWatcher = legacytest.NewService()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+				newResource, err = New(c)
+				if err != nil {
+					t.Fatal("expected", nil, "got", err)
+				}
+			}
+
+			c := controllercontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, c)
+
+			result, err := newResource.GetDesiredState(ctx, tc.obj)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			desiredState, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Fatalf("expected '%T', got '%T'", desiredState, result)
+			}
+
+			if len(desiredState) != 2 {
+				t.Fatalf("expected 2 objects, got %d", len(desiredState))
+			}
+
+			for key, bucketObjectState := range desiredState {
+				if bucketObjectState.Bucket != tc.expectedBucket {
+					t.Fatalf("expected bucket %q, got %q", tc.expectedBucket, bucketObjectState.Bucket)
+				}
+
+				if bucketObjectState.Body != tc.expectedBody {
+					t.Fatalf("expected body %q, got %q", tc.expectedBody, bucketObjectState.Body)
+				}
+
+				if strings.HasSuffix(key, "master") {
+					if !masterKeyRegexp.MatchString(key) {
+						t.Fatalf("expected key %q, to match pattern %q", key, masterKeyPattern)
+					}
+				} else if strings.HasSuffix(key, "worker") {
+					if !workerKeyRegexp.MatchString(key) {
+						t.Fatalf("expected key %q, to match pattern %q", key, workerKeyPattern)
+					}
+				} else {
+					t.Fatalf("unexpected key %q", key)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/s3object/error.go
+++ b/service/controller/v14patch1/resource/s3object/error.go
@@ -1,0 +1,49 @@
+package s3object
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+// IsObjectNotFound asserts object not found error from upstream's API message.
+func IsObjectNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NoSuchKey: The specified key does not exist")
+}
+
+// IsBucketNotFound asserts object not found error from upstream's API message.
+func IsBucketNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NoSuchBucket: The specified bucket does not exist")
+}
+
+// IsKeyNotFound asserts key not found error from upstream's API message.
+func IsKeyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "NotFoundException: Alias arn:aws:kms:")
+}

--- a/service/controller/v14patch1/resource/s3object/mock.go
+++ b/service/controller/v14patch1/resource/s3object/mock.go
@@ -1,0 +1,88 @@
+package s3object
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/randomkeys"
+)
+
+// nopCloser is required to implement the ReadCloser interface required by
+// the Body field in S3's GetObjectOutput
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+type S3ClientMock struct {
+	s3iface.S3API
+
+	isError bool
+	body    string
+}
+
+func (s *S3ClientMock) PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return nil, nil
+}
+
+func (s *S3ClientMock) DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	return nil, nil
+}
+
+func (s *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.GetObjectOutput{
+		Body: nopCloser{strings.NewReader(s.body)},
+	}
+
+	return output, nil
+}
+
+func (s *S3ClientMock) ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	if s.isError {
+		return nil, fmt.Errorf("error!!")
+	}
+
+	output := &s3.ListObjectsV2Output{
+		Contents: []*s3.Object{
+			{
+				Key: aws.String("cloudconfig/myversion/worker"),
+			},
+		},
+	}
+
+	return output, nil
+}
+
+type CloudConfigMock struct {
+	template string
+}
+
+func (c *CloudConfigMock) NewMasterTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets, randomKeys randomkeys.Cluster) (string, error) {
+	return c.template, nil
+}
+
+func (c *CloudConfigMock) NewWorkerTemplate(ctx context.Context, customObject v1alpha1.AWSConfig, certs legacy.CompactTLSAssets) (string, error) {
+	return c.template, nil
+}
+
+type KMSClientMock struct {
+	kmsiface.KMSAPI
+}
+
+func (k *KMSClientMock) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutput, error) {
+	return &kms.EncryptOutput{}, nil
+}

--- a/service/controller/v14patch1/resource/s3object/resource.go
+++ b/service/controller/v14patch1/resource/s3object/resource.go
@@ -1,0 +1,111 @@
+package s3object
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/certs/legacy"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/randomkeys"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "s3objectv14"
+)
+
+// Config represents the configuration used to create a new cloudformation resource.
+type Config struct {
+	// Dependencies.
+	CertWatcher       legacy.Searcher
+	Encrypter         encrypter.Interface
+	Logger            micrologger.Logger
+	RandomKeySearcher randomkeys.Interface
+}
+
+// Resource implements the cloudformation resource.
+type Resource struct {
+	// Dependencies.
+	certWatcher       legacy.Searcher
+	encrypter         encrypter.Interface
+	logger            micrologger.Logger
+	randomKeySearcher randomkeys.Interface
+}
+
+// New creates a new configured cloudformation resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.CertWatcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertWatcher must not be empty")
+	}
+	if config.Encrypter == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Encrypter must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.RandomKeySearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.RandomKeySearcher must not be empty")
+	}
+
+	r := &Resource{
+		// Dependencies.
+		certWatcher:       config.CertWatcher,
+		encrypter:         config.Encrypter,
+		logger:            config.Logger,
+		randomKeySearcher: config.RandomKeySearcher,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return controller.NewPatch(), nil
+}
+
+func toBucketObjectState(v interface{}) (map[string]BucketObjectState, error) {
+	if v == nil {
+		return map[string]BucketObjectState{}, nil
+	}
+
+	bucketObjectState, ok := v.(map[string]BucketObjectState)
+	if !ok {
+		return map[string]BucketObjectState{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObjectState, v)
+	}
+
+	return bucketObjectState, nil
+}
+
+func toPutObjectInput(v interface{}) (s3.PutObjectInput, error) {
+	if v == nil {
+		return s3.PutObjectInput{}, nil
+	}
+
+	bucketObject, ok := v.(BucketObjectState)
+	if !ok {
+		return s3.PutObjectInput{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", bucketObject, v)
+	}
+
+	putObjectInput := s3.PutObjectInput{
+		Key:           aws.String(bucketObject.Key),
+		Body:          strings.NewReader(bucketObject.Body),
+		Bucket:        aws.String(bucketObject.Bucket),
+		ContentLength: aws.Int64(int64(len(bucketObject.Body))),
+	}
+
+	return putObjectInput, nil
+}

--- a/service/controller/v14patch1/resource/s3object/spec.go
+++ b/service/controller/v14patch1/resource/s3object/spec.go
@@ -1,0 +1,12 @@
+package s3object
+
+const (
+	prefixMaster = "master"
+	prefixWorker = "worker"
+)
+
+type BucketObjectState struct {
+	Bucket string
+	Body   string
+	Key    string
+}

--- a/service/controller/v14patch1/resource/s3object/update.go
+++ b/service/controller/v14patch1/resource/s3object/update.go
@@ -1,0 +1,93 @@
+package s3object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	updateBucketState, err := toBucketObjectState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	sc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for key, bucketObject := range updateBucketState {
+		if bucketObject.Key != "" {
+			s3PutInput, err := toPutObjectInput(bucketObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			_, err = sc.AWSClient.S3.PutObject(&s3PutInput)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating S3 object '%s': updated", key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating S3 object '%s': already updated", key))
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentBucketState, err := toBucketObjectState(currentState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	desiredBucketState, err := toBucketObjectState(desiredState)
+	if err != nil {
+		return s3.PutObjectInput{}, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the s3 objects should be updated")
+
+	updateState := map[string]BucketObjectState{}
+
+	for key, bucketObject := range desiredBucketState {
+		if _, ok := currentBucketState[key]; !ok {
+			updateState[key] = BucketObjectState{}
+		}
+
+		currentObject := currentBucketState[key]
+		if currentObject.Body != "" && bucketObject.Body != currentObject.Body {
+			updateState[key] = bucketObject
+		} else {
+			updateState[key] = BucketObjectState{}
+		}
+	}
+
+	return updateState, nil
+}

--- a/service/controller/v14patch1/resource/s3object/update_test.go
+++ b/service/controller/v14patch1/resource/s3object/update_test.go
@@ -1,0 +1,189 @@
+package s3object
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/legacy/legacytest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	awsservice "github.com/giantswarm/aws-operator/service/aws"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/encrypter"
+)
+
+func Test_Resource_S3Object_newUpdate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := v1alpha1.AWSConfig{
+		Spec: v1alpha1.AWSConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           v1alpha1.AWSConfig
+		currentState  map[string]BucketObjectState
+		desiredState  map[string]BucketObjectState
+		expectedState map[string]BucketObjectState
+	}{
+		{
+			description:   "current state empty, desired state empty, empty update change",
+			obj:           clusterTpo,
+			currentState:  map[string]BucketObjectState{},
+			desiredState:  map[string]BucketObjectState{},
+			expectedState: map[string]BucketObjectState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, empty update change",
+			obj:          clusterTpo,
+			currentState: map[string]BucketObjectState{},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+			},
+		},
+		{
+			description: "current state matches desired state, empty update change",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {},
+			},
+		},
+		{
+			description: "current state does not match desired state, update bucket object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+			},
+		},
+		{
+			description: "current state does not match desired state, update bucket object",
+			obj:         clusterTpo,
+			currentState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			desiredState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {
+					Body:   "worker-body",
+					Bucket: "mybucket",
+					Key:    "worker",
+				},
+			},
+			expectedState: map[string]BucketObjectState{
+				"master": {
+					Body:   "master-new-body",
+					Bucket: "mybucket",
+					Key:    "master",
+				},
+				"worker": {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			awsClients := aws.Clients{
+				S3: &S3ClientMock{},
+			}
+
+			awsService := awsservice.AwsServiceMock{}
+
+			cloudconfig := &CloudConfigMock{}
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{}
+				c.CertWatcher = legacytest.NewService()
+				c.Encrypter = &encrypter.EncrypterMock{}
+				c.Logger = microloggertest.New()
+				c.RandomKeySearcher = randomkeystest.NewSearcher()
+
+				newResource, err = New(c)
+				if err != nil {
+					t.Fatal("expected", nil, "got", err)
+				}
+			}
+
+			c := controllercontext.Context{
+				AWSClient:   awsClients,
+				AWSService:  awsService,
+				CloudConfig: cloudconfig,
+			}
+			ctx := context.TODO()
+			ctx = controllercontext.NewContext(ctx, c)
+
+			result, err := newResource.newUpdateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			updateChange, ok := result.(map[string]BucketObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", updateChange, result)
+			}
+
+			if !reflect.DeepEqual(tc.expectedState, updateChange) {
+				t.Error("expected", tc.expectedState, "got", updateChange)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/create.go
+++ b/service/controller/v14patch1/resource/service/create.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToCreate, err := toService(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err = r.k8sClient.CoreV1().Services(namespace).Create(serviceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var serviceToCreate *apiv1.Service
+	if currentService == nil || desiredService.Name != currentService.Name {
+		serviceToCreate = desiredService
+	}
+
+	return serviceToCreate, nil
+}

--- a/service/controller/v14patch1/resource/service/create_test.go
+++ b/service/controller/v14patch1/resource/service/create_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, desired state is empty",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+
+		{
+			description: "current state is empty, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToCreate, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", serviceToCreate, result)
+				}
+				if tc.expectedService.Name != serviceToCreate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToCreate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/current.go
+++ b/service/controller/v14patch1/resource/service/current.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master service in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+
+	// Lookup the current state of the service.
+	var service *apiv1.Service
+	{
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(masterServiceName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master service in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master service in the Kubernetes API")
+			service = manifest
+		}
+	}
+
+	return service, nil
+}

--- a/service/controller/v14patch1/resource/service/delete.go
+++ b/service/controller/v14patch1/resource/service/delete.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToDelete, err := toService(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().Services(namespace).Delete(serviceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the service has to be deleted")
+
+	var serviceToDelete *apiv1.Service
+	if currentService != nil && desiredService.Name == currentService.Name {
+		serviceToDelete = desiredService
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the service has to be deleted")
+
+	return serviceToDelete, nil
+}

--- a/service/controller/v14patch1/resource/service/delete_test.go
+++ b/service/controller/v14patch1/resource/service/delete_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, return desired state",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+		{
+			description: "current and desired states are different, no change",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToDelete, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Fatalf("case expected '%T', got '%T'", serviceToDelete, result)
+				}
+				if tc.expectedService.Name != serviceToDelete.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToDelete.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/desired.go
+++ b/service/controller/v14patch1/resource/service/desired.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	service := &v1.Service{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      "master",
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				key.LabelApp:           "master",
+				key.LegacyLabelCluster: key.ClusterID(customObject),
+				key.LabelCustomer:      key.CustomerID(customObject),
+				key.LabelCluster:       key.ClusterID(customObject),
+				key.LabelOrganization:  key.CustomerID(customObject),
+				key.LabelVersionBundle: key.VersionBundleVersion(customObject),
+			},
+			Annotations: map[string]string{
+				key.AnnotationEtcdDomain:        key.ClusterEtcdDomain(customObject),
+				key.AnnotationPrometheusCluster: key.ClusterID(customObject),
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol:   v1.ProtocolTCP,
+					Port:       httpsPort,
+					TargetPort: intstr.FromInt(httpsPort),
+				},
+			},
+		},
+	}
+
+	return service, nil
+}

--- a/service/controller/v14patch1/resource/service/desired_test.go
+++ b/service/controller/v14patch1/resource/service/desired_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description        string
+		obj                interface{}
+		expectedNamespace  string
+		expectedName       string
+		expectedPort       int
+		expectedTargetPort string
+	}{
+		{
+			description: "Get service from custom object",
+			obj: &v1alpha1.AWSConfig{
+				Spec: v1alpha1.AWSConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			expectedNamespace:  "al9qy",
+			expectedName:       "master",
+			expectedPort:       443,
+			expectedTargetPort: "443",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			desiredService, ok := result.(*apiv1.Service)
+			if !ok {
+				t.Errorf("case expected '%T', got '%T'", desiredService, result)
+			}
+
+			if tc.expectedNamespace != desiredService.ObjectMeta.Namespace {
+				t.Errorf("expected namespace %q got %q", tc.expectedNamespace, desiredService.ObjectMeta.Namespace)
+			}
+
+			if tc.expectedName != desiredService.ObjectMeta.Name {
+				t.Errorf("expected name %q got %q", tc.expectedName, desiredService.ObjectMeta.Name)
+			}
+
+			if int32(tc.expectedPort) != desiredService.Spec.Ports[0].Port {
+				t.Errorf("expected port %q got %q", int32(tc.expectedPort), desiredService.Spec.Ports[0].Port)
+			}
+
+			if intstr.FromInt(tc.expectedPort) != desiredService.Spec.Ports[0].TargetPort {
+				t.Errorf("expected target port %q got %q", intstr.FromInt(tc.expectedPort), desiredService.Spec.Ports[0].TargetPort)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/error.go
+++ b/service/controller/v14patch1/resource/service/error.go
@@ -1,0 +1,30 @@
+package service
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/service/resource.go
+++ b/service/controller/v14patch1/resource/service/resource.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"reflect"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "servicev14"
+
+	httpsPort         = 443
+	masterServiceName = "master"
+)
+
+// Config represents the configuration used to create a new service resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the service resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured service resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func isServiceModified(a, b *apiv1.Service) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	if !portsEqual(a, b) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Spec.Type, b.Spec.Type) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+		return true
+	}
+
+	return false
+}
+
+func toService(v interface{}) (*apiv1.Service, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	service, ok := v.(*apiv1.Service)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Service{}, v)
+	}
+
+	return service, nil
+}
+
+// portsEqual is a function that is checking if ports in the service have same important values.
+func portsEqual(a, b *apiv1.Service) bool {
+	if len(a.Spec.Ports) != len(b.Spec.Ports) {
+		return false
+	}
+
+	for i := 0; i < len(a.Spec.Ports); i++ {
+		portA := a.Spec.Ports[i]
+		portB := b.Spec.Ports[i]
+
+		if portA.Name != portB.Name {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Port, portB.Port) {
+			return false
+		}
+		if !reflect.DeepEqual(portA.TargetPort, portB.TargetPort) {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Protocol, portB.Protocol) {
+			return false
+		}
+	}
+	return true
+}

--- a/service/controller/v14patch1/resource/service/resource_test.go
+++ b/service/controller/v14patch1/resource/service/resource_test.go
@@ -1,0 +1,668 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/aws-operator/service/controller/v13/key"
+)
+
+func Test_toService(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         interface{}
+		expectedState *corev1.Service
+		errorMatcher  func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			expectedState: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 1: wrong type (v1.Service instead of *v1.Service)",
+			input: corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			errorMatcher: IsWrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := toService(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedState) {
+				t.Fatalf("Service == %#v\n, want %#v", result, tc.expectedState)
+			}
+		})
+	}
+}
+
+func Test_isServiceModified(t *testing.T) {
+	testCases := []struct {
+		name           string
+		serviceA       *corev1.Service
+		serviceB       *corev1.Service
+		expectedResult bool
+	}{
+		{
+			name: "case 0: basic match",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 1: label mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy456",
+						key.LabelCustomer:      "customer2",
+						key.LabelCluster:       "xy456",
+						key.LabelOrganization:  "org2",
+						key.LabelVersionBundle: "1.2.4",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 2: annotation mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy456",
+						key.AnnotationEtcdDomain:        "etcd2.cluster.NOTmydomain:433",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 3: ports mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       89,
+							TargetPort: intstr.FromInt(89),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 4: service type mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       httpsPort,
+							TargetPort: intstr.FromInt(httpsPort),
+						},
+					},
+					Type: corev1.ServiceTypeNodePort,
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isServiceModified(tc.serviceA, tc.serviceB)
+
+			if result != tc.expectedResult {
+				t.Fatalf("isServiceModified '%s' failed, got %t, want %t", tc.name, result, tc.expectedResult)
+			}
+		})
+	}
+}
+
+func Test_portsEqual(t *testing.T) {
+	testCases := []struct {
+		name           string
+		serviceA       *corev1.Service
+		serviceB       *corev1.Service
+		expectedResult bool
+	}{
+		{
+			name: "case 0: basic match",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 1: port count mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       442,
+							TargetPort: intstr.FromInt(442),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 2: port count mismatch 2",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 3: protocol mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolUDP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 4: port number mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       445,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 5: targetPort number mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(445),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := portsEqual(tc.serviceA, tc.serviceB)
+
+			if result != tc.expectedResult {
+				t.Fatalf("portEqual '%s' failed, got %t, want %t", tc.name, result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/update.go
+++ b/service/controller/v14patch1/resource/service/update.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+
+	"fmt"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	serviceToUpdate, err := toService(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToUpdate != nil && serviceToUpdate.Spec.ClusterIP != "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating services")
+
+		_, err := r.k8sClient.CoreV1().Services(serviceToUpdate.Namespace).Update(serviceToUpdate)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated services")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to update services")
+	}
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// Service resources are updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be updated")
+
+	if isServiceModified(desiredService, currentService) {
+		// Make a copy and set the resource version so the service can be updated.
+		serviceToUpdate := desiredService.DeepCopy()
+		if currentService != nil {
+			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
+			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found service '%s' that has to be updated", desiredService.GetName()))
+
+		return serviceToUpdate, nil
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no services needs update")
+
+		return nil, nil
+	}
+}

--- a/service/controller/v14patch1/resource/workerasgname/error.go
+++ b/service/controller/v14patch1/resource/workerasgname/error.go
@@ -1,0 +1,12 @@
+package workerasgname
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/resource/workerasgname/resource.go
+++ b/service/controller/v14patch1/resource/workerasgname/resource.go
@@ -1,0 +1,104 @@
+package workerasgname
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v14/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v14/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v14/key"
+)
+
+const (
+	Name = "workerasgnamev14"
+)
+
+type ResourceConfig struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func NewResource(config ResourceConfig) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+// EnsureCreated retrieves worker ASG name from CF stack when it is ready.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	controllerCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var workerASGName string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the guest cluster worker ASG name in the cloud formation stack")
+
+		stackOutputs, _, err := controllerCtx.CloudFormation.DescribeOutputsAndStatus(key.MainGuestStackName(customObject))
+		if cloudformationservice.IsStackNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not yet created")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if cloudformationservice.IsOutputsNotAccessible(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack output values are not accessible due to stack state transition")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		workerASGName, err = controllerCtx.CloudFormation.GetOutputValue(stackOutputs, key.WorkerASGKey)
+		if cloudformationservice.IsOutputNotFound(err) {
+			// Since we are transitioning between versions we will have situations in
+			// which old clusters are updated to new versions and miss the ASG name in
+			// the CF stack outputs. We stop resource reconciliation at this point to
+			// reconcile again at a later point when the stack got upgraded and
+			// contains the ASG name.
+			//
+			// TODO remove this condition as soon as all guest clusters in existence
+			// obtain a ASG name.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not upgraded to the newest version yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster worker ASG name in the cloud formation stack")
+	}
+
+	controllerCtx.Status.Drainer.WorkerASGName = workerASGName
+
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/templates/cloudconfig/decrypt_keys_assets_script.go
+++ b/service/controller/v14patch1/templates/cloudconfig/decrypt_keys_assets_script.go
@@ -1,0 +1,146 @@
+package cloudconfig
+
+const DecryptKeysAssetsScript = `#!/bin/bash -e
+{{ if eq .EncrypterType "vault" }}
+token_path=/var/token
+nonce_path=/var/nonce
+
+wait_for_vault_elb(){
+    local service_name="$1"
+    local state="${2:-active}"
+    for i in $(seq 80); do
+        if curl -k -s -o /dev/null -w "%{http_code}" --max-time 3 {{ .VaultAddress }}/v1/sys/health | grep -q "200"; then
+            return 0
+        fi
+        echo "{{ .VaultAddress }} not accessible yet, waiting..."
+        sleep 15;
+    done
+
+    echo "{{ .VaultAddress }} not accessible"
+    return 1
+}
+
+token_exists () {
+  if [ -f $token_path ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+token_is_valid() {
+  #  https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-
+  echo "Checking token validity"
+  token_lookup=$(curl -k \
+    --request GET \
+    --silent \
+    --header "X-Vault-Token: $(cat $token_path)" \
+    --write-out %{http_code} \
+    --output /dev/null \
+    {{ .VaultAddress }}/v1/auth/token/lookup-self)
+  if [ "$token_lookup" == "200" ]; then
+      echo "$0 - Valid token found, exiting"
+      return 0
+  else
+      echo "$0 - Invalid token found"
+      return 1
+  fi
+}
+
+main () {
+    if ! wait_for_vault_elb; then
+        exit 1;
+    fi
+    if ! token_exists; then
+        aws_login ""
+    elif token_exists && ! token_is_valid; then
+        aws_login "$(cat $nonce_path)"
+    else
+        logger $0 "current vault token is still valid"
+    fi
+
+    echo decrypting keys assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/encryption -name "*.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      cat <<EOF > data.json
+{
+  "ciphertext": "$(cat $encKey)"
+}
+EOF
+      curl -k \
+        --header "X-Vault-Token: $(cat $token_path)" \
+        --silent \
+        --request POST \
+        --data @data.json \
+        {{ .VaultAddress }}/v1/transit/decrypt/{{ .EncryptionKey }} | \
+        jq -r .data.plaintext | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+      rm -f data.json
+    done;
+    echo done.
+}
+
+aws_login () {
+    # query EC2 metadata endpoint (common for all AWS infrastructure).
+    pkcs7=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 | tr -d '\n')
+    if [ -z "$1" ]; then
+        # do not load nonce if initial login
+        login_payload=$(cat <<EOF
+{
+  "role": "decrypter",
+  "pkcs7": "$pkcs7"
+}
+EOF
+)
+    else
+        # load nonce in payload for reauthentication
+        login_payload=$(cat <<EOF
+{
+  "role": "decrypter",
+  "pkcs7": "$pkcs7",
+  "nonce": "$1"
+}
+EOF
+)
+    fi
+
+    curl -k \
+      --request POST \
+      --silent \
+      --data "$login_payload" \
+      {{ .VaultAddress }}/v1/auth/aws/login | tee  \
+      >(jq -r .auth.client_token > $token_path) \
+      >(jq -r .auth.metadata.nonce > $nonce_path)
+}
+
+main
+{{ else }}
+rkt run \
+  --volume=keys,kind=host,source=/etc/kubernetes/encryption,readOnly=false \
+  --mount=volume=keys,target=/etc/kubernetes/encryption \
+  --uuid-file-save=/var/run/coreos/decrypt-keys-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting keys assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/encryption -name "*.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;
+    echo done.'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-keys-assets.uuid || :
+{{ end }}
+`

--- a/service/controller/v14patch1/templates/cloudconfig/decrypt_keys_assets_service.go
+++ b/service/controller/v14patch1/templates/cloudconfig/decrypt_keys_assets_service.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const DecryptKeysAssetsService = `
+[Unit]
+Description=Decrypt Secret Keys
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-keys-assets
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/decrypt_tls_assets_script.go
+++ b/service/controller/v14patch1/templates/cloudconfig/decrypt_tls_assets_script.go
@@ -1,0 +1,145 @@
+package cloudconfig
+
+const DecryptTLSAssetsScript = `#!/bin/bash -e
+{{ if eq .EncrypterType "vault" }}
+token_path=/var/token
+nonce_path=/var/nonce
+
+wait_for_vault_elb(){
+    local service_name="$1"
+    local state="${2:-active}"
+    for i in $(seq 80); do
+        if curl -k -s -o /dev/null -w "%{http_code}" --max-time 3 {{ .VaultAddress }}/v1/sys/health | grep -q "200"; then
+            return 0
+        fi
+        echo "{{ .VaultAddress }} not accessible yet, waiting..."
+        sleep 15;
+    done
+
+    echo "{{ .VaultAddress }} not accessible"
+    return 1
+}
+
+token_exists () {
+  if [ -f $token_path ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+token_is_valid() {
+  #  https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-
+  echo "Checking token validity"
+  token_lookup=$(curl -k \
+    --request GET \
+    --silent \
+    --header "X-Vault-Token: $(cat $token_path)" \
+    --write-out %{http_code} \
+    --output /dev/null \
+    {{ .VaultAddress }}/v1/auth/token/lookup-self)
+  if [ "$token_lookup" == "200" ]; then
+      echo "$0 - Valid token found, exiting"
+      return 0
+  else
+      echo "$0 - Invalid token found"
+      return 1
+  fi
+}
+
+main () {
+   if ! wait_for_vault_elb; then
+        exit 1;
+   fi
+   if ! token_exists; then
+        aws_login ""
+    elif token_exists && ! token_is_valid; then
+        aws_login "$(cat $nonce_path)"
+    else
+        logger $0 "current vault token is still valid"
+    fi
+
+    echo decrypting keys assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/ssl -name "*.pem.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      cat <<EOF > data.json
+{
+  "ciphertext": "$(cat $encKey)"
+}
+EOF
+      curl -k \
+        --header "X-Vault-Token: $(cat $token_path)" \
+        --silent \
+        --request POST \
+        --data @data.json \
+        {{ .VaultAddress }}/v1/transit/decrypt/{{ .EncryptionKey }} | \
+        jq -r .data.plaintext | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+      rm -f data.json
+    done;
+    echo done.
+}
+
+aws_login () {
+    # query EC2 metadata endpoint (common for all AWS infrastructure).
+    pkcs7=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 | tr -d '\n')
+    if [ -z "$1" ]; then
+        # do not load nonce if initial login
+        login_payload=$(cat <<EOF
+{
+  "role": "decrypter",
+  "pkcs7": "$pkcs7"
+}
+EOF
+)
+    else
+        # load nonce in payload for reauthentication
+        login_payload=$(cat <<EOF
+{
+  "role": "decrypter",
+  "pkcs7": "$pkcs7",
+  "nonce": "$1"
+}
+EOF
+)
+    fi
+
+    curl -k \
+      --request POST \
+      --silent \
+      --data "$login_payload" \
+      {{ .VaultAddress }}/v1/auth/aws/login | tee  \
+      >(jq -r .auth.client_token > $token_path) \
+      >(jq -r .auth.metadata.nonce > $nonce_path)
+}
+
+main
+{{ else }}
+rkt run \
+  --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
+  --mount=volume=ssl,target=/etc/kubernetes/ssl \
+  --uuid-file-save=/var/run/coreos/decrypt-tls-assets.uuid \
+  --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+  --net=host \
+  --trust-keys-from-https \
+  quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600 --exec=/bin/bash -- \
+    -ec \
+    'echo decrypting tls assets
+    shopt -s nullglob
+    for encKey in $(find /etc/kubernetes/ssl -name "*.pem.enc"); do
+      echo decrypting $encKey
+      f=$(mktemp $encKey.XXXXXXXX)
+      /usr/bin/aws \
+        --region {{.AWS.Region}} kms decrypt \
+        --ciphertext-blob fileb://$encKey \
+        --output text \
+        --query Plaintext \
+      | base64 -d > $f
+      mv -f $f ${encKey%.enc}
+    done;'
+
+rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid || :
+{{ end }}
+chown -R etcd:etcd /etc/kubernetes/ssl/etcd`

--- a/service/controller/v14patch1/templates/cloudconfig/decrypt_tls_assets_service.go
+++ b/service/controller/v14patch1/templates/cloudconfig/decrypt_tls_assets_service.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const DecryptTLSAssetsService = `
+[Unit]
+Description=Decrypt TLS certificates
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/decrypt-tls-assets
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/encryption_config.go
+++ b/service/controller/v14patch1/templates/cloudconfig/encryption_config.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const EncryptionConfig = `kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{.EncryptionKey}}
+    - identity: {}`

--- a/service/controller/v14patch1/templates/cloudconfig/ephemeral_var_lib_docker_mount.go
+++ b/service/controller/v14patch1/templates/cloudconfig/ephemeral_var_lib_docker_mount.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const EphemeralVarLibDockerMount = `
+[Unit]
+Description=Mount ephemeral volume on /var/lib/docker
+
+[Mount]
+What=/dev/disk/by-label/docker
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/format_etcd_volume.go
+++ b/service/controller/v14patch1/templates/cloudconfig/format_etcd_volume.go
@@ -1,0 +1,24 @@
+package cloudconfig
+
+const FormatEtcdVolume = `
+[Unit]
+Description=Formats EBS volume for etcd
+Before=docker.service var-lib-etcd.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# Do not wipe the disk if it's already being used, so the etcd data is
+# persistent across reboots and updates.
+Environment=DEV=/dev/xvdh
+
+# line 1: Create filesystem if does not exist.
+# line 2: For compatibility with older clusters. Label existing filesystem with etcd label.
+ExecStart=/bin/bash -c "\
+if ! blkid $DEV; then mkfs.ext4 -L etcd $DEV; fi ;\
+[ -L /dev/disk/by-label/etcd ] || e2label $DEV etcd"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/ingress_controller_config_map.go
+++ b/service/controller/v14patch1/templates/cloudconfig/ingress_controller_config_map.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const IngressControllerConfigMap = `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  server-name-hash-bucket-size: "1024"
+  server-name-hash-max-size: "1024"
+  use-proxy-protocol: "true"
+`

--- a/service/controller/v14patch1/templates/cloudconfig/instance_storage.go
+++ b/service/controller/v14patch1/templates/cloudconfig/instance_storage.go
@@ -1,0 +1,12 @@
+package cloudconfig
+
+const InstanceStorage = `
+storage:
+  filesystems:
+    - name: ephemeral1
+      mount:
+        device: /dev/xvdb
+        format: xfs
+        create:
+          force: true
+`

--- a/service/controller/v14patch1/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/v14patch1/templates/cloudconfig/instance_storage_class.go
@@ -1,0 +1,25 @@
+package cloudconfig
+
+const InstanceStorageClass = `
+write_files:
+- path: /srv/default-storage-class.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: storage.k8s.io/v1beta1
+    kind: StorageClass
+    metadata:
+      name: gp2
+      annotations:
+        storageclass.beta.kubernetes.io/is-default-class: "true"
+      labels:
+        kubernetes.io/cluster-service: "true"
+        addonmanager.kubernetes.io/mode: EnsureExists
+    provisioner: kubernetes.io/aws-ebs
+    allowVolumeExpansion: true
+    parameters:
+      type: gp2
+`
+const InstanceStorageClassEncrypted = InstanceStorageClass + `
+      encrypted: "true"
+`

--- a/service/controller/v14patch1/templates/cloudconfig/master_format_var_lib_docker_service.go
+++ b/service/controller/v14patch1/templates/cloudconfig/master_format_var_lib_docker_service.go
@@ -1,0 +1,15 @@
+package cloudconfig
+
+const MasterFormatVarLibDockerService = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "[ -e "/dev/xvdc" ] && /usr/sbin/mkfs.xfs -f /dev/xvdc -L docker"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/mount_etcd_volume.go
+++ b/service/controller/v14patch1/templates/cloudconfig/mount_etcd_volume.go
@@ -1,0 +1,17 @@
+package cloudconfig
+
+const MountEtcdVolume = `
+[Unit]
+Description=etcd3 data volume
+Requires=format-etcd-ebs.service
+After=format-etcd-ebs.service
+Before=etcd3.service
+
+[Mount]
+What=/dev/disk/by-label/etcd
+Where=/var/lib/etcd
+Type=ext4
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/nvme_udev_hack.go
+++ b/service/controller/v14patch1/templates/cloudconfig/nvme_udev_hack.go
@@ -1,0 +1,26 @@
+package cloudconfig
+
+const NVMEUdevRule = `KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/opt/ebs-nvme-mapping /dev/%k", SYMLINK+="%c"
+`
+
+const NVMEUdevScript = `#!/bin/bash
+vol=$(nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+vol=${vol#/dev/}
+if [[ -n "$vol" ]]; then
+    echo ${vol/xvd/sd} ${vol/sd/xvd}
+fi
+`
+
+const NVMEUdevTriggerUnit = `[Unit]
+Description=Reload AWS EBS NVMe rules
+Requires=coreos-setup-environment.service
+After=coreos-setup-environment.service
+Before=user-config.target
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/udevadm control --reload-rules
+ExecStart=/usr/bin/udevadm trigger -y "nvme[0-9]*n[0-9]*"
+ExecStart=/usr/bin/udevadm settle
+`

--- a/service/controller/v14patch1/templates/cloudconfig/persistent_var_lib_docker_mount.go
+++ b/service/controller/v14patch1/templates/cloudconfig/persistent_var_lib_docker_mount.go
@@ -1,0 +1,14 @@
+package cloudconfig
+
+const PersistentVarLibDockerMount = `
+[Unit]
+Description=Mount persistent volume on /var/lib/docker
+
+[Mount]
+What=/dev/disk/by-label/docker
+Where=/var/lib/docker
+Type=xfs
+
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/controller/v14patch1/templates/cloudconfig/small.go
+++ b/service/controller/v14patch1/templates/cloudconfig/small.go
@@ -1,0 +1,45 @@
+package cloudconfig
+
+const Small = `#!/bin/bash
+
+# user-data in EC2 instances has a 16KB limit.
+# To circumvent this limit, we:
+#
+# 1. Upload the final cloudconfig to s3
+# 2. Generate a "small cloudconfig" whose only task is fetching the
+#    final cloudconfig from s3
+# 3. Configure the instance to be able to access the s3 URI where the
+#    final cloudconfig is stored
+# 4. Start the instance with the "small cloudconfig"
+#
+# This file is the "small cloudconfig" mentioned before. Here we simply fetch a
+# gzip+base64 file (the final cloudconfig) from AWS S3 and run coreos-cloudinit
+# with it as an argument.
+
+. /etc/environment
+USERDATA_FILE={{.MachineType}}
+
+# Wait for S3 bucket to be available.
+s3_http_uri="https://{{.S3Domain}}/{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE"
+retry=30
+
+until [ $(curl --output /dev/null --silent --head --fail -w "%{http_code}" $s3_http_uri) -eq "403" ]; do
+   retry=$(( retry - 1))
+   if [ $retry -le 0 ]; then
+     echo "timed out waiting for s3 bucket"
+     exit 1
+   fi
+
+   echo "waiting for $s3_http_uri to be available"
+   sleep 5
+done
+
+/usr/bin/rkt run \
+    --net=host \
+    --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf  \
+    --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
+    --trust-keys-from-https \
+    --insecure-options=image \
+    {{ .AWSCliContainerRegistry }} -- aws s3 --region {{.Region}} cp s3://{{.S3URI}}/cloudconfig/{{.CloudConfigVersion}}/$USERDATA_FILE /var/run/coreos/temp.txt
+base64 -d /var/run/coreos/temp.txt | gunzip > /var/run/coreos/$USERDATA_FILE
+exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE`

--- a/service/controller/v14patch1/templates/cloudconfig/wait_docker_conf.go
+++ b/service/controller/v14patch1/templates/cloudconfig/wait_docker_conf.go
@@ -1,0 +1,7 @@
+package cloudconfig
+
+const WaitDockerConf = `
+[Unit]
+After=var-lib-docker.mount
+Requires=var-lib-docker.mount
+`

--- a/service/controller/v14patch1/templates/cloudconfig/worker_format_var_lib_docker_service.go
+++ b/service/controller/v14patch1/templates/cloudconfig/worker_format_var_lib_docker_service.go
@@ -1,0 +1,15 @@
+package cloudconfig
+
+const WorkerFormatVarLibDockerService = `
+[Unit]
+Description=Format /var/lib/docker to XFS
+Before=docker.service var-lib-docker.mount
+ConditionPathExists=!/var/lib/docker
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "([ -b "/dev/xvdh" ] && /usr/sbin/mkfs.xfs -f /dev/xvdh -L docker) || ([ -b "/dev/nvme1n1" ] && /usr/sbin/mkfs.xfs -f /dev/nvme1n1 -L docker)"
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v14patch1/templates/cloudformation/guest/auto_scaling_group.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/auto_scaling_group.go
@@ -1,0 +1,32 @@
+package guest
+
+const AutoScalingGroup = `{{define "autoscaling_group"}}
+{{- $v := .Guest.AutoScalingGroup }}
+  {{ $v.ASGType }}AutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      VPCZoneIdentifier:
+        - !Ref PrivateSubnet
+      AvailabilityZones: [{{ $v.WorkerAZ }}]
+      DesiredCapacity: {{ $v.ASGMinSize }}
+      MinSize: {{ $v.ASGMinSize }}
+      MaxSize: {{ $v.ASGMaxSize }}
+      LaunchConfigurationName: !Ref {{ $v.ASGType }}LaunchConfiguration
+      LoadBalancerNames:
+        - !Ref IngressLoadBalancer
+      HealthCheckGracePeriod: {{ $v.HealthCheckGracePeriod }}
+      MetricsCollection:
+        - Granularity: "1Minute"
+      Tags:
+        - Key: Name
+          Value: {{ $v.ClusterID }}-{{ $v.ASGType }}
+          PropagateAtLaunch: true
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        # minimum amount of instances that must always be running during a rolling update
+        MinInstancesInService: {{ $v.MinInstancesInService }}
+        # only do a rolling update of this amount of instances max
+        MaxBatchSize: {{ $v.MaxBatchSize }}
+        # after creating a new instance, pause operations on the ASG for this amount of time
+        PauseTime: {{ $v.RollingUpdatePauseTime }}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/iam_policies.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/iam_policies.go
@@ -1,0 +1,123 @@
+package guest
+
+const IAMPolicies = `{{define "iam_policies"}}
+{{- $v := .Guest.IAMPolicies }}
+  MasterRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{ $v.MasterRoleName }}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            Service: {{ $v.EC2ServiceDomain }}
+          Action: "sts:AssumeRole"
+  MasterRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: {{ $v.MasterPolicyName }}
+      Roles:
+        - Ref: "MasterRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "ec2:*"
+            Resource: "*"
+{{ if $v.KMSKeyARN }}
+          - Effect: "Allow"
+            Action: "kms:Decrypt"
+            Resource: "{{ $v.KMSKeyARN }}"
+{{ end }}
+          - Effect: "Allow"
+            Action:
+              - "s3:GetBucketLocation"
+              - "s3:ListAllMyBuckets"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "s3:ListBucket"
+            Resource: "arn:{{ $v.RegionARN }}:s3:::{{ $v.S3Bucket }}"
+
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "arn:{{ $v.RegionARN }}:s3:::{{ $v.S3Bucket }}/*"
+
+          - Effect: "Allow"
+            Action: "elasticloadbalancing:*"
+            Resource: "*"
+  MasterInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: {{ $v.MasterProfileName }}
+      Roles:
+        - Ref: "MasterRole"
+
+  WorkerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{ $v.WorkerRoleName }}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            Service: {{ $v.EC2ServiceDomain }}
+          Action: "sts:AssumeRole"
+  WorkerRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: {{ $v.WorkerPolicyName }}
+      Roles:
+        - Ref: "WorkerRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "ec2:Describe*"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "ec2:AttachVolume"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "ec2:DetachVolume"
+            Resource: "*"
+{{ if $v.KMSKeyARN }}
+          - Effect: "Allow"
+            Action: "kms:Decrypt"
+            Resource: "{{ $v.KMSKeyARN }}"
+{{ end }}
+          - Effect: "Allow"
+            Action:
+              - "s3:GetBucketLocation"
+              - "s3:ListAllMyBuckets"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action: "s3:ListBucket"
+            Resource: "arn:{{ $v.RegionARN }}:s3:::{{ $v.S3Bucket }}"
+
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "arn:{{ $v.RegionARN }}:s3:::{{ $v.S3Bucket }}/*"
+
+          - Effect: "Allow"
+            Action:
+              - "ecr:GetAuthorizationToken"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:DescribeRepositories"
+              - "ecr:ListImages"
+              - "ecr:BatchGetImage"
+            Resource: "*"
+  WorkerInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: {{ $v.WorkerProfileName }}
+      Roles:
+        - Ref: "WorkerRole"
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/instance.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/instance.go
@@ -1,0 +1,60 @@
+package guest
+
+const Instance = `{{ define "instance" }}
+{{- $v := .Guest.Instance }}
+  {{ $v.Master.Instance.ResourceName }}:
+    Type: "AWS::EC2::Instance"
+    Description: Master instance
+    DependsOn:
+    - {{ $v.Master.DockerVolume.ResourceName }}
+    - EtcdVolume
+    Properties:
+      AvailabilityZone: {{ $v.Master.AZ }}
+      IamInstanceProfile: !Ref MasterInstanceProfile
+      ImageId: {{ $v.Image.ID }}
+      InstanceType: {{ $v.Master.Instance.Type }}
+      Monitoring: {{ $v.Master.Instance.Monitoring }}
+      SecurityGroupIds:
+      - !Ref MasterSecurityGroup
+      SubnetId: !Ref PrivateSubnet
+      UserData: {{ $v.Master.CloudConfig }}
+      Tags:
+      - Key: Name
+        Value: {{ $v.Cluster.ID }}-master
+  {{ $v.Master.DockerVolume.ResourceName }}:
+    Type: AWS::EC2::Volume
+    Properties:
+{{ if eq $v.Master.EncrypterBackend "kms" }}
+      Encrypted: true
+{{ end }}
+      Size: 50
+      VolumeType: gp2
+      AvailabilityZone: {{ $v.Master.AZ }}
+      Tags:
+      - Key: Name
+        Value: {{ $v.Master.DockerVolume.Name }}
+  EtcdVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+{{ if eq $v.Master.EncrypterBackend "kms" }}
+      Encrypted: true
+{{ end }}
+      Size: 100
+      VolumeType: gp2
+      AvailabilityZone: {{ $v.Master.AZ }}
+      Tags:
+      - Key: Name
+        Value: {{ $v.Master.EtcdVolume.Name }}
+  {{ $v.Master.Instance.ResourceName }}DockerMountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref {{ $v.Master.Instance.ResourceName }}
+      VolumeId: !Ref {{ $v.Master.DockerVolume.ResourceName }}
+      Device: /dev/xvdc
+  {{ $v.Master.Instance.ResourceName }}EtcdMountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref {{ $v.Master.Instance.ResourceName }}
+      VolumeId: !Ref EtcdVolume
+      Device: /dev/xvdh
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/internet_gateway.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/internet_gateway.go
@@ -1,0 +1,31 @@
+package guest
+
+const InternetGateway = `{{define "internet_gateway"}}
+{{- $v := .Guest.InternetGateway }}
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: {{ $v.ClusterID }}
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    DependsOn:
+      - PublicRouteTable
+      - PrivateRouteTable
+    Properties:
+      InternetGatewayId:
+        Ref: InternetGateway
+      VpcId: !Ref VPC
+
+  InternetGatewayRoute:
+    Type: AWS::EC2::Route
+    DependsOn:
+      - VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: InternetGateway
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/launch_configuration.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/launch_configuration.go
@@ -1,0 +1,25 @@
+package guest
+
+const LaunchConfiguration = `{{define "launch_configuration"}}
+{{- $v := .Guest.LaunchConfiguration }}
+  {{ $v.ASGType }}LaunchConfiguration:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Description: {{ $v.ASGType }} launch configuration
+    Properties:
+      ImageId: {{ $v.WorkerImageID }}
+      SecurityGroups:
+      - !Ref WorkerSecurityGroup
+      InstanceType: {{ $v.WorkerInstanceType }}
+      InstanceMonitoring: {{ $v.WorkerInstanceMonitoring }}
+      IamInstanceProfile: !Ref WorkerInstanceProfile
+      BlockDeviceMappings:
+      {{ range $v.WorkerBlockDeviceMappings }}
+      - DeviceName: "{{ .DeviceName }}"
+        Ebs:
+          DeleteOnTermination: {{ .DeleteOnTermination }}
+          VolumeSize: {{ .VolumeSize }}
+          VolumeType: {{ .VolumeType }}
+      {{ end }}
+      AssociatePublicIpAddress: {{ $v.WorkerAssociatePublicIPAddress }}
+      UserData: {{ $v.WorkerSmallCloudConfig }}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/lifecycle_hooks.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/lifecycle_hooks.go
@@ -1,0 +1,14 @@
+package guest
+
+const LifecycleHooks = `{{ define "lifecycle_hooks" }}
+{{- $v := .Guest.LifecycleHooks }}
+  {{ $v.Worker.LifecycleHook.Name }}LifecycleHook:
+    Type: "AWS::AutoScaling::LifecycleHook"
+    Properties:
+      AutoScalingGroupName:
+        Ref: {{ $v.Worker.ASG.Ref }}
+      DefaultResult: CONTINUE
+      HeartbeatTimeout: 3600
+      LifecycleHookName: {{ $v.Worker.LifecycleHook.Name }}
+      LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING"
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/load_balancers.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/load_balancers.go
@@ -1,0 +1,67 @@
+package guest
+
+const LoadBalancers = `{{define "load_balancers"}}
+{{- $v := .Guest.LoadBalancers }}
+  ApiLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: 1200
+      HealthCheck:
+        HealthyThreshold: {{ $v.ELBHealthCheckHealthyThreshold }}
+        Interval: {{ $v.ELBHealthCheckInterval }}
+        Target: {{ $v.APIElbHealthCheckTarget }}
+        Timeout: {{ $v.ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ $v.ELBHealthCheckUnhealthyThreshold }}
+      Instances:
+      - !Ref {{ $v.MasterInstanceResourceName }}
+      Listeners:
+      {{ range $v.APIElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ $v.APIElbName }}
+      Scheme: {{ $v.APIElbScheme }}
+      SecurityGroups:
+        - !Ref MasterSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet
+
+  IngressLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: 60
+      HealthCheck:
+        HealthyThreshold: {{ $v.ELBHealthCheckHealthyThreshold }}
+        Interval: {{ $v.ELBHealthCheckInterval }}
+        Target: {{ $v.IngressElbHealthCheckTarget }}
+        Timeout: {{ $v.ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ $v.ELBHealthCheckUnhealthyThreshold }}
+      Listeners:
+      {{ range $v.IngressElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ $v.IngressElbName }}
+      Policies:
+      - PolicyName: "EnableProxyProtocol"
+        PolicyType: "ProxyProtocolPolicyType"
+        Attributes:
+        - Name: "ProxyProtocol"
+          Value: "true"
+        InstancePorts:
+        {{ range $v.IngressElbPortsToOpen}}
+        - {{ .PortInstance }}
+        {{ end }}
+      Scheme: {{ $v.IngressElbScheme }}
+      SecurityGroups:
+        - !Ref IngressSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/main.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/main.go
@@ -1,0 +1,24 @@
+package guest
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Guest CloudFormation stack.
+Parameters:
+  VersionBundleVersionParameter:
+    Type: String
+    Description: Sets the VersionBundleVersion used to generate the template. 
+Resources:
+  {{template "vpc" .}}
+  {{template "iam_policies" .}}
+  {{template "security_groups" .}}
+  {{template "route_tables" .}}
+  {{template "subnets" .}}
+  {{template "internet_gateway" .}}
+  {{template "nat_gateway" .}}
+  {{template "instance" .}}
+  {{template "load_balancers" .}}
+  {{template "launch_configuration" .}}
+  {{template "lifecycle_hooks" .}}
+  {{template "autoscaling_group" .}}
+  {{template "record_sets" .}}
+{{template "outputs" .}}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/nat_gateway.go
@@ -1,0 +1,27 @@
+package guest
+
+const NatGateway = `{{define "nat_gateway"}}
+  {{- $v := .Guest.NATGateway }}
+  NATGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+        - NATEIP
+        - AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags:
+        - Key: Name
+          Value: {{ $v.ClusterID }}
+  NATEIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+  NATRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: "NATGateway"
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/outputs.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/outputs.go
@@ -1,0 +1,33 @@
+package guest
+
+const Outputs = `{{define "outputs"}}
+{{- $v := .Guest.Outputs }}
+Outputs:
+  DockerVolumeResourceName:
+    Value: {{ $v.Master.DockerVolume.ResourceName }}
+  {{ if $v.Route53Enabled }}
+  HostedZoneNameServers:
+    Value: !Join [ ',', !GetAtt 'HostedZone.NameServers' ]
+  {{ end }}
+  MasterImageID:
+    Value: {{ $v.Master.ImageID }}
+  MasterInstanceResourceName:
+    Value: {{ $v.Master.Instance.ResourceName }}
+  MasterInstanceType:
+    Value: {{ $v.Master.Instance.Type }}
+  MasterCloudConfigVersion:
+    Value: {{ $v.Master.CloudConfig.Version }}
+  {{ $v.Worker.ASG.Key }}:
+    Value: !Ref {{ $v.Worker.ASG.Ref }}
+  WorkerCount:
+    Value: {{ $v.Worker.Count }}
+  WorkerImageID:
+    Value: {{ $v.Worker.ImageID }}
+  WorkerInstanceType:
+    Value: {{ $v.Worker.InstanceType }}
+  WorkerCloudConfigVersion:
+    Value: {{ $v.Worker.CloudConfig.Version }}
+  VersionBundleVersion:
+    Value:
+      Ref: VersionBundleVersionParameter
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/record_sets.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/record_sets.go
@@ -1,0 +1,49 @@
+package guest
+
+const RecordSets = `{{define "record_sets"}}
+{{- $v := .Guest.RecordSets }}
+{{ if $v.Route53Enabled }}
+  HostedZone:
+    Type: 'AWS::Route53::HostedZone'
+    Properties:
+      Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+  ApiRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt ApiLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApiLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'HostedZone'
+      Type: A
+  EtcdRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: 'etcd.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'HostedZone'
+      TTL: '900'
+      Type: CNAME
+      ResourceRecords:
+        - !GetAtt {{ $v.MasterInstanceResourceName }}.PrivateDnsName
+  IngressRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt IngressLoadBalancer.DNSName
+        HostedZoneId: !GetAtt IngressLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: 'ingress.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'HostedZone'
+      Type: A
+  IngressWildcardRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'HostedZone'
+      TTL: '900'
+      Type: CNAME
+      ResourceRecords:
+        - !Ref 'IngressRecordSet'
+{{end}}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/route_tables.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/route_tables.go
@@ -1,0 +1,28 @@
+package guest
+
+const RouteTables = `{{ define "route_tables" }}
+{{- $v := .Guest.RouteTables }}
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: {{ $v.PublicRouteTableName }}
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: {{ $v.PrivateRouteTableName }}
+
+  VPCPeeringRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: {{ $v.HostClusterCIDR }}
+      VpcPeeringConnectionId:
+        Ref: "VPCPeeringConnection"
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/security_groups.go
@@ -1,0 +1,109 @@
+package guest
+
+const SecurityGroups = `{{define "security_groups" }}
+{{- $v := .Guest.SecurityGroups }}
+  MasterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ $v.MasterSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range $v.MasterSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        CidrIp: {{ .SourceCIDR }}
+      {{ end }}
+      {{- if $v.APIWhitelistEnabled }}
+      -
+        IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: !Join [ "/", [ !Ref NATEIP, "32" ] ]
+      {{- end }}
+      Tags:
+        - Key: Name
+          Value:  {{ $v.MasterSecurityGroupName }}
+
+  WorkerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ $v.WorkerSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range $v.WorkerSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        {{ if .SourceCIDR }}
+        CidrIp: {{ .SourceCIDR }}
+        {{ else }}
+        SourceSecurityGroupId: !Ref {{ .SourceSecurityGroup }}
+        {{ end }}
+      {{ end }}
+      Tags:
+        - Key: Name
+          Value:  {{ $v.WorkerSecurityGroupName }}
+
+  IngressSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: {{ $v.IngressSecurityGroupName }}
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+      {{ range $v.IngressSecurityGroupRules }}
+      -
+        IpProtocol: {{ .Protocol }}
+        FromPort: {{ .Port }}
+        ToPort: {{ .Port }}
+        CidrIp: {{ .SourceCIDR }}
+      {{ end }}
+      Tags:
+        - Key: Name
+          Value: {{ $v.IngressSecurityGroupName }}
+
+  # Allow all access between masters and workers for calico. This is done after
+  # the other rules to avoid circular dependencies.
+  MasterAllowCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: MasterSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+
+  MasterAllowWorkerCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: MasterSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+
+  WorkerAllowCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: WorkerSecurityGroup
+    Properties:
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+
+  WorkerAllowMasterCalicoIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: WorkerSecurityGroup
+    Properties:
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/subnets.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/subnets.go
@@ -1,0 +1,38 @@
+package guest
+
+const Subnets = `{{ define "subnets" }}
+{{- $v := .Guest.Subnets }}
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: {{ $v.PublicSubnetAZ }}
+      CidrBlock: {{ $v.PublicSubnetCIDR }}
+      MapPublicIpOnLaunch: {{ $v.PublicSubnetMapPublicIPOnLaunch }}
+      Tags:
+      - Key: Name
+        Value: {{ $v.PublicSubnetName }}
+      VpcId: !Ref VPC
+
+  PublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet
+
+  PrivateSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: {{ $v.PrivateSubnetAZ }}
+      CidrBlock: {{ $v.PrivateSubnetCIDR }}
+      MapPublicIpOnLaunch: {{ $v.PrivateSubnetMapPublicIPOnLaunch }}
+      Tags:
+      - Key: Name
+        Value: {{ $v.PrivateSubnetName }}
+      VpcId: !Ref VPC
+
+  PrivateSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/guest/vpc.go
+++ b/service/controller/v14patch1/templates/cloudformation/guest/vpc.go
@@ -1,0 +1,26 @@
+package guest
+
+const VPC = `{{define "vpc"}}
+{{- $v := .Guest.VPC }}
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ $v.CidrBlock }}
+      EnableDnsSupport: 'true'
+      EnableDnsHostnames: 'true'
+      Tags:
+      - Key: Name
+        Value: {{ $v.ClusterID }}
+      - Key: Installation
+        Value: {{ $v.InstallationName }}
+  VPCPeeringConnection:
+    Type: 'AWS::EC2::VPCPeeringConnection'
+    Properties:
+      VpcId: !Ref VPC
+      PeerVpcId: {{ $v.PeerVPCID }}
+      PeerOwnerId: '{{ $v.HostAccountID }}'
+      PeerRoleArn: {{ $v.PeerRoleArn }}
+      Tags:
+        - Key: Name
+          Value: {{ $v.ClusterID }}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/hostpost/main.go
+++ b/service/controller/v14patch1/templates/cloudformation/hostpost/main.go
@@ -1,0 +1,8 @@
+package hostpost
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Host Post-Guest CloudFormation stack.
+Resources:
+  {{template "record_sets" .}}
+  {{template "route_tables" .}}
+{{end}}`

--- a/service/controller/v14patch1/templates/cloudformation/hostpost/record_sets.go
+++ b/service/controller/v14patch1/templates/cloudformation/hostpost/record_sets.go
@@ -1,0 +1,15 @@
+package hostpost
+
+const RecordSets = `{{ define "record_sets" }}
+{{ $v := .HostPost.RecordSets }}
+{{ if $v.Route53Enabled }}
+  GuestNSRecordSet:
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      HostedZoneName: '{{ $v.BaseDomain }}.'
+      Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      Type: 'NS'
+      TTL: '900'
+      ResourceRecords: !Split [ ',', '{{ $v.GuestHostedZoneNameServers }}' ]
+{{ end }}
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/hostpost/route_tables.go
+++ b/service/controller/v14patch1/templates/cloudformation/hostpost/route_tables.go
@@ -1,0 +1,23 @@
+package hostpost
+
+const RouteTables = `{{ define "route_tables" }}
+  {{- $v := .HostPost.RouteTables }}
+  {{ range $i, $t := $v.PrivateRouteTables }}
+  PrivateRoute{{$i}}:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: {{$t.RouteTableID}}
+      DestinationCidrBlock: {{$t.CidrBlock}}
+      VpcPeeringConnectionId: {{$t.PeerConnectionID}}
+  {{end}}
+
+  {{ range $i, $t := $v.PublicRouteTables }}
+  PublicRoute{{$i}}:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: {{$t.RouteTableID}}
+      DestinationCidrBlock: {{$t.CidrBlock}}
+      VpcPeeringConnectionId: {{$t.PeerConnectionID}}
+  {{ end }}
+
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/hostpre/iam_roles.go
+++ b/service/controller/v14patch1/templates/cloudformation/hostpre/iam_roles.go
@@ -1,0 +1,25 @@
+package hostpre
+
+const IAMRoles = `{{ define "iam_roles" }}
+{{- $v := .HostPre.IAMRoles }}
+  PeerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: {{ $v.PeerAccessRoleName }}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Principal:
+              AWS: '{{ $v.GuestAccountID }}'
+            Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 'ec2:AcceptVpcPeeringConnection'
+                Resource: '*'
+{{ end }}`

--- a/service/controller/v14patch1/templates/cloudformation/hostpre/main.go
+++ b/service/controller/v14patch1/templates/cloudformation/hostpre/main.go
@@ -1,0 +1,7 @@
+package hostpre
+
+const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
+Description: Main Host Pre-Guest CloudFormation stack.
+Resources:
+  {{template "iam_roles" .}}
+{{end}}`

--- a/service/controller/v14patch1/templates/templates.go
+++ b/service/controller/v14patch1/templates/templates.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+func Render(templates []string, data interface{}) (string, error) {
+	var err error
+
+	main := template.New("main")
+	for _, t := range templates {
+		main, err = main.Parse(t)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	var b bytes.Buffer
+	err = main.ExecuteTemplate(&b, "main", data)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return b.String(), nil
+}

--- a/service/controller/v14patch1/templates/templates_test.go
+++ b/service/controller/v14patch1/templates/templates_test.go
@@ -1,0 +1,25 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/giantswarm/aws-operator/service/controller/v14/templates"
+)
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+	tpl := "some string <{{.Value}}> another string"
+	d := struct {
+		Value string
+	}{"myvalue"}
+	expected := "some string <myvalue> another string"
+
+	actual, err := templates.Render([]string{tpl}, d)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if actual != expected {
+		t.Errorf("unexpected output, want %q, got %q", expected, actual)
+	}
+}

--- a/service/controller/v14patch1/version_bundle.go
+++ b/service/controller/v14patch1/version_bundle.go
@@ -1,0 +1,49 @@
+package v14
+
+import (
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "aws-operator",
+				Description: "Added Route53 support for BYOC accounts.",
+				Kind:        versionbundle.KindAdded,
+			},
+		},
+		Components: []versionbundle.Component{
+			{
+				Name:    "calico",
+				Version: "3.0.5",
+			},
+			{
+				Name:    "containerlinux",
+				Version: "1745.4.0",
+			},
+			{
+				Name:    "docker",
+				Version: "18.03.1",
+			},
+			{
+				Name:    "etcd",
+				Version: "3.3.3",
+			},
+			{
+				Name:    "coredns",
+				Version: "1.1.1",
+			},
+			{
+				Name:    "kubernetes",
+				Version: "1.10.4",
+			},
+			{
+				Name:    "nginx-ingress-controller",
+				Version: "0.12.0",
+			},
+		},
+		Name:    "aws-operator",
+		Version: "3.3.0",
+	}
+}


### PR DESCRIPTION
Adding patch release to disable ingress controller resources in k8scloudconfig. This is for migrating IC to chart-operator on K8s 1.10 clusters.