### PR TITLE
more robust wait for etcd dns availability before calico is upgraded

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -381,8 +381,8 @@
   revision = "79a61ffad296f3f418d8f381e4f5f702d5245b50"
 
 [[projects]]
-  branch = "master"
-  digest = "1:03850c2d6705fdd9db7b931df5fe666e8674d845f4e8ee2cc1e2fe742d6128d5"
+  branch = "teemow-check-etcd-dns-10-times-in-row"
+  digest = "1:ae0aae9fc0c6590e1720bcb6c66b11bc4d4be104a76801526ee1bfd802a90966"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "v_3_3_3",
@@ -393,7 +393,7 @@
     "v_3_7_2",
   ]
   pruneopts = "T"
-  revision = "8fdb44663c709da33987e24bb07162847bf86893"
+  revision = "8a0758ed012fd7c14383c22905f34a4e1e7063b5"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -381,8 +381,8 @@
   revision = "79a61ffad296f3f418d8f381e4f5f702d5245b50"
 
 [[projects]]
-  branch = "teemow-check-etcd-dns-10-times-in-row"
-  digest = "1:ae0aae9fc0c6590e1720bcb6c66b11bc4d4be104a76801526ee1bfd802a90966"
+  branch = "master"
+  digest = "1:075a723474a2f5dde212732a35d4bf30947374396cc2a67a5ab50654b163e5c5"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "v_3_3_3",
@@ -393,7 +393,7 @@
     "v_3_7_2",
   ]
   pruneopts = "T"
-  revision = "8a0758ed012fd7c14383c22905f34a4e1e7063b5"
+  revision = "8e75ac4c46644a19f8b99913311abe6f9a996dea"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,7 +81,7 @@ required = [
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]
-  branch = "teemow-check-etcd-dns-10-times-in-row"
+  branch = "master"
   name = "github.com/giantswarm/k8scloudconfig"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,7 +81,7 @@ required = [
   name = "github.com/giantswarm/helmclient"
 
 [[constraint]]
-  branch = "master"
+  branch = "teemow-check-etcd-dns-10-times-in-row"
   name = "github.com/giantswarm/k8scloudconfig"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
@@ -18,6 +18,18 @@ version directory, and then changes are introduced.
 - Updated Calico to 3.2.3
 - Updated Calico manifest with resource limits to get QoS policy guaranteed.
 
+## [v3.7.2]
+
+### Changed
+- Remove the old master from the k8s api before upgrading calico (k8s-addons)
+- Wait until etcd DNS is resolvable before upgrading calico. Networking pods crashlooping isn't fun!
+
+## [v3.7.1]
+
+### Changed
+- The pod priority class for calico got lost. We found it again! 
+- kube-proxy is now installed before calico during cluster creation and upgrades. 
+
 ## [v3.7.0]
 
 ### Changed


### PR DESCRIPTION
Pull in the changes from k8scloudconfig 3.7.2