### PR TITLE
v19/cloudconfig: extract baseExtension type to its own file

### DIFF
--- a/service/controller/v19/cloudconfig/base_extension.go
+++ b/service/controller/v19/cloudconfig/base_extension.go
@@ -1,0 +1,69 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/aws-operator/service/controller/v19/encrypter"
+	"github.com/giantswarm/aws-operator/service/controller/v19/encrypter/vault"
+	"github.com/giantswarm/microerror"
+)
+
+type baseExtension struct {
+	customObject  v1alpha1.AWSConfig
+	encrypter     encrypter.Interface
+	encryptionKey string
+}
+
+func (e *baseExtension) templateData() templateData {
+	var encrypterType string
+	var vaultAddress string
+	v, ok := e.encrypter.(*vault.Encrypter)
+	if ok {
+		encrypterType = encrypter.VaultBackend
+		vaultAddress = v.Address()
+	} else {
+		encrypterType = encrypter.KMSBackend
+	}
+	data := templateData{
+		AWSConfigSpec: e.customObject.Spec,
+		EncrypterType: encrypterType,
+		VaultAddress:  vaultAddress,
+		EncryptionKey: e.encryptionKey,
+	}
+
+	return data
+}
+
+func (e *baseExtension) encryptAndGzip(ctx context.Context, data []byte) ([]byte, error) {
+	var encrypted []byte
+	{
+		e, err := e.encrypter.Encrypt(ctx, e.encryptionKey, string(data))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		encrypted = []byte(e)
+	}
+
+	var gzipped []byte
+	{
+		buf := new(bytes.Buffer)
+		w := gzip.NewWriter(buf)
+
+		_, err := w.Write(encrypted)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		err = w.Close()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		gzipped = buf.Bytes()
+	}
+
+	return gzipped, nil
+}

--- a/service/controller/v19/cloudconfig/spec.go
+++ b/service/controller/v19/cloudconfig/spec.go
@@ -1,82 +1,8 @@
 package cloudconfig
 
 import (
-	"bytes"
-	"compress/gzip"
-	"context"
-
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/aws-operator/service/controller/v19/encrypter"
-	"github.com/giantswarm/aws-operator/service/controller/v19/encrypter/vault"
-	"github.com/giantswarm/microerror"
 )
-
-// TemplateData is a composed data type that adds encrypter type info to
-// AWSConfigSpec.
-type TemplateData struct {
-	v1alpha1.AWSConfigSpec
-	EncrypterType string
-	VaultAddress  string
-	EncryptionKey string
-}
-
-type baseExtension struct {
-	customObject  v1alpha1.AWSConfig
-	encrypter     encrypter.Interface
-	encryptionKey string
-}
-
-func (e *baseExtension) templateData() TemplateData {
-	var encrypterType string
-	var vaultAddress string
-	v, ok := e.encrypter.(*vault.Encrypter)
-	if ok {
-		encrypterType = encrypter.VaultBackend
-		vaultAddress = v.Address()
-	} else {
-		encrypterType = encrypter.KMSBackend
-	}
-	data := TemplateData{
-		AWSConfigSpec: e.customObject.Spec,
-		EncrypterType: encrypterType,
-		VaultAddress:  vaultAddress,
-		EncryptionKey: e.encryptionKey,
-	}
-
-	return data
-}
-
-func (e *baseExtension) encryptAndGzip(ctx context.Context, data []byte) ([]byte, error) {
-	var encrypted []byte
-	{
-		e, err := e.encrypter.Encrypt(ctx, e.encryptionKey, string(data))
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		encrypted = []byte(e)
-	}
-
-	var gzipped []byte
-	{
-		buf := new(bytes.Buffer)
-		w := gzip.NewWriter(buf)
-
-		_, err := w.Write(encrypted)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		err = w.Close()
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		gzipped = buf.Bytes()
-	}
-
-	return gzipped, nil
-}
 
 type KMSClient interface {
 	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)

--- a/service/controller/v19/cloudconfig/types.go
+++ b/service/controller/v19/cloudconfig/types.go
@@ -1,0 +1,12 @@
+package cloudconfig
+
+import "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+
+// templateData is a composed data type that adds encrypter type info to
+// AWSConfigSpec.
+type templateData struct {
+	v1alpha1.AWSConfigSpec
+	EncrypterType string
+	VaultAddress  string
+	EncryptionKey string
+}


### PR DESCRIPTION
Follow up of https://github.com/giantswarm/aws-operator/pull/1200#discussion_r229022868