### PR TITLE
Temporarily take worker AZs instead of all AZs

### DIFF
--- a/service/controller/clusterapi/v28/adapter/guest_auto_scaling_group.go
+++ b/service/controller/clusterapi/v28/adapter/guest_auto_scaling_group.go
@@ -35,11 +35,7 @@ func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
 	}
 
 	{
-		// TODO(tuommaki): When Cluster - MachineDeployment syncing is
-		// implemented, this information should probably come from Cluster
-		// status - possibly?
-		// OLD: numAZs := len(key.StatusAvailabilityZones(cfg.MachineDeployment))
-		numAZs := len(key.WorkerAvailabilityZones(cfg.MachineDeployment))
+		numAZs := len(key.StatusAvailabilityZones(cfg.MachineDeployment))
 		if numAZs < 1 {
 			return microerror.Maskf(invalidConfigError, "at least one configured availability zone required")
 		}

--- a/service/controller/clusterapi/v28/adapter/guest_auto_scaling_group.go
+++ b/service/controller/clusterapi/v28/adapter/guest_auto_scaling_group.go
@@ -35,7 +35,11 @@ func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
 	}
 
 	{
-		numAZs := len(key.StatusAvailabilityZones(cfg.MachineDeployment))
+		// TODO(tuommaki): When Cluster - MachineDeployment syncing is
+		// implemented, this information should probably come from Cluster
+		// status - possibly?
+		// OLD: numAZs := len(key.StatusAvailabilityZones(cfg.MachineDeployment))
+		numAZs := len(key.WorkerAvailabilityZones(cfg.MachineDeployment))
 		if numAZs < 1 {
 			return microerror.Maskf(invalidConfigError, "at least one configured availability zone required")
 		}

--- a/service/controller/clusterapi/v28/key/machine_deployment.go
+++ b/service/controller/clusterapi/v28/key/machine_deployment.go
@@ -15,8 +15,15 @@ func WorkerClusterID(cr v1alpha1.MachineDeployment) string {
 }
 
 // TODO this method has to be properly implemented and renamed eventually.
-func StatusAvailabilityZones(cluster v1alpha1.MachineDeployment) []g8sv1alpha1.AWSConfigStatusAWSAvailabilityZone {
-	return nil
+func StatusAvailabilityZones(cr v1alpha1.MachineDeployment) []g8sv1alpha1.AWSConfigStatusAWSAvailabilityZone {
+	var azs []g8sv1alpha1.AWSConfigStatusAWSAvailabilityZone
+	for _, s := range WorkerAvailabilityZones(cr) {
+		azs = append(azs, g8sv1alpha1.AWSConfigStatusAWSAvailabilityZone{
+			Name: s,
+		})
+	}
+
+	return azs
 }
 
 func ToMachineDeployment(v interface{}) (v1alpha1.MachineDeployment, error) {


### PR DESCRIPTION
To proceed with CP stack creation, take temporarily worker AZs instead of
cluster AZs when creating ASG.