### PR TITLE
improves collector label mess

### DIFF
--- a/service/collector/asg.go
+++ b/service/collector/asg.go
@@ -10,36 +10,39 @@ import (
 )
 
 const (
-	// ASGLabel is the metric's label key that will hold the ASG name.
-	ASGLabel = "asg"
+	// labelASG is the metric's label key that will hold the ASG name.
+	labelASG = "asg"
+)
 
-	// Subsystem will become the second part of the metric name, right after namespace.
-	Subsystem = "asg"
+const (
+	// subsystemASG will become the second part of the metric name, right after
+	// namespace.
+	subsystemASG = "asg"
 )
 
 var (
 	asgDesiredDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, Subsystem, "desired_count"),
+		prometheus.BuildFQName(namespace, subsystemASG, "desired_count"),
 		"Gauge about the number of EC2 instances that should be in the ASG.",
 		[]string{
-			ASGLabel,
-			AccountLabel,
-			ClusterLabel,
-			InstallationLabel,
-			OrganizationLabel,
+			labelASG,
+			labelAccount,
+			labelCluster,
+			labelInstallation,
+			labelOrganization,
 		},
 		nil,
 	)
 
 	asgInserviceDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, Subsystem, "inservice_count"),
+		prometheus.BuildFQName(namespace, subsystemASG, "inservice_count"),
 		"Gauge about the number of EC2 instances in the ASG that are in state InService.",
 		[]string{
-			ASGLabel,
-			AccountLabel,
-			ClusterLabel,
-			InstallationLabel,
-			OrganizationLabel,
+			labelASG,
+			labelAccount,
+			labelCluster,
+			labelInstallation,
+			labelOrganization,
 		},
 		nil,
 	)
@@ -148,11 +151,11 @@ func (a *ASG) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 
 			for _, tag := range asg.Tags {
 				switch *tag.Key {
-				case ClusterTag:
+				case tagCluster:
 					cluster = *tag.Value
-				case InstallationTag:
+				case tagInstallation:
 					installation = *tag.Value
-				case OrganizationTag:
+				case tagOrganization:
 					organization = *tag.Value
 				}
 			}

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -2,18 +2,20 @@ package collector
 
 const (
 	GaugeValue float64 = 1
-	Namespace          = "aws_operator"
+	namespace          = "aws_operator"
 )
 
 const (
-	ClusterTag      = "giantswarm.io/cluster"
-	InstallationTag = "giantswarm.io/installation"
-	OrganizationTag = "giantswarm.io/organization"
+	tagCluster      = "giantswarm.io/cluster"
+	tagInstallation = "giantswarm.io/installation"
+	tagOrganization = "giantswarm.io/organization"
 )
 
 const (
-	AccountLabel      = "account"
-	ClusterLabel      = "cluster_id"
-	InstallationLabel = "installation"
-	OrganizationLabel = "organization"
+	labelAccount      = "account"
+	labelAccountID    = "account_id"
+	labelCluster      = "cluster_id"
+	labelName         = "name"
+	labelInstallation = "installation"
+	labelOrganization = "organization"
 )

--- a/service/collector/elb.go
+++ b/service/collector/elb.go
@@ -12,23 +12,23 @@ import (
 )
 
 const (
-	ELBLabel = "elb"
+	labelELB = "elb"
 )
 
 const (
-	StateOutOfService = "OutOfService"
+	stateOutOfService = "OutOfService"
 )
 
 var (
 	elbsDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "elb_instance_out_of_service_count"),
+		prometheus.BuildFQName(namespace, "", "elb_instance_out_of_service_count"),
 		"Gauge about ELB instances being out of service.",
 		[]string{
-			ELBLabel,
-			AccountLabel,
-			ClusterLabel,
-			InstallationLabel,
-			OrganizationLabel,
+			labelELB,
+			labelAccount,
+			labelCluster,
+			labelInstallation,
+			labelOrganization,
 		},
 		nil,
 	)
@@ -142,13 +142,13 @@ func (e *ELB) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 		var installation string
 		var organization string
 		for _, t := range tags {
-			if *t.Key == ClusterTag {
+			if *t.Key == tagCluster {
 				cluster = *t.Value
 			}
-			if *t.Key == InstallationTag {
+			if *t.Key == tagInstallation {
 				installation = *t.Value
 			}
-			if *t.Key == OrganizationTag {
+			if *t.Key == tagOrganization {
 				organization = *t.Value
 			}
 		}
@@ -169,7 +169,7 @@ func (e *ELB) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 				return microerror.Mask(err)
 			}
 			for _, s := range o.InstanceStates {
-				if *s.State == StateOutOfService {
+				if *s.State == stateOutOfService {
 					count++
 				}
 			}

--- a/service/collector/trusted_advisor.go
+++ b/service/collector/trusted_advisor.go
@@ -32,25 +32,23 @@ const (
 )
 
 const (
-	labelAccountID = "account_id"
-	labelRegion    = "region"
-	labelService   = "service"
-	labelName      = "name"
+	labelRegion  = "region"
+	labelService = "service"
 )
 
 var (
 	getChecksDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
+		Namespace: namespace,
 		Name:      "trusted_advisor_get_checks_duration",
 		Help:      "Histogram for the duration of Trusted Advisor get checks calls.",
 	})
 	getResourcesDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
+		Namespace: namespace,
 		Name:      "trusted_advisor_get_resources_duration",
 		Help:      "Histogram for the duration of Trusted Advisor get resource calls.",
 	})
 	serviceLimit *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "service_limit"),
+		prometheus.BuildFQName(namespace, "", "service_limit"),
 		"Service limits as reported by Trusted Advisor.",
 		[]string{
 			labelAccountID,
@@ -61,7 +59,7 @@ var (
 		nil,
 	)
 	serviceUsage *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "service_usage"),
+		prometheus.BuildFQName(namespace, "", "service_usage"),
 		"Service usage as reported by Trusted Advisor.",
 		[]string{
 			labelAccountID,

--- a/service/collector/vpc.go
+++ b/service/collector/vpc.go
@@ -12,31 +12,31 @@ import (
 )
 
 const (
-	NameTag      = "Name"
-	StackNameTag = "aws:cloudformation:stack-name"
+	tagName  = "Name"
+	tagStack = "aws:cloudformation:stack-name"
+)
 
-	AccountIdLabel = "account_id"
-	CidrLabel      = "cidr"
-	IDLabel        = "id"
-	NameLabel      = "name"
-	StackNameLabel = "stack_name"
-	StateLabel     = "state"
+const (
+	labelCIDR  = "cidr"
+	labelID    = "id"
+	labelStack = "stack_name"
+	labelState = "state"
 )
 
 var (
 	vpcsDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(Namespace, "", "vpc_info"),
+		prometheus.BuildFQName(namespace, "", "vpc_info"),
 		"VPC information.",
 		[]string{
-			AccountIdLabel,
-			CidrLabel,
-			ClusterLabel,
-			IDLabel,
-			InstallationLabel,
-			NameLabel,
-			OrganizationLabel,
-			StackNameLabel,
-			StateLabel,
+			labelAccountID,
+			labelCIDR,
+			labelCluster,
+			labelID,
+			labelInstallation,
+			labelName,
+			labelOrganization,
+			labelStack,
+			labelState,
 		},
 		nil,
 	)
@@ -128,15 +128,15 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 
 		for _, tag := range vpc.Tags {
 			switch *tag.Key {
-			case ClusterTag:
+			case tagCluster:
 				cluster = *tag.Value
-			case InstallationTag:
+			case tagInstallation:
 				installation = *tag.Value
-			case NameTag:
+			case tagName:
 				name = *tag.Value
-			case OrganizationTag:
+			case tagOrganization:
 				organization = *tag.Value
-			case StackNameTag:
+			case tagStack:
 				stackName = *tag.Value
 			}
 		}


### PR DESCRIPTION
* I made all collector labels private. Let me know when you think they should be public. I think it makes sense though to treat all the same. 
* I would like to have a constant scheme where the type of the constant groups the different entities of such a group by its prefix. 
* I moved constants to `collector.go` when they are used in multiple places. Other constants are still in the files where they are used exclusively. Let me know when you think they should just all be in the same file. 
* I noticed there is not made use of the subsystem property all the time. I did not change that now. That could may be done here or separately when there is more impact and implication down the road. In the future it would also be cool to think about the label structure a bit more as this is all a bit wild still, also due to its grown nature. 