### PR TITLE
drop route53 config in CPI resource

### DIFF
--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -428,7 +428,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			Logger: config.Logger,
 
 			InstallationName: config.InstallationName,
-			Route53Enabled:   config.Route53Enabled,
 		}
 
 		cpiResource, err = cpi.New(c)

--- a/service/controller/v24/resource/cpi/create.go
+++ b/service/controller/v24/resource/cpi/create.go
@@ -59,7 +59,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			c := adapter.Config{
 				CustomObject:   customObject,
 				GuestAccountID: cc.Status.Cluster.AWSAccount.ID,
-				Route53Enabled: r.route53Enabled,
 			}
 
 			newAdapter, err = adapter.NewHostPre(c)

--- a/service/controller/v24/resource/cpi/resource.go
+++ b/service/controller/v24/resource/cpi/resource.go
@@ -21,7 +21,6 @@ type Config struct {
 	Logger      micrologger.Logger
 
 	InstallationName string
-	Route53Enabled   bool
 }
 
 // Resource implements the CPI resource, which stands for Control Plane
@@ -32,7 +31,6 @@ type Resource struct {
 	logger      micrologger.Logger
 
 	installationName string
-	route53Enabled   bool
 }
 
 func New(config Config) (*Resource, error) {
@@ -48,7 +46,6 @@ func New(config Config) (*Resource, error) {
 		logger:      config.Logger,
 
 		installationName: config.InstallationName,
-		route53Enabled:   config.Route53Enabled,
 	}
 
 	return r, nil


### PR DESCRIPTION
The config does not seem to be used at all here. 