### PR TITLE
Use desired capacity to count number nodes

### DIFF
--- a/service/controller/clusterapi/v27/legacykey/key.go
+++ b/service/controller/clusterapi/v27/legacykey/key.go
@@ -494,7 +494,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v22/key/key.go
+++ b/service/controller/legacy/v22/key/key.go
@@ -613,7 +613,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v22patch1/key/key.go
+++ b/service/controller/legacy/v22patch1/key/key.go
@@ -614,7 +614,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v23/key/key.go
+++ b/service/controller/legacy/v23/key/key.go
@@ -613,7 +613,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v24/key/key.go
+++ b/service/controller/legacy/v24/key/key.go
@@ -601,7 +601,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v25/key/key.go
+++ b/service/controller/legacy/v25/key/key.go
@@ -598,7 +598,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v26/key/key.go
+++ b/service/controller/legacy/v26/key/key.go
@@ -598,7 +598,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }

--- a/service/controller/legacy/v27/key/key.go
+++ b/service/controller/legacy/v27/key/key.go
@@ -594,7 +594,8 @@ func ToNodeCount(v interface{}) (int, error) {
 		return 0, microerror.Mask(err)
 	}
 
-	nodeCount := MasterCount(customObject) + WorkerCount(customObject)
+	// DesiredCapacity only returns number of workers, so we need to add the master
+	nodeCount := customObject.Status.Cluster.Scaling.DesiredCapacity + 1
 
 	return nodeCount, nil
 }


### PR DESCRIPTION
Cluster custom resource does not reflect the real state anymore, using the desired capacity works even if the autoscaling is active.