### PR TITLE
Activate gathering of Cluster CR network allocations in IPAM

### DIFF
--- a/service/controller/clusterapi/v27/resource/ipam/create.go
+++ b/service/controller/clusterapi/v27/resource/ipam/create.go
@@ -118,24 +118,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v22/resource/ipam/create.go
+++ b/service/controller/legacy/v22/resource/ipam/create.go
@@ -179,24 +179,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-			TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v22patch1/resource/ipam/create.go
+++ b/service/controller/legacy/v22patch1/resource/ipam/create.go
@@ -179,24 +179,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v23/resource/ipam/create.go
+++ b/service/controller/legacy/v23/resource/ipam/create.go
@@ -179,7 +179,6 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/* TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
 	g.Go(func() error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
@@ -195,7 +194,6 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 
 		return nil
 	})
-	*/
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v24/resource/ipam/create.go
+++ b/service/controller/legacy/v24/resource/ipam/create.go
@@ -179,24 +179,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v25/resource/ipam/create.go
+++ b/service/controller/legacy/v25/resource/ipam/create.go
@@ -128,24 +128,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v26/resource/ipam/create.go
+++ b/service/controller/legacy/v26/resource/ipam/create.go
@@ -128,24 +128,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {

--- a/service/controller/legacy/v27/resource/ipam/create.go
+++ b/service/controller/legacy/v27/resource/ipam/create.go
@@ -128,24 +128,21 @@ func (r *Resource) getReservedNetworks(ctx context.Context) ([]net.IPNet, error)
 		return nil
 	})
 
-	/*
-		TODO(tuommaki): Activate this once there's CRD registered for Cluster type.
-		g.Go(func() error {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
+	g.Go(func() error {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding allocated subnets from Cluster CRs")
 
-			subnets, err := getClusterSubnets(r.cmaClient)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			mutex.Lock()
-			reservedSubnets = append(reservedSubnets, subnets...)
-			mutex.Unlock()
+		subnets, err := getClusterSubnets(r.cmaClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		mutex.Lock()
+		reservedSubnets = append(reservedSubnets, subnets...)
+		mutex.Unlock()
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnets from Cluster CRs")
 
-			return nil
-		})
-	*/
+		return nil
+	})
 
 	err = g.Wait()
 	if err != nil {


### PR DESCRIPTION
When finding out existing network allocations, gather also ones defined in
Cluster CR objects now that Cluster CRD is registered.