### PR TITLE
hard code etcd ports

### DIFF
--- a/service/controller/clusterapi/v26/adapter/guest_load_balancers.go
+++ b/service/controller/clusterapi/v26/adapter/guest_load_balancers.go
@@ -86,17 +86,17 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 		return microerror.Mask(err)
 	}
 
-	a.IngressElbHealthCheckTarget = heathCheckTarget(key.IngressControllerSecurePort(cfg.CustomObject))
+	a.IngressElbHealthCheckTarget = heathCheckTarget(key.IngressControllerSecurePort)
 	a.IngressElbName = ingressElbName
 	a.IngressElbPortsToOpen = []GuestLoadBalancersAdapterPortPair{
 		{
 			PortELB: httpsPort,
 
-			PortInstance: key.IngressControllerSecurePort(cfg.CustomObject),
+			PortInstance: key.IngressControllerSecurePort,
 		},
 		{
 			PortELB:      httpPort,
-			PortInstance: key.IngressControllerInsecurePort(cfg.CustomObject),
+			PortInstance: key.IngressControllerInsecurePort,
 		},
 	}
 	a.IngressElbScheme = externalELBScheme

--- a/service/controller/clusterapi/v26/adapter/guest_security_groups.go
+++ b/service/controller/clusterapi/v26/adapter/guest_security_groups.go
@@ -117,19 +117,19 @@ func (s *GuestSecurityGroupsAdapter) getWorkerRules(customObject v1alpha1.AWSCon
 	return []securityGroupRule{
 		{
 			Description:         "Allow traffic from the ingress security group to the ingress controller port 443.",
-			Port:                key.IngressControllerSecurePort(customObject),
+			Port:                key.IngressControllerSecurePort,
 			Protocol:            tcpProtocol,
 			SourceSecurityGroup: ingressSecurityGroupName,
 		},
 		{
 			Description:         "Allow traffic from the ingress security group to the ingress controller port 80.",
-			Port:                key.IngressControllerInsecurePort(customObject),
+			Port:                key.IngressControllerInsecurePort,
 			Protocol:            tcpProtocol,
 			SourceSecurityGroup: ingressSecurityGroupName,
 		},
 		{
 			Description: "Allow traffic from control plane to ingress controller secure port for tenant cluster scraping.",
-			Port:        key.IngressControllerSecurePort(customObject),
+			Port:        key.IngressControllerSecurePort,
 			Protocol:    tcpProtocol,
 			SourceCIDR:  hostClusterCIDR,
 		},

--- a/service/controller/clusterapi/v26/adapter/guest_security_groups_test.go
+++ b/service/controller/clusterapi/v26/adapter/guest_security_groups_test.go
@@ -28,12 +28,6 @@ func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
 				Spec: v1alpha1.AWSConfigSpec{
 					Cluster: v1alpha1.Cluster{
 						ID: "test-cluster",
-						Kubernetes: v1alpha1.ClusterKubernetes{
-							IngressController: v1alpha1.ClusterKubernetesIngressController{
-								SecurePort:   30010,
-								InsecurePort: 30011,
-							},
-						},
 					},
 				},
 			},
@@ -81,19 +75,19 @@ func TestAdapterSecurityGroupsRegularFields(t *testing.T) {
 			expectedWorkerSecurityGroupRules: []securityGroupRule{
 				{
 					Description:         "Allow traffic from the ingress security group to the ingress controller port 443.",
-					Port:                30010,
-					Protocol:            "tcp",
-					SourceSecurityGroup: "IngressSecurityGroup",
-				},
-				{
-					Description:         "Allow traffic from the ingress security group to the ingress controller port 80.",
 					Port:                30011,
 					Protocol:            "tcp",
 					SourceSecurityGroup: "IngressSecurityGroup",
 				},
 				{
+					Description:         "Allow traffic from the ingress security group to the ingress controller port 80.",
+					Port:                30010,
+					Protocol:            "tcp",
+					SourceSecurityGroup: "IngressSecurityGroup",
+				},
+				{
 					Description: "Allow traffic from control plane to ingress controller secure port for tenant cluster scraping.",
-					Port:        30010,
+					Port:        30011,
 					Protocol:    "tcp",
 					SourceCIDR:  "10.0.0.0/16",
 				},

--- a/service/controller/clusterapi/v26/key/key.go
+++ b/service/controller/clusterapi/v26/key/key.go
@@ -88,6 +88,11 @@ const (
 )
 
 const (
+	IngressControllerInsecurePort = 30010
+	IngressControllerSecurePort   = 30011
+)
+
+const (
 	NodeDrainerLifecycleHookName = "NodeDrainer"
 	WorkerASGRef                 = "workerAutoScalingGroup"
 )
@@ -229,14 +234,6 @@ func BaseDomain(customObject v1alpha1.AWSConfig) string {
 	// Probably the easiest way for now is to just allow single domain for
 	// everything which we do now.
 	return customObject.Spec.AWS.HostedZones.API.Name
-}
-
-func IngressControllerInsecurePort(customObject v1alpha1.AWSConfig) int {
-	return customObject.Spec.Cluster.Kubernetes.IngressController.InsecurePort
-}
-
-func IngressControllerSecurePort(customObject v1alpha1.AWSConfig) int {
-	return customObject.Spec.Cluster.Kubernetes.IngressController.SecurePort
 }
 
 func InstanceProfileName(customObject v1alpha1.AWSConfig, profileType string) string {

--- a/service/controller/clusterapi/v26/key/key_test.go
+++ b/service/controller/clusterapi/v26/key/key_test.go
@@ -333,46 +333,6 @@ func Test_LogVolumeName(t *testing.T) {
 	}
 }
 
-func Test_IngressControllerInsecurePort(t *testing.T) {
-	t.Parallel()
-	expectedPort := 30010
-	customObject := v1alpha1.AWSConfig{
-		Spec: v1alpha1.AWSConfigSpec{
-			Cluster: v1alpha1.Cluster{
-				Kubernetes: v1alpha1.ClusterKubernetes{
-					IngressController: v1alpha1.ClusterKubernetesIngressController{
-						InsecurePort: expectedPort,
-					},
-				},
-			},
-		},
-	}
-
-	if IngressControllerInsecurePort(customObject) != expectedPort {
-		t.Fatalf("Expected ingress controller insecure port %d but was %d", expectedPort, IngressControllerInsecurePort(customObject))
-	}
-}
-
-func Test_IngressControllerSecurePort(t *testing.T) {
-	t.Parallel()
-	expectedPort := 30011
-	customObject := v1alpha1.AWSConfig{
-		Spec: v1alpha1.AWSConfigSpec{
-			Cluster: v1alpha1.Cluster{
-				Kubernetes: v1alpha1.ClusterKubernetes{
-					IngressController: v1alpha1.ClusterKubernetesIngressController{
-						SecurePort: expectedPort,
-					},
-				},
-			},
-		},
-	}
-
-	if IngressControllerSecurePort(customObject) != expectedPort {
-		t.Fatalf("Expected ingress controller secure port %d but was %d", expectedPort, IngressControllerSecurePort(customObject))
-	}
-}
-
 func Test_IsChinaRegion(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
One decision we have made during the Node Pool speccing was to hard code the etcd ports. It does not appear to make a lot of sense to have them configurable per tenant cluster. We are also not able to really configure them as we have the ports hard coded in other places already. We hard code in the operator now as well and remove complexity. This is also reflected in the provider configs of the Cluster API types. 