### PR TITLE
Remove beta from default storage class

### DIFF
--- a/service/controller/clusterapi/v27/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/clusterapi/v27/templates/cloudconfig/instance_storage_class.go
@@ -1,6 +1,6 @@
 package cloudconfig
 
-const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1beta1
+const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2

--- a/service/controller/clusterapi/v27/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/clusterapi/v27/templates/cloudconfig/instance_storage_class.go
@@ -5,7 +5,7 @@ kind: StorageClass
 metadata:
   name: gp2
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/service/controller/legacy/v27/templates/cloudconfig/instance_storage_class.go
+++ b/service/controller/legacy/v27/templates/cloudconfig/instance_storage_class.go
@@ -1,11 +1,11 @@
 package cloudconfig
 
-const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1beta1
+const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists


### PR DESCRIPTION
Current Kubernetes version complaints about `default` storage because of having an old annotation parameter.  