### PR TITLE
move autoscaler iam policy to master

### DIFF
--- a/service/controller/v21/templates/cloudformation/guest/iam_policies.go
+++ b/service/controller/v21/templates/cloudformation/guest/iam_policies.go
@@ -47,6 +47,25 @@ const IAMPolicies = `{{define "iam_policies"}}
           - Effect: "Allow"
             Action: "elasticloadbalancing:*"
             Resource: "*"
+
+          - Effect: "Allow"
+            Action:
+              - "autoscaling:DescribeAutoScalingGroups"
+              - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeTags"
+              - "autoscaling:DescribeLaunchConfigurations"
+              - "ec2:DescribeLaunchTemplateVersions"
+            Resource: "*"
+
+          - Effect: "Allow"
+            Action:
+              - "autoscaling:SetDesiredCapacity"
+              - "autoscaling:TerminateInstanceInAutoScalingGroup"
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:RequestTag/giantswarm.io/cluster: "{{ $v.ClusterID }}"
+
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
@@ -114,24 +133,6 @@ const IAMPolicies = `{{define "iam_policies"}}
               - "ecr:ListImages"
               - "ecr:BatchGetImage"
             Resource: "*"
-
-          - Effect: "Allow"
-            Action:
-              - "autoscaling:DescribeAutoScalingGroups"
-              - "autoscaling:DescribeAutoScalingInstances"
-              - "autoscaling:DescribeTags"
-              - "autoscaling:DescribeLaunchConfigurations"
-              - "ec2:DescribeLaunchTemplateVersions"
-            Resource: "*"
-
-          - Effect: "Allow"
-            Action:
-              - "autoscaling:SetDesiredCapacity"
-              - "autoscaling:TerminateInstanceInAutoScalingGroup"
-            Resource: "*"
-            Condition:
-              StringEquals:
-                aws:RequestTag/giantswarm.io/cluster: "{{ $v.ClusterID }}"
 
   WorkerInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"


### PR DESCRIPTION
the autoscaler should be part of the control plane. therefore only the
master needs to have permissions to modify the autoscaling group.