### PR TITLE
Remove all reference to GuestAWSAccessKey and Secret

### DIFF
--- a/integration/env/aws.go
+++ b/integration/env/aws.go
@@ -12,8 +12,6 @@ const (
 	EnvVarAWSIngressHostedZoneGuest = "AWS_INGRESS_HOSTED_ZONE_GUEST"
 	EnvVarAWSRegion                 = "AWS_REGION"
 	EnvVarGuestAWSARN               = "GUEST_AWS_ARN"
-	EnvVarGuestAWSAccessKeyID       = "GUEST_AWS_ACCESS_KEY_ID"
-	EnvVarGuestAWSAccessKeySecret   = "GUEST_AWS_SECRET_ACCESS_KEY"
 	EnvVarGuestAWSAccessKeyToken    = "GUEST_AWS_SESSION_TOKEN"
 	EnvVarHostAWSAccessKeyID        = "HOST_AWS_ACCESS_KEY_ID"
 	EnvVarHostAWSAccessKeySecret    = "HOST_AWS_SECRET_ACCESS_KEY"
@@ -26,8 +24,6 @@ var (
 	awsIngressHostedZoneGuest string
 	awsRegion                 string
 	guestAWSARN               string
-	guestAWSAccessKeyID       string
-	guestAWSAccessKeySecret   string
 	guestAWSAccessKeyToken    string
 	hostAWSAccessKeyID        string
 	hostAWSAccessKeySecret    string
@@ -54,16 +50,6 @@ func init() {
 	guestAWSARN = os.Getenv(EnvVarGuestAWSARN)
 	if guestAWSARN == "" {
 		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarGuestAWSARN))
-	}
-
-	guestAWSAccessKeyID = os.Getenv(EnvVarGuestAWSAccessKeyID)
-	if guestAWSAccessKeyID == "" {
-		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarGuestAWSAccessKeyID))
-	}
-
-	guestAWSAccessKeySecret = os.Getenv(EnvVarGuestAWSAccessKeySecret)
-	if guestAWSAccessKeySecret == "" {
-		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarGuestAWSAccessKeySecret))
 	}
 
 	guestAWSAccessKeyToken = os.Getenv(EnvVarGuestAWSAccessKeyToken)
@@ -110,13 +96,6 @@ func GuestAWSARN() string {
 	return guestAWSARN
 }
 
-func GuestAWSAccessKeyID() string {
-	return guestAWSAccessKeyID
-}
-
-func GuestAWSAccessKeySecret() string {
-	return guestAWSAccessKeySecret
-}
 
 func GuestAWSAccessKeyToken() string {
 	return guestAWSAccessKeyToken

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -92,8 +92,6 @@ func installAWSOperator(ctx context.Context, config Config) error {
 						Service: chartvalues.AWSOperatorConfigSecretAWSOperatorSecretYamlService{
 							AWS: chartvalues.AWSOperatorConfigSecretAWSOperatorSecretYamlServiceAWS{
 								AccessKey: chartvalues.AWSOperatorConfigSecretAWSOperatorSecretYamlServiceAWSAccessKey{
-									ID:     env.GuestAWSAccessKeyID(),
-									Secret: env.GuestAWSAccessKeySecret(),
 									Token:  env.GuestAWSAccessKeyToken(),
 								},
 								HostAccessKey: chartvalues.AWSOperatorConfigSecretAWSOperatorSecretYamlServiceAWSAccessKey{

--- a/main.go
+++ b/main.go
@@ -108,8 +108,6 @@ func mainError() error {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
-	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.ID, "", "ID of the AWS access key for the account to create guest clusters in.")
-	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.Secret, "", "Secret of the AWS access key for the  account to create guest clusters in.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.AccessKey.Session, "", "Session token of the AWS access key for the  account to create guest clusters in. (Can be empty)")
 	daemonCommand.PersistentFlags().StringSlice(f.Service.AWS.AvailabilityZones, []string{}, "Availability zones as a slice.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.Encrypter, "kms", "Encryption backend to use.")

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -111,12 +111,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
-	if config.GuestAWSConfig.AccessKeyID == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.GuestAWSConfig.AccessKeyID must not be empty")
-	}
-	if config.GuestAWSConfig.AccessKeySecret == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.GuestAWSConfig.AccessKeySecret must not be empty")
-	}
 	if config.GuestAWSConfig.Region == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.GuestAWSConfig.Region must not be empty")
 	}

--- a/service/controller/cluster_test.go
+++ b/service/controller/cluster_test.go
@@ -24,8 +24,6 @@ func newTestClusterConfig() ClusterConfig {
 
 		AccessLogsExpiration: 365,
 		GuestAWSConfig: ClusterConfigAWSConfig{
-			AccessKeyID:       "guest-key",
-			AccessKeySecret:   "guest-secret",
 			AvailabilityZones: []string{"eu-west-1a", "eu-west-1b", "eu-west-1c"},
 			Region:            "guest-myregion",
 			SessionToken:      "guest-token",
@@ -64,8 +62,6 @@ func Test_NewCluster_Fails_Without_Regions(t *testing.T) {
 		{
 			description: "misisng region in guest",
 			guestCredentials: ClusterConfigAWSConfig{
-				AccessKeyID:     "key",
-				AccessKeySecret: "secret",
 				SessionToken:    "token",
 			},
 			hostCredentials: ClusterConfigAWSConfig{
@@ -80,8 +76,6 @@ func Test_NewCluster_Fails_Without_Regions(t *testing.T) {
 		{
 			description: "missing region in host",
 			guestCredentials: ClusterConfigAWSConfig{
-				AccessKeyID:     "key",
-				AccessKeySecret: "secret",
 				Region:          "myregion",
 				SessionToken:    "token",
 			},
@@ -96,8 +90,7 @@ func Test_NewCluster_Fails_Without_Regions(t *testing.T) {
 		{
 			description: "region exists in guest and host",
 			guestCredentials: ClusterConfigAWSConfig{
-				AccessKeyID:       "key",
-				AccessKeySecret:   "secret",
+
 				AvailabilityZones: []string{"eu-west-1a", "eu-west-1b", "eu-west-1c"},
 				Region:            "myregion",
 				SessionToken:      "token",

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -58,12 +58,6 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.GuestAWSConfig.AccessKeyID == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.GuestAWSConfig.AccessKeyID must not be empty", config)
-	}
-	if config.GuestAWSConfig.AccessKeySecret == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.GuestAWSConfig.AccessKeySecret must not be empty", config)
-	}
 	if config.GuestAWSConfig.Region == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GuestAWSConfig.Region must not be empty", config)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -125,8 +125,6 @@ func New(config Config) (*Service, error) {
 			DeleteLoggingBucket:   config.Viper.GetBool(config.Flag.Service.AWS.LoggingBucket.Delete),
 			EncrypterBackend:      config.Viper.GetString(config.Flag.Service.AWS.Encrypter),
 			GuestAWSConfig: controller.ClusterConfigAWSConfig{
-				AccessKeyID:       config.Viper.GetString(config.Flag.Service.AWS.AccessKey.ID),
-				AccessKeySecret:   config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Secret),
 				AvailabilityZones: config.Viper.GetStringSlice(config.Flag.Service.AWS.AvailabilityZones),
 				SessionToken:      config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Session),
 				Region:            config.Viper.GetString(config.Flag.Service.AWS.Region),
@@ -178,8 +176,6 @@ func New(config Config) (*Service, error) {
 			Logger:       config.Logger,
 
 			GuestAWSConfig: controller.DrainerConfigAWS{
-				AccessKeyID:     config.Viper.GetString(config.Flag.Service.AWS.AccessKey.ID),
-				AccessKeySecret: config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Secret),
 				SessionToken:    config.Viper.GetString(config.Flag.Service.AWS.AccessKey.Session),
 				Region:          config.Viper.GetString(config.Flag.Service.AWS.Region),
 			},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func commonViperSettings(f *flag.Flag, v *viper.Viper) {
-	v.Set(f.Service.AWS.AccessKey.ID, "accessKeyID")
-	v.Set(f.Service.AWS.AccessKey.Secret, "accessKeySecret")
 	v.Set(f.Service.AWS.AccessKey.Session, "session")
 	v.Set(f.Service.AWS.AvailabilityZones, []string{"eu-west-1a", "eu-west-1b", "eu-west-1c"})
 	v.Set(f.Service.AWS.Encrypter, "kms")


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

After rolling out Access Key for Control Plane on Adidas, I saw there was still reference to GuestAWSAccessKey and GuestAWSAccessKeySecret in the operator that was not used anymore.

