### PR TITLE
use generic release version label for node labels

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -7,10 +7,12 @@ const (
 const (
 	Cluster       = "giantswarm.io/cluster"
 	Organization  = "giantswarm.io/organization"
+	Provider      = "giantswarm.io/provider"
 	VersionBundle = "giantswarm.io/version-bundle"
 )
 
 const (
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
 	OperatorVersion         = "aws-operator.giantswarm.io/version"
+	ReleaseVersion          = "release.giantswarm.io/version"
 )

--- a/service/controller/clusterapi/v28/key/cluster.go
+++ b/service/controller/clusterapi/v28/key/cluster.go
@@ -147,8 +147,8 @@ func ImageID(cluster v1alpha1.Cluster) string {
 func KubeletLabels(cluster v1alpha1.Cluster) string {
 	var labels string
 
-	labels = ensureLabel(labels, label.ReleaseVersion, ReleaseVersion(&cluster))
 	labels = ensureLabel(labels, label.Provider, "aws")
+	labels = ensureLabel(labels, label.ReleaseVersion, ReleaseVersion(&cluster))
 
 	return labels
 }

--- a/service/controller/clusterapi/v28/key/cluster.go
+++ b/service/controller/clusterapi/v28/key/cluster.go
@@ -147,8 +147,8 @@ func ImageID(cluster v1alpha1.Cluster) string {
 func KubeletLabels(cluster v1alpha1.Cluster) string {
 	var labels string
 
-	labels = ensureLabel(labels, "aws-operator.giantswarm.io/version", OperatorVersion(&cluster))
-	labels = ensureLabel(labels, "giantswarm.io/provider", "aws")
+	labels = ensureLabel(labels, label.ReleaseVersion, ReleaseVersion(&cluster))
+	labels = ensureLabel(labels, label.Provider, "aws")
 
 	return labels
 }

--- a/service/controller/clusterapi/v28/key/common.go
+++ b/service/controller/clusterapi/v28/key/common.go
@@ -95,6 +95,10 @@ func PublicSubnetRouteTableAssociationName(idx int) string {
 	return fmt.Sprintf("PublicSubnetRouteTableAssociation%02d", idx)
 }
 
+func ReleaseVersion(getter LabelsGetter) string {
+	return getter.GetLabels()[label.ReleaseVersion]
+}
+
 func VPCPeeringRouteName(idx int) string {
 	// Since CloudFormation cannot recognize resource renaming, use non-indexed
 	// resource name for first AZ.


### PR DESCRIPTION
Towards Node Pools. 