### PR TITLE
Remove quotes around AvailabilityZones

### DIFF
--- a/helm/aws-operator-chart/templates/03-configmap.yaml
+++ b/helm/aws-operator-chart/templates/03-configmap.yaml
@@ -15,7 +15,7 @@ data:
       aws:
         accessLogsExpiration: '{{ .Values.Installation.V1.Provider.AWS.S3AccessLogsExpiration }}'
         advancedMonitoringEC2: '{{ .Values.Installation.V1.Provider.AWS.AdvancedMonitoringEC2 }}'
-        availabilityZones: '{{ .Values.Installation.V1.Provider.AWS.AvailabilityZones }}'
+        availabilityZones: {{ .Values.Installation.V1.Provider.AWS.AvailabilityZones }}
         encrypter: '{{ .Values.Installation.V1.Provider.AWS.Encrypter }}'
         trustedAdvisorEnabled: '{{ .Values.Installation.V1.Provider.AWS.TrustedAdvisor.Enabled }}'
         includeTags: '{{ .Values.Installation.V1.Provider.AWS.IncludeTags }}'


### PR DESCRIPTION
.Values.Installation.V1.Provider.AWS.AvailabilityZones is a list so when
there are quotes around it, its internal [ and ] get interpreted as part
of a string value -> remove them.