### PR TITLE
drop CR status update for asgstatus resource due to type switch

### DIFF
--- a/service/controller/clusterapi/v27/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v27/resource/asgstatus/create.go
@@ -8,8 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v27/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v27/key"
@@ -92,32 +90,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 		minSize = int(*asg.MinSize)
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("min size of %#q is %d", asgName, minSize))
-	}
-
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "updating status with desired capacity")
-
-		newObj, err := r.g8sClient.ProviderV1alpha1().AWSConfigs(cr.GetNamespace()).Get(cr.GetName(), metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if newObj.Status.Cluster.Scaling.DesiredCapacity != desiredCapacity {
-			newObj.Status.Cluster.Scaling.DesiredCapacity = desiredCapacity
-			_, err = r.g8sClient.ProviderV1alpha1().AWSConfigs(newObj.GetNamespace()).UpdateStatus(newObj)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "updated status with desired capacity")
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-			reconciliationcanceledcontext.SetCanceled(ctx)
-
-			return nil
-		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not update status with desired capacity")
-		}
 	}
 
 	{


### PR DESCRIPTION
We do not work with the AWSConfig CR anymore and thus do not have to update its status in the clusterapi controller. 