### PR TITLE
add structure for machinedeployment resource

### DIFF
--- a/service/controller/clusterapi/v28/resource/machinedeployment/create.go
+++ b/service/controller/clusterapi/v28/resource/machinedeployment/create.go
@@ -1,0 +1,9 @@
+package machinedeployment
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v28/resource/machinedeployment/delete.go
+++ b/service/controller/clusterapi/v28/resource/machinedeployment/delete.go
@@ -1,0 +1,7 @@
+package machinedeployment
+
+import "context"
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v28/resource/machinedeployment/error.go
+++ b/service/controller/clusterapi/v28/resource/machinedeployment/error.go
@@ -1,0 +1,12 @@
+package machinedeployment
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalid config",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v28/resource/machinedeployment/resource.go
+++ b/service/controller/clusterapi/v28/resource/machinedeployment/resource.go
@@ -1,0 +1,41 @@
+package machinedeployment
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "machinedeploymentv28"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
We need a temporary resource to fetch the machine deployment associated to a cluster. This is only one for now as we want to make the current cluster work as it is with the cluster API types. Here I only add the structure. Non controversial PR. 