### PR TITLE
align finalizers for new clusterapi controllers

### DIFF
--- a/service/controller/clusterapi/cluster.go
+++ b/service/controller/clusterapi/cluster.go
@@ -134,7 +134,9 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			ResourceSets: resourceSets,
 			RESTClient:   config.G8sClient.ProviderV1alpha1().RESTClient(),
 
-			Name: config.ProjectName,
+			// Name is used to compute finalizer names. This here results in something
+			// like operatorkit.giantswarm.io/aws-operator-cluster-controller.
+			Name: config.ProjectName + "-cluster-controller",
 		}
 
 		operatorkitController, err = controller.New(c)

--- a/service/controller/clusterapi/drainer.go
+++ b/service/controller/clusterapi/drainer.go
@@ -96,8 +96,8 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 			RESTClient:   config.G8sClient.ProviderV1alpha1().RESTClient(),
 
 			// Name is used to compute finalizer names. This here results in something
-			// like operatorkit.giantswarm.io/aws-operator-drainer.
-			Name: config.ProjectName + "-drainer",
+			// like operatorkit.giantswarm.io/aws-operator-drainer-controller.
+			Name: config.ProjectName + "-drainer-controller",
 		}
 
 		operatorkitController, err = controller.New(c)


### PR DESCRIPTION
This is how it looks right now in the `AWSConfig` CRs. 

```
metadata:
  ...
  finalizers:
  - operatorkit.giantswarm.io/aws-operator
  - operatorkit.giantswarm.io/aws-operator-drainer
  ...
```

This is how it looks with this PR in the `Cluster` types. 

```
metadata:
  ...
  finalizers:
  - operatorkit.giantswarm.io/aws-operator-cluster-controller
  - operatorkit.giantswarm.io/aws-operator-drainer-controller
  ...
```