### PR TITLE
deprecate vpccidr service

### DIFF
--- a/service/controller/v25/resource/vpccidr/error.go
+++ b/service/controller/v25/resource/vpccidr/error.go
@@ -4,6 +4,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/v25/resource/vpccidr/spec.go
+++ b/service/controller/v25/resource/vpccidr/spec.go
@@ -5,7 +5,3 @@ import "github.com/aws/aws-sdk-go/service/ec2"
 type EC2 interface {
 	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 }
-
-type Interface interface {
-	Lookup(vpc string) (string, error)
-}

--- a/service/vpccidr/vpc_cidr.go
+++ b/service/vpccidr/vpc_cidr.go
@@ -1,3 +1,5 @@
+// NOTE this package is deprecated. As soon as v24 is gone, we can drop this
+// package.
 package vpccidr
 
 import (


### PR DESCRIPTION
The `vpccidr` service got recently introduced. I noticed the logic is better to be kept in the `vpccidr` resource itself as it is not needed in different places. This also fixes an issue with the caching mechanism, which was effectively broken from scratch because the service that cached results got initiated from scratch with each reconciliation loop. Now the resource caches results, leading to effective caching. The logging also improved so we see when a cached version is used or not. 