### PR TITLE
change default storage class for multiaz

### DIFF
--- a/service/controller/v19/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/v19/templates/cloudconfig/instance_storage_class.go
@@ -17,6 +17,7 @@ write_files:
         addonmanager.kubernetes.io/mode: EnsureExists
     provisioner: kubernetes.io/aws-ebs
     allowVolumeExpansion: true
+    volumeBindingMode: WaitForFirstConsumer
     parameters:
       type: gp2
 `


### PR DESCRIPTION
make sure that pods and volumes get scheduled into the same az.

activate the volume binding mode 'WaitForFirstConsumer' to the storage
class which will delay the binding and provisioning of a
PersistentVolume until a Pod using the PersistentVolumeClaim is created.