### PR TITLE
export more outputs for node pool preparations

### DIFF
--- a/service/controller/v25/adapter/guest_outputs.go
+++ b/service/controller/v25/adapter/guest_outputs.go
@@ -21,7 +21,6 @@ func (a *GuestOutputsAdapter) Adapt(config Config) error {
 	a.Master.Instance.Type = config.StackState.MasterInstanceType
 	a.Master.CloudConfig.Version = config.StackState.MasterCloudConfigVersion
 
-	a.Worker.ASG.Key = key.WorkerASGKey
 	a.Worker.ASG.Ref = key.WorkerASGRef
 	a.Worker.CloudConfig.Version = config.StackState.WorkerCloudConfigVersion
 	a.Worker.DockerVolumeSizeGB = strconv.Itoa(config.StackState.WorkerDockerVolumeSizeGB)
@@ -62,7 +61,6 @@ type GuestOutputsAdapterWorker struct {
 }
 
 type GuestOutputsAdapterWorkerASG struct {
-	Key string
 	Ref string
 }
 

--- a/service/controller/v25/adapter/spec.go
+++ b/service/controller/v25/adapter/spec.go
@@ -58,8 +58,6 @@ type Hydrater func(config Config) error
 type StackState struct {
 	Name string
 
-	HostedZoneNameServers string
-
 	DockerVolumeResourceName   string
 	MasterImageID              string
 	MasterInstanceType         string

--- a/service/controller/v25/controllercontext/status.go
+++ b/service/controller/v25/controllercontext/status.go
@@ -40,6 +40,7 @@ type ContextStatusTenantCluster struct {
 	HostedZoneNameServers  string
 	KMS                    ContextStatusTenantClusterKMS
 	TCCP                   ContextStatusTenantClusterTCCP
+	VPC                    ContextStatusTenantClusterVPC
 	VPCPeeringConnectionID string
 }
 
@@ -49,4 +50,8 @@ type ContextStatusTenantClusterKMS struct {
 
 type ContextStatusTenantClusterTCCP struct {
 	ASG ContextStatusTenantClusterTCCPASG
+}
+
+type ContextStatusTenantClusterVPC struct {
+	ID string
 }

--- a/service/controller/v25/key/key.go
+++ b/service/controller/v25/key/key.go
@@ -56,15 +56,12 @@ const (
 
 const (
 	DockerVolumeResourceNameKey   = "DockerVolumeResourceName"
-	HostedZoneNameServers         = "HostedZoneNameServers"
 	MasterImageIDKey              = "MasterImageID"
 	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
 	MasterInstanceTypeKey         = "MasterInstanceType"
 	MasterInstanceMonitoring      = "Monitoring"
 	MasterCloudConfigVersionKey   = "MasterCloudConfigVersion"
 	VersionBundleVersionKey       = "VersionBundleVersion"
-	VPCPeeringConnectionIDKey     = "VPCPeeringConnectionID"
-	WorkerASGKey                  = "WorkerASGName"
 	WorkerCountKey                = "WorkerCount"
 	WorkerMaxKey                  = "WorkerMax"
 	WorkerMinKey                  = "WorkerMin"

--- a/service/controller/v25/resource/tccpoutputs/spec.go
+++ b/service/controller/v25/resource/tccpoutputs/spec.go
@@ -3,5 +3,6 @@ package tccpoutputs
 import "github.com/aws/aws-sdk-go/service/ec2"
 
 type EC2 interface {
+	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
 }

--- a/service/controller/v25/templates/cloudformation/tccp/main.go
+++ b/service/controller/v25/templates/cloudformation/tccp/main.go
@@ -4,6 +4,8 @@ const Main = `
 {{define "main"}}
 AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Control Plane Cloud Formation Stack.
+Outputs:
+  {{template "outputs" .}}
 Parameters:
   VersionBundleVersionParameter:
     Type: String
@@ -22,6 +24,5 @@ Resources:
   {{template "lifecycle_hooks" .}}
   {{template "autoscaling_group" .}}
   {{template "record_sets" .}}
-{{template "outputs" .}}
 {{end}}
 `

--- a/service/controller/v25/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/v25/templates/cloudformation/tccp/outputs.go
@@ -16,8 +16,6 @@ const Outputs = `
     Value: {{ .Guest.Outputs.Master.Instance.Type }}
   MasterCloudConfigVersion:
     Value: {{ .Guest.Outputs.Master.CloudConfig.Version }}
-  PrivateRouteTableID:
-    Value: !Ref PrivateRouteTable
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:

--- a/service/controller/v25/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/v25/templates/cloudformation/tccp/outputs.go
@@ -16,14 +16,14 @@ const Outputs = `
     Value: {{ .Guest.Outputs.Master.Instance.Type }}
   MasterCloudConfigVersion:
     Value: {{ .Guest.Outputs.Master.CloudConfig.Version }}
-  {{ .Guest.Outputs.Worker.ASG.Key }}:
-    Value: !Ref {{ .Guest.Outputs.Worker.ASG.Ref }}
   PrivateRouteTableID:
     Value: !Ref PrivateRouteTable
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:
     Value: !Ref VPCPeeringConnection
+  WorkerASGName:
+    Value: !Ref {{ .Guest.Outputs.Worker.ASG.Ref }}
   WorkerDockerVolumeSizeGB:
     Value: {{ .Guest.Outputs.Worker.DockerVolumeSizeGB }}
   WorkerImageID:

--- a/service/controller/v25/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/v25/templates/cloudformation/tccp/outputs.go
@@ -2,34 +2,36 @@ package tccp
 
 const Outputs = `
 {{define "outputs"}}
-{{- $v := .Guest.Outputs }}
-Outputs:
   DockerVolumeResourceName:
-    Value: {{ $v.Master.DockerVolume.ResourceName }}
-  {{ if $v.Route53Enabled }}
+    Value: {{ .Guest.Outputs.Master.DockerVolume.ResourceName }}
+  {{ if .Guest.Outputs.Route53Enabled }}
   HostedZoneNameServers:
     Value: !Join [ ',', !GetAtt 'HostedZone.NameServers' ]
   {{ end }}
   MasterImageID:
-    Value: {{ $v.Master.ImageID }}
+    Value: {{ .Guest.Outputs.Master.ImageID }}
   MasterInstanceResourceName:
-    Value: {{ $v.Master.Instance.ResourceName }}
+    Value: {{ .Guest.Outputs.Master.Instance.ResourceName }}
   MasterInstanceType:
-    Value: {{ $v.Master.Instance.Type }}
+    Value: {{ .Guest.Outputs.Master.Instance.Type }}
   MasterCloudConfigVersion:
-    Value: {{ $v.Master.CloudConfig.Version }}
-  {{ $v.Worker.ASG.Key }}:
-    Value: !Ref {{ $v.Worker.ASG.Ref }}
+    Value: {{ .Guest.Outputs.Master.CloudConfig.Version }}
+  {{ .Guest.Outputs.Worker.ASG.Key }}:
+    Value: !Ref {{ .Guest.Outputs.Worker.ASG.Ref }}
+  PrivateRouteTableID:
+    Value: !Ref PrivateRouteTable
+  VPCID:
+    Value: !Ref VPC
   VPCPeeringConnectionID:
     Value: !Ref VPCPeeringConnection
   WorkerDockerVolumeSizeGB:
-    Value: {{ $v.Worker.DockerVolumeSizeGB }}
+    Value: {{ .Guest.Outputs.Worker.DockerVolumeSizeGB }}
   WorkerImageID:
-    Value: {{ $v.Worker.ImageID }}
+    Value: {{ .Guest.Outputs.Worker.ImageID }}
   WorkerInstanceType:
-    Value: {{ $v.Worker.InstanceType }}
+    Value: {{ .Guest.Outputs.Worker.InstanceType }}
   WorkerCloudConfigVersion:
-    Value: {{ $v.Worker.CloudConfig.Version }}
+    Value: {{ .Guest.Outputs.Worker.CloudConfig.Version }}
   VersionBundleVersion:
     Value:
       Ref: VersionBundleVersionParameter


### PR DESCRIPTION
We need a couple of more information from the TCCP stack in order to get the networking sorted out for the TCDP stacks. I checked the CF cross stack references but this has a little rat tail which does not convince me to be better or easier in the end. I think it makes sense to stick with the current approach of exporting outputs and fetching information actively to put them into the controller context. 