### PR TITLE
move tccp information to related controller context block

### DIFF
--- a/service/controller/v25/controllercontext/status.go
+++ b/service/controller/v25/controllercontext/status.go
@@ -35,16 +35,14 @@ type ContextStatusControlPlaneVPC struct {
 }
 
 type ContextStatusTenantCluster struct {
-	AWSAccountID           string
-	EncryptionKey          string
-	HostedZoneNameServers  string
-	KMS                    ContextStatusTenantClusterKMS
-	MasterInstance         ContextStatusTenantClusterMasterInstance
-	TCCP                   ContextStatusTenantClusterTCCP
-	VersionBundleVersion   string
-	VPC                    ContextStatusTenantClusterVPC
-	VPCPeeringConnectionID string
-	WorkerInstance         ContextStatusTenantClusterWorkerInstance
+	AWSAccountID          string
+	EncryptionKey         string
+	HostedZoneNameServers string
+	KMS                   ContextStatusTenantClusterKMS
+	MasterInstance        ContextStatusTenantClusterMasterInstance
+	TCCP                  ContextStatusTenantClusterTCCP
+	VersionBundleVersion  string
+	WorkerInstance        ContextStatusTenantClusterWorkerInstance
 }
 
 type ContextStatusTenantClusterKMS struct {
@@ -64,10 +62,12 @@ type ContextStatusTenantClusterTCCP struct {
 	IsTransitioning bool
 	RouteTables     []*ec2.RouteTable
 	Subnets         []*ec2.Subnet
+	VPC             ContextStatusTenantClusterTCCPVPC
 }
 
-type ContextStatusTenantClusterVPC struct {
-	ID string
+type ContextStatusTenantClusterTCCPVPC struct {
+	ID                  string
+	PeeringConnectionID string
 }
 
 type ContextStatusTenantClusterWorkerInstance struct {

--- a/service/controller/v25/resource/cpf/create.go
+++ b/service/controller/v25/resource/cpf/create.go
@@ -25,7 +25,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		if cc.Status.TenantCluster.VPCPeeringConnectionID == "" {
+		if cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID == "" {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the VPC Peering Connection ID in the controller context")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
@@ -151,7 +151,7 @@ func (r *Resource) newPrivateRoutes(ctx context.Context, cr v1alpha1.AWSConfig) 
 				CidrBlock: cidrBlock,
 				// The peer connection id is fetched from the cloud formation stack
 				// outputs in the stackoutput resource.
-				PeerConnectionID: cc.Status.TenantCluster.VPCPeeringConnectionID,
+				PeerConnectionID: cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID,
 			}
 
 			routes = append(routes, route)
@@ -181,7 +181,7 @@ func (r *Resource) newPublicRoutes(ctx context.Context, cr v1alpha1.AWSConfig) (
 			CidrBlock: key.StatusNetworkCIDR(cr),
 			// The peer connection id is fetched from the cloud formation stack
 			// outputs in the stackoutput resource.
-			PeerConnectionID: cc.Status.TenantCluster.VPCPeeringConnectionID,
+			PeerConnectionID: cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID,
 		}
 
 		routes = append(routes, route)

--- a/service/controller/v25/resource/tccpoutputs/create.go
+++ b/service/controller/v25/resource/tccpoutputs/create.go
@@ -146,11 +146,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			cc.Status.TenantCluster.VPC.ID = v
+			cc.Status.TenantCluster.TCCP.VPC.ID = v
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			cc.Status.TenantCluster.VPC.ID = v
+			cc.Status.TenantCluster.TCCP.VPC.ID = v
 		}
 	}
 
@@ -167,11 +167,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			cc.Status.TenantCluster.VPCPeeringConnectionID = v
+			cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID = v
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			cc.Status.TenantCluster.VPCPeeringConnectionID = v
+			cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID = v
 		}
 	}
 

--- a/service/controller/v25/resource/tccpsubnet/resource.go
+++ b/service/controller/v25/resource/tccpsubnet/resource.go
@@ -49,7 +49,7 @@ func (r *Resource) addSubnetsToContext(ctx context.Context, cr v1alpha1.AWSConfi
 	// The tenant cluster VPC is a requirement to find its associated subnets and
 	// route tables. In case the VPC ID is not yet tracked in the controller
 	// context we return an error and cause the resource to be canceled.
-	if cc.Status.TenantCluster.VPC.ID == "" {
+	if cc.Status.TenantCluster.TCCP.VPC.ID == "" {
 		return microerror.Mask(vpcNotFoundError)
 	}
 
@@ -59,7 +59,7 @@ func (r *Resource) addSubnetsToContext(ctx context.Context, cr v1alpha1.AWSConfi
 				{
 					Name: aws.String("vpc-id"),
 					Values: []*string{
-						aws.String(cc.Status.TenantCluster.VPC.ID),
+						aws.String(cc.Status.TenantCluster.TCCP.VPC.ID),
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func (r *Resource) addSubnetsToContext(ctx context.Context, cr v1alpha1.AWSConfi
 				{
 					Name: aws.String("vpc-id"),
 					Values: []*string{
-						aws.String(cc.Status.TenantCluster.VPC.ID),
+						aws.String(cc.Status.TenantCluster.TCCP.VPC.ID),
 					},
 				},
 			},


### PR DESCRIPTION
This change will be necessary when working towards node pools, because we are going to have multiple VPCs and need to reflect that somehow appropriately in the controller context structure. 