### PR TITLE
circleci: restore ClusterState tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,12 +250,12 @@ workflows:
 #      - e2eTestWIPMasterClusterState:
 #          requires:
 #            - master
-#      - e2eTestCurPRClusterState:
-#          requires:
-#            - pr
-#      - e2eTestWIPPRClusterState:
-#          requires:
-#            - pr
+      - e2eTestCurPRClusterState:
+          requires:
+            - pr
+      - e2eTestWIPPRClusterState:
+          requires:
+            - pr
 
 
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4692.

It should be fixed with
https://github.com/giantswarm/aws-operator/pull/1288.