### PR TITLE
moves constants from spec file to key package

### DIFF
--- a/service/controller/v19/adapter/adapter_key.go
+++ b/service/controller/v19/adapter/adapter_key.go
@@ -2,10 +2,6 @@ package adapter
 
 import "github.com/giantswarm/aws-operator/service/controller/v19/key"
 
-func asgType(config Config) string {
-	return prefixWorker
-}
-
 func baseDomain(config Config) string {
 	return key.BaseDomain(config.CustomObject)
 }

--- a/service/controller/v19/adapter/guest_auto_scaling_group.go
+++ b/service/controller/v19/adapter/guest_auto_scaling_group.go
@@ -29,7 +29,7 @@ func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
 	a.WorkerAZ = key.AvailabilityZone(cfg.CustomObject)
 	a.ASGMaxSize = workers + 1
 	a.ASGMinSize = workers
-	a.ASGType = asgType(cfg)
+	a.ASGType = key.PrefixWorker
 	a.ClusterID = clusterID(cfg)
 	a.MaxBatchSize = workerCountRatio(workers, asgMaxBatchSizeRatio)
 	a.MinInstancesInService = workerCountRatio(workers, asgMinInstancesRatio)

--- a/service/controller/v19/adapter/guest_auto_scaling_group.go
+++ b/service/controller/v19/adapter/guest_auto_scaling_group.go
@@ -29,7 +29,7 @@ func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
 	a.WorkerAZ = key.AvailabilityZone(cfg.CustomObject)
 	a.ASGMaxSize = workers + 1
 	a.ASGMinSize = workers
-	a.ASGType = key.PrefixWorker
+	a.ASGType = key.KindWorker
 	a.ClusterID = clusterID(cfg)
 	a.MaxBatchSize = workerCountRatio(workers, asgMaxBatchSizeRatio)
 	a.MinInstancesInService = workerCountRatio(workers, asgMinInstancesRatio)

--- a/service/controller/v19/adapter/guest_iam_policies.go
+++ b/service/controller/v19/adapter/guest_iam_policies.go
@@ -28,9 +28,9 @@ func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
 	clusterID := key.ClusterID(cfg.CustomObject)
 
 	i.EC2ServiceDomain = key.EC2ServiceDomain(cfg.CustomObject)
-	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, prefixMaster)
-	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, prefixMaster)
-	i.MasterRoleName = key.RoleName(cfg.CustomObject, prefixMaster)
+	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, key.PrefixMaster)
+	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, key.PrefixMaster)
+	i.MasterRoleName = key.RoleName(cfg.CustomObject, key.PrefixMaster)
 	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, prefixWorker)
 	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, prefixWorker)
 	i.WorkerRoleName = key.RoleName(cfg.CustomObject, prefixWorker)

--- a/service/controller/v19/adapter/guest_iam_policies.go
+++ b/service/controller/v19/adapter/guest_iam_policies.go
@@ -31,9 +31,9 @@ func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
 	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, key.PrefixMaster)
 	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, key.PrefixMaster)
 	i.MasterRoleName = key.RoleName(cfg.CustomObject, key.PrefixMaster)
-	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, prefixWorker)
-	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, prefixWorker)
-	i.WorkerRoleName = key.RoleName(cfg.CustomObject, prefixWorker)
+	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, key.PrefixWorker)
+	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, key.PrefixWorker)
+	i.WorkerRoleName = key.RoleName(cfg.CustomObject, key.PrefixWorker)
 	i.RegionARN = key.RegionARN(cfg.CustomObject)
 
 	// KMSKeyARN

--- a/service/controller/v19/adapter/guest_iam_policies.go
+++ b/service/controller/v19/adapter/guest_iam_policies.go
@@ -28,12 +28,12 @@ func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
 	clusterID := key.ClusterID(cfg.CustomObject)
 
 	i.EC2ServiceDomain = key.EC2ServiceDomain(cfg.CustomObject)
-	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, key.PrefixMaster)
-	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, key.PrefixMaster)
-	i.MasterRoleName = key.RoleName(cfg.CustomObject, key.PrefixMaster)
-	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, key.PrefixWorker)
-	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, key.PrefixWorker)
-	i.WorkerRoleName = key.RoleName(cfg.CustomObject, key.PrefixWorker)
+	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, key.KindMaster)
+	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, key.KindMaster)
+	i.MasterRoleName = key.RoleName(cfg.CustomObject, key.KindMaster)
+	i.WorkerPolicyName = key.PolicyName(cfg.CustomObject, key.KindWorker)
+	i.WorkerProfileName = key.InstanceProfileName(cfg.CustomObject, key.KindWorker)
+	i.WorkerRoleName = key.RoleName(cfg.CustomObject, key.KindWorker)
 	i.RegionARN = key.RegionARN(cfg.CustomObject)
 
 	// KMSKeyARN

--- a/service/controller/v19/adapter/guest_instance.go
+++ b/service/controller/v19/adapter/guest_instance.go
@@ -66,9 +66,9 @@ func (i *GuestInstanceAdapter) Adapt(config Config) error {
 		c := SmallCloudconfigConfig{
 			Region:    key.Region(config.CustomObject),
 			Registry:  key.AWSCliContainerRegistry(config.CustomObject),
-			Role:      key.PrefixMaster,
-			S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.PrefixMaster),
-			S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.PrefixMaster),
+			Role:      key.KindMaster,
+			S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.KindMaster),
+			S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.KindMaster),
 		}
 		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 		if err != nil {

--- a/service/controller/v19/adapter/guest_instance.go
+++ b/service/controller/v19/adapter/guest_instance.go
@@ -66,9 +66,9 @@ func (i *GuestInstanceAdapter) Adapt(config Config) error {
 		c := SmallCloudconfigConfig{
 			Region:    key.Region(config.CustomObject),
 			Registry:  key.AWSCliContainerRegistry(config.CustomObject),
-			Role:      prefixMaster,
-			S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, prefixMaster),
-			S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, prefixMaster),
+			Role:      key.PrefixMaster,
+			S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.PrefixMaster),
+			S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.PrefixMaster),
 		}
 		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 		if err != nil {

--- a/service/controller/v19/adapter/guest_launch_configuration.go
+++ b/service/controller/v19/adapter/guest_launch_configuration.go
@@ -28,7 +28,7 @@ type BlockDeviceMapping struct {
 }
 
 func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
-	l.ASGType = key.PrefixWorker
+	l.ASGType = key.KindWorker
 	l.WorkerInstanceType = key.WorkerInstanceType(config.CustomObject)
 	l.WorkerImageID = workerImageID(config)
 	l.WorkerAssociatePublicIPAddress = false
@@ -55,9 +55,9 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 	c := SmallCloudconfigConfig{
 		Region:    key.Region(config.CustomObject),
 		Registry:  key.AWSCliContainerRegistry(config.CustomObject),
-		Role:      key.PrefixWorker,
-		S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.PrefixWorker),
-		S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.PrefixWorker),
+		Role:      key.KindWorker,
+		S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.KindWorker),
+		S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.KindWorker),
 	}
 	rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 	if err != nil {

--- a/service/controller/v19/adapter/guest_launch_configuration.go
+++ b/service/controller/v19/adapter/guest_launch_configuration.go
@@ -28,7 +28,7 @@ type BlockDeviceMapping struct {
 }
 
 func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
-	l.ASGType = asgType(config)
+	l.ASGType = key.PrefixWorker
 	l.WorkerInstanceType = key.WorkerInstanceType(config.CustomObject)
 	l.WorkerImageID = workerImageID(config)
 	l.WorkerAssociatePublicIPAddress = false
@@ -55,9 +55,9 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 	c := SmallCloudconfigConfig{
 		Region:    key.Region(config.CustomObject),
 		Registry:  key.AWSCliContainerRegistry(config.CustomObject),
-		Role:      prefixWorker,
-		S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, prefixWorker),
-		S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, prefixWorker),
+		Role:      key.PrefixWorker,
+		S3HTTPURL: key.SmallCloudConfigS3HTTPURL(config.CustomObject, accountID, key.PrefixWorker),
+		S3URL:     key.SmallCloudConfigS3URL(config.CustomObject, accountID, key.PrefixWorker),
 	}
 	rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 	if err != nil {

--- a/service/controller/v19/adapter/guest_launch_configuration_test.go
+++ b/service/controller/v19/adapter/guest_launch_configuration_test.go
@@ -102,8 +102,8 @@ func Test_AdapterLaunchConfiguration_RegularFields(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if a.Guest.LaunchConfiguration.ASGType != prefixWorker {
-				t.Errorf("unexpected ASGType, got %q, want %q", a.Guest.LaunchConfiguration.ASGType, prefixWorker)
+			if a.Guest.LaunchConfiguration.ASGType != key.PrefixWorker {
+				t.Errorf("unexpected ASGType, got %q, want %q", a.Guest.LaunchConfiguration.ASGType, key.PrefixWorker)
 			}
 			if a.Guest.LaunchConfiguration.WorkerInstanceType != tc.expectedInstanceType {
 				t.Errorf("unexpected InstanceType, got %q, want %q", a.Guest.LaunchConfiguration.WorkerInstanceType, tc.expectedInstanceType)

--- a/service/controller/v19/adapter/guest_launch_configuration_test.go
+++ b/service/controller/v19/adapter/guest_launch_configuration_test.go
@@ -102,8 +102,8 @@ func Test_AdapterLaunchConfiguration_RegularFields(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if a.Guest.LaunchConfiguration.ASGType != key.PrefixWorker {
-				t.Errorf("unexpected ASGType, got %q, want %q", a.Guest.LaunchConfiguration.ASGType, key.PrefixWorker)
+			if a.Guest.LaunchConfiguration.ASGType != key.KindWorker {
+				t.Errorf("unexpected ASGType, got %q, want %q", a.Guest.LaunchConfiguration.ASGType, key.KindWorker)
 			}
 			if a.Guest.LaunchConfiguration.WorkerInstanceType != tc.expectedInstanceType {
 				t.Errorf("unexpected InstanceType, got %q, want %q", a.Guest.LaunchConfiguration.WorkerInstanceType, tc.expectedInstanceType)

--- a/service/controller/v19/adapter/guest_security_groups.go
+++ b/service/controller/v19/adapter/guest_security_groups.go
@@ -52,7 +52,7 @@ func (s *GuestSecurityGroupsAdapter) Adapt(cfg Config) error {
 
 	s.APIWhitelistEnabled = cfg.APIWhitelist.Enabled
 
-	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixMaster)
+	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixMaster)
 	s.MasterSecurityGroupRules = masterRules
 
 	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixWorker)

--- a/service/controller/v19/adapter/guest_security_groups.go
+++ b/service/controller/v19/adapter/guest_security_groups.go
@@ -55,7 +55,7 @@ func (s *GuestSecurityGroupsAdapter) Adapt(cfg Config) error {
 	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixMaster)
 	s.MasterSecurityGroupRules = masterRules
 
-	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixWorker)
+	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixWorker)
 	s.WorkerSecurityGroupRules = s.getWorkerRules(cfg.CustomObject, hostClusterCIDR)
 
 	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixIngress)

--- a/service/controller/v19/adapter/guest_security_groups.go
+++ b/service/controller/v19/adapter/guest_security_groups.go
@@ -52,13 +52,13 @@ func (s *GuestSecurityGroupsAdapter) Adapt(cfg Config) error {
 
 	s.APIWhitelistEnabled = cfg.APIWhitelist.Enabled
 
-	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixMaster)
+	s.MasterSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.KindMaster)
 	s.MasterSecurityGroupRules = masterRules
 
-	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixWorker)
+	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.KindWorker)
 	s.WorkerSecurityGroupRules = s.getWorkerRules(cfg.CustomObject, hostClusterCIDR)
 
-	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixIngress)
+	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.KindIngress)
 	s.IngressSecurityGroupRules = s.getIngressRules(cfg.CustomObject)
 
 	return nil

--- a/service/controller/v19/adapter/guest_security_groups.go
+++ b/service/controller/v19/adapter/guest_security_groups.go
@@ -58,7 +58,7 @@ func (s *GuestSecurityGroupsAdapter) Adapt(cfg Config) error {
 	s.WorkerSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixWorker)
 	s.WorkerSecurityGroupRules = s.getWorkerRules(cfg.CustomObject, hostClusterCIDR)
 
-	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, prefixIngress)
+	s.IngressSecurityGroupName = key.SecurityGroupName(cfg.CustomObject, key.PrefixIngress)
 	s.IngressSecurityGroupRules = s.getIngressRules(cfg.CustomObject)
 
 	return nil

--- a/service/controller/v19/adapter/spec.go
+++ b/service/controller/v19/adapter/spec.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	prefixIngress = "ingress"
-
 	// asgMaxBatchSizeRatio is the % of instances to be updated during a
 	// rolling update.
 	asgMaxBatchSizeRatio = 0.3

--- a/service/controller/v19/adapter/spec.go
+++ b/service/controller/v19/adapter/spec.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	prefixWorker  = "worker"
 	prefixIngress = "ingress"
 
 	// asgMaxBatchSizeRatio is the % of instances to be updated during a

--- a/service/controller/v19/adapter/spec.go
+++ b/service/controller/v19/adapter/spec.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	prefixMaster  = "master"
 	prefixWorker  = "worker"
 	prefixIngress = "ingress"
 

--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -95,6 +95,7 @@ const (
 
 const (
 	PrefixMaster = "master"
+	PrefixWorker = "worker"
 )
 
 func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -94,9 +94,9 @@ const (
 )
 
 const (
-	PrefixMaster  = "master"
-	PrefixIngress = "ingress"
-	PrefixWorker  = "worker"
+	KindMaster  = "master"
+	KindIngress = "ingress"
+	KindWorker  = "worker"
 )
 
 func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -94,8 +94,9 @@ const (
 )
 
 const (
-	PrefixMaster = "master"
-	PrefixWorker = "worker"
+	PrefixMaster  = "master"
+	PrefixIngress = "ingress"
+	PrefixWorker  = "worker"
 )
 
 func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {

--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -93,6 +93,10 @@ const (
 	WorkerASGRef                 = "workerAutoScalingGroup"
 )
 
+const (
+	PrefixMaster = "master"
+)
+
 func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.Cluster.Kubernetes.API.Domain
 }

--- a/service/controller/v19/resource/s3object/desired.go
+++ b/service/controller/v19/resource/s3object/desired.go
@@ -53,7 +53,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		k := key.BucketObjectName(customObject, prefixMaster)
+		k := key.BucketObjectName(customObject, key.PrefixMaster)
 		output[k] = BucketObjectState{
 			Bucket: key.BucketName(customObject, accountID),
 			Body:   b,

--- a/service/controller/v19/resource/s3object/desired.go
+++ b/service/controller/v19/resource/s3object/desired.go
@@ -53,7 +53,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		k := key.BucketObjectName(customObject, key.PrefixMaster)
+		k := key.BucketObjectName(customObject, key.KindMaster)
 		output[k] = BucketObjectState{
 			Bucket: key.BucketName(customObject, accountID),
 			Body:   b,
@@ -66,7 +66,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		k := key.BucketObjectName(customObject, key.PrefixWorker)
+		k := key.BucketObjectName(customObject, key.KindWorker)
 		output[k] = BucketObjectState{
 			Bucket: key.BucketName(customObject, accountID),
 			Body:   b,

--- a/service/controller/v19/resource/s3object/desired.go
+++ b/service/controller/v19/resource/s3object/desired.go
@@ -66,7 +66,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		k := key.BucketObjectName(customObject, prefixWorker)
+		k := key.BucketObjectName(customObject, key.PrefixWorker)
 		output[k] = BucketObjectState{
 			Bucket: key.BucketName(customObject, accountID),
 			Body:   b,

--- a/service/controller/v19/resource/s3object/spec.go
+++ b/service/controller/v19/resource/s3object/spec.go
@@ -1,9 +1,5 @@
 package s3object
 
-const (
-	prefixWorker = "worker"
-)
-
 type BucketObjectState struct {
 	Bucket string
 	Body   string

--- a/service/controller/v19/resource/s3object/spec.go
+++ b/service/controller/v19/resource/s3object/spec.go
@@ -1,7 +1,6 @@
 package s3object
 
 const (
-	prefixMaster = "master"
 	prefixWorker = "worker"
 )
 


### PR DESCRIPTION
There are `spec.go` files which contain information that rather belong to the `key` package. This PR addresses a small amount of improvements in this direction. 