### PR TITLE
v18/templates/cloudformation: fix API LB creation race

### DIFF
--- a/service/controller/v18/templates/cloudformation/guest/load_balancers.go
+++ b/service/controller/v18/templates/cloudformation/guest/load_balancers.go
@@ -4,6 +4,8 @@ const LoadBalancers = `{{define "load_balancers"}}
 {{- $v := .Guest.LoadBalancers }}
   ApiLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       ConnectionSettings:
         IdleTimeout: 1200
@@ -31,7 +33,8 @@ const LoadBalancers = `{{define "load_balancers"}}
 
   IngressLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
-    DependsOn: VPCGatewayAttachment
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       ConnectionSettings:
         IdleTimeout: 60


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.
Towards https://github.com/giantswarm/giantswarm/issues/4338.

This should fix the error:

	VPC vpc-0ab5f5351864dad88 has no internet gateway (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: InvalidSubnet; Request ID: cd0e87fb-dc17-11e8-923e-cd6ca8bbbc58)