### PR TITLE
add stackoutput resource

### DIFF
--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -35,6 +35,7 @@ type DrainerConfig struct {
 	GuestUpdateEnabled bool
 	HostAWSConfig      DrainerConfigAWS
 	ProjectName        string
+	Route53Enabled     bool
 }
 
 type DrainerConfigAWS struct {
@@ -330,6 +331,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 
 			GuestUpdateEnabled: config.GuestUpdateEnabled,
 			ProjectName:        config.ProjectName,
+			Route53Enabled:     config.Route53Enabled,
 		}
 
 		v24ResourceSet, err = v24.NewDrainerResourceSet(c)

--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -44,6 +44,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/service"
+	"github.com/giantswarm/aws-operator/service/controller/v24/resource/stackoutput"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/workerasgname"
 )
 
@@ -493,6 +494,20 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var stackOutputResource controller.Resource
+	{
+		c := stackoutput.Config{
+			Logger: config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+		}
+
+		stackOutputResource, err = stackoutput.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var workerASGNameResource controller.Resource
 	{
 		c := workerasgname.ResourceConfig{
@@ -508,6 +523,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 
 	resources := []controller.Resource{
 		accountIDResource,
+		stackOutputResource,
 		workerASGNameResource,
 		asgStatusResource,
 		statusResource,

--- a/service/controller/v24/controllercontext/status.go
+++ b/service/controller/v24/controllercontext/status.go
@@ -8,9 +8,10 @@ type Status struct {
 }
 
 type Cluster struct {
-	AWSAccount    ClusterAWSAccount
-	ASG           ClusterASG
-	EncryptionKey string
+	AWSAccount            ClusterAWSAccount
+	ASG                   ClusterASG
+	EncryptionKey         string
+	HostedZoneNameServers string
 }
 
 type ClusterAWSAccount struct {

--- a/service/controller/v24/drainer_resource_set.go
+++ b/service/controller/v24/drainer_resource_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/key"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/drainer"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/drainfinisher"
+	"github.com/giantswarm/aws-operator/service/controller/v24/resource/stackoutput"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/workerasgname"
 )
 
@@ -30,6 +31,7 @@ type DrainerResourceSetConfig struct {
 
 	GuestUpdateEnabled bool
 	ProjectName        string
+	Route53Enabled     bool
 }
 
 func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.ResourceSet, error) {
@@ -61,6 +63,20 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var stackOutputResource controller.Resource
+	{
+		c := stackoutput.Config{
+			Logger: config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+		}
+
+		stackOutputResource, err = stackoutput.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var workerASGNameResource controller.Resource
 	{
 		c := workerasgname.ResourceConfig{
@@ -75,6 +91,7 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []controller.Resource{
+		stackOutputResource,
 		workerASGNameResource,
 		drainerResource,
 		drainFinisherResource,

--- a/service/controller/v24/resource/stackoutput/create.go
+++ b/service/controller/v24/resource/stackoutput/create.go
@@ -1,0 +1,68 @@
+package stackoutput
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+
+	cf "github.com/giantswarm/aws-operator/service/controller/v24/cloudformation"
+	"github.com/giantswarm/aws-operator/service/controller/v24/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v24/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var outputs []*cloudformation.Output
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the tenant cluster cloud formation stack outputs")
+
+		o, s, err := cc.CloudFormation.DescribeOutputsAndStatus(key.MainGuestStackName(cr))
+		if cf.IsStackNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster cloud formation stack outputs")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster cloud formation stack does not exist")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if cf.IsOutputsNotAccessible(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster cloud formation stack outputs")
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the tenant cluster main cloud formation stack output values are not accessible due to stack status %#q", s))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		outputs = o
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster cloud formation stack outputs")
+	}
+
+	{
+		v, err := cc.CloudFormation.GetOutputValue(outputs, key.WorkerASGKey)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		cc.Status.Drainer.WorkerASGName = v
+	}
+
+	if r.route53Enabled {
+		v, err := cc.CloudFormation.GetOutputValue(outputs, key.HostedZoneNameServers)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		cc.Status.Cluster.HostedZoneNameServers = v
+	}
+
+	return nil
+}

--- a/service/controller/v24/resource/stackoutput/delete.go
+++ b/service/controller/v24/resource/stackoutput/delete.go
@@ -1,0 +1,9 @@
+package stackoutput
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v24/resource/stackoutput/error.go
+++ b/service/controller/v24/resource/stackoutput/error.go
@@ -1,0 +1,12 @@
+package stackoutput
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v24/resource/stackoutput/resource.go
+++ b/service/controller/v24/resource/stackoutput/resource.go
@@ -1,0 +1,40 @@
+package stackoutput
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "stackoutputv24"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	Route53Enabled bool
+}
+
+type Resource struct {
+	logger micrologger.Logger
+
+	route53Enabled bool
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		route53Enabled: config.Route53Enabled,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v24/resource/workerasgname/resource.go
+++ b/service/controller/v24/resource/workerasgname/resource.go
@@ -2,7 +2,6 @@ package workerasgname
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
@@ -11,7 +10,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v24/cloudformation"
 	"github.com/giantswarm/aws-operator/service/controller/v24/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v24/key"
 )
@@ -59,7 +57,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	var customObject v1alpha1.AWSConfig
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "fetching latest version of custom resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding latest version of custom resource")
 
 		oldObj, err := key.ToCustomObject(obj)
 		if err != nil {
@@ -72,7 +70,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 		customObject = *newObj
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "fetched latest version of custom resource")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found latest version of custom resource")
 	}
 
 	{
@@ -81,61 +79,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if customObject.Status.AWS.AutoScalingGroup.Name != "" {
 			cc.Status.Drainer.WorkerASGName = customObject.Status.AWS.AutoScalingGroup.Name
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster worker ASG name in the CR")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster worker ASG name in the CR")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the CR")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster worker ASG name in the CR")
 	}
 
-	var workerASGName string
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the guest cluster worker ASG name in the cloud formation stack")
-
-		stackOutputs, stackStatus, err := cc.CloudFormation.DescribeOutputsAndStatus(key.MainGuestStackName(customObject))
-		if cloudformationservice.IsStackNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not yet created")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			return nil
-
-		} else if cloudformationservice.IsOutputsNotAccessible(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the guest cluster main stack output values are not accessible due to stack status '%s'", stackStatus))
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			return nil
-
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-
-		workerASGName, err = cc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerASGKey)
-		if cloudformationservice.IsOutputNotFound(err) {
-			// Since we are transitioning between versions we will have situations in
-			// which old clusters are updated to new versions and miss the ASG name in
-			// the CF stack outputs. We stop resource reconciliation at this point to
-			// reconcile again at a later point when the stack got upgraded and
-			// contains the ASG name.
-			//
-			// TODO remove this condition as soon as all guest clusters in existence
-			// obtain a ASG name.
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the guest cluster worker ASG name in the cloud formation stack")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "the guest cluster main stack is not upgraded to the newest version yet")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-			return nil
-
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found the guest cluster worker ASG name in the cloud formation stack")
-	}
-
-	// Store the ASG name in the CR status.
-	{
+	if cc.Status.Drainer.WorkerASGName != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updating CR status")
 
-		customObject.Status.AWS.AutoScalingGroup.Name = workerASGName
+		customObject.Status.AWS.AutoScalingGroup.Name = cc.Status.Drainer.WorkerASGName
 
 		_, err = r.g8sClient.ProviderV1alpha1().AWSConfigs(customObject.Namespace).UpdateStatus(&customObject)
 		if err != nil {
@@ -143,7 +98,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updated CR status")
-
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -191,6 +191,7 @@ func New(config Config) (*Service, error) {
 			},
 			GuestUpdateEnabled: config.Viper.GetBool(config.Flag.Service.Guest.Update.Enabled),
 			ProjectName:        config.ProjectName,
+			Route53Enabled:     config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 		}
 
 		drainerController, err = controller.NewDrainer(c)


### PR DESCRIPTION
We leverage CF stack outputs as a primitive to obtain tenant cluster information specific to AWS. I try to consolidate the usage of this primitive to have one way of accessing the necessary information. This will be useful when we break up the CF stack specific resources to manage different stacks, especially for node pools. 