### PR TITLE
v18/resource/cloudformation: increase stack creation timeout to 20m

### DIFF
--- a/service/controller/v18/resource/cloudformation/spec.go
+++ b/service/controller/v18/resource/cloudformation/spec.go
@@ -5,7 +5,7 @@ import "github.com/aws/aws-sdk-go/service/cloudformation"
 const (
 	// defaultCreationTimeout is the timeout in minutes for the creation of the
 	// stack.
-	defaultCreationTimeout = 10
+	defaultCreationTimeout = 20
 
 	workerRoleKey = "WorkerRole"
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.

We hit timeouts in e2e tests when we create a lot of stacks for w/e reason. E.g. https://github.com/giantswarm/giantswarm/issues/4481#issuecomment-435873873.