### PR TITLE
Create private routing table for each AZ

### DIFF
--- a/service/controller/v19/adapter/guest_route_tables.go
+++ b/service/controller/v19/adapter/guest_route_tables.go
@@ -9,8 +9,9 @@ import (
 )
 
 type RouteTableName struct {
-	ResourceName string
-	InternalName string
+	ResourceName        string
+	InternalName        string
+	VPCPeeringRouteName string
 }
 
 type GuestRouteTablesAdapter struct {
@@ -34,8 +35,9 @@ func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
 	for i := 0; i < key.SpecAvailabilityZones(cfg.CustomObject); i++ {
 		suffix := fmt.Sprintf("%s%02d", suffixPrivate, i)
 		rtName := RouteTableName{
-			ResourceName: fmt.Sprintf("PrivateRouteTable%02d", i),
-			InternalName: key.RouteTableName(cfg.CustomObject, suffix),
+			ResourceName:        fmt.Sprintf("PrivateRouteTable%02d", i),
+			InternalName:        key.RouteTableName(cfg.CustomObject, suffix),
+			VPCPeeringRouteName: fmt.Sprintf("VPCPeeringRoute%02d", i),
 		}
 		r.PrivateRouteTableNames = append(r.PrivateRouteTableNames, rtName)
 	}

--- a/service/controller/v19/adapter/guest_route_tables.go
+++ b/service/controller/v19/adapter/guest_route_tables.go
@@ -31,7 +31,7 @@ func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
 		InternalName: key.RouteTableName(cfg.CustomObject, suffixPublic),
 	}
 
-	for i := 0; i < key.AvailabilityZones(cfg.CustomObject); i++ {
+	for i := 0; i < key.SpecAvailabilityZones(cfg.CustomObject); i++ {
 		suffix := fmt.Sprintf("%s%02d", suffixPrivate, i)
 		rtName := RouteTableName{
 			ResourceName: fmt.Sprintf("PrivateRouteTable%02d", i),

--- a/service/controller/v19/adapter/guest_route_tables.go
+++ b/service/controller/v19/adapter/guest_route_tables.go
@@ -1,15 +1,22 @@
 package adapter
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/v19/key"
 )
 
+type RouteTableName struct {
+	ResourceName string
+	InternalName string
+}
+
 type GuestRouteTablesAdapter struct {
-	HostClusterCIDR       string
-	PublicRouteTableName  string
-	PrivateRouteTableName string
+	HostClusterCIDR        string
+	PublicRouteTableName   RouteTableName
+	PrivateRouteTableNames []RouteTableName
 }
 
 func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
@@ -19,8 +26,19 @@ func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
 	}
 
 	r.HostClusterCIDR = hostClusterCIDR
-	r.PublicRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPublic)
-	r.PrivateRouteTableName = key.RouteTableName(cfg.CustomObject, suffixPrivate)
+	r.PublicRouteTableName = RouteTableName{
+		ResourceName: "PublicRouteTable00",
+		InternalName: key.RouteTableName(cfg.CustomObject, suffixPublic),
+	}
+
+	for i := 0; i < key.AvailabilityZones(cfg.CustomObject); i++ {
+		suffix := fmt.Sprintf("%s%02d", suffixPrivate, i)
+		rtName := RouteTableName{
+			ResourceName: fmt.Sprintf("PrivateRouteTable%02d", i),
+			InternalName: key.RouteTableName(cfg.CustomObject, suffix),
+		}
+		r.PrivateRouteTableNames = append(r.PrivateRouteTableNames, rtName)
+	}
 
 	return nil
 }

--- a/service/controller/v19/adapter/guest_route_tables.go
+++ b/service/controller/v19/adapter/guest_route_tables.go
@@ -10,7 +10,7 @@ import (
 
 type RouteTableName struct {
 	ResourceName        string
-	InternalName        string
+	TagName             string
 	VPCPeeringRouteName string
 }
 
@@ -29,14 +29,14 @@ func (r *GuestRouteTablesAdapter) Adapt(cfg Config) error {
 	r.HostClusterCIDR = hostClusterCIDR
 	r.PublicRouteTableName = RouteTableName{
 		ResourceName: "PublicRouteTable00",
-		InternalName: key.RouteTableName(cfg.CustomObject, suffixPublic),
+		TagName:      key.RouteTableName(cfg.CustomObject, suffixPublic),
 	}
 
 	for i := 0; i < key.SpecAvailabilityZones(cfg.CustomObject); i++ {
 		suffix := fmt.Sprintf("%s%02d", suffixPrivate, i)
 		rtName := RouteTableName{
 			ResourceName:        fmt.Sprintf("PrivateRouteTable%02d", i),
-			InternalName:        key.RouteTableName(cfg.CustomObject, suffix),
+			TagName:             key.RouteTableName(cfg.CustomObject, suffix),
 			VPCPeeringRouteName: fmt.Sprintf("VPCPeeringRoute%02d", i),
 		}
 		r.PrivateRouteTableNames = append(r.PrivateRouteTableNames, rtName)

--- a/service/controller/v19/adapter/guest_route_tables_test.go
+++ b/service/controller/v19/adapter/guest_route_tables_test.go
@@ -37,12 +37,14 @@ func TestAdapterRouteTablesRegularFields(t *testing.T) {
 			},
 			expectedPrivateRouteTableNames: []RouteTableName{
 				{
-					ResourceName: "PrivateRouteTable00",
-					InternalName: "test-cluster-private00",
+					ResourceName:        "PrivateRouteTable00",
+					InternalName:        "test-cluster-private00",
+					VPCPeeringRouteName: "VPCPeeringRoute00",
 				},
 				{
-					ResourceName: "PrivateRouteTable01",
-					InternalName: "test-cluster-private01",
+					ResourceName:        "PrivateRouteTable01",
+					InternalName:        "test-cluster-private01",
+					VPCPeeringRouteName: "VPCPeeringRoute01",
 				},
 			},
 		},

--- a/service/controller/v19/adapter/guest_route_tables_test.go
+++ b/service/controller/v19/adapter/guest_route_tables_test.go
@@ -33,17 +33,17 @@ func TestAdapterRouteTablesRegularFields(t *testing.T) {
 			expectedHostClusterCIDR: "10.0.0.0/16",
 			expectedPublicRouteTableName: RouteTableName{
 				ResourceName: "PublicRouteTable00",
-				InternalName: "test-cluster-public",
+				TagName:      "test-cluster-public",
 			},
 			expectedPrivateRouteTableNames: []RouteTableName{
 				{
 					ResourceName:        "PrivateRouteTable00",
-					InternalName:        "test-cluster-private00",
+					TagName:             "test-cluster-private00",
 					VPCPeeringRouteName: "VPCPeeringRoute00",
 				},
 				{
 					ResourceName:        "PrivateRouteTable01",
-					InternalName:        "test-cluster-private01",
+					TagName:             "test-cluster-private01",
 					VPCPeeringRouteName: "VPCPeeringRoute01",
 				},
 			},

--- a/service/controller/v19/adapter/host_post_route_tables.go
+++ b/service/controller/v19/adapter/host_post_route_tables.go
@@ -42,8 +42,8 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 		}
 		for _, cidrBlock := range tenantPrivateSubnetCidrs {
 			rt := HostPostRouteTablesAdapterRoute{
-				Name:         routeTableName,
-				RouteTableID: routeTableID,
+				RouteTableName: routeTableName,
+				RouteTableID:   routeTableID,
 				// Requester CIDR block, we create the peering connection from the guest's private subnets.
 				CidrBlock:        cidrBlock,
 				PeerConnectionID: peerConnectionID,
@@ -61,8 +61,8 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 				return microerror.Mask(err)
 			}
 			rt := HostPostRouteTablesAdapterRoute{
-				Name:         routeTableName,
-				RouteTableID: routeTableID,
+				RouteTableName: routeTableName,
+				RouteTableID:   routeTableID,
 				// Requester CIDR block, we create the peering connection from the
 				// guest's CIDR for being able to access Vault's ELB.
 				CidrBlock:        key.ClusterNetworkCIDR(cfg.CustomObject),
@@ -75,7 +75,7 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 }
 
 type HostPostRouteTablesAdapterRoute struct {
-	Name             string
+	RouteTableName   string
 	RouteTableID     string
 	CidrBlock        string
 	PeerConnectionID string

--- a/service/controller/v19/adapter/host_post_route_tables.go
+++ b/service/controller/v19/adapter/host_post_route_tables.go
@@ -17,8 +17,8 @@ import (
 )
 
 type HostPostRouteTablesAdapter struct {
-	PrivateRouteTables []HostPostRouteTablesAdapterRouteTable
-	PublicRouteTables  []HostPostRouteTablesAdapterRouteTable
+	PrivateRoutes []HostPostRouteTablesAdapterRoute
+	PublicRoutes  []HostPostRouteTablesAdapterRoute
 }
 
 func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
@@ -41,14 +41,14 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 			return microerror.Mask(err)
 		}
 		for _, cidrBlock := range tenantPrivateSubnetCidrs {
-			rt := HostPostRouteTablesAdapterRouteTable{
+			rt := HostPostRouteTablesAdapterRoute{
 				Name:         routeTableName,
 				RouteTableID: routeTableID,
 				// Requester CIDR block, we create the peering connection from the guest's private subnets.
 				CidrBlock:        cidrBlock,
 				PeerConnectionID: peerConnectionID,
 			}
-			i.PrivateRouteTables = append(i.PrivateRouteTables, rt)
+			i.PrivateRoutes = append(i.PrivateRoutes, rt)
 		}
 	}
 
@@ -60,7 +60,7 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			rt := HostPostRouteTablesAdapterRouteTable{
+			rt := HostPostRouteTablesAdapterRoute{
 				Name:         routeTableName,
 				RouteTableID: routeTableID,
 				// Requester CIDR block, we create the peering connection from the
@@ -68,13 +68,13 @@ func (i *HostPostRouteTablesAdapter) Adapt(cfg Config) error {
 				CidrBlock:        key.ClusterNetworkCIDR(cfg.CustomObject),
 				PeerConnectionID: peerConnectionID,
 			}
-			i.PublicRouteTables = append(i.PublicRouteTables, rt)
+			i.PublicRoutes = append(i.PublicRoutes, rt)
 		}
 	}
 	return nil
 }
 
-type HostPostRouteTablesAdapterRouteTable struct {
+type HostPostRouteTablesAdapterRoute struct {
 	Name             string
 	RouteTableID     string
 	CidrBlock        string

--- a/service/controller/v19/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v19/resource/cloudformation/main_stack_test.go
@@ -488,6 +488,24 @@ func TestMainHostPostTemplateExistingFields(t *testing.T) {
 				},
 			},
 		},
+		Status: v1alpha1.AWSConfigStatus{
+			AWS: v1alpha1.AWSConfigStatusAWS{
+				AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+					v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+
+						Name: "eu-central-1a",
+						Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
+							Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
+								CIDR: "10.100.1.0/25",
+							},
+							Public: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPublic{
+								CIDR: "10.100.1.128/25",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	cfg := testConfig()

--- a/service/controller/v19/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v19/resource/cloudformation/main_stack_test.go
@@ -113,7 +113,7 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 				},
 				Region:            "eu-central-1",
 				AZ:                "eu-central-1a",
-				AvailabilityZones: 1,
+				AvailabilityZones: 2,
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
 					{
 						ImageID:      "ami-1234-master",
@@ -352,6 +352,10 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 		t.Fatal("PublicSubnet element not found")
 	}
 	if !strings.Contains(body, "PrivateRouteTable00:") {
+		fmt.Println(body)
+		t.Fatal("PrivateRouteTable00 element not found")
+	}
+	if !strings.Contains(body, "PrivateRouteTable01:") {
 		fmt.Println(body)
 		t.Fatal("PrivateRouteTable00 element not found")
 	}

--- a/service/controller/v19/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v19/resource/cloudformation/main_stack_test.go
@@ -99,8 +99,9 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 						IdleTimeoutSeconds: 3600,
 					},
 				},
-				Region: "eu-central-1",
-				AZ:     "eu-central-1a",
+				Region:            "eu-central-1",
+				AZ:                "eu-central-1a",
+				AvailabilityZones: 1,
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
 					{
 						ImageID:      "ami-1234-master",
@@ -294,17 +295,17 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 		fmt.Println(body)
 		t.Fatal("NATGateway element not found")
 	}
-	if !strings.Contains(body, "PublicRouteTable:") {
+	if !strings.Contains(body, "PublicRouteTable00:") {
 		fmt.Println(body)
-		t.Fatal("PublicRouteTable element not found")
+		t.Fatal("PublicRouteTable00 element not found")
 	}
 	if !strings.Contains(body, "PublicSubnet:") {
 		fmt.Println(body)
 		t.Fatal("PublicSubnet element not found")
 	}
-	if !strings.Contains(body, "PrivateRouteTable:") {
+	if !strings.Contains(body, "PrivateRouteTable00:") {
 		fmt.Println(body)
-		t.Fatal("PrivateRouteTable element not found")
+		t.Fatal("PrivateRouteTable00 element not found")
 	}
 	if !strings.Contains(body, "PrivateSubnet:") {
 		fmt.Println(body)

--- a/service/controller/v19/templates/cloudformation/guest/route_tables.go
+++ b/service/controller/v19/templates/cloudformation/guest/route_tables.go
@@ -8,7 +8,7 @@ const RouteTables = `{{ define "route_tables" }}
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: {{ $v.PublicRouteTableName.InternalName }}
+        Value: {{ $v.PublicRouteTableName.TagName }}
 
   {{- range $v.PrivateRouteTableNames }}
   {{ .ResourceName }}:
@@ -17,7 +17,7 @@ const RouteTables = `{{ define "route_tables" }}
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: {{ .InternalName }}
+        Value: {{ .TagName }}
 
   {{ .VPCPeeringRouteName }}:
     Type: AWS::EC2::Route

--- a/service/controller/v19/templates/cloudformation/guest/route_tables.go
+++ b/service/controller/v19/templates/cloudformation/guest/route_tables.go
@@ -2,21 +2,23 @@ package guest
 
 const RouteTables = `{{ define "route_tables" }}
 {{- $v := .Guest.RouteTables }}
-  PublicRouteTable:
+  {{ $v.PublicRouteTableName.ResourceName }}:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: {{ $v.PublicRouteTableName }}
+        Value: {{ $v.PublicRouteTableName.InternalName }}
 
-  PrivateRouteTable:
+  {{- range $v.PrivateRouteTableNames }}
+  {{ .ResourceName }}:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: {{ $v.PrivateRouteTableName }}
+        Value: {{ .InternalName }}
+  {{ end }}
 
   VPCPeeringRoute:
     Type: AWS::EC2::Route

--- a/service/controller/v19/templates/cloudformation/guest/route_tables.go
+++ b/service/controller/v19/templates/cloudformation/guest/route_tables.go
@@ -18,13 +18,13 @@ const RouteTables = `{{ define "route_tables" }}
       Tags:
       - Key: Name
         Value: {{ .InternalName }}
-  {{ end }}
 
-  VPCPeeringRoute:
+  {{ .VPCPeeringRouteName }}:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: !Ref PrivateRouteTable
+      RouteTableId: !Ref {{ .ResourceName }}
       DestinationCidrBlock: {{ $v.HostClusterCIDR }}
       VpcPeeringConnectionId:
         Ref: "VPCPeeringConnection"
+  {{ end }}
 {{ end }}`

--- a/service/controller/v19/templates/cloudformation/hostpost/route_tables.go
+++ b/service/controller/v19/templates/cloudformation/hostpost/route_tables.go
@@ -2,7 +2,7 @@ package hostpost
 
 const RouteTables = `{{ define "route_tables" }}
   {{- $v := .HostPost.RouteTables }}
-  {{ range $i, $t := $v.PrivateRouteTables }}
+  {{ range $i, $t := $v.PrivateRoutes }}
   PrivateRoute{{$i}}:
     Type: AWS::EC2::Route
     Properties:
@@ -11,7 +11,7 @@ const RouteTables = `{{ define "route_tables" }}
       VpcPeeringConnectionId: {{$t.PeerConnectionID}}
   {{end}}
 
-  {{ range $i, $t := $v.PublicRouteTables }}
+  {{ range $i, $t := $v.PublicRoutes }}
   PublicRoute{{$i}}:
     Type: AWS::EC2::Route
     Properties:


### PR DESCRIPTION
To support multi-AZ workers, each AZ needs separate PrivateRoutingTable
that will be then routed to control plane. Single public routing table
will do for now, but refined naming there as well to be consistent.