### PR TITLE
copy tccp resource to tcdp resource

### DIFF
--- a/service/controller/v25/resource/tcdp/create.go
+++ b/service/controller/v25/resource/tcdp/create.go
@@ -1,0 +1,133 @@
+package cpi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v25/key"
+	"github.com/giantswarm/aws-operator/service/controller/v25/resource/cpi/template"
+)
+
+const (
+	capabilityNamesIAM = "CAPABILITY_NAMED_IAM"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(key.MainHostPreStackName(cr)),
+		}
+
+		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DescribeStacks(i)
+		if IsNotExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer CF stack already exists")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster's control plane initializer CF stack")
+	}
+
+	var templateBody string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computing the template of the tenant cluster's control plane initializer CF stack")
+
+		var params *template.ParamsMain
+		{
+			iamRoles, err := r.newIAMRolesParams(ctx, cr)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			params = &template.ParamsMain{
+				IAMRoles: iamRoles,
+			}
+		}
+
+		templateBody, err = template.Render(params)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the creation of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.CreateStackInput{
+			Capabilities: []*string{
+				aws.String(capabilityNamesIAM),
+			},
+			EnableTerminationProtection: aws.Bool(key.EnableTerminationProtection),
+			StackName:                   aws.String(key.MainHostPreStackName(cr)),
+			Tags:                        r.getCloudFormationTags(cr),
+			TemplateBody:                aws.String(templateBody),
+		}
+
+		_, err = cc.Client.ControlPlane.AWS.CloudFormation.CreateStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the creation of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for the creation of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DescribeStacksInput{
+			StackName: aws.String(key.MainHostPreStackName(cr)),
+		}
+
+		err = cc.Client.ControlPlane.AWS.CloudFormation.WaitUntilStackCreateComplete(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "waited for the creation of the tenant cluster's control plane initializer CF stack")
+	}
+
+	return nil
+}
+
+func (r *Resource) newIAMRolesParams(ctx context.Context, cr v1alpha1.AWSConfig) (*template.ParamsMainIAMRoles, error) {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	iamRoles := &template.ParamsMainIAMRoles{
+		PeerAccessRoleName: key.PeerAccessRoleName(cr),
+		Tenant: template.ParamsMainIAMRolesTenant{
+			AWS: template.ParamsMainIAMRolesTenantAWS{
+				Account: template.ParamsMainIAMRolesTenantAWSAccount{
+					ID: cc.Status.TenantCluster.AWSAccountID,
+				},
+			},
+		},
+	}
+
+	return iamRoles, nil
+}

--- a/service/controller/v25/resource/tcdp/delete.go
+++ b/service/controller/v25/resource/tcdp/delete.go
@@ -1,0 +1,66 @@
+package cpi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/v25/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "disabling the termination protection of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.UpdateTerminationProtectionInput{
+			EnableTerminationProtection: aws.Bool(false),
+			StackName:                   aws.String(key.MainHostPreStackName(cr)),
+		}
+
+		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
+		if IsDeleteInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack is being deleted")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if IsNotExists(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer CF stack does not exist")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "disabled the termination protection of the tenant cluster's control plane initializer CF stack")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the deletion of the tenant cluster's control plane initializer CF stack")
+
+		i := &cloudformation.DeleteStackInput{
+			StackName: aws.String(key.MainHostPreStackName(cr)),
+		}
+
+		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DeleteStack(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the deletion of the tenant cluster's control plane initializer CF stack")
+	}
+
+	return nil
+}

--- a/service/controller/v25/resource/tcdp/error.go
+++ b/service/controller/v25/resource/tcdp/error.go
@@ -1,0 +1,63 @@
+package cpi
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/microerror"
+)
+
+var deleteInProgressError = &microerror.Error{
+	Kind: "deleteInProgressError",
+}
+
+// IsDeleteInProgress asserts deleteInProgressError.
+func IsDeleteInProgress(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusDeleteInProgress) {
+		return true
+	}
+
+	if c == deleteInProgressError {
+		return true
+	}
+
+	return false
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notExistsError = &microerror.Error{
+	Kind: "notExistsError",
+}
+
+// IsNotExists asserts notExistsError.
+func IsNotExists(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "does not exist") {
+		return true
+	}
+
+	if c == notExistsError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v25/resource/tcdp/resource.go
+++ b/service/controller/v25/resource/tcdp/resource.go
@@ -1,0 +1,54 @@
+package cpi
+
+import (
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/pkg/awstags"
+	"github.com/giantswarm/aws-operator/service/controller/v25/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cpiv25"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	InstallationName string
+}
+
+// Resource implements the CPI resource, which stands for Control Plane
+// Initializer. This was formerly known as the host pre stack. We manage a
+// dedicated CF stack for the IAM role and VPC Peering setup.
+type Resource struct {
+	logger micrologger.Logger
+
+	installationName string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		installationName: config.InstallationName,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) getCloudFormationTags(customObject v1alpha1.AWSConfig) []*cloudformation.Tag {
+	tags := key.ClusterTags(customObject, r.installationName)
+	return awstags.NewCloudFormation(tags)
+}

--- a/service/controller/v25/resource/tcdp/template/params_main.go
+++ b/service/controller/v25/resource/tcdp/template/params_main.go
@@ -1,0 +1,6 @@
+package template
+
+// ParamsMain is the data structure for the Control Plane Initializer template.
+type ParamsMain struct {
+	IAMRoles *ParamsMainIAMRoles
+}

--- a/service/controller/v25/resource/tcdp/template/params_main_iam_roles.go
+++ b/service/controller/v25/resource/tcdp/template/params_main_iam_roles.go
@@ -1,0 +1,18 @@
+package template
+
+type ParamsMainIAMRoles struct {
+	PeerAccessRoleName string
+	Tenant             ParamsMainIAMRolesTenant
+}
+
+type ParamsMainIAMRolesTenant struct {
+	AWS ParamsMainIAMRolesTenantAWS
+}
+
+type ParamsMainIAMRolesTenantAWS struct {
+	Account ParamsMainIAMRolesTenantAWSAccount
+}
+
+type ParamsMainIAMRolesTenantAWSAccount struct {
+	ID string
+}

--- a/service/controller/v25/resource/tcdp/template/render.go
+++ b/service/controller/v25/resource/tcdp/template/render.go
@@ -1,0 +1,21 @@
+package template
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/v25/templates"
+)
+
+func Render(v interface{}) (string, error) {
+	l := []string{
+		TemplateMain,
+		TemplateMainIAMRoles,
+	}
+
+	s, err := templates.Render(l, v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return s, nil
+}

--- a/service/controller/v25/resource/tcdp/template/render_test.go
+++ b/service/controller/v25/resource/tcdp/template/render_test.go
@@ -1,0 +1,50 @@
+package template
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_Controller_Resource_CPI_Template_Render(t *testing.T) {
+	var err error
+
+	var params *ParamsMain
+	{
+		iamRoles := &ParamsMainIAMRoles{
+			PeerAccessRoleName: "PeerAccessRoleName",
+			Tenant: ParamsMainIAMRolesTenant{
+				AWS: ParamsMainIAMRolesTenantAWS{
+					Account: ParamsMainIAMRolesTenantAWSAccount{
+						ID: "TenantAWSAccountID",
+					},
+				},
+			},
+		}
+
+		params = &ParamsMain{
+			IAMRoles: iamRoles,
+		}
+	}
+
+	var templateBody string
+	{
+		templateBody, err = Render(params)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	{
+		expected := "RoleName: PeerAccessRoleName"
+		if !strings.Contains(templateBody, expected) {
+			t.Fatal("expected", "match", "got", "none")
+		}
+	}
+
+	{
+		expected := "AWS: 'TenantAWSAccountID'"
+		if !strings.Contains(templateBody, expected) {
+			t.Fatal("expected", "match", "got", "none")
+		}
+	}
+}

--- a/service/controller/v25/resource/tcdp/template/template_main.go
+++ b/service/controller/v25/resource/tcdp/template/template_main.go
@@ -1,0 +1,10 @@
+package template
+
+const TemplateMain = `
+{{define "main"}}
+AWSTemplateFormatVersion: 2010-09-09
+Description: Control Plane Initializer Cloud Formation Stack.
+Resources:
+  {{template "iam_roles" .}}
+{{end}}
+`

--- a/service/controller/v25/resource/tcdp/template/template_main_iam_roles.go
+++ b/service/controller/v25/resource/tcdp/template/template_main_iam_roles.go
@@ -1,0 +1,26 @@
+package template
+
+const TemplateMainIAMRoles = `
+{{ define "iam_roles" }}
+  PeerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: {{ .IAMRoles.PeerAccessRoleName }}
+      AssumeRolePolicyDocument:
+        Statement:
+          - Principal:
+              AWS: '{{ .IAMRoles.Tenant.AWS.Account.ID }}'
+            Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 'ec2:AcceptVpcPeeringConnection'
+                Resource: '*'
+{{end}}
+`


### PR DESCRIPTION
Just a copy PR. Real changes come next. Idea here is to have a TCDP resource managing the CF stacks for the node pools. TCDP stands for Tenant Cluster Data Plane. It is the counterpart of the TCCP resource. 