### PR TITLE
terminates master instance on updates and delete events instead of stopping it

### DIFF
--- a/service/controller/v19/ebs/mock_test.go
+++ b/service/controller/v19/ebs/mock_test.go
@@ -52,10 +52,10 @@ func (e *EC2ClientMock) DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachm
 	return nil, nil
 }
 
-func (e *EC2ClientMock) StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
+func (e *EC2ClientMock) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
 	return nil, nil
 }
 
-func (e *EC2ClientMock) WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error {
+func (e *EC2ClientMock) WaitUntilInstanceTerminated(*ec2.DescribeInstancesInput) error {
 	return nil
 }

--- a/service/controller/v19/ebs/spec.go
+++ b/service/controller/v19/ebs/spec.go
@@ -26,8 +26,8 @@ type EC2Client interface {
 	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
-	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
-	WaitUntilInstanceStopped(*ec2.DescribeInstancesInput) error
+	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
+	WaitUntilInstanceTerminated(*ec2.DescribeInstancesInput) error
 }
 
 // Volume is an EBS volume and its attachments.


### PR DESCRIPTION
There seem to be issues on updates where the master node stays in the tenant Kubernetes API, even though the EC2 instance is stopped. Idea here is to terminate it instead. The implications for the EBS volumes and the general workflow have to be verified and tested still.