### PR TITLE
add route table service

### DIFF
--- a/flag/service/aws/aws.go
+++ b/flag/service/aws/aws.go
@@ -17,9 +17,9 @@ type AWS struct {
 	LoggingBucket          loggingbucket.LoggingBucket
 	PodInfraContainerImage string
 	PubKeyFile             string
-	PublicRouteTables      string
 	Region                 string
 	Route53                route53.Route53
+	RouteTables            string
 	S3AccessLogsExpiration string
 	TrustedAdvisor         trustedadvisor.TrustedAdvisor
 	VaultAddress           string

--- a/helm/aws-operator-chart/templates/03-configmap.yaml
+++ b/helm/aws-operator-chart/templates/03-configmap.yaml
@@ -24,9 +24,9 @@ data:
         region: '{{ .Values.Installation.V1.Provider.AWS.Region }}'
         route53:
           enabled: '{{ .Values.Installation.V1.Provider.AWS.Route53.Enabled }}'
+        routeTables: '{{ .Values.Installation.V1.Provider.AWS.RouteTableNames }}'
         trustedAdvisor:
           enabled: '{{ .Values.Installation.V1.Provider.AWS.TrustedAdvisor.Enabled }}'
-        publicRouteTables: '{{ .Values.Installation.V1.Provider.AWS.PublicRouteTableNames }}'
         vaultAddress: '{{ .Values.Installation.V1.Auth.Vault.Address }}'
       guest:
         ssh:

--- a/main.go
+++ b/main.go
@@ -116,8 +116,8 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.ID, "", "ID of the AWS access key for the host cluster account. If empty, guest cluster account is used.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.Secret, "", "Secret of the AWS access key for the host cluster account. If empty, guest cluster account is used.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.HostAccessKey.Session, "", "Session token of the AWS access key for the host cluster account. If empty, guest cluster token is used.")
-	daemonCommand.PersistentFlags().String(f.Service.AWS.PublicRouteTables, "", "Names of the public route tables in host cluster separated by commas, required for accessing public ELBs from guest nodes.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.Region, "", "Region for checking for orphan AWS resources.")
+	daemonCommand.PersistentFlags().String(f.Service.AWS.RouteTables, "", "Names of the public route tables in control plane separated by commas, required for accessing public ELBs from tenant nodes.")
 	daemonCommand.PersistentFlags().String(f.Service.AWS.VaultAddress, "", "Server address for Vault encryption.")
 
 	daemonCommand.PersistentFlags().String(f.Service.RegistryDomain, "quay.io", "Image registry.")

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24"
 	v24adapter "github.com/giantswarm/aws-operator/service/controller/v24/adapter"
 	v24cloudconfig "github.com/giantswarm/aws-operator/service/controller/v24/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/routetable"
 )
 
 type ClusterConfig struct {
@@ -32,6 +33,7 @@ type ClusterConfig struct {
 	K8sClient    kubernetes.Interface
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
+	RouteTable   *routetable.RouteTable
 
 	AccessLogsExpiration       int
 	AdvancedMonitoringEC2      bool
@@ -91,12 +93,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.G8sClient must not be empty")
-	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
-	}
-	if config.K8sExtClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sExtClient must not be empty")
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
@@ -339,6 +335,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			K8sClient:          config.K8sClient,
 			Logger:             config.Logger,
 			RandomKeysSearcher: randomKeysSearcher,
+			RouteTable:         config.RouteTable,
 
 			AccessLogsExpiration:       config.AccessLogsExpiration,
 			AdvancedMonitoringEC2:      config.AdvancedMonitoringEC2,

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -25,7 +25,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24"
 	v24adapter "github.com/giantswarm/aws-operator/service/controller/v24/adapter"
 	v24cloudconfig "github.com/giantswarm/aws-operator/service/controller/v24/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/routetable"
 )
 
 type ClusterConfig struct {
@@ -33,7 +32,6 @@ type ClusterConfig struct {
 	K8sClient    kubernetes.Interface
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
-	RouteTable   *routetable.RouteTable
 
 	AccessLogsExpiration       int
 	AdvancedMonitoringEC2      bool
@@ -335,7 +333,6 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			K8sClient:          config.K8sClient,
 			Logger:             config.Logger,
 			RandomKeysSearcher: randomKeysSearcher,
-			RouteTable:         config.RouteTable,
 
 			AccessLogsExpiration:       config.AccessLogsExpiration,
 			AdvancedMonitoringEC2:      config.AdvancedMonitoringEC2,

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -54,9 +54,9 @@ type ClusterConfig struct {
 	PodInfraContainerImage     string
 	ProjectName                string
 	PubKeyFile                 string
-	PublicRouteTables          string
 	RegistryDomain             string
 	Route53Enabled             bool
+	RouteTables                string
 	SSOPublicKey               string
 	VaultAddress               string
 }
@@ -264,7 +264,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 				SubnetList: config.APIWhitelist.SubnetList,
 			},
 			ProjectName:       config.ProjectName,
-			PublicRouteTables: config.PublicRouteTables,
+			PublicRouteTables: config.RouteTables,
 			RegistryDomain:    config.RegistryDomain,
 			SSOPublicKey:      config.SSOPublicKey,
 			VaultAddress:      config.VaultAddress,
@@ -313,7 +313,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 				SubnetList: config.APIWhitelist.SubnetList,
 			},
 			ProjectName:       config.ProjectName,
-			PublicRouteTables: config.PublicRouteTables,
+			PublicRouteTables: config.RouteTables,
 			RegistryDomain:    config.RegistryDomain,
 			SSOPublicKey:      config.SSOPublicKey,
 			VaultAddress:      config.VaultAddress,
@@ -362,11 +362,11 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 				Enabled:    config.APIWhitelist.Enabled,
 				SubnetList: config.APIWhitelist.SubnetList,
 			},
-			ProjectName:       config.ProjectName,
-			PublicRouteTables: config.PublicRouteTables,
-			RegistryDomain:    config.RegistryDomain,
-			SSOPublicKey:      config.SSOPublicKey,
-			VaultAddress:      config.VaultAddress,
+			ProjectName:    config.ProjectName,
+			RouteTables:    config.RouteTables,
+			RegistryDomain: config.RegistryDomain,
+			SSOPublicKey:   config.SSOPublicKey,
+			VaultAddress:   config.VaultAddress,
 		}
 
 		resourceSetV24, err = v24.NewClusterResourceSet(c)

--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -47,6 +47,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/service"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/stackoutput"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/workerasgname"
+	"github.com/giantswarm/aws-operator/service/routetable"
 )
 
 const (
@@ -64,6 +65,7 @@ type ClusterResourceSetConfig struct {
 	K8sClient          kubernetes.Interface
 	Logger             micrologger.Logger
 	RandomKeysSearcher randomkeys.Interface
+	RouteTable         *routetable.RouteTable
 
 	AccessLogsExpiration       int
 	AdvancedMonitoringEC2      bool
@@ -92,12 +94,10 @@ type ClusterResourceSetConfig struct {
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
 	var err error
 
-	if config.CertsSearcher == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CertsSearcher must not be empty", config)
-	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
+
 	if config.HostAWSConfig.AccessKeyID == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.HostAWSConfig.AccessKeyID must not be empty", config)
 	}
@@ -129,16 +129,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	if config.GuestPublicSubnetMaskBits <= config.GuestSubnetMaskBits {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GuestPublicSubnetMaskBits (%d) must not be smaller or equal than %T.GuestSubnetMaskBits (%d)", config, config.GuestPublicSubnetMaskBits, config, config.GuestSubnetMaskBits)
 	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.RandomKeysSearcher == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.RandomkeysSearcher must not be empty", config)
-	}
-
 	if config.IgnitionPath == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.IgnitionPath must not be empty", config)
 	}

--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -83,8 +83,8 @@ type ClusterResourceSetConfig struct {
 	DeleteLoggingBucket        bool
 	OIDC                       cloudconfig.OIDCConfig
 	ProjectName                string
-	PublicRouteTables          string
 	Route53Enabled             bool
+	RouteTables                string
 	PodInfraContainerImage     string
 	RegistryDomain             string
 	SSOPublicKey               string
@@ -367,7 +367,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			GuestPrivateSubnetMaskBits: config.GuestPrivateSubnetMaskBits,
 			GuestPublicSubnetMaskBits:  config.GuestPublicSubnetMaskBits,
 			InstallationName:           config.InstallationName,
-			PublicRouteTables:          config.PublicRouteTables,
+			PublicRouteTables:          config.RouteTables,
 			Route53Enabled:             config.Route53Enabled,
 		}
 

--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -47,7 +47,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/service"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/stackoutput"
 	"github.com/giantswarm/aws-operator/service/controller/v24/resource/workerasgname"
-	"github.com/giantswarm/aws-operator/service/routetable"
 )
 
 const (
@@ -65,7 +64,6 @@ type ClusterResourceSetConfig struct {
 	K8sClient          kubernetes.Interface
 	Logger             micrologger.Logger
 	RandomKeysSearcher randomkeys.Interface
-	RouteTable         *routetable.RouteTable
 
 	AccessLogsExpiration       int
 	AdvancedMonitoringEC2      bool
@@ -174,6 +172,21 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	default:
 		return nil, microerror.Maskf(invalidConfigError, "unknown encrypter backend %q", config.EncrypterBackend)
 	}
+
+	//var routeTableService *routetable.RouteTable
+	//{
+	//	c := routetable.Config{
+	//		EC2:    config.HostAWSClients.EC2,
+	//		Logger: config.Logger,
+	//
+	//		Names: strings.Split(config.RouteTables, ","),
+	//	}
+	//
+	//	routeTableService, err = routetable.New(c)
+	//	if err != nil {
+	//		return nil, microerror.Mask(err)
+	//	}
+	//}
 
 	var cloudConfig *cloudconfig.CloudConfig
 	{

--- a/service/routetable/error.go
+++ b/service/routetable/error.go
@@ -1,0 +1,32 @@
+package routetable
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/routetable/route_table.go
+++ b/service/routetable/route_table.go
@@ -29,7 +29,7 @@ type RouteTable struct {
 }
 
 // New creates a new route table service that has to be booted using Boot to
-// cache the confiured route table IDs associated with their names.
+// cache the configured route table IDs associated with their names.
 func New(config Config) (*RouteTable, error) {
 	if config.EC2 == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.EC2 must not be empty", config)

--- a/service/routetable/route_table.go
+++ b/service/routetable/route_table.go
@@ -50,24 +50,17 @@ func New(config Config) (*RouteTable, error) {
 	return r, nil
 }
 
-func (r *RouteTable) Boot(ctx context.Context) error {
-	for _, name := range r.names {
-		id, err := r.searchID(ctx, name)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.ids[name] = id
-	}
-
-	return nil
-}
-
-func (r *RouteTable) IdForName(name string) (string, error) {
+func (r *RouteTable) IdForName(ctx context.Context, name string) (string, error) {
 	id, ok := r.ids[name]
-	if !ok {
-		return "", microerror.Maskf(notFoundError, name)
+	if ok {
+		return id, nil
 	}
+
+	id, err := r.searchID(ctx, name)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	r.ids[name] = id
 
 	return id, nil
 }

--- a/service/routetable/route_table.go
+++ b/service/routetable/route_table.go
@@ -1,0 +1,95 @@
+package routetable
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Config struct {
+	EC2    EC2
+	Logger micrologger.Logger
+
+	// Names are the route table names used to lookup IDs.
+	Names []string
+}
+
+type RouteTable struct {
+	ec2    EC2
+	logger micrologger.Logger
+
+	// ids is a mapping of route table names and IDs, where the key is the name
+	// and the value is the ID.
+	ids map[string]string
+
+	names []string
+}
+
+// New creates a new route table service that has to be booted using Boot to
+// cache the confiured route table IDs associated with their names.
+func New(config Config) (*RouteTable, error) {
+	if config.EC2 == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.EC2 must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &RouteTable{
+		ec2:    config.EC2,
+		logger: config.Logger,
+
+		ids: map[string]string{},
+
+		names: config.Names,
+	}
+
+	return r, nil
+}
+
+func (r *RouteTable) Boot(ctx context.Context) error {
+	for _, name := range r.names {
+		id, err := r.searchID(name)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.ids[name] = id
+	}
+
+	return nil
+}
+
+func (r *RouteTable) IdForName(name string) (string, error) {
+	id, ok := r.ids[name]
+	if !ok {
+		return "", microerror.Maskf(notFoundError, name)
+	}
+
+	return id, nil
+}
+
+func (r *RouteTable) searchID(name string) (string, error) {
+	i := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(name),
+				},
+			},
+		},
+	}
+	o, err := r.ec2.DescribeRouteTables(i)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	if len(o.RouteTables) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected one route table, got %d", len(o.RouteTables))
+	}
+
+	return *o.RouteTables[0].RouteTableId, nil
+}

--- a/service/routetable/route_table.go
+++ b/service/routetable/route_table.go
@@ -52,7 +52,7 @@ func New(config Config) (*RouteTable, error) {
 
 func (r *RouteTable) Boot(ctx context.Context) error {
 	for _, name := range r.names {
-		id, err := r.searchID(name)
+		id, err := r.searchID(ctx, name)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -72,7 +72,9 @@ func (r *RouteTable) IdForName(name string) (string, error) {
 	return id, nil
 }
 
-func (r *RouteTable) searchID(name string) (string, error) {
+func (r *RouteTable) searchID(ctx context.Context, name string) (string, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding route table ID for %#q", name)
+
 	i := &ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -91,5 +93,9 @@ func (r *RouteTable) searchID(name string) (string, error) {
 		return "", microerror.Maskf(executionFailedError, "expected one route table, got %d", len(o.RouteTables))
 	}
 
-	return *o.RouteTables[0].RouteTableId, nil
+	id := *o.RouteTables[0].RouteTableId
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found route table ID %#q for %#q", id, name)
+
+	return id, nil
 }

--- a/service/routetable/spec.go
+++ b/service/routetable/spec.go
@@ -1,0 +1,7 @@
+package routetable
+
+import "github.com/aws/aws-sdk-go/service/ec2"
+
+type EC2 interface {
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -5,8 +5,10 @@ package service
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microendpoint/service/version"
 	"github.com/giantswarm/microerror"
@@ -22,6 +24,7 @@ import (
 	"github.com/giantswarm/aws-operator/flag"
 	"github.com/giantswarm/aws-operator/service/collector"
 	"github.com/giantswarm/aws-operator/service/controller"
+	"github.com/giantswarm/aws-operator/service/routetable"
 )
 
 const (
@@ -48,6 +51,7 @@ type Service struct {
 	clusterController       *controller.Cluster
 	drainerController       *controller.Drainer
 	operatorCollector       *collector.Set
+	routeTableService       *routetable.RouteTable
 	statusResourceCollector *statusresource.Collector
 }
 
@@ -103,6 +107,41 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	var awsConfig clientaws.Config
+	{
+		awsConfig = clientaws.Config{
+			AccessKeyID:     config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.ID),
+			AccessKeySecret: config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Secret),
+			Region:          config.Viper.GetString(config.Flag.Service.AWS.Region),
+			SessionToken:    config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Session),
+		}
+	}
+
+	var ec2Client ec2iface.EC2API
+	{
+		clients, err := clientaws.NewClients(awsConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		ec2Client = clients.EC2
+	}
+
+	var routeTableService *routetable.RouteTable
+	{
+		c := routetable.Config{
+			EC2:    ec2Client,
+			Logger: config.Logger,
+
+			Names: strings.Split(config.Viper.GetString(config.Flag.Service.AWS.PublicRouteTables), ","),
+		}
+
+		routeTableService, err = routetable.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var clusterController *controller.Cluster
 	{
 		_, ipamNetworkRange, err := net.ParseCIDR(config.Viper.GetString(config.Flag.Service.Installation.Guest.IPAM.Network.CIDR))
@@ -115,6 +154,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:    k8sClient,
 			K8sExtClient: k8sExtClient,
 			Logger:       config.Logger,
+			RouteTable:   routeTableService,
 
 			APIWhitelist: controller.FrameworkConfigAPIWhitelistConfig{
 				Enabled:    config.Viper.GetBool(config.Flag.Service.Installation.Guest.Kubernetes.API.Security.Whitelist.Enabled),
@@ -200,16 +240,6 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
-	var awsConfig clientaws.Config
-	{
-		awsConfig = clientaws.Config{
-			AccessKeyID:     config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.ID),
-			AccessKeySecret: config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Secret),
-			Region:          config.Viper.GetString(config.Flag.Service.AWS.Region),
-			SessionToken:    config.Viper.GetString(config.Flag.Service.AWS.HostAccessKey.Session),
-		}
-	}
-
 	var operatorCollector *collector.Set
 	{
 		c := collector.SetConfig{
@@ -264,6 +294,7 @@ func New(config Config) (*Service, error) {
 		clusterController:       clusterController,
 		drainerController:       drainerController,
 		operatorCollector:       operatorCollector,
+		routeTableService:       routeTableService,
 		statusResourceCollector: statusResourceCollector,
 	}
 
@@ -272,6 +303,11 @@ func New(config Config) (*Service, error) {
 
 func (s *Service) Boot(ctx context.Context) {
 	s.bootOnce.Do(func() {
+		err := s.routeTableService.Boot(ctx)
+		if err != nil {
+			panic(err)
+		}
+
 		go s.operatorCollector.Boot(ctx)
 		go s.statusResourceCollector.Boot(ctx)
 

--- a/service/service.go
+++ b/service/service.go
@@ -133,7 +133,7 @@ func New(config Config) (*Service, error) {
 			EC2:    ec2Client,
 			Logger: config.Logger,
 
-			Names: strings.Split(config.Viper.GetString(config.Flag.Service.AWS.PublicRouteTables), ","),
+			Names: strings.Split(config.Viper.GetString(config.Flag.Service.AWS.RouteTables), ","),
 		}
 
 		routeTableService, err = routetable.New(c)
@@ -196,9 +196,9 @@ func New(config Config) (*Service, error) {
 			PodInfraContainerImage: config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
 			ProjectName:            config.ProjectName,
 			PubKeyFile:             config.Viper.GetString(config.Flag.Service.AWS.PubKeyFile),
-			PublicRouteTables:      config.Viper.GetString(config.Flag.Service.AWS.PublicRouteTables),
-			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RegistryDomain:         config.Viper.GetString(config.Flag.Service.RegistryDomain),
+			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
+			RouteTables:            config.Viper.GetString(config.Flag.Service.AWS.RouteTables),
 			SSOPublicKey:           config.Viper.GetString(config.Flag.Service.Guest.SSH.SSOPublicKey),
 			VaultAddress:           config.Viper.GetString(config.Flag.Service.AWS.VaultAddress),
 		}


### PR DESCRIPTION
Right now we lookup the route table IDs of the control plane all the time at runtime. Over and over again. That is not necessary. Here is a service implementation suggested that does the lookup at program start. The route table IDs are cached in memory and available for further use. In the next PRs I would make use of this mechanism. For now it is only added and wired up to the cluster controller. 