### PR TITLE
Update vendor bundle

### DIFF
--- a/service/controller/legacy/v27/version_bundle.go
+++ b/service/controller/legacy/v27/version_bundle.go
@@ -8,9 +8,14 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "encrypter",
-				Description: "Fixes for AWS China.",
-				Kind:        versionbundle.KindChanged,
+				Component:   "aws-operator",
+				Description: "Ensure the usage of the correct encryption key for AWS China.",
+				Kind:        versionbundle.KindFixed,
+			},
+			{
+				Component:   "aws-operator",
+				Description: "Prevent race conditions in decryption units for AWS China.",
+				Kind:        versionbundle.KindFixed,
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/legacy/v27/version_bundle.go
+++ b/service/controller/legacy/v27/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "encrypter",
+				Description: "Fixes for AWS China.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
Add a description to version bundle.

The main two PRs 
- https://github.com/giantswarm/aws-operator/pull/1581
- https://github.com/giantswarm/aws-operator/pull/1655

in order to make working the operator in China are related to internal components which we usually don't expose in the changelog. For such this reason I put there a more generic message.

Last word to the @giantswarm/team-ludacris and ultimately to @giantswarm/sig-operator .

Once merged i'll create a new bundle both for `legacy` and `clusterapi`
