### PR TITLE
Add context to network.Allocator callbacks

### DIFF
--- a/service/network/allocator.go
+++ b/service/network/allocator.go
@@ -47,10 +47,14 @@ func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize n
 	var err error
 	var reservedSubnets []net.IPNet
 	{
-		reservedSubnets, err = callbacks.GetReservedNetworks()
+		i.logger.LogCtx(ctx, "level", "debug", "message", "getting allocated subnets")
+
+		reservedSubnets, err = callbacks.GetReservedNetworks(ctx)
 		if err != nil {
 			return net.IPNet{}, microerror.Mask(err)
 		}
+
+		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("got allocated subnets: %q", reservedSubnets))
 	}
 
 	var subnet net.IPNet
@@ -68,7 +72,7 @@ func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize n
 	{
 		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("persisting allocation candidate: %q", subnet.String()))
 
-		err = callbacks.PersistAllocatedNetwork(subnet)
+		err = callbacks.PersistAllocatedNetwork(ctx, subnet)
 		if err != nil {
 			return net.IPNet{}, microerror.Mask(err)
 		}

--- a/service/network/spec.go
+++ b/service/network/spec.go
@@ -11,12 +11,12 @@ type AllocationCallbacks struct {
 	// GetReservedNetworks implementation must return all networks that are
 	// allocated on any given moment. Failing to do that will result in
 	// overlapping allocations.
-	GetReservedNetworks func() ([]net.IPNet, error)
+	GetReservedNetworks func(context.Context) ([]net.IPNet, error)
 
 	// PersistAllocatedNetwork must mutate shared persistent state so that on
 	// successful execution persistet network is visible when
 	// GetReservedNetworks() is called.
-	PersistAllocatedNetwork func(net.IPNet) error
+	PersistAllocatedNetwork func(context.Context, net.IPNet) error
 }
 
 // Allocator is an interface for IPAM implementation that manages network range


### PR DESCRIPTION
Both callbacks perform functions that can / need to use context down the line
of implementation so just pass it as parameter as we have agreed.