### PR TITLE
drop legacy labels

### DIFF
--- a/service/controller/clusterapi/v27/legacykey/key.go
+++ b/service/controller/clusterapi/v27/legacykey/key.go
@@ -73,11 +73,8 @@ const (
 const (
 	LabelApp           = "app"
 	LabelCluster       = "giantswarm.io/cluster"
-	LabelCustomer      = "customer"
 	LabelOrganization  = "giantswarm.io/organization"
 	LabelVersionBundle = "giantswarm.io/version-bundle"
-
-	LegacyLabelCluster = "cluster"
 )
 
 const (

--- a/service/controller/clusterapi/v27/resource/service/desired.go
+++ b/service/controller/clusterapi/v27/resource/service/desired.go
@@ -28,8 +28,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			Namespace: legacykey.ClusterID(customObject),
 			Labels: map[string]string{
 				legacykey.LabelApp:           "master",
-				legacykey.LegacyLabelCluster: legacykey.ClusterID(customObject),
-				legacykey.LabelCustomer:      legacykey.OrganizationID(customObject),
 				legacykey.LabelCluster:       legacykey.ClusterID(customObject),
 				legacykey.LabelOrganization:  legacykey.OrganizationID(customObject),
 				legacykey.LabelVersionBundle: legacykey.VersionBundleVersion(customObject),

--- a/service/controller/clusterapi/v27/resource/service/resource_test.go
+++ b/service/controller/clusterapi/v27/resource/service/resource_test.go
@@ -26,8 +26,6 @@ func Test_toService(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -53,8 +51,6 @@ func Test_toService(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -83,8 +79,6 @@ func Test_toService(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -142,8 +136,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -169,8 +161,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -200,8 +190,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -227,8 +215,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy456",
-						legacykey.LabelCustomer:      "customer2",
 						legacykey.LabelCluster:       "xy456",
 						legacykey.LabelOrganization:  "org2",
 						legacykey.LabelVersionBundle: "1.2.4",
@@ -258,8 +244,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -285,8 +269,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -316,8 +298,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -343,8 +323,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -379,8 +357,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",
@@ -407,8 +383,6 @@ func Test_isServiceModified(t *testing.T) {
 					Namespace: "xy123",
 					Labels: map[string]string{
 						legacykey.LabelApp:           "master",
-						legacykey.LegacyLabelCluster: "xy123",
-						legacykey.LabelCustomer:      "customer1",
 						legacykey.LabelCluster:       "xy123",
 						legacykey.LabelOrganization:  "org1",
 						legacykey.LabelVersionBundle: "1.2.3",


### PR DESCRIPTION
As discussed in Slack: https://gigantic.slack.com/archives/C2MS2VB37/p1557129010041700. I would like to have **3 approvals** for this change. 