### PR TITLE
integration: use dynamic client for CR checks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1760,6 +1760,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apiserver/pkg/endpoints/request",
+    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/rest",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.

This makes the check more generic. Next steps is to move it to `e2e-harness` and use it from there.