### PR TITLE
Add NAT GW for each availability zone

### DIFF
--- a/service/controller/v19/adapter/guest_nat_gateway.go
+++ b/service/controller/v19/adapter/guest_nat_gateway.go
@@ -1,13 +1,36 @@
 package adapter
 
-import "github.com/giantswarm/aws-operator/service/controller/v19/key"
+import (
+	"fmt"
+
+	"github.com/giantswarm/aws-operator/service/controller/v19/key"
+)
+
+type Gateway struct {
+	ClusterID             string
+	NATGWName             string
+	NATEIPName            string
+	NATRouteName          string
+	PrivateRouteTableName string
+	PublicSubnetName      string
+}
 
 type GuestNATGatewayAdapter struct {
-	ClusterID string
+	Gateways []Gateway
 }
 
 func (a *GuestNATGatewayAdapter) Adapt(cfg Config) error {
-	a.ClusterID = key.ClusterID(cfg.CustomObject)
+	for i := 0; i < key.SpecAvailabilityZones(cfg.CustomObject); i++ {
+		gw := Gateway{
+			ClusterID:             key.ClusterID(cfg.CustomObject),
+			NATGWName:             fmt.Sprintf("NATGateway%02d", i),
+			NATEIPName:            fmt.Sprintf("NATEIP%02d", i),
+			NATRouteName:          fmt.Sprintf("NATRoute%02d", i),
+			PrivateRouteTableName: fmt.Sprintf("PrivateRouteTable%02d", i),
+			PublicSubnetName:      fmt.Sprintf("PublicSubnet%02d", i),
+		}
+		a.Gateways = append(a.Gateways, gw)
+	}
 
 	return nil
 }

--- a/service/controller/v19/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v19/resource/cloudformation/main_stack_test.go
@@ -111,8 +111,9 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 						IdleTimeoutSeconds: 3600,
 					},
 				},
-				Region: "eu-central-1",
-				AZ:     "eu-central-1a",
+				Region:            "eu-central-1",
+				AZ:                "eu-central-1a",
+				AvailabilityZones: 2,
 				Masters: []v1alpha1.AWSConfigSpecAWSNode{
 					{
 						ImageID:      "ami-1234-master",
@@ -334,9 +335,13 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 		fmt.Println(body)
 		t.Fatal("InternetGateway element not found")
 	}
-	if !strings.Contains(body, "NATGateway:") {
+	if !strings.Contains(body, "NATGateway00:") {
 		fmt.Println(body)
-		t.Fatal("NATGateway element not found")
+		t.Fatal("NATGateway00 element not found")
+	}
+	if !strings.Contains(body, "NATGateway01:") {
+		fmt.Println(body)
+		t.Fatal("NATGateway01 element not found")
 	}
 	if !strings.Contains(body, "PublicRouteTable:") {
 		fmt.Println(body)

--- a/service/controller/v19/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v19/templates/cloudformation/guest/nat_gateway.go
@@ -10,7 +10,7 @@ const NatGateway = `{{define "nat_gateway"}}
     Properties:
       AllocationId:
         Fn::GetAtt:
-        - NATEIP
+        - {{ .NATEIPName }}
         - AllocationId
       SubnetId: !Ref {{ .PublicSubnetName }}
       Tags:

--- a/service/controller/v19/templates/cloudformation/guest/nat_gateway.go
+++ b/service/controller/v19/templates/cloudformation/guest/nat_gateway.go
@@ -2,7 +2,8 @@ package guest
 
 const NatGateway = `{{define "nat_gateway"}}
   {{- $v := .Guest.NATGateway }}
-  NATGateway:
+  {{- range $v.Gateways }}
+  {{ .NATGWName }}:
     Type: AWS::EC2::NatGateway
     DependsOn:
       - VPCGatewayAttachment
@@ -11,19 +12,20 @@ const NatGateway = `{{define "nat_gateway"}}
         Fn::GetAtt:
         - NATEIP
         - AllocationId
-      SubnetId: !Ref PublicSubnet
+      SubnetId: !Ref {{ .PublicSubnetName }}
       Tags:
         - Key: Name
-          Value: {{ $v.ClusterID }}
-  NATEIP:
+          Value: {{ .ClusterID }}
+  {{ .NATEIPName }}:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
-  NATRoute:
+  {{ .NATRouteName }}:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: !Ref PrivateRouteTable
+      RouteTableId: !Ref {{ .PrivateRouteTableName }}
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
-        Ref: "NATGateway"
+        Ref: "{{ .NATGWName }}"
+{{end}}
 {{end}}`


### PR DESCRIPTION
In order to be able to route traffic when some AZs go down, each AZ must
have a NAT GW present.