### PR TITLE
Lock default security group

### DIFF
--- a/service/controller/v21/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v21/templates/cloudformation/guest/security_groups.go
@@ -143,22 +143,4 @@ const SecurityGroups = `{{define "security_groups" }}
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
 
-  VPCDefaultSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group ingress traffic.
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref VPC.DefaultSecurityGroup
-
-  VPCDefaultSecurityGroupEgress:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      GroupId !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group egress traffic.
-      IpProtocol: -1
-      CidrIp: 127.0.0.1/32
-
 {{ end }}`

--- a/service/controller/v21/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v21/templates/cloudformation/guest/security_groups.go
@@ -143,4 +143,22 @@ const SecurityGroups = `{{define "security_groups" }}
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
 
+  VPCDefaultSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId !GetAtt VPC.DefaultSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref VPC.DefaultSecurityGroup
+
+  VPCDefaultSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId !GetAtt VPC.DefaultSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      CidrIp: 0.0.0.0/0
+
 {{ end }}`

--- a/service/controller/v21/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v21/templates/cloudformation/guest/security_groups.go
@@ -147,6 +147,7 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId !GetAtt VPC.DefaultSecurityGroup
+      Description: Lockdown Default Security Group.
       IpProtocol: -1
       FromPort: -1
       ToPort: -1
@@ -156,6 +157,7 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId !GetAtt VPC.DefaultSecurityGroup
+      Description: Lockdown Default Security Group.
       IpProtocol: -1
       FromPort: -1
       ToPort: -1

--- a/service/controller/v21/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v21/templates/cloudformation/guest/security_groups.go
@@ -147,7 +147,7 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group.
+      Description: Lockdown Default Security Group ingress traffic.
       IpProtocol: -1
       FromPort: -1
       ToPort: -1
@@ -157,10 +157,8 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group.
+      Description: Lockdown Default Security Group egress traffic.
       IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      CidrIp: 0.0.0.0/0
+      CidrIp: 127.0.0.1/32
 
 {{ end }}`

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -143,4 +143,22 @@ const SecurityGroups = `{{define "security_groups" }}
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
 
+  VPCDefaultSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId !GetAtt VPC.DefaultSecurityGroup
+      Description: Lockdown Default Security Group ingress traffic.
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref VPC.DefaultSecurityGroup
+
+  VPCDefaultSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId !GetAtt VPC.DefaultSecurityGroup
+      Description: Lockdown Default Security Group egress traffic.
+      IpProtocol: -1
+      CidrIp: 127.0.0.1/32
+
 {{ end }}`

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -160,5 +160,4 @@ const SecurityGroups = `{{define "security_groups" }}
       Description: Lockdown Default Security Group egress traffic.
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
-
 {{ end }}`

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -143,16 +143,6 @@ const SecurityGroups = `{{define "security_groups" }}
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
 
-  VPCDefaultSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !GetAtt VPC.DefaultSecurityGroup
-      Description: "Allow inbound traffic from instances assigned to the same security group."
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
-
   VPCDefaultSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -151,7 +151,7 @@ const SecurityGroups = `{{define "security_groups" }}
       IpProtocol: -1
       FromPort: -1
       ToPort: -1
-      SourceSecurityGroupId: !Ref VPC.DefaultSecurityGroup
+      SourceSecurityGroupId: !GetAtt VPC.DefaultSecurityGroup
 
   VPCDefaultSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -147,7 +147,7 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group ingress traffic.
+      Description: "Allow inbound traffic from instances assigned to the same security group."
       IpProtocol: -1
       FromPort: -1
       ToPort: -1
@@ -157,7 +157,7 @@ const SecurityGroups = `{{define "security_groups" }}
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId: !GetAtt VPC.DefaultSecurityGroup
-      Description: Lockdown Default Security Group egress traffic.
+      Description: "Allow outbound traffic from loopback address."
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
 {{ end }}`

--- a/service/controller/v22/templates/cloudformation/guest/security_groups.go
+++ b/service/controller/v22/templates/cloudformation/guest/security_groups.go
@@ -146,7 +146,7 @@ const SecurityGroups = `{{define "security_groups" }}
   VPCDefaultSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId !GetAtt VPC.DefaultSecurityGroup
+      GroupId: !GetAtt VPC.DefaultSecurityGroup
       Description: Lockdown Default Security Group ingress traffic.
       IpProtocol: -1
       FromPort: -1
@@ -156,7 +156,7 @@ const SecurityGroups = `{{define "security_groups" }}
   VPCDefaultSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      GroupId !GetAtt VPC.DefaultSecurityGroup
+      GroupId: !GetAtt VPC.DefaultSecurityGroup
       Description: Lockdown Default Security Group egress traffic.
       IpProtocol: -1
       CidrIp: 127.0.0.1/32


### PR DESCRIPTION
This PR locks down the default Security Group created once created the VPC. By default it is blank which means every connection is allowed. As stated here https://github.com/giantswarm/giantswarm/issues/4671 it is not assigned to anything but it is good practice to lock it down.

The PR must be still tested but it would be nice to have the first round of reviews on my first PR 😇