### PR TITLE
migrate key functions #1

### DIFF
--- a/service/collector/ec2_instances.go
+++ b/service/collector/ec2_instances.go
@@ -170,7 +170,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 	{
 		input := &ec2.DescribeInstancesInput{
 			Filters: []*ec2.Filter{
-				&ec2.Filter{
+				{
 					Name: aws.String(fmt.Sprintf("tag:%s", tagInstallation)),
 					Values: []*string{
 						aws.String(e.installationName),

--- a/service/controller/clusterapi/v27/adapter/adapter_test.go
+++ b/service/controller/clusterapi/v27/adapter/adapter_test.go
@@ -64,7 +64,7 @@ func TestAdapterGuestMain(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-central-1a",
 								Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 									Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -109,7 +109,7 @@ func TestAdapterGuestMain(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "cn-north-1a",
 								Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 									Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{

--- a/service/controller/clusterapi/v27/adapter/guest_auto_scaling_group_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_auto_scaling_group_test.go
@@ -50,7 +50,7 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "myaz",
 							},
 						},
@@ -87,7 +87,7 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "myaz",
 							},
 						},
@@ -118,7 +118,7 @@ func TestAdapterAutoScalingGroupRegularFields(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "myaz",
 							},
 						},

--- a/service/controller/clusterapi/v27/adapter/guest_instance_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_instance_test.go
@@ -38,7 +38,7 @@ func Test_Adapter_Instance_RegularFields(t *testing.T) {
 					Status: v1alpha1.AWSConfigStatus{
 						AWS: v1alpha1.AWSConfigStatusAWS{
 							AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-								v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+								{
 									Name: "eu-west-1a",
 								},
 							},
@@ -122,7 +122,7 @@ func Test_Adapter_Instance_SmallCloudConfig(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-west-1a",
 							},
 						},

--- a/service/controller/clusterapi/v27/adapter/guest_record_sets.go
+++ b/service/controller/clusterapi/v27/adapter/guest_record_sets.go
@@ -3,7 +3,7 @@ package adapter
 import "github.com/giantswarm/aws-operator/service/controller/clusterapi/v27/legacykey"
 
 type GuestRecordSetsAdapter struct {
-	ClusterBaseDomain          string
+	BaseDomain                 string
 	EtcdDomain                 string
 	ClusterID                  string
 	MasterInstanceResourceName string
@@ -11,7 +11,7 @@ type GuestRecordSetsAdapter struct {
 }
 
 func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
-	a.ClusterBaseDomain = legacykey.ClusterBaseDomain(config.CustomObject)
+	a.BaseDomain = legacykey.ClusterBaseDomain(config.CustomObject)
 	a.EtcdDomain = legacykey.EtcdDomain(config.CustomObject)
 	a.ClusterID = legacykey.ClusterID(config.CustomObject)
 	a.MasterInstanceResourceName = config.StackState.MasterInstanceResourceName

--- a/service/controller/clusterapi/v27/adapter/guest_record_sets.go
+++ b/service/controller/clusterapi/v27/adapter/guest_record_sets.go
@@ -3,7 +3,7 @@ package adapter
 import "github.com/giantswarm/aws-operator/service/controller/clusterapi/v27/legacykey"
 
 type GuestRecordSetsAdapter struct {
-	BaseDomain                 string
+	ClusterBaseDomain          string
 	EtcdDomain                 string
 	ClusterID                  string
 	MasterInstanceResourceName string
@@ -11,7 +11,7 @@ type GuestRecordSetsAdapter struct {
 }
 
 func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
-	a.BaseDomain = legacykey.BaseDomain(config.CustomObject)
+	a.ClusterBaseDomain = legacykey.ClusterBaseDomain(config.CustomObject)
 	a.EtcdDomain = legacykey.EtcdDomain(config.CustomObject)
 	a.ClusterID = legacykey.ClusterID(config.CustomObject)
 	a.MasterInstanceResourceName = config.StackState.MasterInstanceResourceName

--- a/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
@@ -9,12 +9,12 @@ import (
 func TestAdapterRecordSetsRegularFields(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		description               string
-		customObject              v1alpha1.AWSConfig
-		route53Enabled            bool
-		expectedClusterBaseDomain string
-		expectedClusterID         string
-		expectedRoute53Enabled    bool
+		description            string
+		customObject           v1alpha1.AWSConfig
+		route53Enabled         bool
+		expectedBaseDomain     string
+		expectedClusterID      string
+		expectedRoute53Enabled bool
 	}{
 		{
 			description: "basic matching, all fields present",
@@ -44,10 +44,10 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 					},
 				},
 			},
-			route53Enabled:            true,
-			expectedRoute53Enabled:    true,
-			expectedClusterID:         "test-cluster",
-			expectedClusterBaseDomain: "installation.aws.eu-central-1.gigantic.io",
+			route53Enabled:         true,
+			expectedRoute53Enabled: true,
+			expectedClusterID:      "test-cluster",
+			expectedBaseDomain:     "installation.aws.eu-central-1.gigantic.io",
 		},
 	}
 
@@ -63,8 +63,8 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if a.Guest.RecordSets.ClusterBaseDomain != tc.expectedClusterBaseDomain {
-				t.Fatalf("ClusterBaseDomain == %q, want %q", a.Guest.RecordSets.ClusterBaseDomain, tc.expectedClusterBaseDomain)
+			if a.Guest.RecordSets.ClusterBaseDomain != tc.expectedBaseDomain {
+				t.Fatalf("ClusterBaseDomain == %q, want %q", a.Guest.RecordSets.ClusterBaseDomain, tc.expectedBaseDomain)
 			}
 			if a.Guest.RecordSets.ClusterID != tc.expectedClusterID {
 				t.Fatalf("ClusterID == %q, want %q", a.Guest.RecordSets.ClusterID, tc.expectedClusterID)

--- a/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
@@ -9,12 +9,12 @@ import (
 func TestAdapterRecordSetsRegularFields(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		description            string
-		customObject           v1alpha1.AWSConfig
-		route53Enabled         bool
-		expectedBaseDomain     string
-		expectedClusterID      string
-		expectedRoute53Enabled bool
+		description               string
+		customObject              v1alpha1.AWSConfig
+		route53Enabled            bool
+		expectedClusterBaseDomain string
+		expectedClusterID         string
+		expectedRoute53Enabled    bool
 	}{
 		{
 			description: "basic matching, all fields present",
@@ -44,10 +44,10 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 					},
 				},
 			},
-			route53Enabled:         true,
-			expectedRoute53Enabled: true,
-			expectedClusterID:      "test-cluster",
-			expectedBaseDomain:     "installation.aws.eu-central-1.gigantic.io",
+			route53Enabled:            true,
+			expectedRoute53Enabled:    true,
+			expectedClusterID:         "test-cluster",
+			expectedClusterBaseDomain: "installation.aws.eu-central-1.gigantic.io",
 		},
 	}
 
@@ -63,8 +63,8 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if a.Guest.RecordSets.BaseDomain != tc.expectedBaseDomain {
-				t.Fatalf("BaseDomain == %q, want %q", a.Guest.RecordSets.BaseDomain, tc.expectedBaseDomain)
+			if a.Guest.RecordSets.ClusterBaseDomain != tc.expectedClusterBaseDomain {
+				t.Fatalf("ClusterBaseDomain == %q, want %q", a.Guest.RecordSets.ClusterBaseDomain, tc.expectedClusterBaseDomain)
 			}
 			if a.Guest.RecordSets.ClusterID != tc.expectedClusterID {
 				t.Fatalf("ClusterID == %q, want %q", a.Guest.RecordSets.ClusterID, tc.expectedClusterID)

--- a/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_record_sets_test.go
@@ -63,8 +63,8 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			if a.Guest.RecordSets.ClusterBaseDomain != tc.expectedBaseDomain {
-				t.Fatalf("ClusterBaseDomain == %q, want %q", a.Guest.RecordSets.ClusterBaseDomain, tc.expectedBaseDomain)
+			if a.Guest.RecordSets.BaseDomain != tc.expectedBaseDomain {
+				t.Fatalf("BaseDomain == %q, want %q", a.Guest.RecordSets.BaseDomain, tc.expectedBaseDomain)
 			}
 			if a.Guest.RecordSets.ClusterID != tc.expectedClusterID {
 				t.Fatalf("ClusterID == %q, want %q", a.Guest.RecordSets.ClusterID, tc.expectedClusterID)

--- a/service/controller/clusterapi/v27/adapter/guest_route_tables_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_route_tables_test.go
@@ -31,10 +31,10 @@ func TestAdapterRouteTablesRegularFields(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-central-1a",
 							},
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-central-1b",
 							},
 						},

--- a/service/controller/clusterapi/v27/adapter/guest_subnets_test.go
+++ b/service/controller/clusterapi/v27/adapter/guest_subnets_test.go
@@ -22,7 +22,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 				Status: v1alpha1.AWSConfigStatus{
 					AWS: v1alpha1.AWSConfigStatusAWS{
 						AvailabilityZones: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-west-1b",
 								Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 									Public: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPublic{
@@ -33,7 +33,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 									},
 								},
 							},
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-west-1a",
 								Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 									Public: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPublic{
@@ -44,7 +44,7 @@ func TestAdapterSubnetsRegularFields(t *testing.T) {
 									},
 								},
 							},
-							v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+							{
 								Name: "eu-west-1c",
 								Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 									Public: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPublic{

--- a/service/controller/clusterapi/v27/key/common.go
+++ b/service/controller/clusterapi/v27/key/common.go
@@ -1,0 +1,14 @@
+package key
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+func IsDeleted(v interface{}) bool {
+	m, err := meta.Accessor(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return m.GetDeletionTimestamp() != nil
+}

--- a/service/controller/clusterapi/v27/key/key.go
+++ b/service/controller/clusterapi/v27/key/key.go
@@ -1,0 +1,25 @@
+package key
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.Kubernetes.API.Domain
+}
+
+func ClusterID(customObject v1alpha1.AWSConfig) string {
+	return customObject.Spec.Cluster.ID
+}
+
+func ClusterNamespace(customObject v1alpha1.AWSConfig) string {
+	return ClusterID(customObject)
+}
+
+func BaseDomain(customObject v1alpha1.AWSConfig) string {
+	// TODO remove other zones and make it a BaseDomain in the CR.
+	// CloudFormation creates a separate HostedZone with the same name.
+	// Probably the easiest way for now is to just allow single domain for
+	// everything which we do now.
+	return customObject.Spec.AWS.HostedZones.API.Name
+}

--- a/service/controller/clusterapi/v27/key/key.go
+++ b/service/controller/clusterapi/v27/key/key.go
@@ -1,25 +1,23 @@
 package key
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"fmt"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func ClusterAPIEndpoint(customObject v1alpha1.AWSConfig) string {
-	return customObject.Spec.Cluster.Kubernetes.API.Domain
+func ClusterAPIEndpoint(cluster v1alpha1.Cluster) string {
+	return fmt.Sprintf("api.%s.%s", ClusterID(cluster), ClusterBaseDomain(cluster))
 }
 
-func ClusterID(customObject v1alpha1.AWSConfig) string {
-	return customObject.Spec.Cluster.ID
+func ClusterBaseDomain(cluster v1alpha1.Cluster) string {
+	return providerSpec(cluster).Cluster.DNS.Domain
 }
 
-func ClusterNamespace(customObject v1alpha1.AWSConfig) string {
-	return ClusterID(customObject)
+func ClusterID(cluster v1alpha1.Cluster) string {
+	return providerStatus(cluster).Cluster.ID
 }
 
-func BaseDomain(customObject v1alpha1.AWSConfig) string {
-	// TODO remove other zones and make it a BaseDomain in the CR.
-	// CloudFormation creates a separate HostedZone with the same name.
-	// Probably the easiest way for now is to just allow single domain for
-	// everything which we do now.
-	return customObject.Spec.AWS.HostedZones.API.Name
+func ClusterNamespace(cluster v1alpha1.Cluster) string {
+	return ClusterID(cluster)
 }

--- a/service/controller/clusterapi/v27/key/provider.go
+++ b/service/controller/clusterapi/v27/key/provider.go
@@ -1,4 +1,4 @@
-package legacykey
+package key
 
 import (
 	"encoding/json"

--- a/service/controller/clusterapi/v27/legacykey/key.go
+++ b/service/controller/clusterapi/v27/legacykey/key.go
@@ -228,8 +228,8 @@ func EC2ServiceDomain(customObject v1alpha1.AWSConfig) string {
 	return domain
 }
 
-func BaseDomain(customObject v1alpha1.AWSConfig) string {
-	// TODO remove other zones and make it a BaseDomain in the CR.
+func ClusterBaseDomain(customObject v1alpha1.AWSConfig) string {
+	// TODO remove other zones and make it a ClusterBaseDomain in the CR.
 	// CloudFormation creates a separate HostedZone with the same name.
 	// Probably the easiest way for now is to just allow single domain for
 	// everything which we do now.
@@ -253,7 +253,7 @@ func KubernetesAPISecurePort(customObject v1alpha1.AWSConfig) int {
 }
 
 func EtcdDomain(customObject v1alpha1.AWSConfig) string {
-	return strings.Join([]string{"etcd", ClusterID(customObject), "k8s", BaseDomain(customObject)}, ".")
+	return strings.Join([]string{"etcd", ClusterID(customObject), "k8s", ClusterBaseDomain(customObject)}, ".")
 }
 
 func EtcdPort(customObject v1alpha1.AWSConfig) int {

--- a/service/controller/clusterapi/v27/legacykey/key_test.go
+++ b/service/controller/clusterapi/v27/legacykey/key_test.go
@@ -50,9 +50,9 @@ func Test_AvailabilityZone(t *testing.T) {
 	}
 }
 
-func Test_ClusterBaseDomain(t *testing.T) {
+func Test_BaseDomain(t *testing.T) {
 	t.Parallel()
-	expectedClusterBaseDomain := "installtion.eu-central-1.aws.gigantic.io"
+	expectedBaseDomain := "installtion.eu-central-1.aws.gigantic.io"
 
 	customObject := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
@@ -66,9 +66,9 @@ func Test_ClusterBaseDomain(t *testing.T) {
 		},
 	}
 
-	ClusterBaseDomain := ClusterBaseDomain(customObject)
-	if ClusterBaseDomain != expectedClusterBaseDomain {
-		t.Fatalf("ClusterBaseDomain == %q, want %q", ClusterBaseDomain, expectedClusterBaseDomain)
+	baseDomain := ClusterBaseDomain(customObject)
+	if baseDomain != expectedBaseDomain {
+		t.Fatalf("BaseDomain == %q, want %q", baseDomain, expectedBaseDomain)
 	}
 }
 

--- a/service/controller/clusterapi/v27/legacykey/key_test.go
+++ b/service/controller/clusterapi/v27/legacykey/key_test.go
@@ -50,9 +50,9 @@ func Test_AvailabilityZone(t *testing.T) {
 	}
 }
 
-func Test_BaseDomain(t *testing.T) {
+func Test_ClusterBaseDomain(t *testing.T) {
 	t.Parallel()
-	expectedBaseDomain := "installtion.eu-central-1.aws.gigantic.io"
+	expectedClusterBaseDomain := "installtion.eu-central-1.aws.gigantic.io"
 
 	customObject := v1alpha1.AWSConfig{
 		Spec: v1alpha1.AWSConfigSpec{
@@ -66,9 +66,9 @@ func Test_BaseDomain(t *testing.T) {
 		},
 	}
 
-	baseDomain := BaseDomain(customObject)
-	if baseDomain != expectedBaseDomain {
-		t.Fatalf("BaseDomain == %q, want %q", baseDomain, expectedBaseDomain)
+	ClusterBaseDomain := ClusterBaseDomain(customObject)
+	if ClusterBaseDomain != expectedClusterBaseDomain {
+		t.Fatalf("ClusterBaseDomain == %q, want %q", ClusterBaseDomain, expectedClusterBaseDomain)
 	}
 }
 

--- a/service/controller/clusterapi/v27/resource/bridgezone/create.go
+++ b/service/controller/clusterapi/v27/resource/bridgezone/create.go
@@ -22,7 +22,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	baseDomain := legacykey.BaseDomain(customObject)
+	baseDomain := legacykey.ClusterBaseDomain(customObject)
 	intermediateZone := "k8s." + baseDomain
 	finalZone := legacykey.ClusterID(customObject) + ".k8s." + baseDomain
 

--- a/service/controller/clusterapi/v27/resource/bridgezone/delete.go
+++ b/service/controller/clusterapi/v27/resource/bridgezone/delete.go
@@ -21,7 +21,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	baseDomain := legacykey.BaseDomain(customObject)
+	baseDomain := legacykey.ClusterBaseDomain(customObject)
 	intermediateZone := "k8s." + baseDomain
 	finalZone := legacykey.ClusterID(customObject) + ".k8s." + baseDomain
 

--- a/service/controller/clusterapi/v27/resource/cpf/create.go
+++ b/service/controller/clusterapi/v27/resource/cpf/create.go
@@ -199,7 +199,7 @@ func (r *Resource) newRecordSetsParams(ctx context.Context, cr v1alpha1.AWSConfi
 	var recordSets *template.ParamsMainRecordSets
 	{
 		recordSets = &template.ParamsMainRecordSets{
-			BaseDomain:                 legacykey.BaseDomain(cr),
+			BaseDomain:                 legacykey.ClusterBaseDomain(cr),
 			ClusterID:                  legacykey.ClusterID(cr),
 			GuestHostedZoneNameServers: cc.Status.TenantCluster.HostedZoneNameServers,
 			Route53Enabled:             r.route53Enabled,

--- a/service/controller/clusterapi/v27/resource/cpf/template/render_test.go
+++ b/service/controller/clusterapi/v27/resource/cpf/template/render_test.go
@@ -16,12 +16,12 @@ func Test_Controller_Resource_CPF_Template_Render(t *testing.T) {
 		}
 		routeTables := &ParamsMainRouteTables{
 			PrivateRoutes: []ParamsMainRouteTablesRoute{
-				ParamsMainRouteTablesRoute{
+				{
 					PeerConnectionID: "PeerConnectionID",
 				},
 			},
 			PublicRoutes: []ParamsMainRouteTablesRoute{
-				ParamsMainRouteTablesRoute{
+				{
 					PeerConnectionID: "PeerConnectionID",
 				},
 			},

--- a/service/controller/clusterapi/v27/resource/ipam/create_test.go
+++ b/service/controller/clusterapi/v27/resource/ipam/create_test.go
@@ -139,7 +139,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 			subnet: mustParseCIDR("10.100.4.0/22"),
 			azs:    []string{"eu-west-1b"},
 			expectedAZs: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1b",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -158,7 +158,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 			subnet: mustParseCIDR("10.100.4.0/22"),
 			azs:    []string{"eu-west-1c", "eu-west-1a"},
 			expectedAZs: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1c",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -169,7 +169,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 						},
 					},
 				},
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1a",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -188,7 +188,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 			subnet: mustParseCIDR("10.100.4.0/22"),
 			azs:    []string{"eu-west-1a", "eu-west-1b", "eu-west-1c"},
 			expectedAZs: []v1alpha1.AWSConfigStatusAWSAvailabilityZone{
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1a",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -199,7 +199,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 						},
 					},
 				},
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1b",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{
@@ -210,7 +210,7 @@ func Test_splitSubnetToStatusAZs(t *testing.T) {
 						},
 					},
 				},
-				v1alpha1.AWSConfigStatusAWSAvailabilityZone{
+				{
 					Name: "eu-west-1c",
 					Subnet: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnet{
 						Private: v1alpha1.AWSConfigStatusAWSAvailabilityZoneSubnetPrivate{

--- a/service/controller/clusterapi/v27/resource/migration/resource_test.go
+++ b/service/controller/clusterapi/v27/resource/migration/resource_test.go
@@ -21,7 +21,7 @@ func Test_migrateSpec(t *testing.T) {
 			spec: providerv1alpha1.AWSConfigSpec{
 				AWS: providerv1alpha1.AWSConfigSpecAWS{
 					Workers: []providerv1alpha1.AWSConfigSpecAWSNode{
-						providerv1alpha1.AWSConfigSpecAWSNode{},
+						{},
 					},
 				},
 				Cluster: providerv1alpha1.Cluster{
@@ -50,7 +50,7 @@ func Test_migrateSpec(t *testing.T) {
 						},
 					},
 					Workers: []providerv1alpha1.AWSConfigSpecAWSNode{
-						providerv1alpha1.AWSConfigSpecAWSNode{},
+						{},
 					},
 				},
 				Cluster: providerv1alpha1.Cluster{
@@ -87,7 +87,7 @@ func Test_migrateSpec(t *testing.T) {
 						},
 					},
 					Workers: []providerv1alpha1.AWSConfigSpecAWSNode{
-						providerv1alpha1.AWSConfigSpecAWSNode{},
+						{},
 					},
 				},
 				Cluster: providerv1alpha1.Cluster{
@@ -120,7 +120,7 @@ func Test_migrateSpec(t *testing.T) {
 						},
 					},
 					Workers: []providerv1alpha1.AWSConfigSpecAWSNode{
-						providerv1alpha1.AWSConfigSpecAWSNode{},
+						{},
 					},
 				},
 				Cluster: providerv1alpha1.Cluster{

--- a/service/controller/clusterapi/v27/resource/s3bucket/create.go
+++ b/service/controller/clusterapi/v27/resource/s3bucket/create.go
@@ -121,7 +121,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				Bucket: aws.String(bucketInput.Name),
 				ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
 					Rules: []*s3.ServerSideEncryptionRule{
-						&s3.ServerSideEncryptionRule{
+						{
 							ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
 								SSEAlgorithm: aws.String(S3BucketEncryptionAlgorithm),
 							},


### PR DESCRIPTION
Towards Node Pools. Migrating the first key functions. The PR derailed more than anticipated due to formatting and renaming magic. 