### PR TITLE
circleci: disable ClusterState tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,12 +250,12 @@ workflows:
 #      - e2eTestWIPMasterClusterState:
 #          requires:
 #            - master
-      - e2eTestCurPRClusterState:
-          requires:
-            - pr
-      - e2eTestWIPPRClusterState:
-          requires:
-            - pr
+#      - e2eTestCurPRClusterState:
+#          requires:
+#            - pr
+#      - e2eTestWIPPRClusterState:
+#          requires:
+#            - pr
 
 
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4692

They seem to be failing constantly with `worker nodes are still not found`.
They are disabled temporary to not annoy people when they are being fixed.