### PR TITLE
align deletion between stack managing resources

### DIFF
--- a/service/controller/v25/resource/cpf/delete.go
+++ b/service/controller/v25/resource/cpf/delete.go
@@ -38,6 +38,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			finalizerskeptcontext.SetKept(ctx)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
 			return nil
 
 		} else if IsNotExists(err) {
@@ -45,6 +46,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
+
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
@@ -65,6 +67,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the deletion of the tenant cluster's control plane finalizer cloud formation stack")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+		finalizerskeptcontext.SetKept(ctx)
 	}
 
 	return nil

--- a/service/controller/v25/resource/cpi/delete.go
+++ b/service/controller/v25/resource/cpi/delete.go
@@ -38,6 +38,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			finalizerskeptcontext.SetKept(ctx)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
 			return nil
 
 		} else if IsNotExists(err) {
@@ -45,6 +46,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
+
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
@@ -65,6 +67,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the deletion of the tenant cluster's control plane initializer cloud formation stack")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+		finalizerskeptcontext.SetKept(ctx)
 	}
 
 	return nil

--- a/service/controller/v25/resource/tcdp/delete.go
+++ b/service/controller/v25/resource/tcdp/delete.go
@@ -67,6 +67,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the deletion of the tenant cluster's data plane cloud formation stack")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+		finalizerskeptcontext.SetKept(ctx)
 	}
 
 	return nil


### PR DESCRIPTION
With this the stack management across cpi, cpf, tccp and tcdp resource are basically the same. Only difference is the encrypter handling in the tccp resource. The added "keeping finalizers" is more or less for consistency so we have a basis to abstract the resource logic somehow down the road. Their stacks are usually deleted within a minute or two and only the huge tccp stack takes longer. 