### PR TITLE
integration/env: restore session token env variables

### DIFF
--- a/integration/env/aws.go
+++ b/integration/env/aws.go
@@ -1,3 +1,5 @@
+// +build k8srequired
+
 package env
 
 import (

--- a/integration/env/aws.go
+++ b/integration/env/aws.go
@@ -1,5 +1,3 @@
-// +build k8srequired
-
 package env
 
 import (
@@ -14,8 +12,10 @@ const (
 	EnvVarGuestAWSARN               = "GUEST_AWS_ARN"
 	EnvVarGuestAWSAccessKeyID       = "GUEST_AWS_ACCESS_KEY_ID"
 	EnvVarGuestAWSAccessKeySecret   = "GUEST_AWS_SECRET_ACCESS_KEY"
+	EnvVarGuestAWSAccessKeyToken    = "GUEST_AWS_SESSION_TOKEN"
 	EnvVarHostAWSAccessKeyID        = "HOST_AWS_ACCESS_KEY_ID"
 	EnvVarHostAWSAccessKeySecret    = "HOST_AWS_SECRET_ACCESS_KEY"
+	EnvVarHostAWSAccessKeyToken     = "HOST_AWS_SESSION_TOKEN"
 	EnvVarIDRSAPub                  = "IDRSA_PUB"
 )
 
@@ -26,8 +26,10 @@ var (
 	guestAWSARN               string
 	guestAWSAccessKeyID       string
 	guestAWSAccessKeySecret   string
+	guestAWSAccessKeyToken    string
 	hostAWSAccessKeyID        string
 	hostAWSAccessKeySecret    string
+	hostAWSAccessKeyToken     string
 	idRSAPub                  string
 )
 
@@ -62,6 +64,8 @@ func init() {
 		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarGuestAWSAccessKeySecret))
 	}
 
+	guestAWSAccessKeyToken = os.Getenv(EnvVarGuestAWSAccessKeyToken)
+
 	hostAWSAccessKeyID = os.Getenv(EnvVarHostAWSAccessKeyID)
 	if hostAWSAccessKeyID == "" {
 		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarHostAWSAccessKeyID))
@@ -71,6 +75,8 @@ func init() {
 	if hostAWSAccessKeySecret == "" {
 		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarHostAWSAccessKeySecret))
 	}
+
+	hostAWSAccessKeyToken = os.Getenv(EnvVarHostAWSAccessKeyToken)
 
 	idRSAPub = os.Getenv(EnvVarIDRSAPub)
 	if idRSAPub == "" {
@@ -111,7 +117,7 @@ func GuestAWSAccessKeySecret() string {
 }
 
 func GuestAWSAccessKeyToken() string {
-	return ""
+	return guestAWSAccessKeyToken
 }
 
 func HostAWSAccessKeyID() string {
@@ -123,7 +129,7 @@ func HostAWSAccessKeySecret() string {
 }
 
 func HostAWSAccessKeyToken() string {
-	return ""
+	return hostAWSAccessKeyToken
 }
 
 func IDRSAPub() string {


### PR DESCRIPTION
This might be actually useful for local testing. No reason to always put
empty string there.