### PR TITLE
Fix race condition when checking allocated subnets from CRs

### DIFF
--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -204,7 +204,13 @@ func getAWSConfigSubnets(g8sClient versioned.Interface) ([]net.IPNet, error) {
 	for _, ac := range awsConfigList.Items {
 		cidr := key.ClusterNetworkCIDR(ac)
 		if cidr == "" {
-			continue
+			// To prevent race condition when pre-v19 and v19+ clusters are
+			// created within short period of time and v19+ CR gets picked
+			// first. The pre-v19 CR might not have Status section yet.
+			cidr = key.CIDR(ac)
+			if cidr == "" {
+				continue
+			}
 		}
 
 		_, n, err := net.ParseCIDR(cidr)

--- a/service/controller/v19/resource/ipam/create.go
+++ b/service/controller/v19/resource/ipam/create.go
@@ -207,6 +207,10 @@ func getAWSConfigSubnets(g8sClient versioned.Interface) ([]net.IPNet, error) {
 			// To prevent race condition when pre-v19 and v19+ clusters are
 			// created within short period of time and v19+ CR gets picked
 			// first. The pre-v19 CR might not have Status section yet.
+			//
+			// TODO: When AWSConfig.Spec.AWS.VPC.CIDR field is not used
+			// anymore, it (and correspondingly this branch) should be
+			// removed.
 			cidr = key.CIDR(ac)
 			if cidr == "" {
 				continue


### PR DESCRIPTION
When pre-v19 and v19+ clusters are created within short period of time
and AWSConfig for v19+ cluster gets reconciliation before pre-v19 one,
there was a race that missing Status field for pre-v19 CR lead to
overlapping allocation of tenant subnet.

When gathering present subnet allocations from AWSConfig CRs, use legacy
CIDR field from Spec section when one in Status section is empty (or
missing).