### PR TITLE
rename stackoutput resource to tccpoutputs

### DIFF
--- a/service/controller/v25/cluster_resource_set.go
+++ b/service/controller/v25/cluster_resource_set.go
@@ -46,8 +46,8 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/service"
-	"github.com/giantswarm/aws-operator/service/controller/v25/resource/stackoutput"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/tccp"
+	"github.com/giantswarm/aws-operator/service/controller/v25/resource/tccpoutputs"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/vpccidr"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/workerasgname"
 )
@@ -367,6 +367,20 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var tccpOutputsResource controller.Resource
+	{
+		c := tccpoutputs.Config{
+			Logger: config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+		}
+
+		tccpOutputsResource, err = tccpoutputs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var cpfResource controller.Resource
 	{
 		c := cpf.Config{
@@ -540,20 +554,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var stackOutputResource controller.Resource
-	{
-		c := stackoutput.Config{
-			Logger: config.Logger,
-
-			Route53Enabled: config.Route53Enabled,
-		}
-
-		stackOutputResource, err = stackoutput.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var vpcCIDRResource controller.Resource
 	{
 		c := vpccidr.Config{
@@ -586,7 +586,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		peerRoleARNResource,
 		routeTableResource,
 		vpcCIDRResource,
-		stackOutputResource,
+		tccpOutputsResource,
 		workerASGNameResource,
 		asgStatusResource,
 		statusResource,

--- a/service/controller/v25/drainer_resource_set.go
+++ b/service/controller/v25/drainer_resource_set.go
@@ -17,7 +17,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/v25/key"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/drainer"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/drainfinisher"
-	"github.com/giantswarm/aws-operator/service/controller/v25/resource/stackoutput"
+	"github.com/giantswarm/aws-operator/service/controller/v25/resource/tccpoutputs"
 	"github.com/giantswarm/aws-operator/service/controller/v25/resource/workerasgname"
 )
 
@@ -61,15 +61,15 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var stackOutputResource controller.Resource
+	var tccpOutputsResource controller.Resource
 	{
-		c := stackoutput.Config{
+		c := tccpoutputs.Config{
 			Logger: config.Logger,
 
 			Route53Enabled: config.Route53Enabled,
 		}
 
-		stackOutputResource, err = stackoutput.New(c)
+		tccpOutputsResource, err = tccpoutputs.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -89,7 +89,7 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []controller.Resource{
-		stackOutputResource,
+		tccpOutputsResource,
 		workerASGNameResource,
 		drainerResource,
 		drainFinisherResource,

--- a/service/controller/v25/resource/tccpoutputs/create.go
+++ b/service/controller/v25/resource/tccpoutputs/create.go
@@ -1,4 +1,4 @@
-package stackoutput
+package tccpoutputs
 
 import (
 	"context"

--- a/service/controller/v25/resource/tccpoutputs/delete.go
+++ b/service/controller/v25/resource/tccpoutputs/delete.go
@@ -1,4 +1,4 @@
-package stackoutput
+package tccpoutputs
 
 import (
 	"context"

--- a/service/controller/v25/resource/tccpoutputs/error.go
+++ b/service/controller/v25/resource/tccpoutputs/error.go
@@ -1,4 +1,4 @@
-package stackoutput
+package tccpoutputs
 
 import "github.com/giantswarm/microerror"
 

--- a/service/controller/v25/resource/tccpoutputs/resource.go
+++ b/service/controller/v25/resource/tccpoutputs/resource.go
@@ -1,4 +1,4 @@
-package stackoutput
+package tccpoutputs
 
 import (
 	"github.com/giantswarm/microerror"
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "stackoutputv25"
+	Name = "tccpoutputsv25"
 )
 
 type Config struct {
@@ -16,10 +16,10 @@ type Config struct {
 }
 
 // Resource implements an operatorkit resource and provides a mechanism to fetch
-// information from a cloud formation stack outputs of the Tenant Cluster Main
-// stack.
+// information from Cloud Formation stack outputs of the Tenant Cluster Control
+// Plane stack.
 //
-// The TCM manages the VPC Peering Connection. The peering connection ID is
+// The TCCP manages the VPC Peering Connection. The peering connection ID is
 // added to the controller context and used in the CPF stack.
 //
 type Resource struct {

--- a/service/controller/v25/resource/tccpoutputs/spec.go
+++ b/service/controller/v25/resource/tccpoutputs/spec.go
@@ -1,4 +1,4 @@
-package stackoutput
+package tccpoutputs
 
 import "github.com/aws/aws-sdk-go/service/ec2"
 


### PR DESCRIPTION
In the future we are likely to export more information using stack outputs also from other stacks. The naming here should make clear which outputs are managed. Later we are likely to have `cpfoutputs` and `tcdpoutputs` resources as well. 