### PR TITLE
Render template data only once for all files

### DIFF
--- a/service/controller/v25/cloudconfig/master_template.go
+++ b/service/controller/v25/cloudconfig/master_template.go
@@ -229,8 +229,9 @@ func (e *MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 
 	var fileAssets []k8scloudconfig.FileAsset
 
+	data := e.templateData()
+
 	for _, fm := range filesMeta {
-		data := e.templateData()
 		c, err := k8scloudconfig.RenderFileAssetContent(fm.AssetContent, data)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/controller/v25/cloudconfig/worker_template.go
+++ b/service/controller/v25/cloudconfig/worker_template.go
@@ -145,8 +145,9 @@ func (e *WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 
 	var fileAssets []k8scloudconfig.FileAsset
 
+	data := e.templateData()
+
 	for _, m := range filesMeta {
-		data := e.templateData()
 		c, err := k8scloudconfig.RenderFileAssetContent(m.AssetContent, data)
 		if err != nil {
 			return nil, microerror.Mask(err)


### PR DESCRIPTION
While refactoring cloudconfig package for `azure-operator`, found this