### PR TITLE
don't fail when bucket is already owned by you

### DIFF
--- a/service/controller/v22/resource/s3bucket/create.go
+++ b/service/controller/v22/resource/s3bucket/create.go
@@ -45,6 +45,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				_, err = sc.AWSClient.S3.CreateBucket(i)
 				if IsBucketAlreadyExists(err) {
 					// Fall through.
+				} else if IsBucketAlreadyOwnedByYou(err) {
+					// Fall through.
 				} else if err != nil {
 					return microerror.Mask(err)
 				}


### PR DESCRIPTION
The error handling got dropped recently. It did not appear to make much sense. Now I saw the error happening on CI once. So we just add it back as this is how AWS works. 