### PR TITLE
add more graceful error handling for updating clusters asked to be deleted

### DIFF
--- a/service/controller/v25/resource/cpf/delete.go
+++ b/service/controller/v25/resource/cpf/delete.go
@@ -62,7 +62,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DeleteStack(i)
-		if err != nil {
+		if IsUpdateInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane finalizer cloud formation stack is being updated")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/v25/resource/cpf/error.go
+++ b/service/controller/v25/resource/cpf/error.go
@@ -70,3 +70,26 @@ func IsNotExists(err error) bool {
 
 	return false
 }
+
+var updateInProgressError = &microerror.Error{
+	Kind: "updateInProgressError",
+}
+
+// IsUpdateInProgress asserts updateInProgressError.
+func IsUpdateInProgress(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusUpdateInProgress) {
+		return true
+	}
+
+	if c == updateInProgressError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v25/resource/cpi/delete.go
+++ b/service/controller/v25/resource/cpi/delete.go
@@ -62,7 +62,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.DeleteStack(i)
-		if err != nil {
+		if IsUpdateInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer cloud formation stack is being updated")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/v25/resource/cpi/error.go
+++ b/service/controller/v25/resource/cpi/error.go
@@ -70,3 +70,26 @@ func IsNotExists(err error) bool {
 
 	return false
 }
+
+var updateInProgressError = &microerror.Error{
+	Kind: "updateInProgressError",
+}
+
+// IsUpdateInProgress asserts updateInProgressError.
+func IsUpdateInProgress(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusUpdateInProgress) {
+		return true
+	}
+
+	if c == updateInProgressError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/v25/resource/tccp/delete.go
+++ b/service/controller/v25/resource/tccp/delete.go
@@ -68,7 +68,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		_, err = cc.Client.TenantCluster.AWS.CloudFormation.DeleteStack(i)
-		if err != nil {
+		if IsUpdateInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane cloud formation stack is being updated")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/v25/resource/tccp/error.go
+++ b/service/controller/v25/resource/tccp/error.go
@@ -8,29 +8,6 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-var alreadyExistsError = &microerror.Error{
-	Kind: "alreadyExistsError",
-}
-
-// IsAlreadyExists asserts alreadyExistsError.
-func IsAlreadyExists(err error) bool {
-	c := microerror.Cause(err)
-
-	if c == nil {
-		return false
-	}
-
-	if strings.Contains(c.Error(), cloudformation.ErrCodeAlreadyExistsException) {
-		return true
-	}
-
-	if c == alreadyExistsError {
-		return true
-	}
-
-	return false
-}
-
 var alreadyTerminatedError = &microerror.Error{
 	Kind: "alreadyTerminatedError",
 }
@@ -81,15 +58,6 @@ func IsDeleteInProgress(err error) bool {
 	return false
 }
 
-var deletionMustBeRetriedError = &microerror.Error{
-	Kind: "deletionMustBeRetriedError",
-}
-
-// IsDeletionMustBeRetried asserts deletionMustBeRetriedError.
-func IsDeletionMustBeRetried(err error) bool {
-	return microerror.Cause(err) == deletionMustBeRetriedError
-}
-
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
@@ -131,34 +99,25 @@ func IsNotExists(err error) bool {
 	return false
 }
 
-var resourceNotReadyError = &microerror.Error{
-	Kind: "resourceNotReadyError",
+var updateInProgressError = &microerror.Error{
+	Kind: "updateInProgressError",
 }
 
-// IsResourceNotReady asserts resourceNotReadyError.
-func IsResourceNotReady(err error) bool {
+// IsUpdateInProgress asserts updateInProgressError.
+func IsUpdateInProgress(err error) bool {
 	c := microerror.Cause(err)
 
 	if c == nil {
 		return false
 	}
 
-	if strings.Contains(c.Error(), "ResourceNotReady") {
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusUpdateInProgress) {
 		return true
 	}
 
-	if c == resourceNotReadyError {
+	if c == updateInProgressError {
 		return true
 	}
 
 	return false
-}
-
-var wrongTypeError = &microerror.Error{
-	Kind: "wrongTypeError",
-}
-
-// IsWrongType asserts wrongTypeError.
-func IsWrongType(err error) bool {
-	return microerror.Cause(err) == wrongTypeError
 }

--- a/service/controller/v25/resource/tcdp/delete.go
+++ b/service/controller/v25/resource/tcdp/delete.go
@@ -62,7 +62,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		_, err = cc.Client.TenantCluster.AWS.CloudFormation.DeleteStack(i)
-		if err != nil {
+		if IsUpdateInProgress(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's data plane cloud formation stack is being updated")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/v25/resource/tcdp/error.go
+++ b/service/controller/v25/resource/tcdp/error.go
@@ -70,3 +70,26 @@ func IsNotExists(err error) bool {
 
 	return false
 }
+
+var updateInProgressError = &microerror.Error{
+	Kind: "updateInProgressError",
+}
+
+// IsUpdateInProgress asserts updateInProgressError.
+func IsUpdateInProgress(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusUpdateInProgress) {
+		return true
+	}
+
+	if c == updateInProgressError {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
When clusters are updated and deleted quickly, like in e2e tests, there is an error that we can handle more graceful. 