### PR TITLE
Allow change of master instance type while scaling

### DIFF
--- a/service/controller/v22/resource/cloudformation/update.go
+++ b/service/controller/v22/resource/cloudformation/update.go
@@ -237,10 +237,6 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master image id")
 		return false, nil
 	}
-	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master instance type")
-		return false, nil
-	}
 	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master cloudconfig version")
 		return false, nil
@@ -263,10 +259,16 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 	}
 	if !cc.Status.Cluster.ASG.IsEmpty() && cc.Status.Cluster.ASG.MaxSize != key.ScalingMax(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.max")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if !cc.Status.Cluster.ASG.IsEmpty() && cc.Status.Cluster.ASG.MinSize != key.ScalingMin(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.min")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {

--- a/service/controller/v22patch1/resource/cloudformation/update.go
+++ b/service/controller/v22patch1/resource/cloudformation/update.go
@@ -237,10 +237,6 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master image id")
 		return false, nil
 	}
-	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master instance type")
-		return false, nil
-	}
 	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master cloudconfig version")
 		return false, nil
@@ -263,10 +259,16 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 	}
 	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MaxSize != key.ScalingMax(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.max")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MinSize != key.ScalingMin(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.min")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {

--- a/service/controller/v23/resource/cloudformation/update.go
+++ b/service/controller/v23/resource/cloudformation/update.go
@@ -237,10 +237,6 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master image id")
 		return false, nil
 	}
-	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master instance type")
-		return false, nil
-	}
 	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master cloudconfig version")
 		return false, nil
@@ -263,10 +259,16 @@ func (r *Resource) shouldScale(ctx context.Context, customObject v1alpha1.AWSCon
 	}
 	if !cc.Status.Cluster.ASG.IsEmpty() && cc.Status.Cluster.ASG.MaxSize != key.ScalingMax(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.max")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if !cc.Status.Cluster.ASG.IsEmpty() && cc.Status.Cluster.ASG.MinSize != key.ScalingMin(customObject) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.min")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {

--- a/service/controller/v24/resource/tccp/update.go
+++ b/service/controller/v24/resource/tccp/update.go
@@ -244,10 +244,6 @@ func (r *Resource) shouldScale(ctx context.Context, cr v1alpha1.AWSConfig, curre
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master image id")
 		return false, nil
 	}
-	if currentState.MasterInstanceType != desiredState.MasterInstanceType {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master instance type")
-		return false, nil
-	}
 	if currentState.MasterCloudConfigVersion != desiredState.MasterCloudConfigVersion {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "not scaling due to master cloudconfig version")
 		return false, nil
@@ -270,10 +266,16 @@ func (r *Resource) shouldScale(ctx context.Context, cr v1alpha1.AWSConfig, curre
 	}
 	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MaxSize != key.ScalingMax(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.max")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MinSize != key.ScalingMin(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "scaling due to scaling.min")
+		if currentState.MasterInstanceType != desiredState.MasterInstanceType {
+			r.logger.LogCtx(ctx, "level", "warning", "message", "master instance type will be changed while scaling")
+		}
 		return true, nil
 	}
 	if currentState.VersionBundleVersion != desiredState.VersionBundleVersion {


### PR DESCRIPTION
There are cases where customer doesn't want upgrades on a cluster, but master
instance type should get changed and it should not require full upgrade nor
should it block cluster scaling. Therefore allowing scaling when there's
pending cluster scaling request allows the master instance type to be changed
"on-the-fly" without disturbing workload.

:exclamation:  This doesn't change the functionality of `v25`. From quick look that doesn't obey `Updates.Enabled` flag anymore and therefore performs the instance type change when one is applied to CR (so effectively it doesn't need any change for this).