### PR TITLE
removes unused key function for deprecated cluster version

### DIFF
--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -221,10 +221,6 @@ func ClusterTags(customObject v1alpha1.AWSConfig, installationName string) map[s
 	return tags
 }
 
-func ClusterVersion(customObject v1alpha1.AWSConfig) string {
-	return customObject.Spec.Cluster.Version
-}
-
 func CustomerID(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
 }

--- a/service/controller/v19/key/key_test.go
+++ b/service/controller/v19/key/key_test.go
@@ -216,25 +216,6 @@ func Test_ClusterTags(t *testing.T) {
 	}
 }
 
-func Test_ClusterVersion(t *testing.T) {
-	t.Parallel()
-	expectedVersion := "v_0_1_0"
-
-	cluster := v1alpha1.Cluster{
-		Version: expectedVersion,
-	}
-
-	customObject := v1alpha1.AWSConfig{
-		Spec: v1alpha1.AWSConfigSpec{
-			Cluster: cluster,
-		},
-	}
-
-	if ClusterVersion(customObject) != expectedVersion {
-		t.Fatalf("Expected cluster version %s but was %s", expectedVersion, ClusterVersion(customObject))
-	}
-}
-
 func Test_EC2ServiceDomain(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
Some little sweet boyscouting. Just cleaning this up smoothly. Later when older releases are gone we can also cleanup `apiextensions`. 