### PR TITLE
add routetable resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The aws-operator manages Kubernetes clusters running on AWS.
 
+
+
 ## Getting Project
 
 Download the latest release:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 The aws-operator manages Kubernetes clusters running on AWS.
 
-
-
 ## Getting Project
 
 Download the latest release:

--- a/service/controller/v25/cluster_resource_set.go
+++ b/service/controller/v25/cluster_resource_set.go
@@ -42,6 +42,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/namespace"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/natgatewayaddresses"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/peerrolearn"
+	"github.com/giantswarm/aws-operator/service/controller/v25/resource/routetable"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/service"
@@ -374,7 +375,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			EncrypterBackend: config.EncrypterBackend,
 			InstallationName: config.InstallationName,
 			Route53Enabled:   config.Route53Enabled,
-			RouteTables:      strings.Split(config.RouteTables, ","),
 		}
 
 		cpfResource, err = cpf.New(c)
@@ -436,6 +436,20 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		peerRoleARNResource, err = peerrolearn.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var routeTableResource controller.Resource
+	{
+		c := routetable.Config{
+			Logger: config.Logger,
+
+			Names: strings.Split(config.RouteTables, ","),
+		}
+
+		routeTableResource, err = routetable.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -570,6 +584,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		natGatewayAddressesResource,
 		kmsKeyARNResource,
 		peerRoleARNResource,
+		routeTableResource,
 		vpcCIDRResource,
 		stackOutputResource,
 		workerASGNameResource,

--- a/service/controller/v25/controllercontext/status.go
+++ b/service/controller/v25/controllercontext/status.go
@@ -10,12 +10,20 @@ type ContextStatus struct {
 type ContextStatusControlPlane struct {
 	AWSAccountID string
 	NATGateway   ContextStatusControlPlaneNATGateway
+	RouteTable   ContextStatusControlPlaneRouteTable
 	PeerRole     ContextStatusControlPlanePeerRole
 	VPC          ContextStatusControlPlaneVPC
 }
 
 type ContextStatusControlPlaneNATGateway struct {
 	Addresses []*ec2.Address
+}
+
+type ContextStatusControlPlaneRouteTable struct {
+	// Mappings are key value pairs of control plane route table names and their
+	// IDs, where the map keys are route table names and the map values are route
+	// table IDs. The mapping is managed by the routetable resource.
+	Mappings map[string]string
 }
 
 type ContextStatusControlPlanePeerRole struct {

--- a/service/controller/v25/resource/accountid/resource.go
+++ b/service/controller/v25/resource/accountid/resource.go
@@ -27,11 +27,11 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	newResource := &Resource{
+	r := &Resource{
 		logger: config.Logger,
 	}
 
-	return newResource, nil
+	return r, nil
 }
 
 func (r *Resource) Name() string {

--- a/service/controller/v25/resource/cpf/create.go
+++ b/service/controller/v25/resource/cpf/create.go
@@ -41,11 +41,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			StackName: aws.String(key.MainHostPostStackName(cr)),
 		}
 
-		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DescribeStacks(i)
+		o, err := cc.Client.ControlPlane.AWS.CloudFormation.DescribeStacks(i)
 		if IsNotExists(err) {
 			// fall through
+
 		} else if err != nil {
 			return microerror.Mask(err)
+
+		} else if len(o.Stacks) != 1 {
+			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
+
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
+			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", o.Stacks[0].StackStatus)
+
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane finalizer cloud formation stack already exists")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/v25/resource/cpf/create.go
+++ b/service/controller/v25/resource/cpf/create.go
@@ -136,11 +136,10 @@ func (r *Resource) newPrivateRoutes(ctx context.Context, cr v1alpha1.AWSConfig) 
 
 	var routes []template.ParamsMainRouteTablesRoute
 
-	for name, id := range cc.Status.ControlPlane.RouteTable.Mappings {
+	for _, id := range cc.Status.ControlPlane.RouteTable.Mappings {
 		for _, cidrBlock := range tenantPrivateSubnetCidrs {
 			route := template.ParamsMainRouteTablesRoute{
-				RouteTableName: name,
-				RouteTableID:   id,
+				RouteTableID: id,
 				// Requester CIDR block, we create the peering connection from the
 				// tenant's private subnets.
 				CidrBlock: cidrBlock,
@@ -168,10 +167,9 @@ func (r *Resource) newPublicRoutes(ctx context.Context, cr v1alpha1.AWSConfig) (
 
 	var routes []template.ParamsMainRouteTablesRoute
 
-	for name, id := range cc.Status.ControlPlane.RouteTable.Mappings {
+	for _, id := range cc.Status.ControlPlane.RouteTable.Mappings {
 		route := template.ParamsMainRouteTablesRoute{
-			RouteTableName: name,
-			RouteTableID:   id,
+			RouteTableID: id,
 			// Requester CIDR block, we create the peering connection from the
 			// tenant's CIDR for being able to access Vault's ELB.
 			CidrBlock: key.StatusNetworkCIDR(cr),

--- a/service/controller/v25/resource/cpf/create.go
+++ b/service/controller/v25/resource/cpf/create.go
@@ -136,7 +136,7 @@ func (r *Resource) newPrivateRoutes(ctx context.Context, cr v1alpha1.AWSConfig) 
 
 	var routes []template.ParamsMainRouteTablesRoute
 
-	for id, name := range cc.Status.ControlPlane.RouteTable.Mappings {
+	for name, id := range cc.Status.ControlPlane.RouteTable.Mappings {
 		for _, cidrBlock := range tenantPrivateSubnetCidrs {
 			route := template.ParamsMainRouteTablesRoute{
 				RouteTableName: name,
@@ -168,7 +168,7 @@ func (r *Resource) newPublicRoutes(ctx context.Context, cr v1alpha1.AWSConfig) (
 
 	var routes []template.ParamsMainRouteTablesRoute
 
-	for id, name := range cc.Status.ControlPlane.RouteTable.Mappings {
+	for name, id := range cc.Status.ControlPlane.RouteTable.Mappings {
 		route := template.ParamsMainRouteTablesRoute{
 			RouteTableName: name,
 			RouteTableID:   id,

--- a/service/controller/v25/resource/cpf/error.go
+++ b/service/controller/v25/resource/cpf/error.go
@@ -30,6 +30,15 @@ func IsDeleteInProgress(err error) bool {
 	return false
 }
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/v25/resource/cpf/resource.go
+++ b/service/controller/v25/resource/cpf/resource.go
@@ -21,7 +21,6 @@ type Config struct {
 	EncrypterBackend string
 	InstallationName string
 	Route53Enabled   bool
-	RouteTables      []string
 }
 
 // Resource implements the CPF resource, which stands for Control Plane
@@ -33,7 +32,6 @@ type Resource struct {
 	encrypterBackend string
 	installationName string
 	route53Enabled   bool
-	routeTables      []string
 }
 
 func New(config Config) (*Resource, error) {
@@ -44,9 +42,6 @@ func New(config Config) (*Resource, error) {
 	if config.EncrypterBackend == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.EncrypterBackend must not be empty", config)
 	}
-	if config.RouteTables == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.RouteTables must not be empty", config)
-	}
 
 	r := &Resource{
 		logger: config.Logger,
@@ -54,7 +49,6 @@ func New(config Config) (*Resource, error) {
 		encrypterBackend: config.EncrypterBackend,
 		installationName: config.InstallationName,
 		route53Enabled:   config.Route53Enabled,
-		routeTables:      config.RouteTables,
 	}
 
 	return r, nil

--- a/service/controller/v25/resource/cpf/template/params_main_route_tables.go
+++ b/service/controller/v25/resource/cpf/template/params_main_route_tables.go
@@ -6,7 +6,6 @@ type ParamsMainRouteTables struct {
 }
 
 type ParamsMainRouteTablesRoute struct {
-	RouteTableName   string
 	RouteTableID     string
 	CidrBlock        string
 	PeerConnectionID string

--- a/service/controller/v25/resource/cpi/create.go
+++ b/service/controller/v25/resource/cpi/create.go
@@ -34,13 +34,21 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			StackName: aws.String(key.MainHostPreStackName(cr)),
 		}
 
-		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DescribeStacks(i)
+		o, err := cc.Client.ControlPlane.AWS.CloudFormation.DescribeStacks(i)
 		if IsNotExists(err) {
 			// fall through
+
 		} else if err != nil {
 			return microerror.Mask(err)
+
+		} else if len(o.Stacks) != 1 {
+			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
+
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
+			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", o.Stacks[0].StackStatus)
+
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer CF stack already exists")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer cloud formation stack already exists")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil

--- a/service/controller/v25/resource/cpi/error.go
+++ b/service/controller/v25/resource/cpi/error.go
@@ -30,6 +30,15 @@ func IsDeleteInProgress(err error) bool {
 	return false
 }
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/v25/resource/routetable/create.go
+++ b/service/controller/v25/resource/routetable/create.go
@@ -1,0 +1,16 @@
+package routetable
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.addRouteTableMappingsToContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v25/resource/routetable/delete.go
+++ b/service/controller/v25/resource/routetable/delete.go
@@ -1,0 +1,16 @@
+package routetable
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := r.addRouteTableMappingsToContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v25/resource/routetable/error.go
+++ b/service/controller/v25/resource/routetable/error.go
@@ -1,0 +1,23 @@
+package routetable
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v25/resource/routetable/resource.go
+++ b/service/controller/v25/resource/routetable/resource.go
@@ -78,8 +78,7 @@ func (r *Resource) addRouteTableMappingsToContext(ctx context.Context) error {
 		return nil
 	}
 
-	// We do not have a cached VPC CIDR for the requested VPC ID. So we look it
-	// up.
+	// We do not have the cached mappings, so we look them up.
 	var mappings map[string]string
 	for _, name := range r.names {
 		id, err := r.lookup(ctx, cc.Client.ControlPlane.AWS.EC2, name)

--- a/service/controller/v25/resource/routetable/resource.go
+++ b/service/controller/v25/resource/routetable/resource.go
@@ -79,7 +79,7 @@ func (r *Resource) addRouteTableMappingsToContext(ctx context.Context) error {
 	}
 
 	// We do not have the cached mappings, so we look them up.
-	var mappings map[string]string
+	mappings := map[string]string{}
 	for _, name := range r.names {
 		id, err := r.lookup(ctx, cc.Client.ControlPlane.AWS.EC2, name)
 		if err != nil {

--- a/service/controller/v25/resource/routetable/resource.go
+++ b/service/controller/v25/resource/routetable/resource.go
@@ -70,12 +70,17 @@ func (r *Resource) addRouteTableMappingsToContext(ctx context.Context) error {
 
 	// We check if we have all mappings cached for the configured route table
 	// names. If we find all information, we return them.
-	if len(r.mappings) == len(r.names) {
+	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached route table mappings")
-		cc.Status.ControlPlane.RouteTable.Mappings = r.mappings
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found cached route table mappings")
 
-		return nil
+		if len(r.mappings) == len(r.names) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found cached route table mappings")
+			cc.Status.ControlPlane.RouteTable.Mappings = r.mappings
+
+			return nil
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cached route table mappings")
+		}
 	}
 
 	// We do not have the cached mappings, so we look them up.

--- a/service/controller/v25/resource/routetable/resource.go
+++ b/service/controller/v25/resource/routetable/resource.go
@@ -1,0 +1,133 @@
+package routetable
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
+)
+
+const (
+	Name = "routetablev25"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	Names []string
+}
+
+type Resource struct {
+	logger micrologger.Logger
+
+	// mappings is a mapping of route table names and IDs, where the key is the
+	// name and the value is the ID.
+	mappings map[string]string
+	mutex    sync.Mutex
+
+	names []string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.Names == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Names must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		mappings: map[string]string{},
+		mutex:    sync.Mutex{},
+
+		names: config.Names,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) addRouteTableMappingsToContext(ctx context.Context) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// We check if we have all mappings cached for the configured route table
+	// names. If we find all information, we return them.
+	if len(r.mappings) == len(r.names) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached route table mappings")
+		cc.Status.ControlPlane.RouteTable.Mappings = r.mappings
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found cached route table mappings")
+
+		return nil
+	}
+
+	// We do not have a cached VPC CIDR for the requested VPC ID. So we look it
+	// up.
+	var mappings map[string]string
+	for _, name := range r.names {
+		id, err := r.lookup(ctx, cc.Client.ControlPlane.AWS.EC2, name)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		mappings[name] = id
+	}
+
+	// At this point we found all route table mappings and can cache them
+	// internally.
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "caching route table mappings")
+		r.mappings = mappings
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cached route table mappings")
+	}
+
+	cc.Status.ControlPlane.RouteTable.Mappings = mappings
+
+	return nil
+}
+
+func (r *Resource) lookup(ctx context.Context, client EC2, name string) (string, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding route table ID for %#q", name))
+
+	i := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(name),
+				},
+			},
+		},
+	}
+
+	o, err := client.DescribeRouteTables(i)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	if len(o.RouteTables) != 1 {
+		return "", microerror.Maskf(executionFailedError, "expected one route table, got %d", len(o.RouteTables))
+	}
+
+	id := *o.RouteTables[0].RouteTableId
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found route table ID %#q for %#q", id, name))
+
+	return id, nil
+}

--- a/service/controller/v25/resource/routetable/spec.go
+++ b/service/controller/v25/resource/routetable/spec.go
@@ -1,0 +1,7 @@
+package routetable
+
+import "github.com/aws/aws-sdk-go/service/ec2"
+
+type EC2 interface {
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+}

--- a/service/controller/v25/resource/tcdp/create.go
+++ b/service/controller/v25/resource/tcdp/create.go
@@ -34,11 +34,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			StackName: aws.String(key.MainHostPreStackName(cr)),
 		}
 
-		_, err = cc.Client.TenantCluster.AWS.CloudFormation.DescribeStacks(i)
+		o, err := cc.Client.TenantCluster.AWS.CloudFormation.DescribeStacks(i)
 		if IsNotExists(err) {
 			// fall through
+
 		} else if err != nil {
 			return microerror.Mask(err)
+
+		} else if len(o.Stacks) != 1 {
+			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
+
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
+			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", o.Stacks[0].StackStatus)
+
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's data plane cloud formation stack already exists")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/v25/resource/tcdp/error.go
+++ b/service/controller/v25/resource/tcdp/error.go
@@ -30,6 +30,15 @@ func IsDeleteInProgress(err error) bool {
 	return false
 }
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/routetable/route_table.go
+++ b/service/routetable/route_table.go
@@ -1,3 +1,5 @@
+// NOTE this package is deprecated. As soon as v24 is gone, we can drop this
+// package.
 package routetable
 
 import (


### PR DESCRIPTION
The `routetable` service got recently introduced. I noticed the logic is better to be kept in the `routetable` resource itself as it is not needed in different places. This also fixes an issue with the caching mechanism, which was effectively broken from scratch because the service that cached results got initiated from scratch with each reconciliation loop. Now the resource caches results, leading to effective caching. The logging also improved so we see when a cached version is used or not. 