### PR TITLE
make ClusterID a common key method for different types

### DIFF
--- a/service/controller/clusterapi/v29/adapter/guest_auto_scaling_group.go
+++ b/service/controller/clusterapi/v29/adapter/guest_auto_scaling_group.go
@@ -48,7 +48,7 @@ func (a *GuestAutoScalingGroupAdapter) Adapt(cfg Config) error {
 	a.ASGMaxSize = maxWorkers
 	a.ASGMinSize = minWorkers
 	a.ASGType = "worker"
-	a.ClusterID = key.ClusterID(cfg.CustomObject)
+	a.ClusterID = key.ClusterID(&cfg.CustomObject)
 	a.MaxBatchSize = strconv.Itoa(workerCountRatio(currentDesiredMinWorkers, asgMaxBatchSizeRatio))
 
 	minInstancesInService := workerCountRatio(currentDesiredMinWorkers, asgMinInstancesRatio)

--- a/service/controller/clusterapi/v29/adapter/guest_iam_policies.go
+++ b/service/controller/clusterapi/v29/adapter/guest_iam_policies.go
@@ -19,7 +19,7 @@ type GuestIAMPoliciesAdapter struct {
 }
 
 func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
-	clusterID := key.ClusterID(cfg.CustomObject)
+	clusterID := key.ClusterID(&cfg.CustomObject)
 
 	i.ClusterID = clusterID
 	i.EC2ServiceDomain = key.EC2ServiceDomain(cfg.CustomObject)

--- a/service/controller/clusterapi/v29/adapter/guest_instance.go
+++ b/service/controller/clusterapi/v29/adapter/guest_instance.go
@@ -56,7 +56,7 @@ type GuestInstanceAdapterMasterInstance struct {
 
 func (i *GuestInstanceAdapter) Adapt(config Config) error {
 	{
-		i.Cluster.ID = key.ClusterID(config.CustomObject)
+		i.Cluster.ID = key.ClusterID(&config.CustomObject)
 	}
 
 	{

--- a/service/controller/clusterapi/v29/adapter/guest_internet_gateway.go
+++ b/service/controller/clusterapi/v29/adapter/guest_internet_gateway.go
@@ -10,7 +10,7 @@ type GuestInternetGatewayAdapter struct {
 }
 
 func (a *GuestInternetGatewayAdapter) Adapt(cfg Config) error {
-	a.ClusterID = key.ClusterID(cfg.CustomObject)
+	a.ClusterID = key.ClusterID(&cfg.CustomObject)
 
 	for i := 0; i < len(key.WorkerAvailabilityZones(cfg.MachineDeployment)); i++ {
 		a.PrivateRouteTables = append(a.PrivateRouteTables, key.PrivateRouteTableName(i))

--- a/service/controller/clusterapi/v29/adapter/guest_nat_gateway.go
+++ b/service/controller/clusterapi/v29/adapter/guest_nat_gateway.go
@@ -20,7 +20,7 @@ type GuestNATGatewayAdapter struct {
 func (a *GuestNATGatewayAdapter) Adapt(cfg Config) error {
 	for i := 0; i < len(key.WorkerAvailabilityZones(cfg.MachineDeployment)); i++ {
 		gw := Gateway{
-			ClusterID:             key.ClusterID(cfg.CustomObject),
+			ClusterID:             key.ClusterID(&cfg.CustomObject),
 			NATGWName:             key.NATGatewayName(i),
 			NATEIPName:            key.NATEIPName(i),
 			NATRouteName:          key.NATRouteName(i),

--- a/service/controller/clusterapi/v29/adapter/guest_record_sets.go
+++ b/service/controller/clusterapi/v29/adapter/guest_record_sets.go
@@ -15,7 +15,7 @@ type GuestRecordSetsAdapter struct {
 func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
 	a.BaseDomain = key.ClusterBaseDomain(config.CustomObject)
 	a.EtcdDomain = key.ClusterEtcdEndpoint(config.CustomObject)
-	a.ClusterID = key.ClusterID(config.CustomObject)
+	a.ClusterID = key.ClusterID(&config.CustomObject)
 	a.MasterInstanceResourceName = config.StackState.MasterInstanceResourceName
 	a.Route53Enabled = config.Route53Enabled
 

--- a/service/controller/clusterapi/v29/adapter/guest_vpc.go
+++ b/service/controller/clusterapi/v29/adapter/guest_vpc.go
@@ -18,7 +18,7 @@ type GuestVPCAdapter struct {
 
 func (v *GuestVPCAdapter) Adapt(cfg Config) error {
 	v.CidrBlock = key.StatusClusterNetworkCIDR(cfg.CustomObject)
-	v.ClusterID = key.ClusterID(cfg.CustomObject)
+	v.ClusterID = key.ClusterID(&cfg.CustomObject)
 	v.InstallationName = cfg.InstallationName
 	v.HostAccountID = cfg.ControlPlaneAccountID
 	v.PeerVPCID = cfg.ControlPlaneVPCID

--- a/service/controller/clusterapi/v29/ebs/ebs_test.go
+++ b/service/controller/clusterapi/v29/ebs/ebs_test.go
@@ -7,23 +7,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
 func Test_ListVolumes(t *testing.T) {
 	t.Parallel()
 
 	customObject := v1alpha1.Cluster{
-		Status: v1alpha1.ClusterStatus{
-			ProviderStatus: &runtime.RawExtension{
-				Raw: []byte(`
-					{
-						"cluster": {
-							"id": "test-cluster"
-						}
-					}
-				`),
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				label.Cluster: "test-cluster",
 			},
 		},
 	}

--- a/service/controller/clusterapi/v29/encrypter/kms/key.go
+++ b/service/controller/clusterapi/v29/encrypter/kms/key.go
@@ -9,5 +9,5 @@ import (
 )
 
 func keyAlias(cr v1alpha1.Cluster) string {
-	return fmt.Sprintf("alias/%s", key.ClusterID(cr))
+	return fmt.Sprintf("alias/%s", key.ClusterID(&cr))
 }

--- a/service/controller/clusterapi/v29/encrypter/vault/vault.go
+++ b/service/controller/clusterapi/v29/encrypter/vault/vault.go
@@ -621,8 +621,10 @@ func (e *Encrypter) postAuthAWSRole(name string, data *AWSAuthRole) error {
 	return nil
 }
 
-func (e *Encrypter) keyName(customObject v1alpha1.Cluster) string {
-	return key.ClusterID(customObject)
+// TODO the key function should simply be used. No reason for the pointer
+// receiver wrapper.
+func (e *Encrypter) keyName(cr v1alpha1.Cluster) string {
+	return key.ClusterID(&cr)
 }
 
 func authAWSRolePath(role string) string {

--- a/service/controller/clusterapi/v29/key/cluster.go
+++ b/service/controller/clusterapi/v29/key/cluster.go
@@ -49,7 +49,7 @@ const (
 )
 
 func BucketName(cluster v1alpha1.Cluster, accountID string) string {
-	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(cluster))
+	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(&cluster))
 }
 
 // BucketObjectName computes the S3 object path to the actual cloud config.
@@ -62,7 +62,7 @@ func BucketObjectName(cluster v1alpha1.Cluster, role string) string {
 }
 
 func ClusterAPIEndpoint(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("api.%s.k8s.%s", ClusterID(cluster), ClusterBaseDomain(cluster))
+	return fmt.Sprintf("api.%s.k8s.%s", ClusterID(&cluster), ClusterBaseDomain(cluster))
 }
 
 func ClusterBaseDomain(cluster v1alpha1.Cluster) string {
@@ -70,27 +70,23 @@ func ClusterBaseDomain(cluster v1alpha1.Cluster) string {
 }
 
 func ClusterCloudProviderTag(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("kubernetes.io/cluster/%s", ClusterID(cluster))
+	return fmt.Sprintf("kubernetes.io/cluster/%s", ClusterID(&cluster))
 }
 
 func ClusterEtcdEndpoint(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("etcd.%s.k8s.%s", ClusterID(cluster), ClusterBaseDomain(cluster))
+	return fmt.Sprintf("etcd.%s.k8s.%s", ClusterID(&cluster), ClusterBaseDomain(cluster))
 }
 
 func ClusterEtcdEndpointWithPort(cluster v1alpha1.Cluster) string {
 	return fmt.Sprintf("%s:2379", ClusterEtcdEndpoint(cluster))
 }
 
-func ClusterID(cluster v1alpha1.Cluster) string {
-	return clusterProviderStatus(cluster).Cluster.ID
-}
-
 func ClusterKubeletEndpoint(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("worker.%s.k8s.%s", ClusterID(cluster), ClusterBaseDomain(cluster))
+	return fmt.Sprintf("worker.%s.k8s.%s", ClusterID(&cluster), ClusterBaseDomain(cluster))
 }
 
 func ClusterNamespace(cluster v1alpha1.Cluster) string {
-	return ClusterID(cluster)
+	return ClusterID(&cluster)
 }
 
 func ClusterTags(cluster v1alpha1.Cluster, installationName string) map[string]string {
@@ -98,7 +94,7 @@ func ClusterTags(cluster v1alpha1.Cluster, installationName string) map[string]s
 
 	tags := map[string]string{
 		TagCloudProvider: "owned",
-		TagCluster:       ClusterID(cluster),
+		TagCluster:       ClusterID(&cluster),
 		TagInstallation:  installationName,
 		TagOrganization:  OrganizationID(cluster),
 	}
@@ -129,15 +125,15 @@ func EC2ServiceDomain(cluster v1alpha1.Cluster) string {
 }
 
 func ELBNameAPI(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-api", ClusterID(cluster))
+	return fmt.Sprintf("%s-api", ClusterID(&cluster))
 }
 
 func ELBNameEtcd(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-etcd", ClusterID(cluster))
+	return fmt.Sprintf("%s-etcd", ClusterID(&cluster))
 }
 
 func ELBNameIngress(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-ingress", ClusterID(cluster))
+	return fmt.Sprintf("%s-ingress", ClusterID(&cluster))
 }
 
 func ImageID(cluster v1alpha1.Cluster) string {
@@ -166,7 +162,7 @@ func MasterInstanceResourceName(cluster v1alpha1.Cluster) string {
 }
 
 func MasterInstanceName(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-master", ClusterID(cluster))
+	return fmt.Sprintf("%s-master", ClusterID(&cluster))
 }
 
 func MasterInstanceType(cluster v1alpha1.Cluster) string {
@@ -178,19 +174,19 @@ func OrganizationID(cluster v1alpha1.Cluster) string {
 }
 
 func PolicyNameMaster(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-master-%s", ClusterID(cluster), EC2PolicyK8s)
+	return fmt.Sprintf("%s-master-%s", ClusterID(&cluster), EC2PolicyK8s)
 }
 
 func PolicyNameWorker(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-worker-%s", ClusterID(cluster), EC2PolicyK8s)
+	return fmt.Sprintf("%s-worker-%s", ClusterID(&cluster), EC2PolicyK8s)
 }
 
 func ProfileNameMaster(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-master-%s", ClusterID(cluster), EC2RoleK8s)
+	return fmt.Sprintf("%s-master-%s", ClusterID(&cluster), EC2RoleK8s)
 }
 
 func ProfileNameWorker(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-worker-%s", ClusterID(cluster), EC2RoleK8s)
+	return fmt.Sprintf("%s-worker-%s", ClusterID(&cluster), EC2RoleK8s)
 }
 
 func Region(cluster v1alpha1.Cluster) string {
@@ -216,28 +212,28 @@ func RoleARNWorker(cluster v1alpha1.Cluster, accountID string) string {
 }
 
 func RoleNameMaster(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-master-%s", ClusterID(cluster), EC2RoleK8s)
+	return fmt.Sprintf("%s-master-%s", ClusterID(&cluster), EC2RoleK8s)
 }
 
 func RoleNameWorker(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-worker-%s", ClusterID(cluster), EC2RoleK8s)
+	return fmt.Sprintf("%s-worker-%s", ClusterID(&cluster), EC2RoleK8s)
 }
 
 func RolePeerAccess(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-vpc-peer-access", ClusterID(cluster))
+	return fmt.Sprintf("%s-vpc-peer-access", ClusterID(&cluster))
 }
 
 func RouteTableName(cluster v1alpha1.Cluster, suffix string, idx int) string {
 	// Since CloudFormation cannot recognize resource renaming, use non-indexed
 	// resource name for first AZ.
 	if idx < 1 {
-		return fmt.Sprintf("%s-%s", ClusterID(cluster), suffix)
+		return fmt.Sprintf("%s-%s", ClusterID(&cluster), suffix)
 	}
-	return fmt.Sprintf("%s-%s%02d", ClusterID(cluster), suffix, idx)
+	return fmt.Sprintf("%s-%s%02d", ClusterID(&cluster), suffix, idx)
 }
 
 func SecurityGroupName(cluster v1alpha1.Cluster, groupName string) string {
-	return fmt.Sprintf("%s-%s", ClusterID(cluster), groupName)
+	return fmt.Sprintf("%s-%s", ClusterID(&cluster), groupName)
 }
 
 func SmallCloudConfigPath(cluster v1alpha1.Cluster, accountID string, role string) string {
@@ -249,15 +245,15 @@ func SmallCloudConfigS3URL(cluster v1alpha1.Cluster, accountID string, role stri
 }
 
 func StackNameCPF(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-host-main", ClusterID(cluster))
+	return fmt.Sprintf("cluster-%s-host-main", ClusterID(&cluster))
 }
 
 func StackNameCPI(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-host-setup", ClusterID(cluster))
+	return fmt.Sprintf("cluster-%s-host-setup", ClusterID(&cluster))
 }
 
 func StackNameTCCP(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-guest-main", ClusterID(cluster))
+	return fmt.Sprintf("cluster-%s-guest-main", ClusterID(&cluster))
 }
 
 func StatusClusterNetworkCIDR(cluster v1alpha1.Cluster) string {
@@ -265,7 +261,7 @@ func StatusClusterNetworkCIDR(cluster v1alpha1.Cluster) string {
 }
 
 func TargetLogBucketName(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-g8s-access-logs", ClusterID(cluster))
+	return fmt.Sprintf("%s-g8s-access-logs", ClusterID(&cluster))
 }
 
 func ToCluster(v interface{}) (v1alpha1.Cluster, error) {
@@ -284,19 +280,19 @@ func ToCluster(v interface{}) (v1alpha1.Cluster, error) {
 }
 
 func VolumeNameDocker(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-docker", ClusterID(cluster))
+	return fmt.Sprintf("%s-docker", ClusterID(&cluster))
 }
 
 func VolumeNameEtcd(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-etcd", ClusterID(cluster))
+	return fmt.Sprintf("%s-etcd", ClusterID(&cluster))
 }
 
 func VolumeNameLog(cluster v1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-log", ClusterID(cluster))
+	return fmt.Sprintf("%s-log", ClusterID(&cluster))
 }
 
 func baseRoleARN(cluster v1alpha1.Cluster, accountID string, kind string) string {
-	clusterID := ClusterID(cluster)
+	clusterID := ClusterID(&cluster)
 	partition := RegionARN(cluster)
 
 	return fmt.Sprintf("arn:%s:iam::%s:role/%s-%s-%s", partition, accountID, clusterID, kind, EC2RoleK8s)
@@ -337,7 +333,7 @@ func ensureLabel(labels string, key string, value string) string {
 // getResourcenameWithTimeHash returns a string cromprised of some prefix, a
 // time hash and a cluster ID.
 func getResourcenameWithTimeHash(prefix string, cluster v1alpha1.Cluster) string {
-	id := strings.Replace(ClusterID(cluster), "-", "", -1)
+	id := strings.Replace(ClusterID(&cluster), "-", "", -1)
 
 	h := sha1.New()
 	h.Write([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))

--- a/service/controller/clusterapi/v29/key/common.go
+++ b/service/controller/clusterapi/v29/key/common.go
@@ -6,6 +6,10 @@ import (
 	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
+func ClusterID(getter LabelsGetter) string {
+	return getter.GetLabels()[label.Cluster]
+}
+
 func IsDeleted(getter DeletionTimestampGetter) bool {
 	return getter.GetDeletionTimestamp() != nil
 }

--- a/service/controller/clusterapi/v29/resource/bridgezone/create.go
+++ b/service/controller/clusterapi/v29/resource/bridgezone/create.go
@@ -24,7 +24,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	baseDomain := key.ClusterBaseDomain(cr)
 	intermediateZone := "k8s." + baseDomain
-	finalZone := key.ClusterID(cr) + ".k8s." + baseDomain
+	finalZone := key.ClusterID(&cr) + ".k8s." + baseDomain
 
 	guest, defaultGuest, err := r.route53Clients(ctx)
 	if err != nil {

--- a/service/controller/clusterapi/v29/resource/bridgezone/delete.go
+++ b/service/controller/clusterapi/v29/resource/bridgezone/delete.go
@@ -23,7 +23,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	baseDomain := key.ClusterBaseDomain(cr)
 	intermediateZone := "k8s." + baseDomain
-	finalZone := key.ClusterID(cr) + ".k8s." + baseDomain
+	finalZone := key.ClusterID(&cr) + ".k8s." + baseDomain
 
 	_, defaultGuest, err := r.route53Clients(ctx)
 	if err != nil {

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -32,7 +32,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		l := metav1.AddLabelToSelector(
 			&v1.LabelSelector{},
 			label.Cluster,
-			key.ClusterID(cr),
+			key.ClusterID(&cr),
 		)
 		o := metav1.ListOptions{
 			LabelSelector: labels.Set(l.MatchLabels).String(),

--- a/service/controller/clusterapi/v29/resource/cpf/create.go
+++ b/service/controller/clusterapi/v29/resource/cpf/create.go
@@ -205,7 +205,7 @@ func (r *Resource) newRecordSetsParams(ctx context.Context, cr v1alpha1.Cluster)
 	{
 		recordSets = &template.ParamsMainRecordSets{
 			BaseDomain:                 key.ClusterBaseDomain(cr),
-			ClusterID:                  key.ClusterID(cr),
+			ClusterID:                  key.ClusterID(&cr),
 			GuestHostedZoneNameServers: cc.Status.TenantCluster.HostedZoneNameServers,
 			Route53Enabled:             r.route53Enabled,
 		}

--- a/service/controller/clusterapi/v29/resource/drainer/create.go
+++ b/service/controller/clusterapi/v29/resource/drainer/create.go
@@ -128,7 +128,7 @@ func (r *Resource) createDrainerConfig(ctx context.Context, cr clusterv1alpha1.C
 				annotation.InstanceID: instanceID,
 			},
 			Labels: map[string]string{
-				label.Cluster: key.ClusterID(cr),
+				label.Cluster: key.ClusterID(&cr),
 			},
 			Name: privateDNS,
 		},
@@ -138,7 +138,7 @@ func (r *Resource) createDrainerConfig(ctx context.Context, cr clusterv1alpha1.C
 					API: corev1alpha1.DrainerConfigSpecGuestClusterAPI{
 						Endpoint: key.ClusterAPIEndpoint(cr),
 					},
-					ID: key.ClusterID(cr),
+					ID: key.ClusterID(&cr),
 				},
 				Node: corev1alpha1.DrainerConfigSpecGuestNode{
 					Name: privateDNS,

--- a/service/controller/clusterapi/v29/resource/drainfinisher/create.go
+++ b/service/controller/clusterapi/v29/resource/drainfinisher/create.go
@@ -43,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		n := v1.NamespaceAll
 		o := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(cr)),
+			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(&cr)),
 		}
 
 		drainerConfigs, err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).List(o)

--- a/service/controller/clusterapi/v29/resource/endpoints/desired.go
+++ b/service/controller/clusterapi/v29/resource/endpoints/desired.go
@@ -41,10 +41,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	endpoints := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      masterEndpointsName,
-			Namespace: key.ClusterID(cr),
+			Namespace: key.ClusterID(&cr),
 			Labels: map[string]string{
 				"app":      masterEndpointsName,
-				"cluster":  key.ClusterID(cr),
+				"cluster":  key.ClusterID(&cr),
 				"customer": key.OrganizationID(cr),
 			},
 		},

--- a/service/controller/clusterapi/v29/resource/machinedeployment/create.go
+++ b/service/controller/clusterapi/v29/resource/machinedeployment/create.go
@@ -27,7 +27,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding machine deployment for cluster")
 
 		in := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(cr)),
+			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(&cr)),
 		}
 
 		out, err := r.cmaClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceAll).List(in)

--- a/service/controller/clusterapi/v29/resource/machinedeployment/delete.go
+++ b/service/controller/clusterapi/v29/resource/machinedeployment/delete.go
@@ -27,7 +27,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding machine deployment for cluster")
 
 		in := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(cr)),
+			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(&cr)),
 		}
 
 		out, err := r.cmaClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceAll).List(in)

--- a/service/controller/clusterapi/v29/resource/namespace/desired.go
+++ b/service/controller/clusterapi/v29/resource/namespace/desired.go
@@ -26,7 +26,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		ObjectMeta: metav1.ObjectMeta{
 			Name: key.ClusterNamespace(cr),
 			Labels: map[string]string{
-				"cluster":  key.ClusterID(cr),
+				"cluster":  key.ClusterID(&cr),
 				"customer": key.OrganizationID(cr),
 			},
 		},

--- a/service/controller/clusterapi/v29/resource/s3bucket/create_test.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/create_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
 func Test_Resource_S3Bucket_newCreate(t *testing.T) {
@@ -21,15 +23,9 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 		{
 			description: "current and desired state empty, expected empty",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -40,15 +36,9 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 		{
 			description: "current state empty, desired state not empty, expected desired state",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -67,15 +57,9 @@ func Test_Resource_S3Bucket_newCreate(t *testing.T) {
 		{
 			description: "current state not empty, desired state not empty but different, expected desired state",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},

--- a/service/controller/clusterapi/v29/resource/s3bucket/delete_test.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/delete_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
 func Test_Resource_S3Bucket_newDelete(t *testing.T) {
@@ -21,15 +23,9 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 		{
 			description: "current and desired state empty, expected empty",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -40,15 +36,9 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 		{
 			description: "current state empty, desired state not empty, expected empty",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -63,15 +53,9 @@ func Test_Resource_S3Bucket_newDelete(t *testing.T) {
 		{
 			description: "current state not empty, desired state not empty but equal, expected desired state avoiding delivery log bucket",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},

--- a/service/controller/clusterapi/v29/resource/s3bucket/desired_test.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/desired_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 )
 
@@ -21,15 +22,9 @@ func Test_Resource_S3Bucket_GetDesiredState(t *testing.T) {
 		{
 			description: "Get bucket name from custom object.",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},

--- a/service/controller/clusterapi/v29/resource/s3object/create_test.go
+++ b/service/controller/clusterapi/v29/resource/s3object/create_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/giantswarm/certs/certstest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/randomkeys/randomkeystest"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 )
 
@@ -26,15 +27,9 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state empty, desired state empty, empty create change",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -45,15 +40,9 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state empty, desired state not empty, create change == desired state",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -76,15 +65,9 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state not empty, desired state not empty, create change == desired state",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -113,15 +96,9 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state has 1 object, desired state has 2 objects, create change == missing object",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},
@@ -156,15 +133,9 @@ func Test_Resource_S3Object_newCreate(t *testing.T) {
 		{
 			description: "current state matches desired state, empty create change",
 			obj: &v1alpha1.Cluster{
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "5xchu"
-								}
-							}
-						`),
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
 					},
 				},
 			},

--- a/service/controller/clusterapi/v29/resource/s3object/current_test.go
+++ b/service/controller/clusterapi/v29/resource/s3object/current_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/giantswarm/certs/certstest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/randomkeys/randomkeystest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 )
 
@@ -26,6 +28,11 @@ func Test_CurrentState(t *testing.T) {
 		{
 			description: "basic match",
 			obj: &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
+					},
+				},
 				Spec: v1alpha1.ClusterSpec{
 					ProviderSpec: v1alpha1.ProviderSpec{
 						Value: &runtime.RawExtension{
@@ -41,25 +48,19 @@ func Test_CurrentState(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "test-cluster"
-								}
-							}
-						`),
-					},
-				},
 			},
 			expectedKey:    "cloudconfig/myversion/worker",
-			expectedBucket: "myaccountid-g8s-test-cluster",
+			expectedBucket: "myaccountid-g8s-5xchu",
 			expectedBody:   "mybody",
 		},
 		{
 			description: "S3 error",
 			obj: &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
+					},
+				},
 				Spec: v1alpha1.ClusterSpec{
 					ProviderSpec: v1alpha1.ProviderSpec{
 						Value: &runtime.RawExtension{
@@ -73,17 +74,6 @@ func Test_CurrentState(t *testing.T) {
 								}
 							`),
 						},
-					},
-				},
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "test-cluster"
-								}
-							}
-						`),
 					},
 				},
 			},

--- a/service/controller/clusterapi/v29/resource/s3object/desired.go
+++ b/service/controller/clusterapi/v29/resource/s3object/desired.go
@@ -29,7 +29,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		g := &errgroup.Group{}
 
 		g.Go(func() error {
-			certs, err := r.certsSearcher.SearchCluster(key.ClusterID(cr))
+			certs, err := r.certsSearcher.SearchCluster(key.ClusterID(&cr))
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -39,7 +39,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		})
 
 		g.Go(func() error {
-			keys, err := r.randomKeysSearcher.SearchCluster(key.ClusterID(cr))
+			keys, err := r.randomKeysSearcher.SearchCluster(key.ClusterID(&cr))
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/clusterapi/v29/resource/s3object/desired_test.go
+++ b/service/controller/clusterapi/v29/resource/s3object/desired_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/giantswarm/certs/certstest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/randomkeys/randomkeystest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 )
 
@@ -32,6 +34,11 @@ func Test_DesiredState(t *testing.T) {
 		{
 			description: "basic match",
 			obj: &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						label.Cluster: "5xchu",
+					},
+				},
 				Spec: v1alpha1.ClusterSpec{
 					ProviderSpec: v1alpha1.ProviderSpec{
 						Value: &runtime.RawExtension{
@@ -47,20 +54,9 @@ func Test_DesiredState(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.ClusterStatus{
-					ProviderStatus: &runtime.RawExtension{
-						Raw: []byte(`
-							{
-								"cluster": {
-									"id": "test-cluster"
-								}
-							}
-						`),
-					},
-				},
 			},
 			expectedBody:   "mybody-",
-			expectedBucket: "myaccountid-g8s-test-cluster",
+			expectedBucket: "myaccountid-g8s-5xchu",
 		},
 	}
 

--- a/service/controller/clusterapi/v29/resource/secretfinalizer/secret_accessor.go
+++ b/service/controller/clusterapi/v29/resource/secretfinalizer/secret_accessor.go
@@ -19,13 +19,13 @@ func newSecretAccessors(ctx context.Context, cr v1alpha1.Cluster) []secretAccess
 		// The secret accessors below are associated to the tenant's API
 		// certificate.
 		{
-			Name:      fmt.Sprintf("%s-api", key.ClusterID(cr)),
+			Name:      fmt.Sprintf("%s-api", key.ClusterID(&cr)),
 			Namespace: "default",
 		},
 		// The secret accessors below are associated to the tenant's BYOC
 		// credential.
 		{
-			Name:      fmt.Sprintf("credential-%s", key.ClusterID(cr)),
+			Name:      fmt.Sprintf("credential-%s", key.ClusterID(&cr)),
 			Namespace: "giantswarm",
 		},
 	}

--- a/service/controller/clusterapi/v29/resource/service/desired.go
+++ b/service/controller/clusterapi/v29/resource/service/desired.go
@@ -26,16 +26,16 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "master",
-			Namespace: key.ClusterID(cr),
+			Namespace: key.ClusterID(&cr),
 			Labels: map[string]string{
 				label.App:           "master",
-				label.Cluster:       key.ClusterID(cr),
+				label.Cluster:       key.ClusterID(&cr),
 				label.Organization:  key.OrganizationID(cr),
 				label.VersionBundle: key.OperatorVersion(&cr),
 			},
 			Annotations: map[string]string{
 				AnnotationEtcdDomain:        key.ClusterEtcdEndpointWithPort(cr),
-				AnnotationPrometheusCluster: key.ClusterID(cr),
+				AnnotationPrometheusCluster: key.ClusterID(&cr),
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/service/controller/clusterapi/v29/resource/tccp/resource.go
+++ b/service/controller/clusterapi/v29/resource/tccp/resource.go
@@ -133,7 +133,7 @@ func (r *Resource) searchMasterInstanceID(ctx context.Context, cr v1alpha1.Clust
 				{
 					Name: aws.String("tag:giantswarm.io/cluster"),
 					Values: []*string{
-						aws.String(key.ClusterID(cr)),
+						aws.String(key.ClusterID(&cr)),
 					},
 				},
 				{


### PR DESCRIPTION
Towards Node Pools. One problem we get now with `Cluster` and `MachineDeployment` types is that we need one way of accessing certain information, but from different sources. I would like to change the interface of `ClusterID` to go with an labels getter interface like we do in different places already. The changes have to be made now in a lot of places but doing it in one PR should make our life easier down the road. 