### PR TITLE
keep finalizers on delete

### DIFF
--- a/service/controller/v25/resource/cpf/delete.go
+++ b/service/controller/v25/resource/cpf/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v25/key"
@@ -32,9 +33,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane finalizer cloud formation stack is being deleted")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
+
 		} else if IsNotExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane finalizer cloud formation stack does not exist")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/v25/resource/cpi/delete.go
+++ b/service/controller/v25/resource/cpi/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v25/key"
@@ -32,9 +33,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer cloud formation stack is being deleted")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
+
 		} else if IsNotExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer cloud formation stack does not exist")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/v25/resource/tcdp/delete.go
+++ b/service/controller/v25/resource/tcdp/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/v25/key"
@@ -32,9 +33,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.TenantCluster.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's data plane cloud formation stack is being deleted")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
+
 		} else if IsNotExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's data plane cloud formation stack does not exist")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")


### PR DESCRIPTION
The change here does not really improve anything right now as the `tcdp` resource is not yet in use and the `cpi` and `cpf` resources are pretty short lived. We have special handing for the `tccp` resource, because it is still fucking special. I plan to change that but that takes a bit more time. 