### PR TITLE
put vpc peering connection id into cloudformation stack outputs

### DIFF
--- a/service/controller/v24/adapter/host_post_route_tables.go
+++ b/service/controller/v24/adapter/host_post_route_tables.go
@@ -116,7 +116,6 @@ func waitForPeeringConnectionID(cfg Config) (string, error) {
 	}
 
 	o := func() error {
-		fmt.Printf("%#v\n", "finding VPC Peering Connection ID")
 		output, err := cfg.Clients.EC2.DescribeVpcPeeringConnections(input)
 		if err != nil {
 			return microerror.Mask(err)
@@ -135,10 +134,6 @@ func waitForPeeringConnectionID(cfg Config) (string, error) {
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
-	fmt.Printf("\n")
-	fmt.Printf("%#v\n", "found VPC Peering Connection ID")
-	fmt.Printf("    %#v\n", peeringID)
-	fmt.Printf("\n")
 
 	return peeringID, nil
 }

--- a/service/controller/v24/adapter/host_post_route_tables.go
+++ b/service/controller/v24/adapter/host_post_route_tables.go
@@ -116,6 +116,7 @@ func waitForPeeringConnectionID(cfg Config) (string, error) {
 	}
 
 	o := func() error {
+		fmt.Printf("%#v\n", "finding VPC Peering Connection ID")
 		output, err := cfg.Clients.EC2.DescribeVpcPeeringConnections(input)
 		if err != nil {
 			return microerror.Mask(err)
@@ -134,6 +135,10 @@ func waitForPeeringConnectionID(cfg Config) (string, error) {
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
+	fmt.Printf("\n")
+	fmt.Printf("%#v\n", "found VPC Peering Connection ID")
+	fmt.Printf("    %#v\n", peeringID)
+	fmt.Printf("\n")
 
 	return peeringID, nil
 }

--- a/service/controller/v24/templates/cloudformation/guest/outputs.go
+++ b/service/controller/v24/templates/cloudformation/guest/outputs.go
@@ -19,6 +19,8 @@ Outputs:
     Value: {{ $v.Master.CloudConfig.Version }}
   {{ $v.Worker.ASG.Key }}:
     Value: !Ref {{ $v.Worker.ASG.Ref }}
+  VPCPeeringConnectionID:
+    Value: !Ref VPCPeeringConnection
   WorkerDockerVolumeSizeGB:
     Value: {{ $v.Worker.DockerVolumeSizeGB }}
   WorkerImageID:


### PR DESCRIPTION
I want to get the VPC peering connection ID into the CF stack outputs so we can put it into the controller context. Related to https://github.com/giantswarm/aws-operator/pull/1428. Goal is to refactor and cleanup the CF stack management. This is work towards node pools. 