### PR TITLE
Disabled master protection before terminate it

### DIFF
--- a/service/controller/v24/resource/tccp/update.go
+++ b/service/controller/v24/resource/tccp/update.go
@@ -74,6 +74,11 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				}
 			}
 
+			err = r.disableMasterTerminationProtection(ctx, key.MasterInstanceName(cr))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			{
 				err := r.terminateOldMasterInstance(ctx, obj)
 				if err != nil {

--- a/service/controller/v25/resource/tccp/update.go
+++ b/service/controller/v25/resource/tccp/update.go
@@ -74,6 +74,11 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 				}
 			}
 
+			err = r.disableMasterTerminationProtection(ctx, key.MasterInstanceName(cr))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			{
 				err := r.terminateOldMasterInstance(ctx, obj)
 				if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5453

The upgrade step should disable the master protection before delete it or it will fail
https://github.com/giantswarm/aws-operator/pull/1435#issuecomment-473232872
