### PR TITLE
fixes panic by assigning the correct variable within scope

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -817,7 +817,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			VaultAddress:      config.VaultAddress,
 		}
 
-		resourceSetV18, err = v18patch1.NewClusterResourceSet(c)
+		resourceSetV18patch1, err = v18patch1.NewClusterResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
The issue was here: https://github.com/giantswarm/aws-operator/pull/1252/files#diff-a3f89d6784b982e6b94dc49b66a2aea4R820. 