### PR TITLE
Fix subnet route table association resource names

### DIFF
--- a/service/controller/v19/adapter/guest_subnets.go
+++ b/service/controller/v19/adapter/guest_subnets.go
@@ -49,7 +49,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                "PublicSubnet",
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           "PublicRouteTableAssociation",
+				Name:           "PublicSubnetRouteTableAssociation",
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     "PublicSubnet",
 			},
@@ -63,7 +63,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                "PrivateSubnet",
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           "PrivateRouteTableAssociation",
+				Name:           "PrivateSubnetRouteTableAssociation",
 				RouteTableName: "PrivateRouteTable",
 				SubnetName:     "PrivateSubnet",
 			},
@@ -79,7 +79,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           fmt.Sprintf("PublicRouteTableAssociation%02d", i),
+				Name:           fmt.Sprintf("PublicSubnetRouteTableAssociation%02d", i),
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     snetName,
 			},
@@ -93,7 +93,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           fmt.Sprintf("PrivateRouteTableAssociation%02d", i),
+				Name:           fmt.Sprintf("PrivateSubnetRouteTableAssociation%02d", i),
 				RouteTableName: fmt.Sprintf("PrivateRouteTable%02d", i),
 				SubnetName:     snetName,
 			},

--- a/service/controller/v19/adapter/guest_subnets_test.go
+++ b/service/controller/v19/adapter/guest_subnets_test.go
@@ -65,7 +65,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.2.0/25",
 					Name:             "PublicSubnet",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation",
+						Name:           "PublicSubnetRouteTableAssociation",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet",
 					},
@@ -75,7 +75,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.1.0/25",
 					Name:             "PublicSubnet01",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation01",
+						Name:           "PublicSubnetRouteTableAssociation01",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet01",
 					},
@@ -85,7 +85,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.3.0/25",
 					Name:             "PublicSubnet02",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation02",
+						Name:           "PublicSubnetRouteTableAssociation02",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet02",
 					},
@@ -97,7 +97,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.2.128/25",
 					Name:             "PrivateSubnet",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation",
+						Name:           "PrivateSubnetRouteTableAssociation",
 						RouteTableName: "PrivateRouteTable",
 						SubnetName:     "PrivateSubnet",
 					},
@@ -107,7 +107,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.1.128/25",
 					Name:             "PrivateSubnet01",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation01",
+						Name:           "PrivateSubnetRouteTableAssociation01",
 						RouteTableName: "PrivateRouteTable01",
 						SubnetName:     "PrivateSubnet01",
 					},
@@ -117,7 +117,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.3.128/25",
 					Name:             "PrivateSubnet02",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation02",
+						Name:           "PrivateSubnetRouteTableAssociation02",
 						RouteTableName: "PrivateRouteTable02",
 						SubnetName:     "PrivateSubnet02",
 					},

--- a/service/controller/v20/adapter/guest_subnets.go
+++ b/service/controller/v20/adapter/guest_subnets.go
@@ -47,7 +47,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           key.PublicRouteTableAssociationName(i),
+				Name:           key.PublicSubnetRouteTableAssociationName(i),
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     snetName,
 			},
@@ -61,7 +61,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           key.PrivateRouteTableAssociationName(i),
+				Name:           key.PrivateSubnetRouteTableAssociationName(i),
 				RouteTableName: key.PrivateRouteTableName(i),
 				SubnetName:     snetName,
 			},

--- a/service/controller/v20/adapter/guest_subnets.go
+++ b/service/controller/v20/adapter/guest_subnets.go
@@ -49,7 +49,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                "PublicSubnet",
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           "PublicRouteTableAssociation",
+				Name:           "PublicSubnetRouteTableAssociation",
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     "PublicSubnet",
 			},
@@ -63,7 +63,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                "PrivateSubnet",
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           "PrivateRouteTableAssociation",
+				Name:           "PrivateSubnetRouteTableAssociation",
 				RouteTableName: "PrivateRouteTable",
 				SubnetName:     "PrivateSubnet",
 			},
@@ -79,7 +79,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           fmt.Sprintf("PublicRouteTableAssociation%02d", i),
+				Name:           fmt.Sprintf("PublicSubnetRouteTableAssociation%02d", i),
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     snetName,
 			},
@@ -93,7 +93,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 			Name:                snetName,
 			MapPublicIPOnLaunch: false,
 			RouteTableAssociation: RouteTableAssociation{
-				Name:           fmt.Sprintf("PrivateRouteTableAssociation%02d", i),
+				Name:           fmt.Sprintf("PrivateSubnetRouteTableAssociation%02d", i),
 				RouteTableName: fmt.Sprintf("PrivateRouteTable%02d", i),
 				SubnetName:     snetName,
 			},

--- a/service/controller/v20/adapter/guest_subnets_test.go
+++ b/service/controller/v20/adapter/guest_subnets_test.go
@@ -65,7 +65,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.2.0/25",
 					Name:             "PublicSubnet",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation",
+						Name:           "PublicSubnetRouteTableAssociation",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet",
 					},
@@ -75,7 +75,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.1.0/25",
 					Name:             "PublicSubnet01",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation01",
+						Name:           "PublicSubnetRouteTableAssociation01",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet01",
 					},
@@ -85,7 +85,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.3.0/25",
 					Name:             "PublicSubnet02",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PublicRouteTableAssociation02",
+						Name:           "PublicSubnetRouteTableAssociation02",
 						RouteTableName: "PublicRouteTable",
 						SubnetName:     "PublicSubnet02",
 					},
@@ -97,7 +97,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.2.128/25",
 					Name:             "PrivateSubnet",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation",
+						Name:           "PrivateSubnetRouteTableAssociation",
 						RouteTableName: "PrivateRouteTable",
 						SubnetName:     "PrivateSubnet",
 					},
@@ -107,7 +107,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.1.128/25",
 					Name:             "PrivateSubnet01",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation01",
+						Name:           "PrivateSubnetRouteTableAssociation01",
 						RouteTableName: "PrivateRouteTable01",
 						SubnetName:     "PrivateSubnet01",
 					},
@@ -117,7 +117,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 					CIDR:             "10.100.3.128/25",
 					Name:             "PrivateSubnet02",
 					RouteTableAssociation: RouteTableAssociation{
-						Name:           "PrivateRouteTableAssociation02",
+						Name:           "PrivateSubnetRouteTableAssociation02",
 						RouteTableName: "PrivateRouteTable02",
 						SubnetName:     "PrivateSubnet02",
 					},

--- a/service/controller/v20/key/key.go
+++ b/service/controller/v20/key/key.go
@@ -415,13 +415,13 @@ func PolicyName(customObject v1alpha1.AWSConfig, profileType string) string {
 	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, PolicyNameTemplate)
 }
 
-func PrivateRouteTableAssociationName(idx int) string {
+func PrivateSubnetRouteTableAssociationName(idx int) string {
 	// Since CloudFormation cannot recognize resource renaming, use non-indexed
 	// resource name for first AZ.
 	if idx < 1 {
-		return "PrivateRouteTableAssociation"
+		return "PrivateSubnetRouteTableAssociation"
 	}
-	return fmt.Sprintf("PrivateRouteTableAssociation%02d", idx)
+	return fmt.Sprintf("PrivateSubnetRouteTableAssociation%02d", idx)
 }
 
 func PrivateRouteTableName(idx int) string {
@@ -450,13 +450,13 @@ func PublicSubnetCIDR(customObject v1alpha1.AWSConfig) string {
 	return customObject.Spec.AWS.VPC.PublicSubnetCIDR
 }
 
-func PublicRouteTableAssociationName(idx int) string {
+func PublicSubnetRouteTableAssociationName(idx int) string {
 	// Since CloudFormation cannot recognize resource renaming, use non-indexed
 	// resource name for first AZ.
 	if idx < 1 {
-		return "PublicRouteTableAssociation"
+		return "PublicSubnetRouteTableAssociation"
 	}
-	return fmt.Sprintf("PublicRouteTableAssociation%02d", idx)
+	return fmt.Sprintf("PublicSubnetRouteTableAssociation%02d", idx)
 }
 
 func PublicRouteTableName(idx int) string {


### PR DESCRIPTION
I made a mistake by dropping "Subnet" part from subnets' route table
association resource names and this broke migration path from old
clusters to new clusters.

Towards https://github.com/giantswarm/giantswarm/issues/4792