### PR TITLE
Fix encryption certificates

### DIFF
--- a/service/controller/v22/cloudconfig/master_template.go
+++ b/service/controller/v22/cloudconfig/master_template.go
@@ -2,6 +2,7 @@ package cloudconfig
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
@@ -200,6 +201,7 @@ func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		},
 	}
 
+	certsMeta := []k8scloudconfig.FileMetadata{}
 	{
 		certFiles := certs.NewFilesClusterMaster(e.ClusterCerts)
 
@@ -225,7 +227,7 @@ func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 				Permissions: 0700,
 			}
 
-			filesMeta = append(filesMeta, meta)
+			certsMeta = append(certsMeta, meta)
 		}
 	}
 
@@ -241,6 +243,16 @@ func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		asset := k8scloudconfig.FileAsset{
 			Metadata: fm,
 			Content:  c,
+		}
+
+		fileAssets = append(fileAssets, asset)
+	}
+
+	for _, cm := range certsMeta {
+		c := base64.StdEncoding.EncodeToString([]byte(cm.AssetContent))
+		asset := k8scloudconfig.FileAsset{
+			Metadata: cm,
+			Content: c,
 		}
 
 		fileAssets = append(fileAssets, asset)

--- a/service/controller/v22/cloudconfig/master_template.go
+++ b/service/controller/v22/cloudconfig/master_template.go
@@ -252,7 +252,7 @@ func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		c := base64.StdEncoding.EncodeToString([]byte(cm.AssetContent))
 		asset := k8scloudconfig.FileAsset{
 			Metadata: cm,
-			Content: c,
+			Content:  c,
 		}
 
 		fileAssets = append(fileAssets, asset)

--- a/service/controller/v22/cloudconfig/worker_template.go
+++ b/service/controller/v22/cloudconfig/worker_template.go
@@ -2,6 +2,7 @@ package cloudconfig
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
@@ -117,6 +118,7 @@ func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		},
 	}
 
+	certsMeta := []k8scloudconfig.FileMetadata{}
 	{
 		certFiles := certs.NewFilesClusterWorker(e.ClusterCerts)
 
@@ -142,7 +144,7 @@ func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 				Permissions: 0700,
 			}
 
-			filesMeta = append(filesMeta, meta)
+			certsMeta = append(certsMeta, meta)
 		}
 	}
 
@@ -157,6 +159,16 @@ func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 
 		asset := k8scloudconfig.FileAsset{
 			Metadata: m,
+			Content:  c,
+		}
+
+		fileAssets = append(fileAssets, asset)
+	}
+
+	for _, cm := range certsMeta {
+		c := base64.StdEncoding.EncodeToString([]byte(cm.AssetContent))
+		asset := k8scloudconfig.FileAsset{
+			Metadata: cm,
 			Content:  c,
 		}
 


### PR DESCRIPTION
This PR aims to resolve the issue https://github.com/giantswarm/giantswarm/issues/5179

During cluster creation an error is reported that both master and worker templates are invalid due to unrecognised characters.

The issue is that when the certificates are encoded in base64 with the function `RenderFileAssetContent` then the result is not valid.

The solution resides on encoding in base64 directly rather than passing the asset content to the function.

The questions we could try to reply to make things clear are:

1. Why this issue now? Why has not been found out before? Any regression in any library or any changes?
2. Why the function `RenderFileAssetContent`? The creation of the template invalidates in case of certs breaks the the certs?

cc @corest 