### PR TITLE
helm: add aws-operator chart

### DIFF
--- a/helm/aws-operator/Chart.yaml
+++ b/helm/aws-operator/Chart.yaml
@@ -1,0 +1,2 @@
+name: aws-operator
+version: [[ .Version ]]

--- a/helm/aws-operator/templates/00-service-account.yaml
+++ b/helm/aws-operator/templates/00-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-operator
+  namespace: {{ .Values.namespace }}

--- a/helm/aws-operator/templates/01-rbac.yaml
+++ b/helm/aws-operator/templates/01-rbac.yaml
@@ -1,0 +1,141 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-operator
+rules:
+  - apiGroups:
+      - cluster.giantswarm.io
+    resources:
+      - awses
+    verbs:
+      - "*"
+  - apiGroups:
+      - cluster.k8s.io
+    resources:
+      - clusters
+      - machinedeployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups:
+      - extensions
+    resources:
+      - thirdpartyresources
+    verbs:
+      - "*"
+  - apiGroups:
+      - provider.giantswarm.io
+    resources:
+      - awsconfigs
+      - awsconfigs/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - provider.giantswarm.io
+    resources:
+      - awsconfigs/status
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - core.giantswarm.io
+    resources:
+      - nodeconfigs
+    verbs:
+      - "*"
+  - apiGroups:
+      - core.giantswarm.io
+    resources:
+      - drainerconfigs
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - aws-operator-configmap
+    verbs:
+      - get
+  - nonResourceURLs:
+      - "/"
+      - "/healthz"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-operator
+subjects:
+  - kind: ServiceAccount
+    name: aws-operator
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: aws-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-operator-psp
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - aws-operator-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-operator-psp
+subjects:
+  - kind: ServiceAccount
+    name: aws-operator
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: aws-operator-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/aws-operator/templates/02-psp.yaml
+++ b/helm/aws-operator/templates/02-psp.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: aws-operator-psp
+spec:
+  privileged: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'secret'
+    - 'configMap'
+    - 'hostPath'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false

--- a/helm/aws-operator/templates/03-configmap.yaml
+++ b/helm/aws-operator/templates/03-configmap.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-operator-configmap
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+    server:
+      enable:
+        debug:
+          server: true
+      listen:
+        address: 'http://0.0.0.0:8000'
+    service:
+      aws:
+        accessLogsExpiration: '{{ .Values.Installation.V1.Provider.AWS.S3AccessLogsExpiration }}'
+        advancedMonitoringEC2: '{{ .Values.Installation.V1.Provider.AWS.AdvancedMonitoringEC2 }}'
+        availabilityZones: '{{ range $index, $element := .Values.Installation.V1.Provider.AWS.AvailabilityZones }}{{if $index}} {{end}}{{$element}}{{end}}'
+        encrypter: '{{ .Values.Installation.V1.Provider.AWS.Encrypter }}'
+        includeTags: '{{ .Values.Installation.V1.Provider.AWS.IncludeTags }}'
+        loggingBucket:
+          delete: '{{ .Values.Installation.V1.Provider.AWS.DeleteLoggingBucket }}'
+        podInfraContainerImage: '{{ .Values.Installation.V1.Provider.AWS.PodInfraContainerImage }}'
+        region: '{{ .Values.Installation.V1.Provider.AWS.Region }}'
+        route53:
+          enabled: '{{ .Values.Installation.V1.Provider.AWS.Route53.Enabled }}'
+        routeTables: '{{ .Values.Installation.V1.Provider.AWS.RouteTableNames }}'
+        trustedAdvisor:
+          enabled: '{{ .Values.Installation.V1.Provider.AWS.TrustedAdvisor.Enabled }}'
+        vaultAddress: '{{ .Values.Installation.V1.Auth.Vault.Address }}'
+        vpcPeerID: '{{ .Values.Installation.V1.Provider.AWS.VPCPeerID }}'
+      cluster:
+        calico:
+          cidr: '{{ .Values.Installation.V1.Guest.Calico.CIDR }}'
+          mtu: 1430
+          subnet: '{{ .Values.Installation.V1.Guest.Calico.Subnet }}'
+        docker:
+          daemon:
+            cidr: '{{ .Values.Installation.V1.Guest.Docker.CIDR }}'
+        kubernetes:
+          api:
+            clusterIPRange: '{{ .Values.Installation.V1.Guest.Kubernetes.API.ClusterIPRange }}'
+          networkSetup:
+            docker:
+              image: '{{ .Values.Installation.V1.Registry.Domain }}/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9'
+          ssh:
+            userList: '{{ .Values.Installation.V1.Guest.SSH.UserList }}'
+      guest:
+        ssh:
+          ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'
+      registryDomain: '{{ .Values.Installation.V1.Registry.Domain }}'
+      installation:
+        name: '{{ .Values.Installation.V1.Name }}'
+        {{- if .Values.Installation.V1.Guest }}
+        guest:
+          ipam:
+            network:
+              CIDR: '{{ .Values.Installation.V1.Guest.IPAM.NetworkCIDR }}'
+              subnetMaskBits: '{{ .Values.Installation.V1.Guest.IPAM.CIDRMask }}'
+              privateSubnetMaskBits: '{{ .Values.Installation.V1.Guest.IPAM.PrivateSubnetMask }}'
+              publicSubnetMaskBits: '{{ .Values.Installation.V1.Guest.IPAM.PublicSubnetMask }}'
+          kubernetes:
+            api:
+              auth:
+                provider:
+                  oidc:
+                    clientID: '{{ .Values.Installation.V1.Guest.Kubernetes.API.Auth.Provider.OIDC.ClientID }}'
+                    issuerURL: '{{ .Values.Installation.V1.Guest.Kubernetes.API.Auth.Provider.OIDC.IssuerURL }}'
+                    usernameClaim: '{{ .Values.Installation.V1.Guest.Kubernetes.API.Auth.Provider.OIDC.UsernameClaim }}'
+                    groupsClaim: '{{ .Values.Installation.V1.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim }}'
+              security:
+                whitelist:
+                  enabled: {{ .Values.Installation.V1.Security.RestrictAccess.GuestAPI }}
+                  {{- if .Values.Installation.V1.Security.RestrictAccess.GuestAPI }}
+                  subnetList: "{{ .Values.Installation.V1.Security.Subnet.VPN }},{{ .Values.Installation.V1.Security.Subnet.Customer }}"
+                  {{- end }}
+        {{- end }}
+      kubernetes:
+        incluster: true

--- a/helm/aws-operator/templates/04-service.yaml
+++ b/helm/aws-operator/templates/04-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aws-operator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: aws-operator
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  type: NodePort
+  ports:
+  - port: 8000
+  selector:
+    app: aws-operator

--- a/helm/aws-operator/templates/05-pull-secret.yml
+++ b/helm/aws-operator/templates/05-pull-secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: aws-operator-pull-secret
+  namespace: {{ .Values.namespace }}
+data:
+  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/aws-operator/templates/06-secret.yaml
+++ b/helm/aws-operator/templates/06-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: aws-operator-secret
+  namespace: {{ .Values.namespace }}
+data:
+  secret.yaml: {{ .Values.Installation.V1.Secret.AWSOperator.SecretYaml | b64enc | quote }}

--- a/helm/aws-operator/templates/07-credential-default.yaml
+++ b/helm/aws-operator/templates/07-credential-default.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: credential-default
+  namespace: giantswarm
+  labels:
+    app: credentiald
+    giantswarm.io/managed-by: credentiald
+    giantswarm.io/organization: giantswarm
+    giantswarm.io/service-type: system
+data:
+  aws.admin.arn: {{ .Values.Installation.V1.Secret.AWSOperator.CredentialDefault.AdminARN | b64enc }}
+  aws.awsoperator.arn: {{ .Values.Installation.V1.Secret.AWSOperator.CredentialDefault.AWSOperatorARN | b64enc }}

--- a/helm/aws-operator/templates/08-deployment.yaml
+++ b/helm/aws-operator/templates/08-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: aws-operator
       containers:
       - name: aws-operator
-        image: quay.io/giantswarm/aws-operator:[[ .SHA ]]
+        image: quay.io/giantswarm/aws-operator:[[ .DockerTag ]]
         volumeMounts:
         - name: aws-operator-configmap
           mountPath: /var/run/aws-operator/configmap/

--- a/helm/aws-operator/templates/08-deployment.yaml
+++ b/helm/aws-operator/templates/08-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: aws-operator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: aws-operator
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        releasetime: {{ $.Release.Time }}
+      labels:
+        app: aws-operator
+    spec:
+      volumes:
+      - name: aws-operator-configmap
+        configMap:
+          name: aws-operator-configmap
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: aws-operator-secret
+        secret:
+          secretName: aws-operator-secret
+          items:
+          - key: secret.yaml
+            path: secret.yaml
+      - name: certs
+        hostPath:
+          path: /etc/ssl/certs/ca-certificates.crt
+      serviceAccountName: aws-operator
+      containers:
+      - name: aws-operator
+        image: quay.io/giantswarm/aws-operator:[[ .SHA ]]
+        volumeMounts:
+        - name: aws-operator-configmap
+          mountPath: /var/run/aws-operator/configmap/
+        - name: aws-operator-secret
+          mountPath: /var/run/aws-operator/secret/
+          readOnly: true
+        - name: certs
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+        ports:
+        - name: http
+          containerPort: 8000
+        args:
+        - daemon
+        - --config.dirs=/var/run/aws-operator/configmap/
+        - --config.dirs=/var/run/aws-operator/secret/
+        - --config.files=config
+        - --config.files=secret
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 250Mi
+          limits:
+            cpu: 250m
+            memory: 250Mi
+      imagePullSecrets:
+      - name: aws-operator-pull-secret

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -1,0 +1,1 @@
+namespace: giantswarm


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6154.

This is almost pure copy.

Output of `git patch --no-index ./helm/aws-operator{-chart,}`:

```diff
diff --git a/./helm/aws-operator-chart/Chart.yaml b/./helm/aws-operator/Chart.yaml
index f00e69be1..b91e1ec29 100644
--- a/./helm/aws-operator-chart/Chart.yaml
+++ b/./helm/aws-operator/Chart.yaml
@@ -1,2 +1,2 @@
-name: aws-operator-chart
-version: 1.0.0-[[ .SHA ]]
+name: aws-operator
+version: [[ .Version ]]
diff --git a/./helm/aws-operator-chart/templates/08-deployment.yaml b/./helm/aws-operator/templates/08-deployment.yaml
index e6114db2e..0d08fbad5 100644
--- a/./helm/aws-operator-chart/templates/08-deployment.yaml
+++ b/./helm/aws-operator/templates/08-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: aws-operator
       containers:
       - name: aws-operator
-        image: quay.io/giantswarm/aws-operator:[[ .SHA ]]
+        image: quay.io/giantswarm/aws-operator:[[ .DockerTag ]]
         volumeMounts:
         - name: aws-operator-configmap
           mountPath: /var/run/aws-operator/configmap/
```