### PR TITLE
add MachineDeployment to Controller Context

### DIFF
--- a/service/controller/clusterapi/v27/controllercontext/status.go
+++ b/service/controller/clusterapi/v27/controllercontext/status.go
@@ -1,6 +1,9 @@
 package controllercontext
 
-import "github.com/aws/aws-sdk-go/service/ec2"
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
 
 type ContextStatus struct {
 	ControlPlane  ContextStatusControlPlane
@@ -57,11 +60,12 @@ type ContextStatusTenantClusterMasterInstance struct {
 }
 
 type ContextStatusTenantClusterTCCP struct {
-	ASG             ContextStatusTenantClusterTCCPASG
-	IsTransitioning bool
-	RouteTables     []*ec2.RouteTable
-	Subnets         []*ec2.Subnet
-	VPC             ContextStatusTenantClusterTCCPVPC
+	ASG               ContextStatusTenantClusterTCCPASG
+	IsTransitioning   bool
+	MachineDeployment v1alpha1.MachineDeployment
+	RouteTables       []*ec2.RouteTable
+	Subnets           []*ec2.Subnet
+	VPC               ContextStatusTenantClusterTCCPVPC
 }
 
 type ContextStatusTenantClusterTCCPVPC struct {


### PR DESCRIPTION
This is some ugly hack we have to do meanwhile we transition to the CMA (Cluster Management API) types. I will provide a PR to fetch the correct Machine Deployment later, so that the context will be properly filled. Here I just want to have a simple PR that introduces the rather huge implications. During a reconciliation loop the Machine Deployment can then be accessed with like this. 

```
cc.Status.TenantCluster.TCCP.MachineDeployment
```

After our type transitioning phase we introduce a separate controller and move resources once again. Then we can drop the machine deployment from the controller context again. 