### PR TITLE
v17: move cloudconfig out of controllercontext

### DIFF
--- a/service/controller/cluster_test.go
+++ b/service/controller/cluster_test.go
@@ -33,6 +33,7 @@ func newTestClusterConfig() ClusterConfig {
 		DeleteLoggingBucket: true,
 		ProjectName:         "aws-operator",
 		PubKeyFile:          "~/.ssh/id_rsa.pub",
+		RegistryDomain:      "quay.io",
 		SSOPublicKey:        "test",
 		EncrypterBackend:    "kms",
 	}

--- a/service/controller/v17/cluster_resource_set.go
+++ b/service/controller/v17/cluster_resource_set.go
@@ -155,6 +155,24 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		return nil, microerror.Maskf(invalidConfigError, "unknown encrypter backend %q", config.EncrypterBackend)
 	}
 
+	var cloudConfig *cloudconfig.CloudConfig
+	{
+		c := cloudconfig.Config{
+			Encrypter: encrypterObject,
+			Logger:    config.Logger,
+
+			OIDC: config.OIDC,
+			PodInfraContainerImage: config.PodInfraContainerImage,
+			RegistryDomain:         config.RegistryDomain,
+			SSOPublicKey:           config.SSOPublicKey,
+		}
+
+		cloudConfig, err = cloudconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var encryptionKeyResource controller.Resource
 	{
 		c := encryptionkey.Config{
@@ -239,6 +257,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	{
 		c := s3object.Config{
 			CertWatcher:       config.CertsSearcher,
+			CloudConfig:       cloudConfig,
 			Encrypter:         encrypterObject,
 			Logger:            config.Logger,
 			RandomKeySearcher: config.RandomkeysSearcher,
@@ -500,24 +519,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			}
 		}
 
-		var cloudConfig *cloudconfig.CloudConfig
-		{
-			c := cloudconfig.Config{
-				Encrypter: encrypterObject,
-				Logger:    config.Logger,
-
-				OIDC: config.OIDC,
-				PodInfraContainerImage: config.PodInfraContainerImage,
-				RegistryDomain:         config.RegistryDomain,
-				SSOPublicKey:           config.SSOPublicKey,
-			}
-
-			cloudConfig, err = cloudconfig.New(c)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		}
-
 		var ebsService ebs.Interface
 		{
 			c := ebs.Config{
@@ -545,7 +546,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		c := controllercontext.Context{
 			AWSClient:      awsClient,
 			AWSService:     awsService,
-			CloudConfig:    cloudConfig,
 			CloudFormation: *cloudFormationService,
 			EBSService:     ebsService,
 		}

--- a/service/controller/v17/controllercontext/context.go
+++ b/service/controller/v17/controllercontext/context.go
@@ -7,7 +7,6 @@ import (
 
 	awsclient "github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
-	"github.com/giantswarm/aws-operator/service/controller/v17/cloudconfig"
 	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v17/cloudformation"
 	"github.com/giantswarm/aws-operator/service/controller/v17/ebs"
 )
@@ -19,7 +18,6 @@ const controllerKey contextKey = "controller"
 type Context struct {
 	AWSClient      awsclient.Clients
 	AWSService     awsservice.Interface
-	CloudConfig    cloudconfig.Interface
 	CloudFormation cloudformationservice.CloudFormation
 	EBSService     ebs.Interface
 

--- a/service/controller/v17/resource/s3object/create_test.go
+++ b/service/controller/v17/resource/s3object/create_test.go
@@ -161,6 +161,7 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 	{
 		c := Config{}
 		c.CertWatcher = legacytest.NewService()
+		c.CloudConfig = cloudconfig
 		c.Encrypter = &encrypter.EncrypterMock{}
 		c.Logger = microloggertest.New()
 		c.RandomKeySearcher = randomkeystest.NewSearcher()
@@ -174,9 +175,8 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			c := controllercontext.Context{
-				AWSClient:   awsClients,
-				AWSService:  awsService,
-				CloudConfig: cloudconfig,
+				AWSClient:  awsClients,
+				AWSService: awsService,
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)

--- a/service/controller/v17/resource/s3object/current_test.go
+++ b/service/controller/v17/resource/s3object/current_test.go
@@ -75,6 +75,7 @@ func Test_CurrentState(t *testing.T) {
 			{
 				c := Config{}
 				c.CertWatcher = legacytest.NewService()
+				c.CloudConfig = cloudconfig
 				c.Encrypter = &encrypter.EncrypterMock{}
 				c.Logger = microloggertest.New()
 				c.RandomKeySearcher = randomkeystest.NewSearcher()
@@ -85,9 +86,8 @@ func Test_CurrentState(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient:   awsClients,
-				AWSService:  awsService,
-				CloudConfig: cloudconfig,
+				AWSClient:  awsClients,
+				AWSService: awsService,
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)

--- a/service/controller/v17/resource/s3object/desired.go
+++ b/service/controller/v17/resource/s3object/desired.go
@@ -55,7 +55,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	output := map[string]BucketObjectState{}
 
 	{
-		b, err := sc.CloudConfig.NewMasterTemplate(ctx, customObject, *tlsAssets, clusterKeys)
+		b, err := r.cloudConfig.NewMasterTemplate(ctx, customObject, *tlsAssets, clusterKeys)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -68,7 +68,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	{
-		b, err := sc.CloudConfig.NewWorkerTemplate(ctx, customObject, *tlsAssets)
+		b, err := r.cloudConfig.NewWorkerTemplate(ctx, customObject, *tlsAssets)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/v17/resource/s3object/desired_test.go
+++ b/service/controller/v17/resource/s3object/desired_test.go
@@ -69,6 +69,7 @@ func Test_DesiredState(t *testing.T) {
 				c.Logger = microloggertest.New()
 				c.Encrypter = &encrypter.EncrypterMock{}
 				c.CertWatcher = legacytest.NewService()
+				c.CloudConfig = cloudconfig
 				c.RandomKeySearcher = randomkeystest.NewSearcher()
 				newResource, err = New(c)
 				if err != nil {
@@ -77,9 +78,8 @@ func Test_DesiredState(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient:   awsClients,
-				AWSService:  awsService,
-				CloudConfig: cloudconfig,
+				AWSClient:  awsClients,
+				AWSService: awsService,
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)

--- a/service/controller/v17/resource/s3object/resource.go
+++ b/service/controller/v17/resource/s3object/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/randomkeys"
 
+	"github.com/giantswarm/aws-operator/service/controller/v17/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/controller/v17/encrypter"
 )
 
@@ -21,6 +22,7 @@ const (
 // Config represents the configuration used to create a new cloudformation resource.
 type Config struct {
 	CertWatcher       legacy.Searcher
+	CloudConfig       cloudconfig.Interface
 	Encrypter         encrypter.Interface
 	Logger            micrologger.Logger
 	RandomKeySearcher randomkeys.Interface
@@ -29,6 +31,7 @@ type Config struct {
 // Resource implements the cloudformation resource.
 type Resource struct {
 	certWatcher       legacy.Searcher
+	cloudConfig       cloudconfig.Interface
 	encrypter         encrypter.Interface
 	logger            micrologger.Logger
 	randomKeySearcher randomkeys.Interface
@@ -38,6 +41,9 @@ type Resource struct {
 func New(config Config) (*Resource, error) {
 	if config.CertWatcher == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.CertWatcher must not be empty")
+	}
+	if config.CloudConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CloudConfig must not be empty", config)
 	}
 	if config.Encrypter == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Encrypter must not be empty")
@@ -51,6 +57,7 @@ func New(config Config) (*Resource, error) {
 
 	r := &Resource{
 		certWatcher:       config.CertWatcher,
+		cloudConfig:       config.CloudConfig,
 		encrypter:         config.Encrypter,
 		logger:            config.Logger,
 		randomKeySearcher: config.RandomKeySearcher,

--- a/service/controller/v17/resource/s3object/update_test.go
+++ b/service/controller/v17/resource/s3object/update_test.go
@@ -154,6 +154,7 @@ func Test_Resource_S3Object_newUpdate(t *testing.T) {
 			{
 				c := Config{}
 				c.CertWatcher = legacytest.NewService()
+				c.CloudConfig = cloudconfig
 				c.Encrypter = &encrypter.EncrypterMock{}
 				c.Logger = microloggertest.New()
 				c.RandomKeySearcher = randomkeystest.NewSearcher()
@@ -165,9 +166,8 @@ func Test_Resource_S3Object_newUpdate(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient:   awsClients,
-				AWSService:  awsService,
-				CloudConfig: cloudconfig,
+				AWSClient:  awsClients,
+				AWSService: awsService,
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -27,6 +27,8 @@ func commonViperSettings(f *flag.Flag, v *viper.Viper) {
 
 	v.Set(f.Service.Kubernetes.Address, "http://127.0.0.1:6443")
 	v.Set(f.Service.Kubernetes.InCluster, "false")
+
+	v.Set(f.Service.RegistryDomain, "quay.io")
 }
 
 func Test_Service_New(t *testing.T) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3783

Removes some cyclic dependencies from encrypter package. Needed for further
refactorings. Also I believe explicit dependencies are better.