### PR TITLE
Make kubelet volume same size as docker volume

### DIFF
--- a/service/controller/v25/adapter/guest_launch_configuration.go
+++ b/service/controller/v25/adapter/guest_launch_configuration.go
@@ -70,24 +70,6 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 		}
 	}
 
-	{
-		cur := config.StackState.WorkerKubeletVolumeSizeGB
-		def := defaultEBSVolumeSize
-
-		if cur == "" {
-			cur = "0"
-		}
-
-		curi, err := strconv.Atoi(cur)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if curi <= 0 {
-			config.StackState.WorkerKubeletVolumeSizeGB = def
-		}
-	}
-
 	l.WorkerBlockDeviceMappings = []BlockDeviceMapping{
 		{
 			DeleteOnTermination: true,
@@ -104,7 +86,10 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 		{
 			DeleteOnTermination: true,
 			DeviceName:          kubeletEBSVolumeMountPoint,
-			VolumeSize:          config.StackState.WorkerKubeletVolumeSizeGB,
+			// TL;DR; kubelet volume same size as docker volume 
+			// this is a temporary solution that should stay around until Node Pools story is ready.
+			// See here for furhter info https://github.com/giantswarm/giantswarm/issues/5582#issuecomment-476170597
+			VolumeSize:          config.StackState.WorkerDockerVolumeSizeGB,
 			VolumeType:          defaultEBSVolumeType,
 		},
 	}

--- a/service/controller/v25/adapter/guest_launch_configuration.go
+++ b/service/controller/v25/adapter/guest_launch_configuration.go
@@ -83,8 +83,8 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 			VolumeSize:          config.StackState.WorkerLogVolumeSizeGB,
 			VolumeType:          defaultEBSVolumeType,
 		},
-		{	
-			// TL;DR; kubelet volume same size as docker volume 
+		{
+			// TL;DR; kubelet volume same size as docker volume
 			// this is a temporary solution that should stay around until Node Pools story is ready.
 			// See here for furhter info https://github.com/giantswarm/giantswarm/issues/5582#issuecomment-476170597
 			DeleteOnTermination: true,

--- a/service/controller/v25/adapter/guest_launch_configuration.go
+++ b/service/controller/v25/adapter/guest_launch_configuration.go
@@ -83,12 +83,12 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 			VolumeSize:          config.StackState.WorkerLogVolumeSizeGB,
 			VolumeType:          defaultEBSVolumeType,
 		},
-		{
-			DeleteOnTermination: true,
-			DeviceName:          kubeletEBSVolumeMountPoint,
+		{	
 			// TL;DR; kubelet volume same size as docker volume 
 			// this is a temporary solution that should stay around until Node Pools story is ready.
 			// See here for furhter info https://github.com/giantswarm/giantswarm/issues/5582#issuecomment-476170597
+			DeleteOnTermination: true,
+			DeviceName:          kubeletEBSVolumeMountPoint,
 			VolumeSize:          config.StackState.WorkerDockerVolumeSizeGB,
 			VolumeType:          defaultEBSVolumeType,
 		},

--- a/service/controller/v25/adapter/guest_launch_configuration.go
+++ b/service/controller/v25/adapter/guest_launch_configuration.go
@@ -70,6 +70,24 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 		}
 	}
 
+	{
+		cur := config.StackState.WorkerKubeletVolumeSizeGB
+		def := defaultEBSVolumeSize
+
+		if cur == "" {
+			cur = "0"
+		}
+
+		curi, err := strconv.Atoi(cur)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if curi <= 0 {
+			config.StackState.WorkerKubeletVolumeSizeGB = def
+		}
+	}
+
 	l.WorkerBlockDeviceMappings = []BlockDeviceMapping{
 		{
 			DeleteOnTermination: true,
@@ -89,7 +107,7 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 			// See here for furhter info https://github.com/giantswarm/giantswarm/issues/5582#issuecomment-476170597
 			DeleteOnTermination: true,
 			DeviceName:          kubeletEBSVolumeMountPoint,
-			VolumeSize:          config.StackState.WorkerDockerVolumeSizeGB,
+			VolumeSize:          config.StackState.WorkerKubeletVolumeSizeGB,
 			VolumeType:          defaultEBSVolumeType,
 		},
 	}

--- a/service/controller/v25/adapter/guest_launch_configuration_test.go
+++ b/service/controller/v25/adapter/guest_launch_configuration_test.go
@@ -109,7 +109,8 @@ func Test_AdapterLaunchConfiguration_RegularFields(t *testing.T) {
 			cfg := Config{
 				CustomObject: tc.customObject,
 				StackState: StackState{
-					WorkerDockerVolumeSizeGB: key.WorkerDockerVolumeSizeGB(tc.customObject),
+					WorkerDockerVolumeSizeGB:  key.WorkerDockerVolumeSizeGB(tc.customObject),
+					WorkerKubeletVolumeSizeGB: key.WorkerDockerVolumeSizeGB(tc.customObject),
 				},
 			}
 			err := a.Guest.LaunchConfiguration.Adapt(cfg)

--- a/service/controller/v25/adapter/guest_launch_configuration_test.go
+++ b/service/controller/v25/adapter/guest_launch_configuration_test.go
@@ -57,7 +57,7 @@ func Test_AdapterLaunchConfiguration_RegularFields(t *testing.T) {
 				{
 					DeleteOnTermination: true,
 					DeviceName:          kubeletEBSVolumeMountPoint,
-					VolumeSize:          defaultEBSVolumeSize,
+					VolumeSize:          "250",
 					VolumeType:          defaultEBSVolumeType,
 				},
 			},

--- a/service/controller/v25/adapter/spec.go
+++ b/service/controller/v25/adapter/spec.go
@@ -73,15 +73,15 @@ type StackState struct {
 	// TODO the cloud config versions shouldn't be injected here. These should
 	// actually always only be the ones the operator has hard coded. No other
 	// version should be used here ever.
-	WorkerCloudConfigVersion  string
-	WorkerDesired             int
-	WorkerDockerVolumeSizeGB  string
-	WorkerLogVolumeSizeGB     string
-	WorkerImageID             string
-	WorkerInstanceMonitoring  bool
-	WorkerInstanceType        string
-	WorkerMax                 int
-	WorkerMin                 int
+	WorkerCloudConfigVersion string
+	WorkerDesired            int
+	WorkerDockerVolumeSizeGB string
+	WorkerLogVolumeSizeGB    string
+	WorkerImageID            string
+	WorkerInstanceMonitoring bool
+	WorkerInstanceType       string
+	WorkerMax                int
+	WorkerMin                int
 
 	VersionBundleVersion string
 }

--- a/service/controller/v25/adapter/spec.go
+++ b/service/controller/v25/adapter/spec.go
@@ -77,7 +77,6 @@ type StackState struct {
 	WorkerDesired             int
 	WorkerDockerVolumeSizeGB  string
 	WorkerLogVolumeSizeGB     string
-	WorkerKubeletVolumeSizeGB string
 	WorkerImageID             string
 	WorkerInstanceMonitoring  bool
 	WorkerInstanceType        string

--- a/service/controller/v25/adapter/spec.go
+++ b/service/controller/v25/adapter/spec.go
@@ -73,15 +73,16 @@ type StackState struct {
 	// TODO the cloud config versions shouldn't be injected here. These should
 	// actually always only be the ones the operator has hard coded. No other
 	// version should be used here ever.
-	WorkerCloudConfigVersion string
-	WorkerDesired            int
-	WorkerDockerVolumeSizeGB string
-	WorkerLogVolumeSizeGB    string
-	WorkerImageID            string
-	WorkerInstanceMonitoring bool
-	WorkerInstanceType       string
-	WorkerMax                int
-	WorkerMin                int
+	WorkerCloudConfigVersion  string
+	WorkerDesired             int
+	WorkerDockerVolumeSizeGB  string
+	WorkerKubeletVolumeSizeGB string
+	WorkerLogVolumeSizeGB     string
+	WorkerImageID             string
+	WorkerInstanceMonitoring  bool
+	WorkerInstanceType        string
+	WorkerMax                 int
+	WorkerMin                 int
 
 	VersionBundleVersion string
 }

--- a/service/controller/v25/resource/tccp/create.go
+++ b/service/controller/v25/resource/tccp/create.go
@@ -306,11 +306,14 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.AWSConfig, t
 				WorkerCloudConfigVersion: key.CloudConfigVersion,
 				WorkerDesired:            cc.Status.TenantCluster.TCCP.ASG.DesiredCapacity,
 				WorkerDockerVolumeSizeGB: key.WorkerDockerVolumeSizeGB(cr),
-				WorkerImageID:            im,
-				WorkerInstanceMonitoring: r.instanceMonitoring,
-				WorkerInstanceType:       key.WorkerInstanceType(cr),
-				WorkerMax:                cc.Status.TenantCluster.TCCP.ASG.MaxSize,
-				WorkerMin:                cc.Status.TenantCluster.TCCP.ASG.MinSize,
+				// TODO: https://github.com/giantswarm/giantswarm/issues/4105#issuecomment-421772917
+				// TODO: for now we use same value as for DockerVolumeSizeFromNode, when we have kubelet size in spec we should use that.
+				WorkerKubeletVolumeSizeGB: key.WorkerDockerVolumeSizeGB(cr),
+				WorkerImageID:             im,
+				WorkerInstanceMonitoring:  r.instanceMonitoring,
+				WorkerInstanceType:        key.WorkerInstanceType(cr),
+				WorkerMax:                 cc.Status.TenantCluster.TCCP.ASG.MaxSize,
+				WorkerMin:                 cc.Status.TenantCluster.TCCP.ASG.MinSize,
 
 				VersionBundleVersion: key.VersionBundleVersion(cr),
 			},


### PR DESCRIPTION
Make kubelet volume same size as docker volume

When the customer (or us) will change the value in the CR for the docker volume size then this will trigger the change also in the kubelet volume.  