### PR TITLE
fix namespace when listing clusters

### DIFF
--- a/service/controller/clusterapi/v28/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v28/machine_deployment_resource_set.go
@@ -2,7 +2,6 @@ package v28
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -95,11 +94,9 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 				return nil, microerror.Mask(err)
 			}
 
-			fmt.Printf("%#v\n", md.Labels)
-
 			id := key.WorkerClusterID(md)
 
-			m, err := config.CMAClient.ClusterV1alpha1().Clusters(metav1.NamespaceAll).Get(id, metav1.GetOptions{})
+			m, err := config.CMAClient.ClusterV1alpha1().Clusters(md.Namespace).Get(id, metav1.GetOptions{})
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/service/controller/clusterapi/v28/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v28/machine_deployment_resource_set.go
@@ -2,6 +2,7 @@ package v28
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -93,6 +94,8 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
+
+			fmt.Printf("%#v\n", md.Labels)
 
 			id := key.WorkerClusterID(md)
 


### PR DESCRIPTION
Towards Node Pools. Figured out this is wrong. Got errors like these. 

```
an empty namespace may not be set when a resource name is provided
```