### PR TITLE
set encryption key to controller context status

### DIFF
--- a/service/controller/v22/cloudconfig/master_template.go
+++ b/service/controller/v22/cloudconfig/master_template.go
@@ -25,11 +25,7 @@ func (c *CloudConfig) NewMasterTemplate(ctx context.Context, customObject v1alph
 		return "", microerror.Mask(err)
 	}
 
-	encryptionKey, err := c.encrypter.EncryptionKey(ctx, customObject)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-	randomKeyTmplSet, err := renderRandomKeyTmplSet(ctx, c.encrypter, encryptionKey, clusterKeys)
+	randomKeyTmplSet, err := renderRandomKeyTmplSet(ctx, c.encrypter, ctlCtx.Status.Cluster.EncryptionKey, clusterKeys)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -39,7 +35,7 @@ func (c *CloudConfig) NewMasterTemplate(ctx context.Context, customObject v1alph
 		be := baseExtension{
 			customObject:  customObject,
 			encrypter:     c.encrypter,
-			encryptionKey: encryptionKey,
+			encryptionKey: ctlCtx.Status.Cluster.EncryptionKey,
 		}
 
 		params = k8scloudconfig.DefaultParams()
@@ -109,9 +105,9 @@ type MasterExtension struct {
 }
 
 func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
-	// TODO Pass context to k8scloudconfig rendering fucntions
+	// TODO Pass context to k8scloudconfig rendering functions.
 	//
-	//	See https://github.com/giantswarm/giantswarm/issues/4329.
+	//     https://github.com/giantswarm/giantswarm/issues/4329
 	//
 	var storageClass string
 	_, ok := e.encrypter.(*vault.Encrypter)

--- a/service/controller/v22/cloudconfig/worker_template.go
+++ b/service/controller/v22/cloudconfig/worker_template.go
@@ -23,17 +23,12 @@ func (c *CloudConfig) NewWorkerTemplate(ctx context.Context, customObject v1alph
 		return "", microerror.Mask(err)
 	}
 
-	encryptionKey, err := c.encrypter.EncryptionKey(ctx, customObject)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
 	var params k8scloudconfig.Params
 	{
 		be := baseExtension{
 			customObject:  customObject,
 			encrypter:     c.encrypter,
-			encryptionKey: encryptionKey,
+			encryptionKey: ctlCtx.Status.Cluster.EncryptionKey,
 		}
 
 		// Default registry, kubernetes, etcd images etcd.

--- a/service/controller/v22/cluster_resource_set.go
+++ b/service/controller/v22/cluster_resource_set.go
@@ -310,12 +310,11 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var s3BucketObjectResource controller.Resource
+	var s3ObjectResource controller.Resource
 	{
 		c := s3object.Config{
 			CertsSearcher:      config.CertsSearcher,
 			CloudConfig:        cloudConfig,
-			Encrypter:          encrypterObject,
 			Logger:             config.Logger,
 			RandomKeysSearcher: config.RandomKeysSearcher,
 		}
@@ -325,7 +324,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			return nil, microerror.Mask(err)
 		}
 
-		s3BucketObjectResource, err = toCRUDResource(config.Logger, ops)
+		s3ObjectResource, err = toCRUDResource(config.Logger, ops)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -503,7 +502,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		bridgeZoneResource,
 		encryptionKeyResource,
 		s3BucketResource,
-		s3BucketObjectResource,
+		s3ObjectResource,
 		loadBalancerResource,
 		ebsVolumeResource,
 		cloudformationResource,

--- a/service/controller/v22/controllercontext/status.go
+++ b/service/controller/v22/controllercontext/status.go
@@ -8,7 +8,8 @@ type Status struct {
 }
 
 type Cluster struct {
-	AWSAccount ClusterAWSAccount
+	AWSAccount    ClusterAWSAccount
+	EncryptionKey string
 	// HostedZones is filled by the hostedzone resource. This information
 	// is used when creating CloudFormation templates.
 	HostedZones ClusterHostedZones

--- a/service/controller/v22/encrypter/kms/kms.go
+++ b/service/controller/v22/encrypter/kms/kms.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 	"github.com/giantswarm/aws-operator/service/controller/v22/key"
 )
 
@@ -213,32 +212,6 @@ func (e *Encrypter) EnsureDeletedEncryptionKey(ctx context.Context, customObject
 	}
 
 	return nil
-}
-
-func (k *Encrypter) CurrentState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
-	var currentState encrypter.EncryptionKeyState
-
-	output, err := k.describeKey(ctx, customObject)
-	if IsKeyNotFound(err) {
-		// Fall through.
-		return currentState, nil
-	}
-	if err != nil {
-		return currentState, microerror.Mask(err)
-	}
-
-	currentState.KeyID = *output.KeyMetadata.KeyId
-	currentState.KeyName = keyAlias(customObject)
-
-	return currentState, nil
-}
-
-func (k *Encrypter) DesiredState(ctx context.Context, customObject v1alpha1.AWSConfig) (encrypter.EncryptionKeyState, error) {
-	desiredState := encrypter.EncryptionKeyState{}
-
-	desiredState.KeyName = keyAlias(customObject)
-
-	return desiredState, nil
 }
 
 func (k *Encrypter) EncryptionKey(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {

--- a/service/controller/v22/encrypter/spec.go
+++ b/service/controller/v22/encrypter/spec.go
@@ -11,11 +11,6 @@ const (
 	VaultBackend = "vault"
 )
 
-type EncryptionKeyState struct {
-	KeyID   string
-	KeyName string
-}
-
 type Interface interface {
 	Encrypter
 	Resource

--- a/service/controller/v22/resource/encryptionkey/create.go
+++ b/service/controller/v22/resource/encryptionkey/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/key"
 )
 
@@ -18,6 +19,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	encryptionKey, err := r.encrypter.EncryptionKey(ctx, customObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc.Status.Cluster.EncryptionKey = encryptionKey
 
 	return nil
 }

--- a/service/controller/v22/resource/encryptionkey/delete.go
+++ b/service/controller/v22/resource/encryptionkey/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/key"
 )
 
@@ -18,6 +19,21 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	encryptionKey, err := r.encrypter.EncryptionKey(ctx, customObject)
+	if r.encrypter.IsKeyNotFound(err) {
+		// We can get here during deletion, if the key is already deleted we can
+		// safely exit.
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc.Status.Cluster.EncryptionKey = encryptionKey
 
 	return nil
 }

--- a/service/controller/v22/resource/encryptionkey/delete.go
+++ b/service/controller/v22/resource/encryptionkey/delete.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/key"
 )
 
@@ -19,21 +18,6 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	encryptionKey, err := r.encrypter.EncryptionKey(ctx, customObject)
-	if r.encrypter.IsKeyNotFound(err) {
-		// We can get here during deletion, if the key is already deleted we can
-		// safely exit.
-		return nil
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	cc.Status.Cluster.EncryptionKey = encryptionKey
 
 	return nil
 }

--- a/service/controller/v22/resource/encryptionkey/resource.go
+++ b/service/controller/v22/resource/encryptionkey/resource.go
@@ -12,12 +12,12 @@ const (
 )
 
 type Config struct {
-	Encrypter encrypter.Resource
+	Encrypter encrypter.Interface
 	Logger    micrologger.Logger
 }
 
 type Resource struct {
-	encrypter encrypter.Resource
+	encrypter encrypter.Interface
 	logger    micrologger.Logger
 }
 

--- a/service/controller/v22/resource/s3object/create_test.go
+++ b/service/controller/v22/resource/s3object/create_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
 
 func Test_Resource_S3Object_newCreate(t *testing.T) {
@@ -162,7 +161,6 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		c := Config{
 			CertsSearcher:      certstest.NewSearcher(),
 			CloudConfig:        cloudConfig,
-			Encrypter:          &encrypter.EncrypterMock{},
 			Logger:             microloggertest.New(),
 			RandomKeysSearcher: randomkeystest.NewSearcher(),
 		}

--- a/service/controller/v22/resource/s3object/current.go
+++ b/service/controller/v22/resource/s3object/current.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v22/key"
@@ -26,10 +27,20 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
+	// During deletion, it might happen that the encryption key got already
+	// deleted. In such a case we do not have to do anything here anymore. The
+	// desired state computation usually requires the encryption key to come up
+	// with the deletion state, but in case it is gone we do not have to do
+	// anything here anymore. The current implementation relies on the bucket
+	// deletion of the s3bucket resource, which deletes all S3 objects and the
+	// bucket itself.
 	if key.IsDeleted(customObject) {
 		if cc.Status.Cluster.EncryptionKey == "" {
-			// We can get here during deletion, if the key is already deleted we can
-			// safely exit.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "no encryption key in controller context")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			resourcecanceledcontext.SetCanceled(ctx)
+
 			return nil, nil
 		}
 	}

--- a/service/controller/v22/resource/s3object/current.go
+++ b/service/controller/v22/resource/s3object/current.go
@@ -26,6 +26,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
+	if key.IsDeleted(customObject) {
+		if cc.Status.Cluster.EncryptionKey == "" {
+			// We can get here during deletion, if the key is already deleted we can
+			// safely exit.
+			return nil, nil
+		}
+	}
+
 	bucketName := key.BucketName(customObject, cc.Status.Cluster.AWSAccount.ID)
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucketName),

--- a/service/controller/v22/resource/s3object/current_test.go
+++ b/service/controller/v22/resource/s3object/current_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
 
 func Test_CurrentState(t *testing.T) {
@@ -64,7 +63,6 @@ func Test_CurrentState(t *testing.T) {
 				c := Config{
 					CertsSearcher:      certstest.NewSearcher(),
 					CloudConfig:        cloudconfig,
-					Encrypter:          &encrypter.EncrypterMock{},
 					Logger:             microloggertest.New(),
 					RandomKeysSearcher: randomkeystest.NewSearcher(),
 				}

--- a/service/controller/v22/resource/s3object/desired.go
+++ b/service/controller/v22/resource/s3object/desired.go
@@ -21,15 +21,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	_, err = r.encrypter.EncryptionKey(ctx, customObject)
-	if r.encrypter.IsKeyNotFound(err) && key.IsDeleted(customObject) {
-		// We can get here during deletion, if the key is already deleted we can
-		// safely exit.
-		return nil, nil
-	} else if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	var clusterCerts certs.Cluster
 	var clusterKeys randomkeys.Cluster
 	{

--- a/service/controller/v22/resource/s3object/desired_test.go
+++ b/service/controller/v22/resource/s3object/desired_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
 
 func Test_DesiredState(t *testing.T) {
@@ -62,7 +61,6 @@ func Test_DesiredState(t *testing.T) {
 				c := Config{
 					CertsSearcher:      certstest.NewSearcher(),
 					CloudConfig:        cloudconfig,
-					Encrypter:          &encrypter.EncrypterMock{},
 					Logger:             microloggertest.New(),
 					RandomKeysSearcher: randomkeystest.NewSearcher(),
 				}

--- a/service/controller/v22/resource/s3object/resource.go
+++ b/service/controller/v22/resource/s3object/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/giantswarm/randomkeys"
 
 	"github.com/giantswarm/aws-operator/service/controller/v22/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
 
 const (
@@ -23,7 +22,6 @@ const (
 type Config struct {
 	CertsSearcher      certs.Interface
 	CloudConfig        cloudconfig.Interface
-	Encrypter          encrypter.Interface
 	Logger             micrologger.Logger
 	RandomKeysSearcher randomkeys.Interface
 }
@@ -32,7 +30,6 @@ type Config struct {
 type Resource struct {
 	certsSearcher      certs.Interface
 	cloudConfig        cloudconfig.Interface
-	encrypter          encrypter.Interface
 	logger             micrologger.Logger
 	randomKeysSearcher randomkeys.Interface
 }
@@ -45,9 +42,6 @@ func New(config Config) (*Resource, error) {
 	if config.CloudConfig == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.CloudConfig must not be empty", config)
 	}
-	if config.Encrypter == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Encrypter must not be empty")
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
@@ -58,7 +52,6 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		certsSearcher:      config.CertsSearcher,
 		cloudConfig:        config.CloudConfig,
-		encrypter:          config.Encrypter,
 		logger:             config.Logger,
 		randomKeysSearcher: config.RandomKeysSearcher,
 	}

--- a/service/controller/v22/resource/s3object/update_test.go
+++ b/service/controller/v22/resource/s3object/update_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
 	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/v22/encrypter"
 )
 
 func Test_Resource_S3Object_newUpdate(t *testing.T) {
@@ -155,7 +154,6 @@ func Test_Resource_S3Object_newUpdate(t *testing.T) {
 				c := Config{
 					CertsSearcher:      certstest.NewSearcher(),
 					CloudConfig:        cloudConfig,
-					Encrypter:          &encrypter.EncrypterMock{},
 					Logger:             microloggertest.New(),
 					RandomKeysSearcher: randomkeystest.NewSearcher(),
 				}


### PR DESCRIPTION
This PR provides further optimizations for the reconciliation and communication between resource implementations. We replace 3 calls to fetch the encryption key with 1 call. 