### PR TITLE
Use longer InitialInterval for backoff when deleting EBS volume

### DIFF
--- a/service/controller/legacy/v22/ebs/ebs.go
+++ b/service/controller/legacy/v22/ebs/ebs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	cenkaltibackoff "github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,24 @@ func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+
+	var b cenkaltibackoff.BackOff
+	{
+		b := &cenkaltibackoff.ExponentialBackOff{
+			// If EBS cannot be deleted on first try, it's probably still in use so it
+			// makes sense to give some time for unmount/detach logic to complete
+			// before retrying.
+			InitialInterval:     5 * time.Second,
+			RandomizationFactor: cenkaltibackoff.DefaultRandomizationFactor,
+			Multiplier:          cenkaltibackoff.DefaultMultiplier,
+			MaxInterval:         30 * time.Second,
+			MaxElapsedTime:      5 * time.Second,
+			Clock:               cenkaltibackoff.SystemClock,
+		}
+
+		b.Reset()
+	}
+
 	n := backoff.NewNotifier(e.logger, context.Background())
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {

--- a/service/controller/legacy/v22patch1/ebs/ebs.go
+++ b/service/controller/legacy/v22patch1/ebs/ebs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	cenkaltibackoff "github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,24 @@ func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+
+	var b cenkaltibackoff.BackOff
+	{
+		b := &cenkaltibackoff.ExponentialBackOff{
+			// If EBS cannot be deleted on first try, it's probably still in use so it
+			// makes sense to give some time for unmount/detach logic to complete
+			// before retrying.
+			InitialInterval:     5 * time.Second,
+			RandomizationFactor: cenkaltibackoff.DefaultRandomizationFactor,
+			Multiplier:          cenkaltibackoff.DefaultMultiplier,
+			MaxInterval:         30 * time.Second,
+			MaxElapsedTime:      5 * time.Second,
+			Clock:               cenkaltibackoff.SystemClock,
+		}
+
+		b.Reset()
+	}
+
 	n := backoff.NewNotifier(e.logger, context.Background())
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {

--- a/service/controller/legacy/v23/ebs/ebs.go
+++ b/service/controller/legacy/v23/ebs/ebs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	cenkaltibackoff "github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,24 @@ func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+
+	var b cenkaltibackoff.BackOff
+	{
+		b := &cenkaltibackoff.ExponentialBackOff{
+			// If EBS cannot be deleted on first try, it's probably still in use so it
+			// makes sense to give some time for unmount/detach logic to complete
+			// before retrying.
+			InitialInterval:     5 * time.Second,
+			RandomizationFactor: cenkaltibackoff.DefaultRandomizationFactor,
+			Multiplier:          cenkaltibackoff.DefaultMultiplier,
+			MaxInterval:         30 * time.Second,
+			MaxElapsedTime:      5 * time.Second,
+			Clock:               cenkaltibackoff.SystemClock,
+		}
+
+		b.Reset()
+	}
+
 	n := backoff.NewNotifier(e.logger, context.Background())
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {

--- a/service/controller/legacy/v24/ebs/ebs.go
+++ b/service/controller/legacy/v24/ebs/ebs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	cenkaltibackoff "github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -62,7 +63,24 @@ func (e *EBS) DeleteVolume(ctx context.Context, volumeID string) error {
 
 		return nil
 	}
-	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+
+	var b cenkaltibackoff.BackOff
+	{
+		b := &cenkaltibackoff.ExponentialBackOff{
+			// If EBS cannot be deleted on first try, it's probably still in use so it
+			// makes sense to give some time for unmount/detach logic to complete
+			// before retrying.
+			InitialInterval:     5 * time.Second,
+			RandomizationFactor: cenkaltibackoff.DefaultRandomizationFactor,
+			Multiplier:          cenkaltibackoff.DefaultMultiplier,
+			MaxInterval:         30 * time.Second,
+			MaxElapsedTime:      5 * time.Second,
+			Clock:               cenkaltibackoff.SystemClock,
+		}
+
+		b.Reset()
+	}
+
 	n := backoff.NewNotifier(e.logger, context.Background())
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {


### PR DESCRIPTION
When deleting cluster the EBS volume deletion fails on few first tries as the
volume is still being unmounted/detached. With default backoff configuration
this causes multiple retries within short time period.

Unmounting and detaching is often relatively slow operation so it makes sense
to have higher InitialInterval before first retry. This way we don't storm AWS
API with requests that we almost certainly know will fail.