### PR TITLE
Ensure pods run as non-root

### DIFF
--- a/helm/aws-operator-chart/templates/02-psp.yaml
+++ b/helm/aws-operator-chart/templates/02-psp.yaml
@@ -5,9 +5,17 @@ metadata:
 spec:
   privileged: false
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
   runAsUser:
-    rule: RunAsAny
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -16,6 +24,7 @@ spec:
     - 'secret'
     - 'configMap'
     - 'hostPath'
+  allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/helm/aws-operator-chart/templates/08-deployment.yaml
+++ b/helm/aws-operator-chart/templates/08-deployment.yaml
@@ -34,6 +34,9 @@ spec:
         hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
       serviceAccountName: aws-operator
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
       containers:
       - name: aws-operator
         image: quay.io/giantswarm/aws-operator:[[ .SHA ]]

--- a/helm/aws-operator-chart/values.yaml
+++ b/helm/aws-operator-chart/values.yaml
@@ -1,1 +1,4 @@
 namespace: giantswarm
+
+userID: 1000
+groupID: 1000

--- a/helm/aws-operator/templates/02-psp.yaml
+++ b/helm/aws-operator/templates/02-psp.yaml
@@ -5,9 +5,17 @@ metadata:
 spec:
   privileged: false
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
   runAsUser:
-    rule: RunAsAny
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -16,6 +24,7 @@ spec:
     - 'secret'
     - 'configMap'
     - 'hostPath'
+  allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/helm/aws-operator/templates/08-deployment.yaml
+++ b/helm/aws-operator/templates/08-deployment.yaml
@@ -34,6 +34,9 @@ spec:
         hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
       serviceAccountName: aws-operator
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
       containers:
       - name: aws-operator
         image: quay.io/giantswarm/aws-operator:[[ .DockerTag ]]

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -1,1 +1,4 @@
 namespace: giantswarm
+
+userID: 1000
+groupID: 1000


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/6013

I've left the Dockerfile alone for the time being until we've settled on a standard for the base image.