### PR TITLE
Gather node pool AZs into controllercontext

### DIFF
--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -29,6 +29,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/clusterazs"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ebsvolume"
@@ -221,6 +222,19 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var clusterAZsResource controller.Resource
+	{
+		c := clusterazs.Config{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		clusterAZsResource, err = clusterazs.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -587,6 +601,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 
 	resources := []controller.Resource{
 		machineDeploymentResource,
+		clusterAZsResource,
 		accountIDResource,
 		natGatewayAddressesResource,
 		peerRoleARNResource,

--- a/service/controller/clusterapi/v29/controllercontext/status.go
+++ b/service/controller/clusterapi/v29/controllercontext/status.go
@@ -38,6 +38,7 @@ type ContextStatusControlPlaneVPC struct {
 }
 
 type ContextStatusTenantCluster struct {
+	AvailabilityZones     []string
 	AWSAccountID          string
 	Encryption            ContextStatusTenantClusterEncryption
 	HostedZoneNameServers string

--- a/service/controller/clusterapi/v29/key/cluster.go
+++ b/service/controller/clusterapi/v29/key/cluster.go
@@ -153,6 +153,10 @@ func KubeletLabels(cluster v1alpha1.Cluster) string {
 	return labels
 }
 
+func MasterAvailabilityZone(cluster v1alpha1.Cluster) string {
+	return clusterProviderSpec(cluster).Provider.Master.AvailabilityZone
+}
+
 func MasterCount(cluster v1alpha1.Cluster) int {
 	return 1
 }

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -1,0 +1,73 @@
+package clusterazs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var machineDeployments []clusterv1alpha1.MachineDeployment
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding MachineDeployments for tenant cluster")
+
+		l := metav1.AddLabelToSelector(
+			&v1.LabelSelector{},
+			label.Cluster,
+			key.ClusterID(cr),
+		)
+		o := metav1.ListOptions{
+			LabelSelector: labels.Set(l.MatchLabels).String(),
+		}
+
+		list, err := r.cmaClient.ClusterV1alpha1().MachineDeployments(cr.Namespace).List(o)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		machineDeployments = list.Items
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d MachineDeployments for tenant cluster", len(machineDeployments)))
+	}
+
+	var azs []string
+	{
+		var azsMap map[string]struct{}
+
+		for _, md := range machineDeployments {
+			for _, az := range key.WorkerAvailabilityZones(md) {
+				azsMap[az] = struct{}{}
+			}
+		}
+
+		for az, _ := range azsMap {
+			azs = append(azs, az)
+		}
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting cluster availability zones to controllercontext: %#v", azs))
+
+		cc.Status.TenantCluster.AvailabilityZones = azs
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -55,7 +55,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		// Include master's AZ.
 		azsMap[key.MasterAvailabilityZone(cr)] = struct{}{}
 
-		// ...and workers'.
+		// Include worker AZs.
 		for _, md := range machineDeployments {
 			for _, az := range key.WorkerAvailabilityZones(md) {
 				azsMap[az] = struct{}{}

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -52,6 +52,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		var azsMap map[string]struct{}
 
+		// Include master's AZ.
+		azsMap[key.MasterAvailabilityZone(cr)] = struct{}{}
+
+		// ...and workers'.
 		for _, md := range machineDeployments {
 			for _, az := range key.WorkerAvailabilityZones(md) {
 				azsMap[az] = struct{}{}

--- a/service/controller/clusterapi/v29/resource/clusterazs/delete.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/delete.go
@@ -1,0 +1,9 @@
+package clusterazs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/clusterazs/error.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/error.go
@@ -1,0 +1,12 @@
+package clusterazs
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalid config",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v29/resource/clusterazs/resource.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/resource.go
@@ -1,0 +1,43 @@
+// Package clusterazs implements a resource to gather all distinct availability
+// zones for a tenant cluster cluster.
+package clusterazs
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "clusterazsv29"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
This change adds a resource which does an inventory over cluster's
MachineDeployments and gathers distinct availability zones that are required to
be present for a cluster. Availability zones are stored in controllercontext
and used later for dynamic management of public subnet infrastructure of a
tenant cluster.