### PR TITLE
Wire cluster-api client to IPAM resources

### DIFF
--- a/service/controller/clusterapi/cluster.go
+++ b/service/controller/clusterapi/cluster.go
@@ -204,6 +204,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 		c := v27.ClusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
 			ControlPlaneAWSClients: controlPlaneAWSClients,
+			CMAClient:              config.CMAClient,
 			G8sClient:              config.G8sClient,
 			HostAWSConfig: awsclient.Config{
 				AccessKeyID:     config.HostAWSConfig.AccessKeyID,

--- a/service/controller/clusterapi/v27/cluster_resource_set.go
+++ b/service/controller/clusterapi/v27/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v27/adapter"
@@ -63,6 +64,7 @@ const (
 type ClusterResourceSetConfig struct {
 	CertsSearcher          certs.Interface
 	ControlPlaneAWSClients aws.Clients
+	CMAClient              clientset.Interface
 	G8sClient              versioned.Interface
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
@@ -241,6 +243,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/clusterapi/v27/resource/ipam/resource.go
+++ b/service/controller/clusterapi/v27/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator
@@ -25,6 +27,7 @@ type Config struct {
 }
 
 type Resource struct {
+	cmaClient        clientset.Interface
 	g8sClient        versioned.Interface
 	logger           micrologger.Logger
 	networkAllocator network.Allocator
@@ -35,6 +38,9 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -53,6 +59,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
+		cmaClient:        config.CMAClient,
 		g8sClient:        config.G8sClient,
 		logger:           config.Logger,
 		networkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/cluster.go
+++ b/service/controller/legacy/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/randomkeys"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	awsclient "github.com/giantswarm/aws-operator/client/aws"
 	v22 "github.com/giantswarm/aws-operator/service/controller/legacy/v22"
@@ -41,6 +42,7 @@ import (
 )
 
 type ClusterConfig struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	K8sClient        kubernetes.Interface
 	K8sExtClient     apiextensionsclient.Interface
@@ -216,6 +218,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v22.ClusterResourceSetConfig{
 			CertsSearcher: certsSearcher,
+			CMAClient:     config.CMAClient,
 			G8sClient:     config.G8sClient,
 			HostAWSConfig: awsclient.Config{
 				AccessKeyID:     config.HostAWSConfig.AccessKeyID,
@@ -271,6 +274,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v22patch1.ClusterResourceSetConfig{
 			CertsSearcher: certsSearcher,
+			CMAClient:     config.CMAClient,
 			G8sClient:     config.G8sClient,
 			HostAWSConfig: awsclient.Config{
 				AccessKeyID:     config.HostAWSConfig.AccessKeyID,
@@ -326,6 +330,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v23.ClusterResourceSetConfig{
 			CertsSearcher: certsSearcher,
+			CMAClient:     config.CMAClient,
 			G8sClient:     config.G8sClient,
 			HostAWSConfig: awsclient.Config{
 				AccessKeyID:     config.HostAWSConfig.AccessKeyID,
@@ -381,6 +386,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v24.ClusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
+			CMAClient:              config.CMAClient,
 			ControlPlaneAWSClients: controlPlaneAWSClients,
 			G8sClient:              config.G8sClient,
 			HostAWSConfig: awsclient.Config{
@@ -435,6 +441,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v25.ClusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
+			CMAClient:              config.CMAClient,
 			ControlPlaneAWSClients: controlPlaneAWSClients,
 			G8sClient:              config.G8sClient,
 			HostAWSConfig: awsclient.Config{
@@ -489,6 +496,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v26.ClusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
+			CMAClient:              config.CMAClient,
 			ControlPlaneAWSClients: controlPlaneAWSClients,
 			G8sClient:              config.G8sClient,
 			HostAWSConfig: awsclient.Config{
@@ -543,6 +551,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 	{
 		c := v27.ClusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
+			CMAClient:              config.CMAClient,
 			ControlPlaneAWSClients: controlPlaneAWSClients,
 			G8sClient:              config.G8sClient,
 			HostAWSConfig: awsclient.Config{

--- a/service/controller/legacy/cluster_test.go
+++ b/service/controller/legacy/cluster_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	clusterapiclientfake "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
 )
 
 func newTestClusterConfig() ClusterConfig {
@@ -31,6 +32,7 @@ func newTestClusterConfig() ClusterConfig {
 	}
 
 	return ClusterConfig{
+		CMAClient:        clusterapiclientfake.NewSimpleClientset(),
 		G8sClient:        versionedfake.NewSimpleClientset(),
 		K8sClient:        kubernetesfake.NewSimpleClientset(),
 		K8sExtClient:     apiextensionsclientfake.NewSimpleClientset(),

--- a/service/controller/legacy/v22/cluster_resource_set.go
+++ b/service/controller/legacy/v22/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
@@ -57,6 +58,7 @@ const (
 
 type ClusterResourceSetConfig struct {
 	CertsSearcher      certs.Interface
+	CMAClient          clientset.Interface
 	G8sClient          versioned.Interface
 	HostAWSConfig      aws.Config
 	HostAWSClients     aws.Clients
@@ -258,6 +260,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v22/resource/ipam/resource.go
+++ b/service/controller/legacy/v22/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator

--- a/service/controller/legacy/v22patch1/cluster_resource_set.go
+++ b/service/controller/legacy/v22patch1/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
@@ -58,6 +59,7 @@ const (
 
 type ClusterResourceSetConfig struct {
 	CertsSearcher      certs.Interface
+	CMAClient          clientset.Interface
 	G8sClient          versioned.Interface
 	HostAWSConfig      aws.Config
 	HostAWSClients     aws.Clients
@@ -259,6 +261,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v22patch1/resource/ipam/resource.go
+++ b/service/controller/legacy/v22patch1/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator

--- a/service/controller/legacy/v23/cluster_resource_set.go
+++ b/service/controller/legacy/v23/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	awsservice "github.com/giantswarm/aws-operator/service/aws"
@@ -57,6 +58,7 @@ const (
 
 type ClusterResourceSetConfig struct {
 	CertsSearcher      certs.Interface
+	CMAClient          clientset.Interface
 	G8sClient          versioned.Interface
 	HostAWSConfig      aws.Config
 	HostAWSClients     aws.Clients
@@ -258,6 +260,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v23/resource/ipam/resource.go
+++ b/service/controller/legacy/v23/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator

--- a/service/controller/legacy/v24/cluster_resource_set.go
+++ b/service/controller/legacy/v24/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v24/adapter"
@@ -62,6 +63,7 @@ const (
 type ClusterResourceSetConfig struct {
 	CertsSearcher          certs.Interface
 	ControlPlaneAWSClients aws.Clients
+	CMAClient              clientset.Interface
 	G8sClient              versioned.Interface
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
@@ -227,6 +229,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v24/resource/ipam/resource.go
+++ b/service/controller/legacy/v24/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator
@@ -25,6 +27,7 @@ type Config struct {
 }
 
 type Resource struct {
+	cmaClient        clientset.Interface
 	g8sClient        versioned.Interface
 	logger           micrologger.Logger
 	networkAllocator network.Allocator
@@ -35,6 +38,9 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -53,6 +59,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
+		cmaClient:        config.CMAClient,
 		g8sClient:        config.G8sClient,
 		logger:           config.Logger,
 		networkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v25/cluster_resource_set.go
+++ b/service/controller/legacy/v25/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/adapter"
@@ -64,6 +65,7 @@ const (
 type ClusterResourceSetConfig struct {
 	CertsSearcher          certs.Interface
 	ControlPlaneAWSClients aws.Clients
+	CMAClient              clientset.Interface
 	G8sClient              versioned.Interface
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
@@ -241,6 +243,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v25/resource/ipam/resource.go
+++ b/service/controller/legacy/v25/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator
@@ -25,6 +27,7 @@ type Config struct {
 }
 
 type Resource struct {
+	cmaClient        clientset.Interface
 	g8sClient        versioned.Interface
 	logger           micrologger.Logger
 	networkAllocator network.Allocator
@@ -35,6 +38,9 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -53,6 +59,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
+		cmaClient:        config.CMAClient,
 		g8sClient:        config.G8sClient,
 		logger:           config.Logger,
 		networkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v26/cluster_resource_set.go
+++ b/service/controller/legacy/v26/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/adapter"
@@ -64,6 +65,7 @@ const (
 type ClusterResourceSetConfig struct {
 	CertsSearcher          certs.Interface
 	ControlPlaneAWSClients aws.Clients
+	CMAClient              clientset.Interface
 	G8sClient              versioned.Interface
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
@@ -241,6 +243,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v26/resource/ipam/resource.go
+++ b/service/controller/legacy/v26/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator
@@ -25,6 +27,7 @@ type Config struct {
 }
 
 type Resource struct {
+	cmaClient        clientset.Interface
 	g8sClient        versioned.Interface
 	logger           micrologger.Logger
 	networkAllocator network.Allocator
@@ -35,6 +38,9 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -53,6 +59,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
+		cmaClient:        config.CMAClient,
 		g8sClient:        config.G8sClient,
 		logger:           config.Logger,
 		networkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v27/cluster_resource_set.go
+++ b/service/controller/legacy/v27/cluster_resource_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/statusresource"
 	"github.com/giantswarm/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/adapter"
@@ -63,6 +64,7 @@ const (
 type ClusterResourceSetConfig struct {
 	CertsSearcher          certs.Interface
 	ControlPlaneAWSClients aws.Clients
+	CMAClient              clientset.Interface
 	G8sClient              versioned.Interface
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
@@ -241,6 +243,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var ipamResource controller.Resource
 	{
 		c := ipam.Config{
+			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
 			NetworkAllocator: config.NetworkAllocator,

--- a/service/controller/legacy/v27/resource/ipam/resource.go
+++ b/service/controller/legacy/v27/resource/ipam/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/network"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 const (
@@ -15,6 +16,7 @@ const (
 )
 
 type Config struct {
+	CMAClient        clientset.Interface
 	G8sClient        versioned.Interface
 	Logger           micrologger.Logger
 	NetworkAllocator network.Allocator
@@ -25,6 +27,7 @@ type Config struct {
 }
 
 type Resource struct {
+	cmaClient        clientset.Interface
 	g8sClient        versioned.Interface
 	logger           micrologger.Logger
 	networkAllocator network.Allocator
@@ -35,6 +38,9 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
 	}
@@ -53,6 +59,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newResource := &Resource{
+		cmaClient:        config.CMAClient,
 		g8sClient:        config.G8sClient,
 		logger:           config.Logger,
 		networkAllocator: config.NetworkAllocator,

--- a/service/service.go
+++ b/service/service.go
@@ -242,6 +242,7 @@ func New(config Config) (*Service, error) {
 		}
 
 		c := legacy.ClusterConfig{
+			CMAClient:        cmaClient,
 			G8sClient:        g8sClient,
 			K8sClient:        k8sClient,
 			K8sExtClient:     k8sExtClient,


### PR DESCRIPTION
In order to be able to gather existing network allocations from Cluster and
MachineDeployment CRs, there must be appropriate client configured for
resources.