### PR TITLE
wire route table names separately into the CPF resource

### DIFF
--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -408,6 +408,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			EncrypterBackend: config.EncrypterBackend,
 			InstallationName: config.InstallationName,
 			Route53Enabled:   config.Route53Enabled,
+			RouteTables:      strings.Split(config.RouteTables, ","),
 		}
 
 		cpfResource, err = cpf.New(c)

--- a/service/controller/v24/resource/cpf/resource.go
+++ b/service/controller/v24/resource/cpf/resource.go
@@ -21,10 +21,10 @@ type Config struct {
 	Logger         micrologger.Logger
 	RouteTable     *routetable.RouteTable
 
-	EncrypterBackend  string
-	InstallationName  string
-	PublicRouteTables string
-	Route53Enabled    bool
+	EncrypterBackend string
+	InstallationName string
+	Route53Enabled   bool
+	RouteTables      []string
 }
 
 // Resource implements the CPF resource, which stands for Control Plane
@@ -35,10 +35,10 @@ type Resource struct {
 	logger         micrologger.Logger
 	routeTable     *routetable.RouteTable
 
-	encrypterBackend  string
-	installationName  string
-	publicRouteTables string
-	route53Enabled    bool
+	encrypterBackend string
+	installationName string
+	route53Enabled   bool
+	routeTables      []string
 }
 
 func New(config Config) (*Resource, error) {
@@ -55,16 +55,19 @@ func New(config Config) (*Resource, error) {
 	if config.EncrypterBackend == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.EncrypterBackend must not be empty", config)
 	}
+	if config.RouteTables == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RouteTables must not be empty", config)
+	}
 
 	r := &Resource{
 		cloudFormation: config.CloudFormation,
 		logger:         config.Logger,
 		routeTable:     config.RouteTable,
 
-		encrypterBackend:  config.EncrypterBackend,
-		installationName:  config.InstallationName,
-		publicRouteTables: config.PublicRouteTables,
-		route53Enabled:    config.Route53Enabled,
+		encrypterBackend: config.EncrypterBackend,
+		installationName: config.InstallationName,
+		route53Enabled:   config.Route53Enabled,
+		routeTables:      config.RouteTables,
 	}
 
 	return r, nil


### PR DESCRIPTION
When we dropped `Boot` from the new route table service implementation we decided to inject the route table names separately and drop it from the service configuration. This PR is the first step towards this. 