### PR TITLE
rename guest templates to tccp

### DIFF
--- a/service/controller/v24/key/key.go
+++ b/service/controller/v24/key/key.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/giantswarm/aws-operator/service/controller/v24/templates/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/controller/v24/templates/cloudformation/cpf"
-	"github.com/giantswarm/aws-operator/service/controller/v24/templates/cloudformation/guest"
 	"github.com/giantswarm/aws-operator/service/controller/v24/templates/cloudformation/hostpre"
+	"github.com/giantswarm/aws-operator/service/controller/v24/templates/cloudformation/tccp"
 )
 
 const (
@@ -152,21 +152,21 @@ func CloudConfigSmallTemplates() []string {
 
 func CloudFormationGuestTemplates() []string {
 	return []string{
-		guest.AutoScalingGroup,
-		guest.IAMPolicies,
-		guest.Instance,
-		guest.InternetGateway,
-		guest.LaunchConfiguration,
-		guest.LoadBalancers,
-		guest.Main,
-		guest.NatGateway,
-		guest.LifecycleHooks,
-		guest.Outputs,
-		guest.RecordSets,
-		guest.RouteTables,
-		guest.SecurityGroups,
-		guest.Subnets,
-		guest.VPC,
+		tccp.AutoScalingGroup,
+		tccp.IAMPolicies,
+		tccp.Instance,
+		tccp.InternetGateway,
+		tccp.LaunchConfiguration,
+		tccp.LoadBalancers,
+		tccp.Main,
+		tccp.NatGateway,
+		tccp.LifecycleHooks,
+		tccp.Outputs,
+		tccp.RecordSets,
+		tccp.RouteTables,
+		tccp.SecurityGroups,
+		tccp.Subnets,
+		tccp.VPC,
 	}
 }
 

--- a/service/controller/v24/templates/cloudformation/tccp/auto_scaling_group.go
+++ b/service/controller/v24/templates/cloudformation/tccp/auto_scaling_group.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const AutoScalingGroup = `{{define "autoscaling_group"}}
 {{- $v := .Guest.AutoScalingGroup }}

--- a/service/controller/v24/templates/cloudformation/tccp/iam_policies.go
+++ b/service/controller/v24/templates/cloudformation/tccp/iam_policies.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const IAMPolicies = `{{define "iam_policies"}}
 {{- $v := .Guest.IAMPolicies }}

--- a/service/controller/v24/templates/cloudformation/tccp/instance.go
+++ b/service/controller/v24/templates/cloudformation/tccp/instance.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const Instance = `{{ define "instance" }}
 {{- $v := .Guest.Instance }}

--- a/service/controller/v24/templates/cloudformation/tccp/internet_gateway.go
+++ b/service/controller/v24/templates/cloudformation/tccp/internet_gateway.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const InternetGateway = `{{define "internet_gateway"}}
 {{- $v := .Guest.InternetGateway }}

--- a/service/controller/v24/templates/cloudformation/tccp/launch_configuration.go
+++ b/service/controller/v24/templates/cloudformation/tccp/launch_configuration.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const LaunchConfiguration = `{{define "launch_configuration"}}
 {{- $v := .Guest.LaunchConfiguration }}

--- a/service/controller/v24/templates/cloudformation/tccp/lifecycle_hooks.go
+++ b/service/controller/v24/templates/cloudformation/tccp/lifecycle_hooks.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const LifecycleHooks = `{{ define "lifecycle_hooks" }}
 {{- $v := .Guest.LifecycleHooks }}

--- a/service/controller/v24/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/v24/templates/cloudformation/tccp/load_balancers.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const LoadBalancers = `{{define "load_balancers"}}
 {{- $v := .Guest.LoadBalancers }}

--- a/service/controller/v24/templates/cloudformation/tccp/main.go
+++ b/service/controller/v24/templates/cloudformation/tccp/main.go
@@ -1,11 +1,11 @@
-package guest
+package tccp
 
 const Main = `{{define "main"}}AWSTemplateFormatVersion: 2010-09-09
 Description: Main Guest CloudFormation stack.
 Parameters:
   VersionBundleVersionParameter:
     Type: String
-    Description: Sets the VersionBundleVersion used to generate the template. 
+    Description: Sets the VersionBundleVersion used to generate the template.
 Resources:
   {{template "vpc" .}}
   {{template "iam_policies" .}}

--- a/service/controller/v24/templates/cloudformation/tccp/nat_gateway.go
+++ b/service/controller/v24/templates/cloudformation/tccp/nat_gateway.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const NatGateway = `{{define "nat_gateway"}}
   {{- $v := .Guest.NATGateway }}

--- a/service/controller/v24/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/v24/templates/cloudformation/tccp/outputs.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const Outputs = `{{define "outputs"}}
 {{- $v := .Guest.Outputs }}

--- a/service/controller/v24/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/v24/templates/cloudformation/tccp/record_sets.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const RecordSets = `{{define "record_sets"}}
 {{- $v := .Guest.RecordSets }}

--- a/service/controller/v24/templates/cloudformation/tccp/route_tables.go
+++ b/service/controller/v24/templates/cloudformation/tccp/route_tables.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const RouteTables = `{{ define "route_tables" }}
 {{- $v := .Guest.RouteTables }}

--- a/service/controller/v24/templates/cloudformation/tccp/security_groups.go
+++ b/service/controller/v24/templates/cloudformation/tccp/security_groups.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const SecurityGroups = `{{define "security_groups" }}
 {{- $v := .Guest.SecurityGroups }}

--- a/service/controller/v24/templates/cloudformation/tccp/subnets.go
+++ b/service/controller/v24/templates/cloudformation/tccp/subnets.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const Subnets = `{{ define "subnets" }}
 {{- $v := .Guest.Subnets }}

--- a/service/controller/v24/templates/cloudformation/tccp/vpc.go
+++ b/service/controller/v24/templates/cloudformation/tccp/vpc.go
@@ -1,4 +1,4 @@
-package guest
+package tccp
 
 const VPC = `{{define "vpc"}}
 {{- $v := .Guest.VPC }}


### PR DESCRIPTION
TCCP stands for Tenant Cluster Control Plane. The counterparts are CPI and CPF. 