### PR TITLE
manage parallel execution without context

### DIFF
--- a/service/controller/v22/resource/bridgezone/resource.go
+++ b/service/controller/v22/resource/bridgezone/resource.go
@@ -169,7 +169,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g := &errgroup.Group{}
 
 	var intermediateZoneID string
 	g.Go(func() error {

--- a/service/controller/v22/resource/ipam/create.go
+++ b/service/controller/v22/resource/ipam/create.go
@@ -139,7 +139,7 @@ func (r *Resource) allocateSubnet(ctx context.Context) (net.IPNet, error) {
 	var mutex sync.Mutex
 	var reservedSubnets []net.IPNet
 
-	g, ctx := errgroup.WithContext(ctx)
+	g := &errgroup.Group{}
 
 	g.Go(func() error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from VPCs")

--- a/service/controller/v22/resource/s3bucket/create.go
+++ b/service/controller/v22/resource/s3bucket/create.go
@@ -46,7 +46,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			}
 		}
 
-		g, ctx := errgroup.WithContext(ctx)
+		g := &errgroup.Group{}
 
 		if r.includeTags {
 			g.Go(func() error {

--- a/service/controller/v22/resource/s3bucket/current.go
+++ b/service/controller/v22/resource/s3bucket/current.go
@@ -33,7 +33,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the S3 buckets")
 
-		g, ctx := errgroup.WithContext(ctx)
+		g := &errgroup.Group{}
 
 		for _, inputBucketName := range bucketStateNames {
 			bucketName := inputBucketName

--- a/service/controller/v22/resource/s3bucket/delete.go
+++ b/service/controller/v22/resource/s3bucket/delete.go
@@ -35,7 +35,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 		return microerror.Mask(err)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g := &errgroup.Group{}
 
 	for _, b := range bucketsInput {
 		bucketName := b.Name


### PR DESCRIPTION
I noticed the wrapped context gets canceled after parallel execution, which does not work when there are further actions made using that context. The best is to not interfere with the context at all and manage the parallel execution without it. 