### PR TITLE
set etcd dns ttl to 60s

### DIFF
--- a/service/controller/v18patch1/templates/cloudformation/guest/record_sets.go
+++ b/service/controller/v18patch1/templates/cloudformation/guest/record_sets.go
@@ -22,7 +22,7 @@ const RecordSets = `{{define "record_sets"}}
     Properties:
       Name: 'etcd.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'HostedZone'
-      TTL: '900'
+      TTL: '60'
       Type: CNAME
       ResourceRecords:
         - !GetAtt {{ $v.MasterInstanceResourceName }}.PrivateDnsName

--- a/service/controller/v19/templates/cloudformation/guest/record_sets.go
+++ b/service/controller/v19/templates/cloudformation/guest/record_sets.go
@@ -22,7 +22,7 @@ const RecordSets = `{{define "record_sets"}}
     Properties:
       Name: 'etcd.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'HostedZone'
-      TTL: '900'
+      TTL: '60'
       Type: CNAME
       ResourceRecords:
         - !GetAtt {{ $v.MasterInstanceResourceName }}.PrivateDnsName


### PR DESCRIPTION
to avoid etcd dns issues (with calico) during upgrades we have to lower
the ttl to at least 60s.