### PR TITLE
update autoscaler iam policy to scale to 0

### DIFF
--- a/service/controller/v21/templates/cloudformation/guest/iam_policies.go
+++ b/service/controller/v21/templates/cloudformation/guest/iam_policies.go
@@ -120,6 +120,8 @@ const IAMPolicies = `{{define "iam_policies"}}
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
               - "autoscaling:DescribeTags"
+              - "autoscaling:DescribeLaunchConfigurations"
+              - "ec2:DescribeLaunchTemplateVersions"
             Resource: "*"
 
           - Effect: "Allow"


### PR DESCRIPTION
the autoscaler needs additional permissions to scale an ASG to 0 nodes.

see
https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#scaling-a-node-group-to-0