### PR TITLE
refactor EBS service

### DIFF
--- a/service/controller/v25/ebs/ebs.go
+++ b/service/controller/v25/ebs/ebs.go
@@ -98,7 +98,7 @@ func (e *EBS) DetachVolume(ctx context.Context, volumeID string, attachment Volu
 	}
 
 	if shutdown && wait {
-		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for instance %#q being stopped", attachment.InstanceID))
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for instance %#q to stop", attachment.InstanceID))
 
 		i := &ec2.DescribeInstancesInput{
 			InstanceIds: []*string{
@@ -111,7 +111,7 @@ func (e *EBS) DetachVolume(ctx context.Context, volumeID string, attachment Volu
 			return microerror.Mask(err)
 		}
 
-		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for instance %#q being stopped", attachment.InstanceID))
+		e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for instance %#q to stop", attachment.InstanceID))
 	}
 
 	{


### PR DESCRIPTION
I am thinking to put the tccp and ebsvolume resources together. They need the master instance and ebs volume magic. The code could be a bit simplified IMO so I would go down that road when there is no veto. This PR here is only some minor refactoring. 