### PR TITLE
restructure controller context clients

### DIFF
--- a/service/controller/v24/controllercontext/client.go
+++ b/service/controller/v24/controllercontext/client.go
@@ -1,0 +1,18 @@
+package controllercontext
+
+import (
+	"github.com/giantswarm/aws-operator/client/aws"
+)
+
+type ContextClient struct {
+	ControlPlane  ContextClientControlPlane
+	TenantCluster ContextClientTenantCluster
+}
+
+type ContextClientControlPlane struct {
+	AWS aws.Clients
+}
+
+type ContextClientTenantCluster struct {
+	AWS aws.Clients
+}

--- a/service/controller/v24/controllercontext/context.go
+++ b/service/controller/v24/controllercontext/context.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	awsclient "github.com/giantswarm/aws-operator/client/aws"
 	cloudformationservice "github.com/giantswarm/aws-operator/service/controller/v24/cloudformation"
 	"github.com/giantswarm/aws-operator/service/controller/v24/ebs"
 )
@@ -15,10 +14,12 @@ type contextKey string
 const controllerKey contextKey = "controller"
 
 type Context struct {
-	AWSClient      awsclient.Clients
 	CloudFormation cloudformationservice.CloudFormation
 	EBSService     ebs.Interface
 
+	// Client holds the client implementations used for several tenant cluster
+	// specific actions.
+	Client ContextClient
 	// Status holds the data used to communicate between controller's
 	// resources. It can be edited in place as Context is stored as
 	// a pointer within context.Context.

--- a/service/controller/v24/encrypter/kms/kms.go
+++ b/service/controller/v24/encrypter/kms/kms.go
@@ -83,7 +83,7 @@ func (e *Encrypter) EnsureCreatedEncryptionKey(ctx context.Context, customObject
 			AliasName: aws.String(keyAlias(customObject)),
 		}
 
-		_, err = cc.AWSClient.KMS.DeleteAlias(in)
+		_, err = cc.Client.TenantCluster.AWS.KMS.DeleteAlias(in)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -107,7 +107,7 @@ func (e *Encrypter) EnsureCreatedEncryptionKey(ctx context.Context, customObject
 			Tags: awstags.NewKMS(tags),
 		}
 
-		out, err := cc.AWSClient.KMS.CreateKey(in)
+		out, err := cc.Client.TenantCluster.AWS.KMS.CreateKey(in)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -128,7 +128,7 @@ func (e *Encrypter) EnsureCreatedEncryptionKey(ctx context.Context, customObject
 			KeyId: keyID,
 		}
 
-		_, err = cc.AWSClient.KMS.EnableKeyRotation(in)
+		_, err = cc.Client.TenantCluster.AWS.KMS.EnableKeyRotation(in)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -144,7 +144,7 @@ func (e *Encrypter) EnsureCreatedEncryptionKey(ctx context.Context, customObject
 			TargetKeyId: keyID,
 		}
 
-		_, err = cc.AWSClient.KMS.CreateAlias(in)
+		_, err = cc.Client.TenantCluster.AWS.KMS.CreateAlias(in)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -203,7 +203,7 @@ func (e *Encrypter) EnsureDeletedEncryptionKey(ctx context.Context, customObject
 			PendingWindowInDays: pendingWindowInDays,
 		}
 
-		_, err = cc.AWSClient.KMS.ScheduleKeyDeletion(in)
+		_, err = cc.Client.TenantCluster.AWS.KMS.ScheduleKeyDeletion(in)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -239,7 +239,7 @@ func (k *Encrypter) Encrypt(ctx context.Context, key, plaintext string) (string,
 		Plaintext: []byte(plaintext),
 	}
 
-	encryptOutput, err := cc.AWSClient.KMS.Encrypt(encryptInput)
+	encryptOutput, err := cc.Client.TenantCluster.AWS.KMS.Encrypt(encryptInput)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -261,7 +261,7 @@ func (k *Encrypter) describeKey(ctx context.Context, customObject v1alpha1.AWSCo
 		KeyId: aws.String(keyAlias(customObject)),
 	}
 
-	out, err := cc.AWSClient.KMS.DescribeKey(input)
+	out, err := cc.Client.TenantCluster.AWS.KMS.DescribeKey(input)
 	if IsKeyNotFound(err) {
 		return nil, microerror.Mask(keyNotFoundError)
 	} else if err != nil {

--- a/service/controller/v24/resource/accountid/resource.go
+++ b/service/controller/v24/resource/accountid/resource.go
@@ -85,7 +85,7 @@ func (r *Resource) addAccountIDToContext(ctx context.Context) error {
 		{
 			c := accountid.Config{
 				Logger: r.logger,
-				STS:    cc.AWSClient.STS,
+				STS:    cc.Client.TenantCluster.AWS.STS,
 			}
 
 			accountIDService, err = accountid.New(c)

--- a/service/controller/v24/resource/asgstatus/create.go
+++ b/service/controller/v24/resource/asgstatus/create.go
@@ -39,7 +39,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				&workerASGName,
 			},
 		}
-		o, err := cc.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
+		o, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/v24/resource/bridgezone/resource.go
+++ b/service/controller/v24/resource/bridgezone/resource.go
@@ -270,7 +270,7 @@ func (r *Resource) route53Clients(ctx context.Context) (guest, defaultGuest *rou
 		if err != nil {
 			return nil, nil, microerror.Mask(err)
 		}
-		guest = cc.AWSClient.Route53
+		guest = cc.Client.TenantCluster.AWS.Route53
 	}
 
 	// defaultGuest

--- a/service/controller/v24/resource/drainer/create.go
+++ b/service/controller/v24/resource/drainer/create.go
@@ -47,7 +47,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			},
 		}
 
-		o, err := cc.AWSClient.AutoScaling.DescribeAutoScalingGroups(i)
+		o, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -169,7 +169,7 @@ func (r *Resource) privateDNSForInstance(ctx context.Context, instanceID string)
 		return "", microerror.Mask(err)
 	}
 
-	o, err := cc.AWSClient.EC2.DescribeInstances(i)
+	o, err := cc.Client.TenantCluster.AWS.EC2.DescribeInstances(i)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/v24/resource/drainfinisher/create.go
+++ b/service/controller/v24/resource/drainfinisher/create.go
@@ -115,7 +115,7 @@ func (r *Resource) completeLifecycleHook(ctx context.Context, instanceID, worker
 		return microerror.Mask(err)
 	}
 
-	_, err = cc.AWSClient.AutoScaling.CompleteLifecycleAction(i)
+	_, err = cc.Client.TenantCluster.AWS.AutoScaling.CompleteLifecycleAction(i)
 	if IsNoActiveLifecycleAction(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not found lifecycle hook action for guest cluster node '%s'", instanceID))
 	} else if err != nil {

--- a/service/controller/v24/resource/endpoints/desired_test.go
+++ b/service/controller/v24/resource/endpoints/desired_test.go
@@ -58,9 +58,15 @@ func Test_Resource_Endpoints_GetDesiredState(t *testing.T) {
 					privateIPAddress: tc.expectedIPAddress,
 				},
 			}
-
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.GetDesiredState(ctx, tc.obj)
 			if err != nil {

--- a/service/controller/v24/resource/endpoints/instance.go
+++ b/service/controller/v24/resource/endpoints/instance.go
@@ -32,7 +32,7 @@ func (r Resource) findMasterInstance(ctx context.Context, instanceName string) (
 		},
 	}
 
-	output, err := cc.AWSClient.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
+	output, err := cc.Client.TenantCluster.AWS.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
 		Filters: filters,
 	})
 	if err != nil {

--- a/service/controller/v24/resource/ipam/create.go
+++ b/service/controller/v24/resource/ipam/create.go
@@ -252,7 +252,7 @@ func getVPCSubnets(ctx context.Context) ([]net.IPNet, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	out, err := cc.AWSClient.EC2.DescribeSubnets(nil)
+	out, err := cc.Client.TenantCluster.AWS.EC2.DescribeSubnets(nil)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/v24/resource/loadbalancer/delete.go
+++ b/service/controller/v24/resource/loadbalancer/delete.go
@@ -34,7 +34,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		for _, lbName := range lbState.LoadBalancerNames {
-			_, err := cc.AWSClient.ELB.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{
+			_, err := cc.Client.TenantCluster.AWS.ELB.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{
 				LoadBalancerName: aws.String(lbName),
 			})
 			if err != nil {

--- a/service/controller/v24/resource/loadbalancer/elb.go
+++ b/service/controller/v24/resource/loadbalancer/elb.go
@@ -27,7 +27,7 @@ func (r *Resource) clusterLoadBalancers(ctx context.Context, customObject v1alph
 	}
 
 	// We get all load balancers because the API does not allow tag filters.
-	output, err := cc.AWSClient.ELB.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
+	output, err := cc.Client.TenantCluster.AWS.ELB.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -43,7 +43,7 @@ func (r *Resource) clusterLoadBalancers(ctx context.Context, customObject v1alph
 		tagsInput := &elb.DescribeTagsInput{
 			LoadBalancerNames: lbNames,
 		}
-		tagsOutput, err := cc.AWSClient.ELB.DescribeTags(tagsInput)
+		tagsOutput, err := cc.Client.TenantCluster.AWS.ELB.DescribeTags(tagsInput)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/v24/resource/loadbalancer/elb_test.go
+++ b/service/controller/v24/resource/loadbalancer/elb_test.go
@@ -210,7 +210,14 @@ func Test_clusterLoadBalancers(t *testing.T) {
 				},
 			}
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.clusterLoadBalancers(ctx, tc.obj)
 			if err != nil {

--- a/service/controller/v24/resource/s3bucket/create.go
+++ b/service/controller/v24/resource/s3bucket/create.go
@@ -34,7 +34,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				Bucket: aws.String(bucketInput.Name),
 			}
 
-			_, err = cc.AWSClient.S3.CreateBucket(i)
+			_, err = cc.Client.TenantCluster.AWS.S3.CreateBucket(i)
 			if IsBucketAlreadyExists(err) {
 				// Fall through.
 			} else if IsBucketAlreadyOwnedByYou(err) {
@@ -52,7 +52,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				},
 			}
 
-			_, err = cc.AWSClient.S3.PutBucketTagging(i)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketTagging(i)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -65,7 +65,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				GrantWrite:   aws.String(key.LogDeliveryURI),
 			}
 
-			_, err = cc.AWSClient.S3.PutBucketAcl(i)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketAcl(i)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -88,7 +88,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				},
 			}
 
-			_, err = cc.AWSClient.S3.PutBucketLifecycleConfiguration(i)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketLifecycleConfiguration(i)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -105,7 +105,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				},
 			}
 
-			_, err = cc.AWSClient.S3.PutBucketLogging(i)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketLogging(i)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/v24/resource/s3bucket/current.go
+++ b/service/controller/v24/resource/s3bucket/current.go
@@ -100,7 +100,7 @@ func (r *Resource) isBucketCreated(ctx context.Context, name string) (bool, erro
 	headInput := &s3.HeadBucketInput{
 		Bucket: aws.String(name),
 	}
-	_, err = cc.AWSClient.S3.HeadBucket(headInput)
+	_, err = cc.Client.TenantCluster.AWS.S3.HeadBucket(headInput)
 	if IsBucketNotFound(err) {
 		return false, nil
 	} else if err != nil {
@@ -119,7 +119,7 @@ func (r *Resource) getLoggingConfiguration(ctx context.Context, name string) (*s
 	bucketLoggingInput := &s3.GetBucketLoggingInput{
 		Bucket: aws.String(name),
 	}
-	bucketLoggingOutput, err := cc.AWSClient.S3.GetBucketLogging(bucketLoggingInput)
+	bucketLoggingOutput, err := cc.Client.TenantCluster.AWS.S3.GetBucketLogging(bucketLoggingInput)
 	if err != nil {
 		return bucketLoggingOutput, microerror.Mask(err)
 	}

--- a/service/controller/v24/resource/s3bucket/delete.go
+++ b/service/controller/v24/resource/s3bucket/delete.go
@@ -51,7 +51,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 					i := &s3.ListObjectsV2Input{
 						Bucket: aws.String(bucketName),
 					}
-					o, err := cc.AWSClient.S3.ListObjectsV2(i)
+					o, err := cc.Client.TenantCluster.AWS.S3.ListObjectsV2(i)
 					if err != nil {
 						return microerror.Mask(err)
 					}
@@ -77,7 +77,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 							Quiet:   aws.Bool(true),
 						},
 					}
-					_, err := cc.AWSClient.S3.DeleteObjects(i)
+					_, err := cc.Client.TenantCluster.AWS.S3.DeleteObjects(i)
 					if err != nil {
 						return microerror.Mask(err)
 					}
@@ -110,7 +110,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 				i := &s3.DeleteBucketInput{
 					Bucket: aws.String(bucketName),
 				}
-				_, err = cc.AWSClient.S3.DeleteBucket(i)
+				_, err = cc.Client.TenantCluster.AWS.S3.DeleteBucket(i)
 				if err != nil {
 					return microerror.Mask(err)
 				}

--- a/service/controller/v24/resource/s3object/create.go
+++ b/service/controller/v24/resource/s3object/create.go
@@ -28,7 +28,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				return microerror.Mask(err)
 			}
 
-			_, err = cc.AWSClient.S3.PutObject(&s3PutInput)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutObject(&s3PutInput)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/v24/resource/s3object/create_test.go
+++ b/service/controller/v24/resource/s3object/create_test.go
@@ -170,11 +170,15 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			c := controllercontext.Context{
-				AWSClient: awsClients,
-			}
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, c)
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {

--- a/service/controller/v24/resource/s3object/current.go
+++ b/service/controller/v24/resource/s3object/current.go
@@ -52,7 +52,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			Bucket: aws.String(bucketName),
 		}
 
-		o, err := cc.AWSClient.S3.ListObjectsV2(i)
+		o, err := cc.Client.TenantCluster.AWS.S3.ListObjectsV2(i)
 		if IsBucketNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find the S3 bucket %#q", bucketName))
 			return nil, nil
@@ -101,7 +101,7 @@ func (r *Resource) getBucketObjectBody(ctx context.Context, bucketName string, k
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(keyName),
 	}
-	result, err := cc.AWSClient.S3.GetObject(input)
+	result, err := cc.Client.TenantCluster.AWS.S3.GetObject(input)
 	if IsObjectNotFound(err) || IsBucketNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find S3 object %#q", keyName))
 		return "", nil

--- a/service/controller/v24/resource/s3object/current_test.go
+++ b/service/controller/v24/resource/s3object/current_test.go
@@ -73,8 +73,12 @@ func Test_CurrentState(t *testing.T) {
 				}
 			}
 
-			c := controllercontext.Context{
-				AWSClient: awsClients,
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
 				Status: controllercontext.ContextStatus{
 					TenantCluster: controllercontext.ContextStatusTenantCluster{
 						AWSAccountID: "myaccountid",
@@ -82,7 +86,7 @@ func Test_CurrentState(t *testing.T) {
 				},
 			}
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, c)
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.GetCurrentState(ctx, tc.obj)
 			if err != nil && !tc.expectedS3Error {

--- a/service/controller/v24/resource/s3object/desired_test.go
+++ b/service/controller/v24/resource/s3object/desired_test.go
@@ -72,7 +72,11 @@ func Test_DesiredState(t *testing.T) {
 			}
 
 			c := controllercontext.Context{
-				AWSClient: awsClients,
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
 				Status: controllercontext.ContextStatus{
 					TenantCluster: controllercontext.ContextStatusTenantCluster{
 						AWSAccountID: "myaccountid",

--- a/service/controller/v24/resource/s3object/update.go
+++ b/service/controller/v24/resource/s3object/update.go
@@ -29,7 +29,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				return microerror.Mask(err)
 			}
 
-			_, err = cc.AWSClient.S3.PutObject(&s3PutInput)
+			_, err = cc.Client.TenantCluster.AWS.S3.PutObject(&s3PutInput)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/v24/resource/s3object/update_test.go
+++ b/service/controller/v24/resource/s3object/update_test.go
@@ -161,11 +161,15 @@ func Test_Resource_S3Object_newUpdate(t *testing.T) {
 				}
 			}
 
-			c := controllercontext.Context{
-				AWSClient: awsClients,
-			}
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, c)
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.newUpdateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {

--- a/service/controller/v24/resource/stackoutput/create.go
+++ b/service/controller/v24/resource/stackoutput/create.go
@@ -67,7 +67,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			//
 			//     https://github.com/giantswarm/giantswarm/issues/5496
 			//
-			v, err := searchPeeringConnectionID(cc.AWSClient.EC2, key.ClusterID(cr))
+			v, err := searchPeeringConnectionID(cc.Client.TenantCluster.AWS.EC2, key.ClusterID(cr))
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/v24/resource/tccp/create.go
+++ b/service/controller/v24/resource/tccp/create.go
@@ -40,7 +40,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			}
 		}
 
-		_, err = cc.AWSClient.CloudFormation.CreateStack(&stackInput)
+		_, err = cc.Client.TenantCluster.AWS.CloudFormation.CreateStack(&stackInput)
 		if IsAlreadyExists(err) {
 			// fall through
 		} else if err != nil {
@@ -50,7 +50,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		defer cancel()
 
-		err = cc.AWSClient.CloudFormation.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
+		err = cc.Client.TenantCluster.AWS.CloudFormation.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
 			StackName: stackInput.StackName,
 		})
 		if ctx.Err() == context.DeadlineExceeded {

--- a/service/controller/v24/resource/tccp/create_test.go
+++ b/service/controller/v24/resource/tccp/create_test.go
@@ -121,7 +121,14 @@ func Test_Resource_Cloudformation_newCreate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.newCreateChange(ctx, tc.obj, tc.currentState, tc.desiredState)
 			if err != nil {

--- a/service/controller/v24/resource/tccp/delete.go
+++ b/service/controller/v24/resource/tccp/delete.go
@@ -37,7 +37,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			EnableTerminationProtection: aws.Bool(false),
 			StackName:                   stackName,
 		}
-		_, err = cc.AWSClient.CloudFormation.UpdateTerminationProtection(updateTerminationProtection)
+		_, err = cc.Client.TenantCluster.AWS.CloudFormation.UpdateTerminationProtection(updateTerminationProtection)
 		if IsDeleteInProgress(err) {
 			// fall through
 		} else if IsNotExists(err) {
@@ -48,7 +48,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			i := &cloudformation.DeleteStackInput{
 				StackName: stackName,
 			}
-			_, err = cc.AWSClient.CloudFormation.DeleteStack(i)
+			_, err = cc.Client.TenantCluster.AWS.CloudFormation.DeleteStack(i)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/v24/resource/tccp/main_stack.go
+++ b/service/controller/v24/resource/tccp/main_stack.go
@@ -19,8 +19,8 @@ func (r *Resource) getMainGuestTemplateBody(ctx context.Context, customObject v1
 	}
 
 	adapterClients := adapter.Clients{
-		IAM: cc.AWSClient.IAM,
-		KMS: cc.AWSClient.KMS,
+		IAM: cc.Client.TenantCluster.AWS.IAM,
+		KMS: cc.Client.TenantCluster.AWS.KMS,
 	}
 
 	cfg := adapter.Config{

--- a/service/controller/v24/resource/tccp/main_stack_test.go
+++ b/service/controller/v24/resource/tccp/main_stack_test.go
@@ -73,7 +73,14 @@ func TestMainGuestTemplateGetEmptyBody(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+	cc := controllercontext.Context{
+		Client: controllercontext.ContextClient{
+			TenantCluster: controllercontext.ContextClientTenantCluster{
+				AWS: awsClients,
+			},
+		},
+	}
+	ctx = controllercontext.NewContext(ctx, cc)
 
 	_, err = newResource.getMainGuestTemplateBody(ctx, customObject, StackState{})
 	if err == nil {
@@ -216,7 +223,14 @@ func TestMainGuestTemplateExistingFields(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+	cc := controllercontext.Context{
+		Client: controllercontext.ContextClient{
+			TenantCluster: controllercontext.ContextClientTenantCluster{
+				AWS: awsClients,
+			},
+		},
+	}
+	ctx = controllercontext.NewContext(ctx, cc)
 
 	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
 	if err != nil {
@@ -522,7 +536,14 @@ func TestMainGuestTemplateRoute53Disabled(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+	cc := controllercontext.Context{
+		Client: controllercontext.ContextClient{
+			TenantCluster: controllercontext.ContextClientTenantCluster{
+				AWS: awsClients,
+			},
+		},
+	}
+	ctx = controllercontext.NewContext(ctx, cc)
 
 	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
 	if err != nil {
@@ -646,7 +667,14 @@ func TestMainGuestTemplateChinaRegion(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+	cc := controllercontext.Context{
+		Client: controllercontext.ContextClient{
+			TenantCluster: controllercontext.ContextClientTenantCluster{
+				AWS: awsClients,
+			},
+		},
+	}
+	ctx = controllercontext.NewContext(ctx, cc)
 
 	body, err := newResource.getMainGuestTemplateBody(ctx, customObject, stackState)
 	if err != nil {

--- a/service/controller/v24/resource/tccp/update.go
+++ b/service/controller/v24/resource/tccp/update.go
@@ -73,7 +73,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		// Once the etcd volume is cleaned up and the master instance is down we can
 		// go ahead to let CloudFormation do its job.
-		_, err = cc.AWSClient.CloudFormation.UpdateStack(&stackStateToUpdate.UpdateStackInput)
+		_, err = cc.Client.TenantCluster.AWS.CloudFormation.UpdateStack(&stackStateToUpdate.UpdateStackInput)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -343,7 +343,7 @@ func (r *Resource) terminateOldMasterInstance(ctx context.Context, obj interface
 			},
 		}
 
-		result, err = cc.AWSClient.EC2.DescribeInstances(i)
+		result, err = cc.Client.TenantCluster.AWS.EC2.DescribeInstances(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -379,7 +379,7 @@ func (r *Resource) terminateOldMasterInstance(ctx context.Context, obj interface
 				aws.String(instanceID),
 			},
 		}
-		_, err := cc.AWSClient.EC2.TerminateInstances(i)
+		_, err := cc.Client.TenantCluster.AWS.EC2.TerminateInstances(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/v24/resource/tccp/update_test.go
+++ b/service/controller/v24/resource/tccp/update_test.go
@@ -407,7 +407,7 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesAllowed(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			cc := testContextWithASG()
-			cc.AWSClient = awsClients
+			cc.Client.TenantCluster.AWS = awsClients
 
 			ctx := updateallowedcontext.NewContext(context.Background(), make(chan struct{}))
 			updateallowedcontext.SetUpdateAllowed(ctx)
@@ -848,7 +848,14 @@ func Test_Resource_Cloudformation_newUpdateChange_updatesNotAllowed(t *testing.T
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			ctx := context.TODO()
-			ctx = controllercontext.NewContext(ctx, controllercontext.Context{AWSClient: awsClients})
+			cc := controllercontext.Context{
+				Client: controllercontext.ContextClient{
+					TenantCluster: controllercontext.ContextClientTenantCluster{
+						AWS: awsClients,
+					},
+				},
+			}
+			ctx = controllercontext.NewContext(ctx, cc)
 
 			result, err := newResource.newUpdateChange(ctx, customObject, tc.currentState, tc.desiredState)
 			if err != nil {


### PR DESCRIPTION
My goal here is to get the services out of the controller context and only have the clients and the status in there. The services should be managed within the resources by using the clients from the controller context. This PR also aligns the structure between clients and status and makes it more consistent and obvious what is about the control plane and what is about the tenant cluster. 