### PR TITLE
include memleak patch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -312,7 +312,7 @@
     "v_3_6_0",
     "v_3_6_1"
   ]
-  revision = "cde5c654f6e4e51ea2cb992fdbed2ab3bf188dff"
+  revision = "f006b0a1fd85172bfb34fca24ad60b82de50eb75"
 
 [[projects]]
   branch = "master"

--- a/service/controller/v17/cloudconfig/master_template.go
+++ b/service/controller/v17/cloudconfig/master_template.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs/legacy"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeys"
 

--- a/service/controller/v17/cloudconfig/worker_template.go
+++ b/service/controller/v17/cloudconfig/worker_template.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs/legacy"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/v17/templates/cloudconfig"

--- a/service/controller/v17/version_bundle.go
+++ b/service/controller/v17/version_bundle.go
@@ -22,6 +22,21 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Set higher timeouts for NVME driver.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "calico",
+				Description: "Updated calico to 3.2.0.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "kubernetes",
+				Description: "Patched Kubernetes v1.11.1 with apimachinery fix to plug apiserver memory leak.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Set higher timeouts for NVME driver.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/v18/cloudconfig/master_template.go
+++ b/service/controller/v18/cloudconfig/master_template.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs/legacy"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeys"
 

--- a/service/controller/v18/cloudconfig/worker_template.go
+++ b/service/controller/v18/cloudconfig/worker_template.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs/legacy"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_6_1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/v18/templates/cloudconfig"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4287

Using k8scc `v_3_6_1` (which includes the 1.11 mem leak fix) in both `v17` and `v18`.