### PR TITLE
add separate ASG status resource to update scaling status

### DIFF
--- a/service/controller/v22/cluster_resource_set.go
+++ b/service/controller/v22/cluster_resource_set.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
-	"github.com/giantswarm/aws-operator/service/controller/v18/resource/workerasgname"
 	"github.com/giantswarm/aws-operator/service/controller/v22/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/v22/cloudconfig"
 	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v22/cloudformation"
@@ -45,6 +44,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v22/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/controller/v22/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/v22/resource/service"
+	"github.com/giantswarm/aws-operator/service/controller/v22/resource/workerasgname"
 )
 
 const (

--- a/service/controller/v22/controllercontext/status.go
+++ b/service/controller/v22/controllercontext/status.go
@@ -9,11 +9,18 @@ type Status struct {
 
 type Cluster struct {
 	AWSAccount    ClusterAWSAccount
+	ASG           ClusterASG
 	EncryptionKey string
 }
 
 type ClusterAWSAccount struct {
 	ID string
+}
+
+type ClusterASG struct {
+	DesiredCapacity int
+	MaxSize         int
+	MinSize         int
 }
 
 type Drainer struct {

--- a/service/controller/v22/resource/asgstatus/create.go
+++ b/service/controller/v22/resource/asgstatus/create.go
@@ -1,0 +1,106 @@
+package asgstatus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/v22/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v22/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	workerASGName := cc.Status.Drainer.WorkerASGName
+	if workerASGName == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
+	var asg *autoscaling.Group
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding ASG %#q", workerASGName))
+
+		i := &autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{
+				&workerASGName,
+			},
+		}
+		o, err := cc.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(o.AutoScalingGroups) != 1 {
+			return microerror.Maskf(executionFailedError, "there must be one item for ASG %#q", workerASGName)
+		}
+		asg = o.AutoScalingGroups[0]
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ASG %#q", workerASGName))
+	}
+
+	var desiredCapacity int
+	{
+		if asg.DesiredCapacity == nil {
+			return microerror.Maskf(executionFailedError, "desired capacity must not be empty for ASG %#q", workerASGName)
+		}
+		desiredCapacity = int(*asg.DesiredCapacity)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desired capacity of %#q is %d", workerASGName, desiredCapacity))
+	}
+
+	var maxSize int
+	{
+		if asg.MaxSize == nil {
+			return microerror.Maskf(executionFailedError, "max size must not be empty for ASG %#q", workerASGName)
+		}
+		maxSize = int(*asg.MaxSize)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("max size of %#q is %d", workerASGName, maxSize))
+	}
+
+	var minSize int
+	{
+		if asg.MinSize == nil {
+			return microerror.Maskf(executionFailedError, "min size must not be empty for ASG %#q", workerASGName)
+		}
+		minSize = int(*asg.MinSize)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", workerASGName, minSize))
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating status with desired capacity")
+
+		newObj, err := r.g8sClient.ProviderV1alpha1().AWSConfigs(cr.GetNamespace()).Get(cr.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		newObj.Status.Cluster.Scaling.DesiredCapacity = desiredCapacity
+
+		_, err = r.g8sClient.ProviderV1alpha1().AWSConfigs(newObj.GetNamespace()).UpdateStatus(newObj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated status with desired capacity")
+	}
+
+	{
+		cc.Status.Cluster.ASG.DesiredCapacity = desiredCapacity
+		cc.Status.Cluster.ASG.MaxSize = maxSize
+		cc.Status.Cluster.ASG.MinSize = minSize
+	}
+
+	return nil
+}

--- a/service/controller/v22/resource/asgstatus/delete.go
+++ b/service/controller/v22/resource/asgstatus/delete.go
@@ -1,0 +1,9 @@
+package asgstatus
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v22/resource/asgstatus/error.go
+++ b/service/controller/v22/resource/asgstatus/error.go
@@ -1,0 +1,23 @@
+package asgstatus
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v22/resource/asgstatus/resource.go
+++ b/service/controller/v22/resource/asgstatus/resource.go
@@ -1,0 +1,41 @@
+package asgstatus
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "asgstatusv22"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v22/resource/cloudformation/current.go
+++ b/service/controller/v22/resource/cloudformation/current.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
@@ -194,10 +193,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return StackState{}, microerror.Mask(err)
 		}
 
-		workerASGName, err := ctlCtx.CloudFormation.GetOutputValue(stackOutputs, key.WorkerASGKey)
-		if err != nil {
-			return StackState{}, microerror.Mask(err)
-		}
 		workerCloudConfigVersion, err := ctlCtx.CloudFormation.GetOutputValue(stackOutputs, key.WorkerCloudConfigVersionKey)
 		if err != nil {
 			return StackState{}, microerror.Mask(err)
@@ -209,37 +204,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		workerInstanceType, err := ctlCtx.CloudFormation.GetOutputValue(stackOutputs, key.WorkerInstanceTypeKey)
 		if err != nil {
 			return StackState{}, microerror.Mask(err)
-		}
-		var workerDesired, workerMin, workerMax int
-		{
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding out worker asg properties")
-
-			i := &autoscaling.DescribeAutoScalingGroupsInput{
-				AutoScalingGroupNames: []*string{
-					&workerASGName,
-				},
-			}
-			o, err := ctlCtx.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
-			if err != nil {
-				return StackState{}, microerror.Mask(err)
-			}
-			if len(o.AutoScalingGroups) == 0 {
-				return StackState{}, microerror.Maskf(executionFailedError, "asg for name %s", workerASGName)
-			}
-			asg := o.AutoScalingGroups[0]
-			if asg.DesiredCapacity == nil {
-				return StackState{}, microerror.Maskf(executionFailedError, "desired capacity for asg is nil")
-			}
-			workerDesired = int(*asg.DesiredCapacity)
-			if asg.MaxSize == nil {
-				return StackState{}, microerror.Maskf(executionFailedError, "max size for asg is nil")
-			}
-			workerMax = int(*asg.MaxSize)
-			if asg.MinSize == nil {
-				return StackState{}, microerror.Maskf(executionFailedError, "min size for asg is nil")
-			}
-			workerMin = int(*asg.MinSize)
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found out worker asg properties: desiredCapacity: %d, min: %d, max: %d", workerDesired, workerMin, workerMax))
 		}
 
 		versionBundleVersion, err := ctlCtx.CloudFormation.GetOutputValue(stackOutputs, key.VersionBundleVersionKey)
@@ -259,12 +223,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			MasterCloudConfigVersion:   masterCloudConfigVersion,
 
 			WorkerCloudConfigVersion: workerCloudConfigVersion,
-			WorkerDesired:            workerDesired,
 			WorkerDockerVolumeSizeGB: workerDockerVolumeSizeGB,
 			WorkerImageID:            workerImageID,
 			WorkerInstanceType:       workerInstanceType,
-			WorkerMax:                workerMax,
-			WorkerMin:                workerMin,
 
 			VersionBundleVersion: versionBundleVersion,
 		}

--- a/service/controller/v22/resource/cloudformation/desired.go
+++ b/service/controller/v22/resource/cloudformation/desired.go
@@ -50,8 +50,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			WorkerInstanceMonitoring: r.monitoring,
 			WorkerInstanceType:       workerInstanceType,
 			WorkerCloudConfigVersion: key.CloudConfigVersion,
-			WorkerMax:                key.ScalingMax(customObject),
-			WorkerMin:                key.ScalingMin(customObject),
 
 			VersionBundleVersion: key.VersionBundleVersion(customObject),
 		}

--- a/service/controller/v22/resource/cloudformation/main_stack.go
+++ b/service/controller/v22/resource/cloudformation/main_stack.go
@@ -54,13 +54,13 @@ func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1
 			MasterInstanceMonitoring:   stackState.MasterInstanceMonitoring,
 
 			WorkerCloudConfigVersion: stackState.WorkerCloudConfigVersion,
-			WorkerDesired:            stackState.WorkerDesired,
+			WorkerDesired:            sc.Status.Cluster.ASG.DesiredCapacity,
 			WorkerDockerVolumeSizeGB: stackState.WorkerDockerVolumeSizeGB,
 			WorkerImageID:            stackState.WorkerImageID,
 			WorkerInstanceMonitoring: stackState.WorkerInstanceMonitoring,
 			WorkerInstanceType:       stackState.WorkerInstanceType,
-			WorkerMax:                stackState.WorkerMax,
-			WorkerMin:                stackState.WorkerMin,
+			WorkerMax:                sc.Status.Cluster.ASG.MaxSize,
+			WorkerMin:                sc.Status.Cluster.ASG.MinSize,
 
 			VersionBundleVersion: stackState.VersionBundleVersion,
 		},

--- a/service/controller/v22/resource/cloudformation/resource.go
+++ b/service/controller/v22/resource/cloudformation/resource.go
@@ -64,16 +64,16 @@ type Resource struct {
 // New creates a new configured cloudformation resource.
 func New(config Config) (*Resource, error) {
 	if config.EncrypterBackend == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.EncrypterBackend must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.EncrypterBackend must not be empty", config)
 	}
 	if config.G8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.G8sClient must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
 	if config.HostClients == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.HostClients must not be empty", config)
 	}
 	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 	// GuestPrivateSubnetMaskBits && GuestPublicSubnetMaskBits has been
 	// validated on upper level because all IPAM related configuration

--- a/service/controller/v22/resource/cloudformation/spec.go
+++ b/service/controller/v22/resource/cloudformation/spec.go
@@ -33,13 +33,10 @@ type StackState struct {
 	ShouldUpdate bool
 
 	WorkerCloudConfigVersion string
-	WorkerDesired            int
 	WorkerDockerVolumeSizeGB int
 	WorkerImageID            string
 	WorkerInstanceMonitoring bool
 	WorkerInstanceType       string
-	WorkerMax                int
-	WorkerMin                int
 
 	UpdateStackInput cloudformation.UpdateStackInput
 

--- a/service/controller/v22/resource/cloudformation/update_test.go
+++ b/service/controller/v22/resource/cloudformation/update_test.go
@@ -99,8 +99,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                3,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -114,8 +112,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                3,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -412,9 +408,13 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			cc := testContextWithASG()
+			cc.AWSClient = awsClients
+
 			ctx := updateallowedcontext.NewContext(context.Background(), make(chan struct{}))
-			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
 			updateallowedcontext.SetUpdateAllowed(ctx)
+
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
 			if err != nil {
@@ -448,10 +448,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 					IngressController: v1alpha1.ClusterKubernetesIngressController{
 						Domain: "mysubdomain.mydomain.com",
 					},
-				},
-				Scaling: v1alpha1.ClusterScaling{
-					Max: 1,
-					Min: 1,
 				},
 			},
 			AWS: v1alpha1.AWSConfigSpecAWS{
@@ -514,8 +510,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                3,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -529,8 +523,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                3,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -774,8 +766,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                4,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "CHANGED",
 			},
@@ -789,8 +779,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                4,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -810,8 +798,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                4,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "1.0.0",
 			},
@@ -825,8 +811,6 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				WorkerCloudConfigVersion: "1.0.0",
 				WorkerImageID:            "ami-123",
 				WorkerInstanceType:       "m3.large",
-				WorkerMax:                4,
-				WorkerMin:                3,
 
 				VersionBundleVersion: "CHANGED",
 			},
@@ -882,5 +866,19 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 				t.Fatalf("expected %v, got %v", *tc.expectedChange.StackName, *updateChange.UpdateStackInput.StackName)
 			}
 		})
+	}
+}
+
+func testContextWithASG() controllercontext.Context {
+	return controllercontext.Context{
+		Status: controllercontext.Status{
+			Cluster: controllercontext.Cluster{
+				ASG: controllercontext.ClusterASG{
+					DesiredCapacity: 1,
+					MaxSize:         1,
+					MinSize:         1,
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
Based on #1338. We have an issue where, let's say a cluster having 2 nodes is scaled to 3 nodes. The status update magic and the CF stack update conflict each other. When the scaling is triggered the CF stack output values are not accessible due to state transitions. Meanwhile the ASG got a kick and did things. We want to reflect that update as soon as possible and do not want to be blocked by the CF stack outputs. Here we propose the separation of the ASG status magic in order to sort that regardless.