### PR TITLE
v17/encrypter/vault: make it more resource-like

### DIFF
--- a/service/controller/v17/encrypter/vault/vault.go
+++ b/service/controller/v17/encrypter/vault/vault.go
@@ -302,9 +302,7 @@ func (e *Encrypter) EnsureCreatedAuthorizedIAMRoles(ctx context.Context, customO
 	{
 		e.logger.LogCtx(ctx, "level", "debug", "message", "finding decrypter AWS auth role")
 
-		p := authAWSRolePath(decrypterVaultRole)
-
-		roleData, err = e.getAWSAuthRole(p)
+		roleData, err = e.getAWSAuthRole(decrypterVaultRole)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -359,9 +357,7 @@ func (e *Encrypter) EnsureDeletedAuthorizedIAMRoles(ctx context.Context, customO
 	{
 		e.logger.LogCtx(ctx, "level", "debug", "message", "finding out decrypter AWS auth role")
 
-		p := authAWSRolePath(decrypterVaultRole)
-
-		roleData, err = e.getAWSAuthRole(p)
+		roleData, err = e.getAWSAuthRole(decrypterVaultRole)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3783.

Splitting https://github.com/giantswarm/aws-operator/pull/1170 into smaller chunks. Something was not working during my manual testing.


Changes:
- Added scopes.
- Added logging.