### PR TITLE
Move generic network splitting functionality to network package

### DIFF
--- a/service/controller/clusterapi/v28/resource/ipam/create.go
+++ b/service/controller/clusterapi/v28/resource/ipam/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/bits"
 	"net"
 	"sync"
 
@@ -248,42 +247,4 @@ func getVPCSubnets(ctx context.Context) ([]net.IPNet, error) {
 	}
 
 	return results, nil
-}
-
-// calculateSubnetMask calculates new subnet mask to accommodate n subnets.
-func calculateSubnetMask(networkMask net.IPMask, n uint) (net.IPMask, error) {
-	if n == 0 {
-		return nil, microerror.Maskf(invalidParameterError, "divide by zero")
-	}
-
-	// Amount of bits needed to accommodate enough subnets for public and
-	// private subnet in each AZ.
-	subnetBitsNeeded := bits.Len(n - 1)
-
-	maskOnes, maskBits := networkMask.Size()
-	if subnetBitsNeeded > maskBits-maskOnes {
-		return nil, microerror.Maskf(invalidParameterError, "no room in network mask %s to accommodate %d subnets", networkMask.String(), n)
-	}
-
-	return net.CIDRMask(maskOnes+subnetBitsNeeded, maskBits), nil
-}
-
-// splitNetwork returns n subnets from network.
-func splitNetwork(network net.IPNet, n uint) ([]net.IPNet, error) {
-	mask, err := calculateSubnetMask(network.Mask, n)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	var subnets []net.IPNet
-	for i := uint(0); i < n; i++ {
-		subnet, err := ipam.Free(network, mask, subnets)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		subnets = append(subnets, subnet)
-	}
-
-	return subnets, nil
 }

--- a/service/controller/clusterapi/v28/resource/ipam/error.go
+++ b/service/controller/clusterapi/v28/resource/ipam/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidParameterError = &microerror.Error{
-	Kind: "invalid parameter",
-}
-
-// IsInvalidParameter asserts invalidParameterError.
-func IsInvalidParameter(err error) bool {
-	return microerror.Cause(err) == invalidParameterError
-}

--- a/service/network/error.go
+++ b/service/network/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var invalidParameterError = &microerror.Error{
+	Kind: "invalid parameter",
+}
+
+// IsInvalidParameter asserts invalidParameterError.
+func IsInvalidParameter(err error) bool {
+	return microerror.Cause(err) == invalidParameterError
+}

--- a/service/network/splitter.go
+++ b/service/network/splitter.go
@@ -1,0 +1,47 @@
+package network
+
+import (
+	"math/bits"
+	"net"
+
+	"github.com/giantswarm/ipam"
+	"github.com/giantswarm/microerror"
+)
+
+// CalculateSubnetMask calculates new subnet mask to accommodate n subnets.
+func CalculateSubnetMask(networkMask net.IPMask, n uint) (net.IPMask, error) {
+	if n == 0 {
+		return nil, microerror.Maskf(invalidParameterError, "divide by zero")
+	}
+
+	// Amount of bits needed to accommodate enough subnets for public and
+	// private subnet in each AZ.
+	subnetBitsNeeded := bits.Len(n - 1)
+
+	maskOnes, maskBits := networkMask.Size()
+	if subnetBitsNeeded > maskBits-maskOnes {
+		return nil, microerror.Maskf(invalidParameterError, "no room in network mask %s to accommodate %d subnets", networkMask.String(), n)
+	}
+
+	return net.CIDRMask(maskOnes+subnetBitsNeeded, maskBits), nil
+}
+
+// Split returns n subnets from network.
+func Split(network net.IPNet, n uint) ([]net.IPNet, error) {
+	mask, err := CalculateSubnetMask(network.Mask, n)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var subnets []net.IPNet
+	for i := uint(0); i < n; i++ {
+		subnet, err := ipam.Free(network, mask, subnets)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		subnets = append(subnets, subnet)
+	}
+
+	return subnets, nil
+}

--- a/service/network/splitter.go
+++ b/service/network/splitter.go
@@ -14,8 +14,7 @@ func CalculateSubnetMask(networkMask net.IPMask, n uint) (net.IPMask, error) {
 		return nil, microerror.Maskf(invalidParameterError, "divide by zero")
 	}
 
-	// Amount of bits needed to accommodate enough subnets for public and
-	// private subnet in each AZ.
+	// Calculate amount of bits needed to accommodate at least N subnets.
 	subnetBitsNeeded := bits.Len(n - 1)
 
 	maskOnes, maskBits := networkMask.Size()

--- a/service/network/splitter_test.go
+++ b/service/network/splitter_test.go
@@ -1,4 +1,4 @@
-package ipam
+package network
 
 import (
 	"fmt"
@@ -7,16 +7,7 @@ import (
 	"testing"
 )
 
-func mustParseCIDR(val string) net.IPNet {
-	_, n, err := net.ParseCIDR(val)
-	if err != nil {
-		panic(err)
-	}
-
-	return *n
-}
-
-func Test_calculateSubnetMask(t *testing.T) {
+func Test_CalculateSubnetMask(t *testing.T) {
 	testCases := []struct {
 		name         string
 		mask         net.IPMask
@@ -84,7 +75,7 @@ func Test_calculateSubnetMask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mask, err := calculateSubnetMask(tc.mask, tc.n)
+			mask, err := CalculateSubnetMask(tc.mask, tc.n)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:
@@ -104,7 +95,7 @@ func Test_calculateSubnetMask(t *testing.T) {
 	}
 }
 
-func Test_splitNetwork(t *testing.T) {
+func Test_Split(t *testing.T) {
 	testCases := []struct {
 		name            string
 		network         net.IPNet
@@ -150,7 +141,7 @@ func Test_splitNetwork(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			subnets, err := splitNetwork(tc.network, tc.n)
+			subnets, err := Split(tc.network, tc.n)
 
 			switch {
 			case err == nil && tc.errorMatcher == nil:


### PR DESCRIPTION
Functions to split network into smaller subnets is generic and needed in
several different resources (e.g. both Cluster and MachineDeployment IPAMs) so
it makes sense to have it in shared package.