### PR TITLE
Improve legacy tenant subnet CIDR detection

### DIFF
--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -39,15 +39,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		//
 		//     https://github.com/giantswarm/giantswarm/issues/4192
 		//
-		if key.CIDR(customObject) != "" {
+		_, presentSubnet, err := net.ParseCIDR(key.CIDR(customObject))
+		if err == nil {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found out allocated cluster CIDR from legacy field in CR")
 
-			_, c, err := net.ParseCIDR(key.CIDR(customObject))
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
-			subnetCIDR = *c
+			subnetCIDR = *presentSubnet
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find out allocated subnet for cluster")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "allocating subnet for cluster")


### PR DESCRIPTION
When checking AWSConfig CR if there's a tenant subnet already allocated
in legacy CIDR field, improve the check so that if it's a proper CIDR
then use it and otherwise proceed with new subnet allocation.

This way we can either use empty string or "DEPRECATED" etc. in legacy
CIDR field for migration period.