### PR TITLE
adds account ID resource

### DIFF
--- a/service/controller/v22/controllercontext/status.go
+++ b/service/controller/v22/controllercontext/status.go
@@ -8,9 +8,14 @@ type Status struct {
 }
 
 type Cluster struct {
+	AWSAccount ClusterAWSAccount
 	// HostedZones is filled by the hostedzone resource. This information
 	// is used when creating CloudFormation templates.
 	HostedZones ClusterHostedZones
+}
+
+type ClusterAWSAccount struct {
+	ID string
 }
 
 type ClusterHostedZones struct {

--- a/service/controller/v22/encrypter/vault/vault.go
+++ b/service/controller/v22/encrypter/vault/vault.go
@@ -152,7 +152,7 @@ func (e *Encrypter) EnsureCreatedAuthorizedIAMRoles(ctx context.Context, customO
 		return microerror.Mask(err)
 	}
 
-	ctlCtx, err := controllercontext.FromContext(ctx)
+	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -160,13 +160,8 @@ func (e *Encrypter) EnsureCreatedAuthorizedIAMRoles(ctx context.Context, customO
 	var masterRoleARN string
 	var workerRoleARN string
 	{
-		accountID, err := ctlCtx.AWSService.GetAccountID()
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		masterRoleARN = key.MasterRoleARN(customObject, accountID)
-		workerRoleARN = key.WorkerRoleARN(customObject, accountID)
+		masterRoleARN = key.MasterRoleARN(customObject, cc.Status.Cluster.AWSAccount.ID)
+		workerRoleARN = key.WorkerRoleARN(customObject, cc.Status.Cluster.AWSAccount.ID)
 	}
 
 	var roleData *AWSAuthRole
@@ -259,7 +254,7 @@ func (e *Encrypter) EnsureCreatedEncryptionKey(ctx context.Context, customObject
 }
 
 func (e *Encrypter) EnsureDeletedAuthorizedIAMRoles(ctx context.Context, customObject v1alpha1.AWSConfig) error {
-	ctlCtx, err := controllercontext.FromContext(ctx)
+	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -267,13 +262,8 @@ func (e *Encrypter) EnsureDeletedAuthorizedIAMRoles(ctx context.Context, customO
 	var masterRoleARN string
 	var workerRoleARN string
 	{
-		accountID, err := ctlCtx.AWSService.GetAccountID()
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		masterRoleARN = key.MasterRoleARN(customObject, accountID)
-		workerRoleARN = key.WorkerRoleARN(customObject, accountID)
+		masterRoleARN = key.MasterRoleARN(customObject, cc.Status.Cluster.AWSAccount.ID)
+		workerRoleARN = key.WorkerRoleARN(customObject, cc.Status.Cluster.AWSAccount.ID)
 	}
 
 	var roleData *AWSAuthRole

--- a/service/controller/v22/resource/accountid/create.go
+++ b/service/controller/v22/resource/accountid/create.go
@@ -1,0 +1,16 @@
+package accountid
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := addAccountIDToContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v22/resource/accountid/delete.go
+++ b/service/controller/v22/resource/accountid/delete.go
@@ -1,0 +1,16 @@
+package accountid
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := addAccountIDToContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v22/resource/accountid/error.go
+++ b/service/controller/v22/resource/accountid/error.go
@@ -1,0 +1,14 @@
+package accountid
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v22/resource/accountid/resource.go
+++ b/service/controller/v22/resource/accountid/resource.go
@@ -1,0 +1,54 @@
+package accountid
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
+)
+
+const (
+	Name = "accountidv22"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		logger: config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func addAccountIDToContext(ctx context.Context) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	accountID, err := cc.AWSService.GetAccountID()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cc.Status.Cluster.AWSAccount.ID = accountID
+
+	return nil
+}

--- a/service/controller/v22/resource/s3bucket/create_test.go
+++ b/service/controller/v22/resource/s3bucket/create_test.go
@@ -79,13 +79,15 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 	}
 
 	var err error
+
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.Logger = microloggertest.New()
-		resourceConfig.InstallationName = "test-install"
+		c := Config{
+			Logger:           microloggertest.New(),
+			InstallationName: "test-install",
+		}
 
-		newResource, err = New(resourceConfig)
+		newResource, err = New(c)
 		if err != nil {
 			t.Error("expected", nil, "got", err)
 		}

--- a/service/controller/v22/resource/s3bucket/current.go
+++ b/service/controller/v22/resource/s3bucket/current.go
@@ -20,7 +20,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the S3 buckets")
 
-	sc, err := controllercontext.FromContext(ctx)
+	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -31,14 +31,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	//
 	//     https://github.com/giantswarm/giantswarm/issues/5126
 	//
-	accountID, err := sc.AWSService.GetAccountID()
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	bucketStateNames := []string{
 		key.TargetLogBucketName(customObject),
-		key.BucketName(customObject, accountID),
+		key.BucketName(customObject, cc.Status.Cluster.AWSAccount.ID),
 	}
 
 	var currentBucketState []BucketState

--- a/service/controller/v22/resource/s3bucket/delete_test.go
+++ b/service/controller/v22/resource/s3bucket/delete_test.go
@@ -79,13 +79,15 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 	}
 
 	var err error
+
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.Logger = microloggertest.New()
-		resourceConfig.InstallationName = "test-install"
+		c := Config{
+			Logger:           microloggertest.New(),
+			InstallationName: "test-install",
+		}
 
-		newResource, err = New(resourceConfig)
+		newResource, err = New(c)
 		if err != nil {
 			t.Error("expected", nil, "got", err)
 		}

--- a/service/controller/v22/resource/s3bucket/desired.go
+++ b/service/controller/v22/resource/s3bucket/desired.go
@@ -15,12 +15,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	sc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	accountID, err := sc.AWSService.GetAccountID()
+	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -34,7 +29,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			IsLoggingEnabled: true,
 		},
 		{
-			Name:             key.BucketName(customObject, accountID),
+			Name:             key.BucketName(customObject, cc.Status.Cluster.AWSAccount.ID),
 			IsLoggingBucket:  false,
 			IsLoggingEnabled: true,
 		},

--- a/service/controller/v22/resource/s3bucket/resource.go
+++ b/service/controller/v22/resource/s3bucket/resource.go
@@ -29,15 +29,6 @@ type Config struct {
 	InstallationName     string
 }
 
-// DefaultConfig provides a default configuration to create a new s3bucket
-// resource by best effort.
-func DefaultConfig() Config {
-	return Config{
-		// Dependencies.
-		Logger: nil,
-	}
-}
-
 // Resource implements the s3bucket resource.
 type Resource struct {
 	// Dependencies.

--- a/service/controller/v22/resource/s3object/current_test.go
+++ b/service/controller/v22/resource/s3object/current_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/randomkeys/randomkeystest"
 
 	"github.com/giantswarm/aws-operator/client/aws"
-	awsservice "github.com/giantswarm/aws-operator/service/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
@@ -27,13 +26,12 @@ func Test_CurrentState(t *testing.T) {
 	}
 
 	testCases := []struct {
-		obj              *v1alpha1.AWSConfig
-		description      string
-		expectedIAMError bool
-		expectedS3Error  bool
-		expectedKey      string
-		expectedBucket   string
-		expectedBody     string
+		obj             *v1alpha1.AWSConfig
+		description     string
+		expectedS3Error bool
+		expectedKey     string
+		expectedBucket  string
+		expectedBody    string
 	}{
 		{
 			description:    "basic match",
@@ -41,11 +39,6 @@ func Test_CurrentState(t *testing.T) {
 			expectedKey:    "cloudconfig/myversion/worker",
 			expectedBucket: "myaccountid-g8s-test-cluster",
 			expectedBody:   "mybody",
-		},
-		{
-			description:      "IAM error",
-			obj:              clusterTpo,
-			expectedIAMError: true,
 		},
 		{
 			description:     "S3 error",
@@ -61,11 +54,6 @@ func Test_CurrentState(t *testing.T) {
 					isError: tc.expectedS3Error,
 					body:    tc.expectedBody,
 				},
-			}
-
-			awsService := awsservice.AwsServiceMock{
-				AccountID: "myaccountid",
-				IsError:   tc.expectedIAMError,
 			}
 
 			cloudconfig := &CloudConfigMock{}
@@ -88,24 +76,27 @@ func Test_CurrentState(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient:  awsClients,
-				AWSService: awsService,
+				AWSClient: awsClients,
+				Status: controllercontext.Status{
+					Cluster: controllercontext.Cluster{
+						AWSAccount: controllercontext.ClusterAWSAccount{
+							ID: "myaccountid",
+						},
+					},
+				},
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)
 
 			result, err := newResource.GetCurrentState(ctx, tc.obj)
-			if err != nil && !tc.expectedIAMError && !tc.expectedS3Error {
+			if err != nil && !tc.expectedS3Error {
 				t.Errorf("unexpected error %v", err)
-			}
-			if err == nil && tc.expectedIAMError {
-				t.Error("expected IAM error didn't happen")
 			}
 			if err == nil && tc.expectedS3Error {
 				t.Error("expected S3 error didn't happen")
 			}
 
-			if !tc.expectedIAMError && !tc.expectedS3Error {
+			if !tc.expectedS3Error {
 				currentState, ok := result.(map[string]BucketObjectState)
 				if !ok {
 					t.Errorf("expected '%T', got '%T'", currentState, result)

--- a/service/controller/v22/resource/s3object/desired_test.go
+++ b/service/controller/v22/resource/s3object/desired_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/randomkeys/randomkeystest"
 
 	"github.com/giantswarm/aws-operator/client/aws"
-	awsservice "github.com/giantswarm/aws-operator/service/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
@@ -53,11 +52,6 @@ func Test_DesiredState(t *testing.T) {
 				KMS: &KMSClientMock{},
 			}
 
-			awsService := awsservice.AwsServiceMock{
-				AccountID: "myaccountid",
-				KeyArn:    "mykeyarn",
-			}
-
 			cloudconfig := &CloudConfigMock{
 				template: tc.expectedBody,
 			}
@@ -80,8 +74,14 @@ func Test_DesiredState(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient:  awsClients,
-				AWSService: awsService,
+				AWSClient: awsClients,
+				Status: controllercontext.Status{
+					Cluster: controllercontext.Cluster{
+						AWSAccount: controllercontext.ClusterAWSAccount{
+							ID: "myaccountid",
+						},
+					},
+				},
 			}
 			ctx := context.TODO()
 			ctx = controllercontext.NewContext(ctx, c)


### PR DESCRIPTION
This PR suggests a new `accountid` resource. It is pretty simple. It only fetches the AWS Account ID once and puts it into the controller context. This saves about 6 calls to AWS STS during one reconciliation loop. 