### PR TITLE
v17, v18: fix nat gateway creation race

### DIFF
--- a/service/controller/v17/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v17/templates/cloudformation/guest/nat_gateway.go
@@ -4,6 +4,8 @@ const NatGateway = `{{define "nat_gateway"}}
   {{- $v := .Guest.NATGateway }}
   NATGateway:
     Type: AWS::EC2::NatGateway
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       AllocationId:
         Fn::GetAtt:

--- a/service/controller/v18/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v18/templates/cloudformation/guest/nat_gateway.go
@@ -4,6 +4,8 @@ const NatGateway = `{{define "nat_gateway"}}
   {{- $v := .Guest.NATGateway }}
   NATGateway:
     Type: AWS::EC2::NatGateway
+    DependsOn:
+      - VPCGatewayAttachment
     Properties:
       AllocationId:
         Fn::GetAtt:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.
Towards https://github.com/giantswarm/giantswarm/issues/4338.

This should fix the error:

	NatGateway nat-0b029ecb4621bff2a is in state failed and hence failed to stabilize. Detailed failure message: Network vpc-09c4137b451be0b1f has no Internet gateway attached