### PR TITLE
remove version fallback

### DIFF
--- a/service/controller/v24/resource/tccp/current.go
+++ b/service/controller/v24/resource/tccp/current.go
@@ -86,41 +86,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	var currentState StackState
 	{
 		dockerVolumeResourceName, err := cc.CloudFormation.GetOutputValue(stackOutputs, key.DockerVolumeResourceNameKey)
-		if cloudformationservice.IsOutputNotFound(err) {
-			// Since we are transitioning between versions we will have situations in
-			// which old clusters are updated to new versions and miss the docker
-			// volume resource name in the CF stack outputs. We ignore this problem
-			// for now and move on regardless. On the next resync period the output
-			// value will be there, once the cluster got updated.
-			//
-			// TODO remove this condition as soon as all guest clusters in existence
-			// obtain a docker volume resource.
-			dockerVolumeResourceName = ""
-		} else if err != nil {
+		if err != nil {
 			return StackState{}, microerror.Mask(err)
-		}
-
-		var workerDockerVolumeSizeGB int
-		{
-			v, err := cc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerDockerVolumeSizeKey)
-			if cloudformationservice.IsOutputNotFound(err) {
-				// Since we are transitioning between versions we will have situations in
-				// which old clusters are updated to new versions and miss the docker
-				// volume resource name in the CF stack outputs. We ignore this problem
-				// for now and move on regardless. On the next resync period the output
-				// value will be there, once the cluster got updated.
-				//
-				// TODO remove this condition as soon as all guest clusters in existence
-				// obtain a docker volume size. Tracked here: https://github.com/giantswarm/giantswarm/issues/4139.
-				v = "100"
-			} else if err != nil {
-				return StackState{}, microerror.Mask(err)
-			}
-
-			workerDockerVolumeSizeGB, err = strconv.Atoi(v)
-			if err != nil {
-				return StackState{}, microerror.Mask(err)
-			}
 		}
 
 		masterImageID, err := cc.CloudFormation.GetOutputValue(stackOutputs, key.MasterImageIDKey)
@@ -144,6 +111,18 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		if err != nil {
 			return StackState{}, microerror.Mask(err)
 		}
+		var workerDockerVolumeSizeGB int
+		{
+			v, err := cc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerDockerVolumeSizeKey)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+
+			workerDockerVolumeSizeGB, err = strconv.Atoi(v)
+			if err != nil {
+				return StackState{}, microerror.Mask(err)
+			}
+		}
 		workerImageID, err := cc.CloudFormation.GetOutputValue(stackOutputs, key.WorkerImageIDKey)
 		if err != nil {
 			return StackState{}, microerror.Mask(err)
@@ -161,7 +140,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		currentState = StackState{
 			Name: stackName,
 
-			DockerVolumeResourceName:   dockerVolumeResourceName,
+			DockerVolumeResourceName: dockerVolumeResourceName,
+
 			MasterImageID:              masterImageID,
 			MasterInstanceResourceName: masterInstanceResourceName,
 			MasterInstanceType:         masterInstanceType,


### PR DESCRIPTION
In the masses of PRs I was smashing I fucked up one thing. I did this very change in the wrong version. See https://github.com/giantswarm/aws-operator/pull/1446. It should not harm anyway, but I want to get it into the latest version for sure. 