### PR TITLE
simplify and align tccp deletion with other resources

### DIFF
--- a/service/controller/v25/resource/tcdp/delete.go
+++ b/service/controller/v25/resource/tcdp/delete.go
@@ -38,6 +38,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			finalizerskeptcontext.SetKept(ctx)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
 			return nil
 
 		} else if IsNotExists(err) {
@@ -45,6 +46,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
+
 		} else if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
It would be cool to use the simple resource interface for the tccp resource just like for the other stack managing resources. This here is one step towards that goal. There is also a PM I am working on which could be addressed down the road, but I need to work my way through a little bit. 