### PR TITLE
backoff on initial encryption key creation

### DIFF
--- a/service/controller/v25/resource/encryptionkey/create.go
+++ b/service/controller/v25/resource/encryptionkey/create.go
@@ -26,6 +26,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// For some obscure reasons the encryption key is not immediately available
+	// when creating it. On each cluster creation we saw the retry resource
+	// kicking in once because of a not found error. To prevent the error, instead
+	// we backoff silently upfront where we know we have to.
 	var encryptionKey string
 	{
 		o := func() error {

--- a/service/controller/v25/resource/encryptionkey/create.go
+++ b/service/controller/v25/resource/encryptionkey/create.go
@@ -2,7 +2,9 @@ package encryptionkey
 
 import (
 	"context"
+	"time"
 
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/v25/controllercontext"
@@ -10,25 +12,38 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	customObject, err := key.ToCustomObject(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	err = r.encrypter.EnsureCreatedEncryptionKey(ctx, customObject)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	encryptionKey, err := r.encrypter.EncryptionKey(ctx, customObject)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	err = r.encrypter.EnsureCreatedEncryptionKey(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var encryptionKey string
+	{
+		o := func() error {
+			encryptionKey, err = r.encrypter.EncryptionKey(ctx, cr)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(3, 1*time.Second)
+
+		err := backoff.Retry(o, b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	cc.Status.TenantCluster.EncryptionKey = encryptionKey
 
 	return nil


### PR DESCRIPTION
That is a minor issue that annoys me greatly. For some obscure reasons the encryption key is not immediately available when creating it. On each cluster creation we see the retry resource kicking once in because of an error. I would like to prevent the error and instead backoff silently upfront where we know we have to. 

> {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:74","controller":"aws-operator","event":"update","level":"warning","loop":"6","message":"retrying due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/awsconfigs/2y6ks","resource":"encryptionkeyv24","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:67: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v24/resource/encryptionkey/create.go:25: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v24/encrypter/kms/kms.go:220: } {/go/src/github.com/giantswarm/aws-operator/service/controller/v24/encrypter/kms/kms.go:266: } {key not found error}]","time":"2019-03-21T14:26:23.222448+00:00","underlyingResource":"encryptionkeyv24","version":"109161921"}