### PR TITLE
simplify tccp update

### DIFF
--- a/service/controller/v25/resource/tccp/spec.go
+++ b/service/controller/v25/resource/tccp/spec.go
@@ -1,7 +1,5 @@
 package tccp
 
-import "github.com/aws/aws-sdk-go/service/cloudformation"
-
 // StackState is the state representation on which the resource methods work.
 type StackState struct {
 	Name     string
@@ -25,8 +23,6 @@ type StackState struct {
 	WorkerImageID            string
 	WorkerInstanceMonitoring bool
 	WorkerInstanceType       string
-
-	UpdateStackInput cloudformation.UpdateStackInput
 
 	VersionBundleVersion string
 }


### PR DESCRIPTION
I plan to get the master management in the tccp resource a bit more straight. We also have a EBS service implementation which could be split a bit. I am not 100% sure yet on the primitives because there is some EBS Volume handling in another resource as well but this can probably be a bit better. Step by step. 