### PR TITLE
Fetch list of available AZs programmatically in IPAM

### DIFF
--- a/service/controller/v24/resource/ipam/create.go
+++ b/service/controller/v24/resource/ipam/create.go
@@ -94,7 +94,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			randomAZs, err := r.selectRandomAZs(key.SpecAvailabilityZones(customResource))
+			randomAZs, err := r.selectRandomAZs(r.availabilityZones, key.SpecAvailabilityZones(customResource))
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -195,14 +195,14 @@ func (r *Resource) allocateSubnet(ctx context.Context) (net.IPNet, error) {
 	return subnet, nil
 }
 
-func (r *Resource) selectRandomAZs(n int) ([]string, error) {
-	if n > len(r.availabilityZones) {
-		return nil, microerror.Maskf(invalidParameterError, "requested nubmer of AZs %d is bigger than number of available AZs %d", n, len(r.availabilityZones))
+func (r *Resource) selectRandomAZs(azs []string, n int) ([]string, error) {
+	if n > len(azs) {
+		return nil, microerror.Maskf(invalidParameterError, "requested nubmer of AZs %d is bigger than number of available AZs %d", n, len(azs))
 	}
 
 	// availabilityZones must be copied so that original slice doesn't get shuffled.
-	shuffledAZs := make([]string, len(r.availabilityZones))
-	copy(shuffledAZs, r.availabilityZones)
+	shuffledAZs := make([]string, len(azs))
+	copy(shuffledAZs, azs)
 	rand.Shuffle(len(shuffledAZs), func(i, j int) {
 		shuffledAZs[i], shuffledAZs[j] = shuffledAZs[j], shuffledAZs[i]
 	})

--- a/service/controller/v24/resource/ipam/create.go
+++ b/service/controller/v24/resource/ipam/create.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/ipam"
@@ -94,7 +96,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			randomAZs, err := r.selectRandomAZs(r.availabilityZones, key.SpecAvailabilityZones(customResource))
+			availabilityZones, err := getAvailabilityZonesForInstanceTypes(ctx, key.MasterInstanceType(customResource), key.WorkerInstanceType(customResource))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			randomAZs, err := r.selectRandomAZs(availabilityZones, key.SpecAvailabilityZones(customResource))
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -210,6 +217,63 @@ func (r *Resource) selectRandomAZs(azs []string, n int) ([]string, error) {
 	shuffledAZs = shuffledAZs[0:n]
 	sort.Strings(shuffledAZs)
 	return shuffledAZs, nil
+}
+
+// getAvailabilityZonesForInstanceTypes gets availability zones for current
+// region and removes ones that don't have required instance types present.
+func getAvailabilityZonesForInstanceTypes(ctx context.Context, instanceTypes ...string) ([]string, error) {
+	ctlCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var azs []string
+	{
+		// List all available AZs.
+		i := &ec2.DescribeAvailabilityZonesInput{}
+		o, err := ctlCtx.AWSClient.EC2.DescribeAvailabilityZones(i)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		for _, az := range o.AvailabilityZones {
+			azs = append(azs, *az.ZoneName)
+		}
+	}
+
+	// Verify that AZs provide specified instance types.
+	if len(instanceTypes) > 0 {
+		// The mechanism here to find out whether given AZ provides required
+		// instance types or not is really a hack, but as of writing this, AWS
+		// SDK doesn't provide direct way to query available instance types and
+		// indirect use of spot price API for this seems to be the common thing
+		// to do.
+		//
+		// So what happens here is that for each AZ there is a request to getch
+		// EC2 spot instance price history for last minute to see whether the
+		// instance type is available or not.
+		minuteAgo := time.Now().Add(-11 * time.Minute)
+
+		var awsInstanceTypes []*string
+		for _, it := range instanceTypes {
+			awsInstanceTypes = append(awsInstanceTypes, aws.String(it))
+		}
+
+		for _, az := range azs {
+			i := &ec2.DescribeSpotPriceHistoryInput{
+				AvailabilityZone: aws.String(az),
+				InstanceTypes:    awsInstanceTypes,
+				StartTime:        &minuteAgo,
+			}
+
+			_, err := ctlCtx.AWSClient.EC2.DescribeSpotPriceHistory(i)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+	}
+
+	return azs, nil
 }
 
 func getAWSConfigSubnets(g8sClient versioned.Interface) ([]net.IPNet, error) {

--- a/service/controller/v24/resource/ipam/create_test.go
+++ b/service/controller/v24/resource/ipam/create_test.go
@@ -59,7 +59,7 @@ func Test_selectRandomAZs_properties(t *testing.T) {
 				availabilityZones: tc.azs,
 			}
 
-			azs, err := r.selectRandomAZs(tc.n)
+			azs, err := r.selectRandomAZs(tc.azs, tc.n)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:
@@ -95,7 +95,7 @@ func Test_selectRandomAZs_random(t *testing.T) {
 	selectedAZs := make([][]string, 0)
 
 	for i := 0; i < nTestRounds; i++ {
-		azs, err := r.selectRandomAZs(numAZs)
+		azs, err := r.selectRandomAZs(originalAZs, numAZs)
 		if err != nil {
 			t.Fatalf("unexpected error: %#v", err)
 		}


### PR DESCRIPTION
In order to avoid situation where such AZ gets allocated for a tenant
cluster that doesn't provide required instance types we fetch the list
of AZs programmatically and verify each AZ for required instance types
via EC2 Spot Instance pricing history API.

This is quite an indirect hack to perform this operation, but as of writing,
there is no direct method to get this information otherwise without
launching an instance on a given AZ.