### PR TITLE
adapts the ipam resource to deal with old clusters having subnets allocated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,25 @@ jobs:
         chmod +x ./architect
         ./architect version
 
+    - run: |
+        date +"%Y" > /tmp/year
+        date +"%m" > /tmp/month
+        date +"%d" > /tmp/day
+    - restore_cache:
+        keys:
+        - go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}-{{ checksum "/tmp/day" }}
+        - go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}
+        - go-cache-v1-{{ checksum "/tmp/year" }}
+
     - run: ./architect build
 
     - store_test_results:
         path: /tmp/results
+
+    - save_cache:
+        key: go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}-{{ checksum "/tmp/day" }}
+        paths:
+        - /tmp/go/cache
 
     - persist_to_workspace:
         root: .

--- a/service/controller/v19/adapter/guest_security_groups.go
+++ b/service/controller/v19/adapter/guest_security_groups.go
@@ -207,7 +207,7 @@ func getKubernetesAPIRules(cfg Config, hostClusterCIDR string) ([]securityGroupR
 				Description: "Allow traffic from tenant cluster CIDR.",
 				Port:        key.KubernetesAPISecurePort(cfg.CustomObject),
 				Protocol:    tcpProtocol,
-				SourceCIDR:  cfg.CustomObject.Spec.AWS.VPC.CIDR,
+				SourceCIDR:  key.ClusterNetworkCIDR(cfg.CustomObject),
 			},
 		}
 

--- a/service/controller/v19/adapter/guest_security_groups_test.go
+++ b/service/controller/v19/adapter/guest_security_groups_test.go
@@ -237,17 +237,19 @@ func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
 			description: "case 1: API whitelisting enabled with default rules",
 			customObject: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
-					AWS: v1alpha1.AWSConfigSpecAWS{
-						VPC: v1alpha1.AWSConfigSpecAWSVPC{
-							CIDR: "10.1.1.0/24",
-						},
-					},
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
 						Kubernetes: v1alpha1.ClusterKubernetes{
 							API: v1alpha1.ClusterKubernetesAPI{
 								SecurePort: 443,
 							},
+						},
+					},
+				},
+				Status: v1alpha1.AWSConfigStatus{
+					Cluster: v1alpha1.StatusCluster{
+						Network: v1alpha1.StatusClusterNetwork{
+							CIDR: "10.1.1.0/24",
 						},
 					},
 				},
@@ -274,17 +276,19 @@ func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
 			description: "case 2: API whitelisting enabled with single configured subnet",
 			customObject: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
-					AWS: v1alpha1.AWSConfigSpecAWS{
-						VPC: v1alpha1.AWSConfigSpecAWSVPC{
-							CIDR: "10.1.1.0/24",
-						},
-					},
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
 						Kubernetes: v1alpha1.ClusterKubernetes{
 							API: v1alpha1.ClusterKubernetesAPI{
 								SecurePort: 443,
 							},
+						},
+					},
+				},
+				Status: v1alpha1.AWSConfigStatus{
+					Cluster: v1alpha1.StatusCluster{
+						Network: v1alpha1.StatusClusterNetwork{
+							CIDR: "10.1.1.0/24",
 						},
 					},
 				},
@@ -318,17 +322,19 @@ func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
 			description: "case 3: API whitelisting enabled with multiple configured subnets",
 			customObject: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
-					AWS: v1alpha1.AWSConfigSpecAWS{
-						VPC: v1alpha1.AWSConfigSpecAWSVPC{
-							CIDR: "10.1.1.0/24",
-						},
-					},
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
 						Kubernetes: v1alpha1.ClusterKubernetes{
 							API: v1alpha1.ClusterKubernetesAPI{
 								SecurePort: 443,
 							},
+						},
+					},
+				},
+				Status: v1alpha1.AWSConfigStatus{
+					Cluster: v1alpha1.StatusCluster{
+						Network: v1alpha1.StatusClusterNetwork{
+							CIDR: "10.1.1.0/24",
 						},
 					},
 				},
@@ -374,17 +380,19 @@ func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
 			description: "case 4: API whitelisting enabled with NAT gateway EIPs",
 			customObject: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
-					AWS: v1alpha1.AWSConfigSpecAWS{
-						VPC: v1alpha1.AWSConfigSpecAWSVPC{
-							CIDR: "10.1.1.0/24",
-						},
-					},
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
 						Kubernetes: v1alpha1.ClusterKubernetes{
 							API: v1alpha1.ClusterKubernetesAPI{
 								SecurePort: 443,
 							},
+						},
+					},
+				},
+				Status: v1alpha1.AWSConfigStatus{
+					Cluster: v1alpha1.StatusCluster{
+						Network: v1alpha1.StatusClusterNetwork{
+							CIDR: "10.1.1.0/24",
 						},
 					},
 				},
@@ -427,17 +435,19 @@ func TestAdapterSecurityGroupsKubernetesAPIRules(t *testing.T) {
 			description: "case 5: API whitelisting enabled with subnets and NAT gateway EIPs",
 			customObject: v1alpha1.AWSConfig{
 				Spec: v1alpha1.AWSConfigSpec{
-					AWS: v1alpha1.AWSConfigSpecAWS{
-						VPC: v1alpha1.AWSConfigSpecAWSVPC{
-							CIDR: "10.1.1.0/24",
-						},
-					},
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
 						Kubernetes: v1alpha1.ClusterKubernetes{
 							API: v1alpha1.ClusterKubernetesAPI{
 								SecurePort: 443,
 							},
+						},
+					},
+				},
+				Status: v1alpha1.AWSConfigStatus{
+					Cluster: v1alpha1.StatusCluster{
+						Network: v1alpha1.StatusClusterNetwork{
+							CIDR: "10.1.1.0/24",
 						},
 					},
 				},

--- a/service/controller/v19/key/key.go
+++ b/service/controller/v19/key/key.go
@@ -386,6 +386,10 @@ func PrivateSubnetCIDR(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.AWS.VPC.PrivateSubnetCIDR
 }
 
+func PublicSubnetCIDR(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.AWS.VPC.PublicSubnetCIDR
+}
+
 func CIDR(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.AWS.VPC.CIDR
 }

--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -53,7 +53,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 							CIDR: key.PrivateSubnetCIDR(customObject),
 						},
 						Public: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPublic{
-							CIDR: key.PrivateSubnetCIDR(customObject),
+							CIDR: key.PublicSubnetCIDR(customObject),
 						},
 					},
 				},

--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -42,7 +42,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		//
 		var statusAZs []v1alpha1.AWSConfigStatusAWSAvailabilityZone
 		var subnetCIDR net.IPNet
-		if customObject.ClusterStatus().HasUpdatedCondition() {
+		if customObject.ClusterStatus().HasUpdatingCondition() || customObject.ClusterStatus().HasUpdatedCondition() {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "reusing allocated cluster CIDR")
 
 			statusAZs = []v1alpha1.AWSConfigStatusAWSAvailabilityZone{

--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v19/key"
 	"github.com/giantswarm/ipam"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -107,6 +108,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "updated CR status")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+			reconciliationcanceledcontext.SetCanceled(ctx)
 		}
 
 	} else {


### PR DESCRIPTION
Right now the CR status is not properly managed for old clusters having subnets allocated already. This change proposes the CR status management of older clusters having only one availability zone. 