### PR TITLE
fetch ASG name in a different way

### DIFF
--- a/service/controller/clusterapi/v27/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v27/resource/asgstatus/create.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,60 +25,73 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCCP.ASG.Name
-	if workerASGName == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
+	var asgName string
+	{
+		i := &cloudformation.DescribeStackResourceInput{
+			LogicalResourceId: aws.String(legacykey.WorkerASGRef),
+			StackName:         aws.String(legacykey.StackNameTCCP(cr)),
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.CloudFormation.DescribeStackResource(i)
+		if IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		asgName = *o.StackResourceDetail.PhysicalResourceId
 	}
 
 	var asg *autoscaling.Group
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding ASG %#q", workerASGName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding ASG %#q", asgName))
 
 		i := &autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: []*string{
-				&workerASGName,
+				&asgName,
 			},
 		}
+
 		o, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		if len(o.AutoScalingGroups) != 1 {
-			return microerror.Maskf(executionFailedError, "there must be one item for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "there must be one item for ASG %#q", asgName)
 		}
 		asg = o.AutoScalingGroups[0]
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ASG %#q", workerASGName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ASG %#q", asgName))
 	}
 
 	var desiredCapacity int
 	{
 		if asg.DesiredCapacity == nil {
-			return microerror.Maskf(executionFailedError, "desired capacity must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "desired capacity must not be empty for ASG %#q", asgName)
 		}
 		desiredCapacity = int(*asg.DesiredCapacity)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desired capacity of %#q is %d", workerASGName, desiredCapacity))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desired capacity of %#q is %d", asgName, desiredCapacity))
 	}
 
 	var maxSize int
 	{
 		if asg.MaxSize == nil {
-			return microerror.Maskf(executionFailedError, "max size must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "max size must not be empty for ASG %#q", asgName)
 		}
 		maxSize = int(*asg.MaxSize)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("max size of %#q is %d", workerASGName, maxSize))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("max size of %#q is %d", asgName, maxSize))
 	}
 
 	var minSize int
 	{
 		if asg.MinSize == nil {
-			return microerror.Maskf(executionFailedError, "min size must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "min size must not be empty for ASG %#q", asgName)
 		}
 		minSize = int(*asg.MinSize)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", workerASGName, minSize))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", asgName, minSize))
 	}
 
 	{
@@ -109,6 +124,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		cc.Status.TenantCluster.TCCP.ASG.DesiredCapacity = desiredCapacity
 		cc.Status.TenantCluster.TCCP.ASG.MaxSize = maxSize
 		cc.Status.TenantCluster.TCCP.ASG.MinSize = minSize
+		cc.Status.TenantCluster.TCCP.ASG.Name = asgName
 	}
 
 	return nil

--- a/service/controller/clusterapi/v27/resource/asgstatus/error.go
+++ b/service/controller/clusterapi/v27/resource/asgstatus/error.go
@@ -1,6 +1,8 @@
 package asgstatus
 
 import (
+	"strings"
+
 	"github.com/giantswarm/microerror"
 )
 
@@ -20,4 +22,27 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "does not exist") {
+		return true
+	}
+
+	if c == notFoundError {
+		return true
+	}
+
+	return false
 }

--- a/service/controller/clusterapi/v27/resource/tccpoutputs/create.go
+++ b/service/controller/clusterapi/v27/resource/tccpoutputs/create.go
@@ -118,14 +118,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, WorkerASGNameKey)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		cc.Status.TenantCluster.TCCP.ASG.Name = v
-	}
-
-	{
 		v, err := cloudFormation.GetOutputValue(outputs, legacykey.VersionBundleVersionKey)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/legacy/v27/resource/asgstatus/create.go
+++ b/service/controller/legacy/v27/resource/asgstatus/create.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,60 +25,73 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCCP.ASG.Name
-	if workerASGName == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
+	var asgName string
+	{
+		i := &cloudformation.DescribeStackResourceInput{
+			LogicalResourceId: aws.String(key.WorkerASGRef),
+			StackName:         aws.String(key.MainGuestStackName(cr)),
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.CloudFormation.DescribeStackResource(i)
+		if IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		asgName = *o.StackResourceDetail.PhysicalResourceId
 	}
 
 	var asg *autoscaling.Group
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding ASG %#q", workerASGName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding ASG %#q", asgName))
 
 		i := &autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: []*string{
-				&workerASGName,
+				&asgName,
 			},
 		}
+
 		o, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(i)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		if len(o.AutoScalingGroups) != 1 {
-			return microerror.Maskf(executionFailedError, "there must be one item for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "there must be one item for ASG %#q", asgName)
 		}
 		asg = o.AutoScalingGroups[0]
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ASG %#q", workerASGName))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found ASG %#q", asgName))
 	}
 
 	var desiredCapacity int
 	{
 		if asg.DesiredCapacity == nil {
-			return microerror.Maskf(executionFailedError, "desired capacity must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "desired capacity must not be empty for ASG %#q", asgName)
 		}
 		desiredCapacity = int(*asg.DesiredCapacity)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desired capacity of %#q is %d", workerASGName, desiredCapacity))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desired capacity of %#q is %d", asgName, desiredCapacity))
 	}
 
 	var maxSize int
 	{
 		if asg.MaxSize == nil {
-			return microerror.Maskf(executionFailedError, "max size must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "max size must not be empty for ASG %#q", asgName)
 		}
 		maxSize = int(*asg.MaxSize)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("max size of %#q is %d", workerASGName, maxSize))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("max size of %#q is %d", asgName, maxSize))
 	}
 
 	var minSize int
 	{
 		if asg.MinSize == nil {
-			return microerror.Maskf(executionFailedError, "min size must not be empty for ASG %#q", workerASGName)
+			return microerror.Maskf(executionFailedError, "min size must not be empty for ASG %#q", asgName)
 		}
 		minSize = int(*asg.MinSize)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", workerASGName, minSize))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", asgName, minSize))
 	}
 
 	{
@@ -109,6 +124,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		cc.Status.TenantCluster.TCCP.ASG.DesiredCapacity = desiredCapacity
 		cc.Status.TenantCluster.TCCP.ASG.MaxSize = maxSize
 		cc.Status.TenantCluster.TCCP.ASG.MinSize = minSize
+		cc.Status.TenantCluster.TCCP.ASG.Name = asgName
 	}
 
 	return nil

--- a/service/controller/legacy/v27/resource/asgstatus/error.go
+++ b/service/controller/legacy/v27/resource/asgstatus/error.go
@@ -1,6 +1,8 @@
 package asgstatus
 
 import (
+	"strings"
+
 	"github.com/giantswarm/microerror"
 )
 
@@ -28,5 +30,19 @@ var notFoundError = &microerror.Error{
 
 // IsNotFound asserts notFoundError.
 func IsNotFound(err error) bool {
-	return microerror.Cause(err) == notFoundError
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "does not exist") {
+		return true
+	}
+
+	if c == notFoundError {
+		return true
+	}
+
+	return false
 }

--- a/service/controller/legacy/v27/resource/asgstatus/error.go
+++ b/service/controller/legacy/v27/resource/asgstatus/error.go
@@ -21,3 +21,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/legacy/v27/resource/tccpoutputs/create.go
+++ b/service/controller/legacy/v27/resource/tccpoutputs/create.go
@@ -118,14 +118,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, WorkerASGNameKey)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		cc.Status.TenantCluster.TCCP.ASG.Name = v
-	}
-
-	{
 		v, err := cloudFormation.GetOutputValue(outputs, key.VersionBundleVersionKey)
 		if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Towards Node Pools. We need to find a better way to deal with ASG name information as we are about to not use the CR Status as means for an intermediate storage anymore. I will mirror the changes to the clusterapi resources before merging. 