### PR TITLE
add separate host pre resource

### DIFF
--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/bridgezone"
 	cloudformationresource "github.com/giantswarm/aws-operator/service/controller/v24/resource/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v24/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/ebsvolume"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/encryptionkey"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/endpoints"
@@ -390,6 +391,27 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var cpiResource controller.Resource
+	{
+		c := cpi.Config{
+			HostClients: &adapter.Clients{
+				EC2:            config.HostAWSClients.EC2,
+				IAM:            config.HostAWSClients.IAM,
+				STS:            config.HostAWSClients.STS,
+				CloudFormation: config.HostAWSClients.CloudFormation,
+			},
+			Logger: config.Logger,
+
+			InstallationName: config.InstallationName,
+			Route53Enabled:   config.Route53Enabled,
+		}
+
+		cpiResource, err = cpi.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
@@ -518,6 +540,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		s3ObjectResource,
 		loadBalancerResource,
 		ebsVolumeResource,
+		cpiResource,
 		cloudformationResource,
 		namespaceResource,
 		serviceResource,

--- a/service/controller/v24/key/key.go
+++ b/service/controller/v24/key/key.go
@@ -97,6 +97,10 @@ const (
 )
 
 const (
+	CapabilityNamesIAM = "CAPABILITY_NAMED_IAM"
+)
+
+const (
 	KindMaster  = "master"
 	KindIngress = "ingress"
 	KindWorker  = "worker"

--- a/service/controller/v24/key/key.go
+++ b/service/controller/v24/key/key.go
@@ -97,10 +97,6 @@ const (
 )
 
 const (
-	CapabilityNamesIAM = "CAPABILITY_NAMED_IAM"
-)
-
-const (
 	KindMaster  = "master"
 	KindIngress = "ingress"
 	KindWorker  = "worker"

--- a/service/controller/v24/resource/cloudformation/current.go
+++ b/service/controller/v24/resource/cloudformation/current.go
@@ -51,7 +51,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	if key.IsDeleted(customObject) {
 		stackNames := []string{
 			key.MainGuestStackName(customObject),
-			key.MainHostPreStackName(customObject),
 			key.MainHostPostStackName(customObject),
 		}
 

--- a/service/controller/v24/resource/cloudformation/delete.go
+++ b/service/controller/v24/resource/cloudformation/delete.go
@@ -67,37 +67,6 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	if stackStateToDelete.Name != "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster pre stack")
-
-		stackName := aws.String(key.MainHostPreStackName(customObject))
-
-		updateTerminationProtection := &cloudformation.UpdateTerminationProtectionInput{
-			EnableTerminationProtection: aws.Bool(false),
-			StackName:                   stackName,
-		}
-		_, err = r.hostClients.CloudFormation.UpdateTerminationProtection(updateTerminationProtection)
-		if IsDeleteInProgress(err) {
-			// fall through
-		} else if IsNotExists(err) {
-			// fall through
-		} else if err != nil {
-			return microerror.Mask(err)
-		} else {
-			i := &cloudformation.DeleteStackInput{
-				StackName: stackName,
-			}
-			_, err = r.hostClients.CloudFormation.DeleteStack(i)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the host cluster pre stack")
-		}
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "not deleting the host cluster pre stack")
-	}
-
-	if stackStateToDelete.Name != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the host cluster post stack")
 
 		stackName := aws.String(key.MainHostPostStackName(customObject))

--- a/service/controller/v24/resource/cloudformation/main_stack.go
+++ b/service/controller/v24/resource/cloudformation/main_stack.go
@@ -79,43 +79,6 @@ func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1
 	return rendered, nil
 }
 
-func (r *Resource) getMainHostPreTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig) (string, error) {
-	sc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	adapterClients := adapter.Clients{
-		CloudFormation: sc.AWSClient.CloudFormation,
-		EC2:            sc.AWSClient.EC2,
-		IAM:            sc.AWSClient.IAM,
-		KMS:            sc.AWSClient.KMS,
-		ELB:            sc.AWSClient.ELB,
-		STS:            sc.AWSClient.STS,
-	}
-
-	guestAccountID, err := adapter.AccountID(adapterClients)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-	cfg := adapter.Config{
-		CustomObject:   customObject,
-		GuestAccountID: guestAccountID,
-		Route53Enabled: r.route53Enabled,
-	}
-	adp, err := adapter.NewHostPre(cfg)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	rendered, err := templates.Render(key.CloudFormationHostPreTemplates(), adp)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	return rendered, nil
-}
-
 func (r *Resource) getMainHostPostTemplateBody(ctx context.Context, customObject v1alpha1.AWSConfig, guestMainStackState StackState) (string, error) {
 	sc, err := controllercontext.FromContext(ctx)
 	if err != nil {

--- a/service/controller/v24/resource/cloudformation/main_stack_test.go
+++ b/service/controller/v24/resource/cloudformation/main_stack_test.go
@@ -425,59 +425,6 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	}
 }
 
-func TestMainHostPreTemplateExistingFields(t *testing.T) {
-	t.Parallel()
-	// customObject with example fields for both asg and launch config
-	customObject := v1alpha1.AWSConfig{
-		Spec: v1alpha1.AWSConfigSpec{
-			Cluster: v1alpha1.Cluster{
-				ID: "test-cluster",
-			},
-		},
-	}
-
-	cfg := testConfig()
-	cfg.HostClients = &adapter.Clients{
-		EC2: &adapter.EC2ClientMock{},
-		IAM: &adapter.IAMClientMock{},
-		STS: &adapter.STSClientMock{},
-	}
-	newResource, err := New(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	awsClients := aws.Clients{
-		EC2: &adapter.EC2ClientMock{},
-		IAM: &adapter.IAMClientMock{},
-		STS: &adapter.STSClientMock{},
-	}
-
-	ctx := context.TODO()
-	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
-
-	body, err := newResource.getMainHostPreTemplateBody(ctx, customObject)
-
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	if !strings.Contains(body, "Description: Main Host Pre-Guest CloudFormation stack.") {
-		fmt.Println(body)
-		t.Fatal("stack header not found")
-	}
-
-	if !strings.Contains(body, "  PeerRole:") {
-		fmt.Println(body)
-		t.Fatal("peer role header not found")
-	}
-
-	if !strings.Contains(body, "  RoleName: test-cluster-vpc-peer-access") {
-		fmt.Println(body)
-		t.Fatal("role name not found")
-	}
-}
-
 func TestMainHostPostTemplateExistingFields(t *testing.T) {
 	t.Parallel()
 	// customObject with example fields for both asg and launch config

--- a/service/controller/v24/resource/cpi/create.go
+++ b/service/controller/v24/resource/cpi/create.go
@@ -13,6 +13,10 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/templates"
 )
 
+const (
+	capabilityNamesIAM = "CAPABILITY_NAMED_IAM"
+)
+
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	customObject, err := key.ToCustomObject(obj)
 	if err != nil {
@@ -77,7 +81,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		i := &cloudformation.CreateStackInput{
 			Capabilities: []*string{
-				aws.String(key.CapabilityNamesIAM),
+				aws.String(capabilityNamesIAM),
 			},
 			EnableTerminationProtection: aws.Bool(key.EnableTerminationProtection),
 			StackName:                   aws.String(key.MainHostPreStackName(customObject)),

--- a/service/controller/v24/resource/cpi/create.go
+++ b/service/controller/v24/resource/cpi/create.go
@@ -33,6 +33,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer CF stack already exists")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
 		}

--- a/service/controller/v24/resource/cpi/create.go
+++ b/service/controller/v24/resource/cpi/create.go
@@ -1,0 +1,111 @@
+package cpi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v24/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v24/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v24/key"
+	"github.com/giantswarm/aws-operator/service/controller/v24/templates"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(key.MainHostPreStackName(customObject)),
+		}
+
+		_, err = r.hostClients.CloudFormation.DescribeStacks(i)
+		if IsNotExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer CF stack already exists")
+
+			return nil
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster's control plane initializer CF stack")
+	}
+
+	var templateBody string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computing the template of the tenant cluster's control plane initializer CF stack")
+
+		cc, err := controllercontext.FromContext(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		var newAdapter adapter.Adapter
+		{
+			c := adapter.Config{
+				CustomObject:   customObject,
+				GuestAccountID: cc.Status.Cluster.AWSAccount.ID,
+				Route53Enabled: r.route53Enabled,
+			}
+
+			newAdapter, err = adapter.NewHostPre(c)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		templateBody, err = templates.Render(key.CloudFormationHostPreTemplates(), newAdapter)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the creation of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.CreateStackInput{
+			Capabilities: []*string{
+				aws.String(key.CapabilityNamesIAM),
+			},
+			EnableTerminationProtection: aws.Bool(key.EnableTerminationProtection),
+			StackName:                   aws.String(key.MainHostPreStackName(customObject)),
+			Tags:                        r.getCloudFormationTags(customObject),
+			TemplateBody:                aws.String(templateBody),
+		}
+
+		_, err = r.hostClients.CloudFormation.CreateStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the creation of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for the creation of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(key.MainHostPreStackName(customObject)),
+		}
+
+		err = r.hostClients.CloudFormation.WaitUntilStackCreateComplete(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "waited for the creation of the tenant cluster's control plane initializer CF stack")
+	}
+
+	return nil
+}

--- a/service/controller/v24/resource/cpi/delete.go
+++ b/service/controller/v24/resource/cpi/delete.go
@@ -27,10 +27,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = r.hostClients.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack is being deleted")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
 		} else if IsNotExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack does not exist")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
 		} else if err != nil {

--- a/service/controller/v24/resource/cpi/delete.go
+++ b/service/controller/v24/resource/cpi/delete.go
@@ -1,0 +1,59 @@
+package cpi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v24/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "disabling the termination protection of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.UpdateTerminationProtectionInput{
+			EnableTerminationProtection: aws.Bool(false),
+			StackName:                   aws.String(key.MainHostPreStackName(customObject)),
+		}
+
+		_, err = r.hostClients.CloudFormation.UpdateTerminationProtection(i)
+		if IsDeleteInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack is being deleted")
+
+			return nil
+		} else if IsNotExists(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack does not exist")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "disabled the termination protection of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the deletion of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPreStackName(customObject)),
+		}
+
+		_, err = r.hostClients.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the deletion of the tenant cluster's control plane initializer CF stack")
+	}
+
+	return nil
+}

--- a/service/controller/v24/resource/cpi/error.go
+++ b/service/controller/v24/resource/cpi/error.go
@@ -30,24 +30,6 @@ func IsDeleteInProgress(err error) bool {
 	return false
 }
 
-var deletionMustBeRetriedError = &microerror.Error{
-	Kind: "deletionMustBeRetriedError",
-}
-
-// IsDeletionMustBeRetried asserts deletionMustBeRetriedError.
-func IsDeletionMustBeRetried(err error) bool {
-	return microerror.Cause(err) == deletionMustBeRetriedError
-}
-
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
-}
-
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
@@ -74,29 +56,6 @@ func IsNotExists(err error) bool {
 	}
 
 	if c == notExistsError {
-		return true
-	}
-
-	return false
-}
-
-var resourceNotReadyError = &microerror.Error{
-	Kind: "resourceNotReadyError",
-}
-
-// IsResourceNotReady asserts resourceNotReadyError.
-func IsResourceNotReady(err error) bool {
-	c := microerror.Cause(err)
-
-	if c == nil {
-		return false
-	}
-
-	if strings.Contains(c.Error(), "ResourceNotReady") {
-		return true
-	}
-
-	if c == resourceNotReadyError {
 		return true
 	}
 

--- a/service/controller/v24/resource/cpi/error.go
+++ b/service/controller/v24/resource/cpi/error.go
@@ -1,0 +1,104 @@
+package cpi
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+var deleteInProgressError = &microerror.Error{
+	Kind: "deleteInProgressError",
+}
+
+// IsDeleteInProgress asserts deleteInProgressError.
+func IsDeleteInProgress(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusDeleteInProgress) {
+		return true
+	}
+
+	if c == deleteInProgressError {
+		return true
+	}
+
+	return false
+}
+
+var deletionMustBeRetriedError = &microerror.Error{
+	Kind: "deletionMustBeRetriedError",
+}
+
+// IsDeletionMustBeRetried asserts deletionMustBeRetriedError.
+func IsDeletionMustBeRetried(err error) bool {
+	return microerror.Cause(err) == deletionMustBeRetriedError
+}
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notExistsError = &microerror.Error{
+	Kind: "notExistsError",
+}
+
+// IsNotExists asserts notExistsError.
+func IsNotExists(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "does not exist") {
+		return true
+	}
+
+	if c == notExistsError {
+		return true
+	}
+
+	return false
+}
+
+var resourceNotReadyError = &microerror.Error{
+	Kind: "resourceNotReadyError",
+}
+
+// IsResourceNotReady asserts resourceNotReadyError.
+func IsResourceNotReady(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "ResourceNotReady") {
+		return true
+	}
+
+	if c == resourceNotReadyError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v24/resource/cpi/resource.go
+++ b/service/controller/v24/resource/cpi/resource.go
@@ -1,0 +1,64 @@
+package cpi
+
+import (
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/pkg/awstags"
+	"github.com/giantswarm/aws-operator/service/controller/v24/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/v24/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cpiv24"
+)
+
+type Config struct {
+	HostClients *adapter.Clients
+	Logger      micrologger.Logger
+
+	InstallationName string
+	Route53Enabled   bool
+}
+
+// Resource implements the CPI resource, which stands for Control Plane
+// Initializer. This was formerly known as the host pre stack. We manage a
+// dedicated CF stack for the IAM role and VPC Peering setup.
+type Resource struct {
+	hostClients *adapter.Clients
+	logger      micrologger.Logger
+
+	installationName string
+	route53Enabled   bool
+}
+
+func New(config Config) (*Resource, error) {
+	if config.HostClients == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostClients must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		hostClients: config.HostClients,
+		logger:      config.Logger,
+
+		installationName: config.InstallationName,
+		route53Enabled:   config.Route53Enabled,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) getCloudFormationTags(customObject v1alpha1.AWSConfig) []*cloudformation.Tag {
+	tags := key.ClusterTags(customObject, r.installationName)
+	return awstags.NewCloudFormation(tags)
+}


### PR DESCRIPTION
We want to extend the CF stack management. A first step is to separate the management a bit. Here is a new resource suggested which manages what we called "host pre stack" so far. The naming here is not clear so feel free to suggest something. For now I used "Control Plane Initializer", because it is the control plane initialization of the tenant if that makes sense. 