### PR TITLE
v17/templates/cloudformation: backport fix API LB creation race

### DIFF
--- a/service/controller/v17/templates/cloudformation/guest/load_balancers.go
+++ b/service/controller/v17/templates/cloudformation/guest/load_balancers.go
@@ -4,6 +4,8 @@ const LoadBalancers = `{{define "load_balancers"}}
 {{- $v := .Guest.LoadBalancers }}
   ApiLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       ConnectionSettings:
         IdleTimeout: 1200
@@ -31,7 +33,8 @@ const LoadBalancers = `{{define "load_balancers"}}
 
   IngressLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
-    DependsOn: VPCGatewayAttachment
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       ConnectionSettings:
         IdleTimeout: 60


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.
Towards https://github.com/giantswarm/giantswarm/issues/4338.

This is backport of https://github.com/giantswarm/aws-operator/pull/1231 to v17.

I think we should backport is because it (at least partially) solves `k8s API is still down` issue.