### PR TITLE
Fixes segfault in logger_meta

### DIFF
--- a/vendor/github.com/giantswarm/micrologger/loggermeta/logger_meta.go
+++ b/vendor/github.com/giantswarm/micrologger/loggermeta/logger_meta.go
@@ -40,6 +40,10 @@ func NewContext(ctx context.Context, v *LoggerMeta) context.Context {
 
 // FromContext returns the logger struct, if any.
 func FromContext(ctx context.Context) (*LoggerMeta, bool) {
+	if ctx == nil {
+		return nil, true
+	}
+
 	v, ok := ctx.Value(loggerMetaKey).(*LoggerMeta)
 	return v, ok
 }


### PR DESCRIPTION
If you modify either of the credentialSecret name or namespace values, e.g:
```
spec:
  aws:
    api:
      elb:
        idleTimeoutSeconds: 0
      hostedZones: ""
    availabilityZones: 1
    az: cn-north-1a
    credentialSecret:
      name: credential-default
      namespace: giantswarm-fuckyou
```
the operator immediately crashes w/ 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x5428c6]

goroutine 31 [running]:
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/micrologger/loggermeta.FromContext(0x0, 0x0, 0x4727a2, 0xc000726d90)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/micrologger/loggermeta/logger_meta.go:43 +0x26
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/micrologger.(*MicroLogger).LogCtx(0xc0000e5750, 0x0, 0x0, 0xc00057e480, 0x6, 0x6, 0x1c6, 0x228b9a0)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/micrologger/logger.go:53 +0x50
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).updateFunc(0xc0001d6960, 0x0, 0x0, 0x1f2ecc0, 0xc0002db400)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:341 +0x55f
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).ProcessEvents.func1(0xc00072c080, 0xc00072c0a0)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:286 +0x650
github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc0005dd180, 0x7f724a3a8028, 0xc00072c080, 0xc000725920, 0x0, 0x0)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0xbb
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).ProcessEvents(0xc0001d6960, 0x22ad2e0, 0xc0002d6270, 0xc0001a5380, 0xc0001a53e0, 0xc0001a5440, 0x0, 0x0)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:303 +0x18c
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).bootWithError(0xc0001d6960, 0x22ad2e0, 0xc0002d6270, 0x10cdddc, 0xc0004ba280)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:415 +0x392
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot.func1.1(0xc000562f40, 0xc000562f60)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:141 +0x3c
github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc000562f20, 0x7f724a3a8028, 0xc000562f40, 0xc0002d62a0, 0x0, 0x0)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0xbb
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot.func1()
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:151 +0x13e
sync.(*Once).Do(0xc0001d69b8, 0xc000473f98)
	/usr/local/go/src/sync/once.go:44 +0xb3
github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot(0xc0001d6960, 0x22ad260, 0xc000046018)
	/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:139 +0xbc
created by github.com/giantswarm/aws-operator/service.(*Service).Boot.func1
	/go/src/github.com/giantswarm/aws-operator/service/service.go:277 +0xe1
```
