### PR TITLE
Switch current WIP v28 to cloudconfig 4.5.0

### DIFF
--- a/service/controller/legacy/v28/cloudconfig/master_template.go
+++ b/service/controller/legacy/v28/cloudconfig/master_template.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_4_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_5_0"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeys"
 

--- a/service/controller/legacy/v28/cloudconfig/worker_template.go
+++ b/service/controller/legacy/v28/cloudconfig/worker_template.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_4_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_5_0"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/controllercontext"

--- a/service/controller/legacy/v28/key/key.go
+++ b/service/controller/legacy/v28/key/key.go
@@ -17,7 +17,7 @@ import (
 const (
 	// CloudConfigVersion defines the version of k8scloudconfig in use.
 	// It is used in the main stack output and S3 object paths.
-	CloudConfigVersion = "v_4_4_0"
+	CloudConfigVersion = "v_4_5_0"
 
 	// CloudProviderTagName is used to add Cloud Provider tags to AWS resources.
 	CloudProviderTagName = "kubernetes.io/cluster/%s"

--- a/service/controller/legacy/v28/version_bundle.go
+++ b/service/controller/legacy/v28/version_bundle.go
@@ -27,6 +27,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Update to 3.3.13. More info here: https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3313-2019-05-02",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "ignition",
+				Description: "Added name label for default and kube-system namespaces.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
v28 is still in WIP and it needs namespace labeling to work with network policies