### PR TITLE
add-vpc-s3-endpoint

### DIFF
--- a/service/controller/v21/adapter/guest_iam_policies.go
+++ b/service/controller/v21/adapter/guest_iam_policies.go
@@ -14,6 +14,7 @@ import (
 type GuestIAMPoliciesAdapter struct {
 	ClusterID         string
 	EC2ServiceDomain  string
+	GuestAccountID    string
 	KMSKeyARN         string
 	MasterRoleName    string
 	MasterPolicyName  string
@@ -30,6 +31,7 @@ func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
 
 	i.ClusterID = clusterID
 	i.EC2ServiceDomain = key.EC2ServiceDomain(cfg.CustomObject)
+	i.GuestAccountID = cfg.GuestAccountID
 	i.MasterPolicyName = key.PolicyName(cfg.CustomObject, key.KindMaster)
 	i.MasterProfileName = key.InstanceProfileName(cfg.CustomObject, key.KindMaster)
 	i.MasterRoleName = key.RoleName(cfg.CustomObject, key.KindMaster)

--- a/service/controller/v21/adapter/guest_vpc.go
+++ b/service/controller/v21/adapter/guest_vpc.go
@@ -16,6 +16,7 @@ type GuestVPCAdapter struct {
 	HostAccountID    string
 	PeerVPCID        string
 	PeerRoleArn      string
+	RouteTableNames  []RouteTableName
 }
 
 func (v *GuestVPCAdapter) Adapt(cfg Config) error {
@@ -35,6 +36,21 @@ func (v *GuestVPCAdapter) Adapt(cfg Config) error {
 		return microerror.Mask(err)
 	}
 	v.PeerRoleArn = *output.Role.Arn
+
+	PublicRouteTable := RouteTableName{
+		ResourceName: key.PublicRouteTableName(0),
+		TagName:      key.RouteTableName(cfg.CustomObject, suffixPublic, 0),
+	}
+	v.RouteTableNames = append(v.RouteTableNames, PublicRouteTable)
+
+	for i := 0; i < len(key.StatusAvailabilityZones(cfg.CustomObject)); i++ {
+		rtName := RouteTableName{
+			ResourceName:        key.PrivateRouteTableName(i),
+			TagName:             key.RouteTableName(cfg.CustomObject, suffixPrivate, i),
+			VPCPeeringRouteName: key.VPCPeeringRouteName(i),
+		}
+		v.RouteTableNames = append(v.RouteTableNames, rtName)
+	}
 
 	return nil
 }

--- a/service/controller/v21/templates/cloudformation/guest/iam_policies.go
+++ b/service/controller/v21/templates/cloudformation/guest/iam_policies.go
@@ -73,6 +73,17 @@ const IAMPolicies = `{{define "iam_policies"}}
       Roles:
         - Ref: "MasterRole"
 
+  VPCS3EndpointPolicy:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{ $v.ClusterID }}-vpc-s3-endpoint
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "*"
+            Resource: "arn:{{ $v.RegionARN }}:s3::{{ $v.GuestAccountID }}:*"
+
   WorkerRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/service/controller/v21/templates/cloudformation/guest/vpc.go
+++ b/service/controller/v21/templates/cloudformation/guest/vpc.go
@@ -23,4 +23,13 @@ const VPC = `{{define "vpc"}}
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}
+  VPCS3Endpoint:
+    Type: 'AWS::EC2::VPCEndpoint',
+    Properties:
+      VpcId: !Ref VPC
+      RouteTableIds:
+        {{- range $v.RouteTableNames }}
+        - !Ref .ResourceName
+        {{end}}
+      Policy: !Ref VPCS3EndpointPolicy
 {{end}}`

--- a/service/controller/v21/version_bundle.go
+++ b/service/controller/v21/version_bundle.go
@@ -12,6 +12,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Replace cloudinit with ignition.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "aws-operator",
+				Description: "Add S3 VPC endpoint.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
add VPC endpoint for S3, but only for s3 bucket from the guest cluster account