### PR TITLE
disable decrypting certs automatically on reboot

### DIFF
--- a/service/controller/v17/cloudconfig/worker_template.go
+++ b/service/controller/v17/cloudconfig/worker_template.go
@@ -168,7 +168,7 @@ func (e *WorkerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		{
 			AssetContent: cloudconfig.DecryptTLSAssetsService,
 			Name:         "decrypt-tls-assets.service",
-			Enable:       true,
+			Enable:       false,
 			Command:      "start",
 		},
 		{


### PR DESCRIPTION
this causes a race condition if a machine is rebooted. the systemd unit will be started before the new certificates are downloaded. we've fixed that in the master already. see: https://github.com/giantswarm/aws-operator/issues/658