### PR TITLE
adds elb collector

### DIFF
--- a/service/collector/aws.go
+++ b/service/collector/aws.go
@@ -11,6 +11,16 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v15/credential"
 )
 
+const (
+	ClusterTag      = "giantswarm.io/cluster"
+	InstallationTag = "giantswarm.io/installation"
+	OrganizationTag = "giantswarm.io/organization"
+
+	ClusterLabel      = "cluster_id"
+	InstallationLabel = "installation"
+	OrganizationLabel = "organization"
+)
+
 // getARNs list all unique aws IAM ARN from credential secret.
 func (c Collector) getARNs() ([]string, error) {
 	var arns []string

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -129,8 +129,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 	collectFuncs := []func(chan<- prometheus.Metric, []awsutil.Clients){
 		c.collectClusterInfo,
-		c.collectAccountsVPCs,
 		c.collectAccountsELBs,
+		c.collectAccountsVPCs,
 	}
 
 	if c.trustedAdvisorEnabled {

--- a/service/collector/elb.go
+++ b/service/collector/elb.go
@@ -1,0 +1,136 @@
+package collector
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	AccountLabel = "account"
+)
+
+var (
+	elbsDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, "", "elb_instance_out_of_service_count"),
+		"Gauge about ELB instances being out of service.",
+		[]string{
+			AccountLabel,
+			ClusterLabel,
+			InstallationLabel,
+			OrganizationLabel,
+		},
+		nil,
+	)
+)
+
+func (c *Collector) collectAccountsELBs(ch chan<- prometheus.Metric, clients []aws.Clients) {
+	var wg sync.WaitGroup
+
+	for _, client := range clients {
+		wg.Add(1)
+		go func(awsClients aws.Clients) {
+			defer wg.Done()
+			err := c.collectELBs(ch, awsClients)
+			if err != nil {
+				c.logger.Log("level", "error", "message", "failed collecting ELB metrics", "stack", fmt.Sprintf("%#v", err))
+			}
+		}(client)
+	}
+
+	wg.Wait()
+}
+
+func (c *Collector) collectELBs(ch chan<- prometheus.Metric, awsClients aws.Clients) error {
+	c.logger.Log("level", "debug", "message", "collecting metrics for elbs")
+
+	account, err := c.awsAccountID(awsClients)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var loadbalancers []*elb.LoadBalancerDescription
+	{
+		i := &elb.DescribeLoadBalancersInput{}
+		o, err := awsClients.ELB.DescribeLoadBalancers(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		loadbalancers = o.LoadBalancerDescriptions
+	}
+
+	for _, l := range loadbalancers {
+		var tags []*elb.Tag
+		{
+			i := &elb.DescribeTagsInput{
+				LoadBalancerNames: []*string{
+					l.LoadBalancerName,
+				},
+			}
+
+			o, err := awsClients.ELB.DescribeTags(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			for _, d := range o.TagDescriptions {
+				tags = append(tags, d.Tags...)
+			}
+		}
+
+		var cluster string
+		var installation string
+		var organization string
+		for _, t := range tags {
+			if *t.Key == ClusterTag {
+				cluster = *t.Value
+			}
+			if *t.Key == InstallationTag {
+				installation = *t.Value
+			}
+			if *t.Key == OrganizationTag {
+				organization = *t.Value
+			}
+		}
+
+		if installation != c.installationName {
+			continue
+		}
+
+		var count float64
+		{
+			i := &elb.DescribeInstanceHealthInput{
+				Instances:        l.Instances,
+				LoadBalancerName: l.LoadBalancerName,
+			}
+
+			o, err := awsClients.ELB.DescribeInstanceHealth(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			for _, s := range o.InstanceStates {
+				if *s.State == "OutOfService" {
+					count++
+				}
+			}
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			elbsDesc,
+			prometheus.GaugeValue,
+			count,
+			account,
+			cluster,
+			installation,
+			organization,
+		)
+	}
+
+	c.logger.Log("level", "debug", "message", "collected metrics for elbs")
+
+	return nil
+}

--- a/service/collector/elb.go
+++ b/service/collector/elb.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	AccountLabel = "account"
+	ELBLabel     = "elb"
 )
 
 var (
@@ -20,6 +21,7 @@ var (
 		prometheus.BuildFQName(Namespace, "", "elb_instance_out_of_service_count"),
 		"Gauge about ELB instances being out of service.",
 		[]string{
+			ELBLabel,
 			AccountLabel,
 			ClusterLabel,
 			InstallationLabel,
@@ -123,6 +125,7 @@ func (c *Collector) collectELBs(ch chan<- prometheus.Metric, awsClients aws.Clie
 			elbsDesc,
 			prometheus.GaugeValue,
 			count,
+			*l.LoadBalancerName,
 			account,
 			cluster,
 			installation,

--- a/service/collector/elb.go
+++ b/service/collector/elb.go
@@ -16,6 +16,10 @@ const (
 	ELBLabel     = "elb"
 )
 
+const (
+	StateOutOfService = "OutOfService"
+)
+
 var (
 	elbsDesc *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, "", "elb_instance_out_of_service_count"),
@@ -115,7 +119,7 @@ func (c *Collector) collectELBs(ch chan<- prometheus.Metric, awsClients aws.Clie
 				return microerror.Mask(err)
 			}
 			for _, s := range o.InstanceStates {
-				if *s.State == "OutOfService" {
+				if *s.State == StateOutOfService {
 					count++
 				}
 			}

--- a/service/collector/error.go
+++ b/service/collector/error.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -10,6 +11,24 @@ const (
 	// if Trusted Advisor is not supported (support plan is not Business or Enterprise).
 	trustedAdvisorSubscriptionRequiredExceptionCode = "SubscriptionRequiredException"
 )
+
+var alreadyRegisteredError = &microerror.Error{
+	Kind: "alreadyRegisteredError",
+}
+
+// IsAlreadyRegisteredError asserts alreadyRegisteredError.
+func IsAlreadyRegisteredError(err error) bool {
+	c := microerror.Cause(err)
+	_, ok := c.(prometheus.AlreadyRegisteredError)
+	if ok {
+		return true
+	}
+	if c == alreadyRegisteredError {
+		return true
+	}
+
+	return false
+}
 
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",

--- a/service/collector/vpc.go
+++ b/service/collector/vpc.go
@@ -11,23 +11,15 @@ import (
 )
 
 const (
-	ClusterTag      = "giantswarm.io/cluster"
-	InstallationTag = "giantswarm.io/installation"
-	NameTag         = "Name"
-	OrganizationTag = "giantswarm.io/organization"
-	StackNameTag    = "aws:cloudformation:stack-name"
+	NameTag      = "Name"
+	StackNameTag = "aws:cloudformation:stack-name"
 
-	GaugeValue float64 = 1
-
-	AccountIdLabel    = "account_id"
-	CidrLabel         = "cidr"
-	ClusterLabel      = "cluster_id"
-	IDLabel           = "id"
-	InstallationLabel = "installation"
-	NameLabel         = "name"
-	OrganizationLabel = "organization"
-	StackNameLabel    = "stack_name"
-	StateLabel        = "state"
+	AccountIdLabel = "account_id"
+	CidrLabel      = "cidr"
+	IDLabel        = "id"
+	NameLabel      = "name"
+	StackNameLabel = "stack_name"
+	StateLabel     = "state"
 )
 
 var (
@@ -78,15 +70,6 @@ func (c *Collector) collectVPCs(ch chan<- prometheus.Metric, awsClients aws.Clie
 	}
 
 	for _, vpc := range o.Vpcs {
-		installationName := installationFromTags(vpc.Tags)
-
-		c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' belongs to installation '%s'", *vpc.VpcId, installationName))
-		if installationName != c.installationName {
-			c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' is being skipped for metrics collection", *vpc.VpcId))
-			continue
-		}
-		c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' is being used for metrics collection", *vpc.VpcId))
-
 		cluster := ""
 		installation := ""
 		name := ""
@@ -111,6 +94,13 @@ func (c *Collector) collectVPCs(ch chan<- prometheus.Metric, awsClients aws.Clie
 			}
 		}
 
+		c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' belongs to installation '%s'", *vpc.VpcId, installation))
+		if installation != c.installationName {
+			c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' is being skipped for metrics collection", *vpc.VpcId))
+			continue
+		}
+		c.logger.Log("level", "debug", "message", fmt.Sprintf("VPC '%s' is being used for metrics collection", *vpc.VpcId))
+
 		ch <- prometheus.MustNewConstMetric(
 			vpcsDesc,
 			prometheus.GaugeValue,
@@ -128,20 +118,4 @@ func (c *Collector) collectVPCs(ch chan<- prometheus.Metric, awsClients aws.Clie
 	}
 
 	c.logger.Log("level", "debug", "message", "finished collecting metrics for vpcs")
-}
-
-func installationFromTags(tags []*ec2.Tag) string {
-	for _, t := range tags {
-		if *t.Key == InstallationTag {
-			return *t.Value
-		}
-
-		// TODO the old hard coded tag "Installation" should be removed at some
-		// point. Then we can get rid of this extra check.
-		if *t.Key == "Installation" {
-			return *t.Value
-		}
-	}
-
-	return ""
 }

--- a/service/service.go
+++ b/service/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/client/k8srestconfig"
 	"github.com/giantswarm/statusresource"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -274,7 +273,6 @@ func New(config Config) (*Service, error) {
 
 func (s *Service) Boot(ctx context.Context) {
 	s.bootOnce.Do(func() {
-		prometheus.MustRegister(s.metricsCollector)
 		go s.metricsCollector.Boot(ctx)
 		go s.statusResourceCollector.Boot(ctx)
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4298. Also see https://github.com/giantswarm/g8s-prometheus/pull/357. 

```
# HELP aws_operator_elb_instance_out_of_service_count Gauge about ELB instances being out of service.
# TYPE aws_operator_elb_instance_out_of_service_count gauge
aws_operator_elb_instance_out_of_service_count{account="084190472784",cluster_id="",elb="gauss-master",installation="gauss",organization=""} 0
aws_operator_elb_instance_out_of_service_count{account="084190472784",cluster_id="",elb="gauss-vault",installation="gauss",organization=""} 0
aws_operator_elb_instance_out_of_service_count{account="084190472784",cluster_id="",elb="gauss-worker",installation="gauss",organization=""} 0
aws_operator_elb_instance_out_of_service_count{account="270935918670",cluster_id="nt7aa",elb="nt7aa-api",installation="gauss",organization="giantswarm"} 1
aws_operator_elb_instance_out_of_service_count{account="270935918670",cluster_id="nt7aa",elb="nt7aa-ingress",installation="gauss",organization="giantswarm"} 2
aws_operator_elb_instance_out_of_service_count{account="270935918670",cluster_id="yh66d",elb="yh66d-api",installation="gauss",organization="giantswarm"} 0
aws_operator_elb_instance_out_of_service_count{account="270935918670",cluster_id="yh66d",elb="yh66d-ingress",installation="gauss",organization="giantswarm"} 0
```