### PR TITLE
improve create state handling in tccp resource

### DIFF
--- a/service/controller/v25/resource/tccp/spec.go
+++ b/service/controller/v25/resource/tccp/spec.go
@@ -4,7 +4,11 @@ import "github.com/aws/aws-sdk-go/service/cloudformation"
 
 // StackState is the state representation on which the resource methods work.
 type StackState struct {
-	Name string
+	Name     string
+	Template string
+
+	// NOTE everything below is deprecated. We try to cleanup the state being
+	// dispatched between resource operations.
 
 	DockerVolumeResourceName   string
 	MasterImageID              string


### PR DESCRIPTION
This goes towards further simplifying the tccp resource. The type to create the cloud formation stack should not be dispatched between resource operations, but instead be used, in this case, in `ApplyCreateChange`. We only need to dispatch a limited amount of information. 