### PR TITLE
drop cloud config version from outputs resource

### DIFF
--- a/service/controller/clusterapi/v29/controllercontext/status.go
+++ b/service/controller/clusterapi/v29/controllercontext/status.go
@@ -57,7 +57,6 @@ type ContextStatusTenantClusterMasterInstance struct {
 	Image                    string
 	ResourceName             string
 	Type                     string
-	CloudConfigVersion       string
 }
 
 type ContextStatusTenantClusterTCCP struct {
@@ -76,7 +75,6 @@ type ContextStatusTenantClusterTCCPVPC struct {
 
 type ContextStatusTenantClusterWorkerInstance struct {
 	DockerVolumeSizeGB string
-	CloudConfigVersion string
 	Image              string
 	Type               string
 }

--- a/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/detection"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
 )
 
 const (
@@ -177,7 +176,6 @@ func defaultControllerContext() controllercontext.Context {
 				VersionBundleVersion: "6.3.0",
 				WorkerInstance: controllercontext.ContextStatusTenantClusterWorkerInstance{
 					DockerVolumeSizeGB: "100",
-					CloudConfigVersion: key.CloudConfigVersion,
 					Image:              "ami-0eb0d9bb7ad1bd1e9",
 					Type:               "m5.xlarge",
 				},

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -12,8 +12,6 @@ Outputs:
     Value: rsc-ac0dc01
   MasterInstanceType:
     Value: m5.xlarge
-  MasterCloudConfigVersion:
-    Value: v_4_5_0
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:
@@ -26,8 +24,6 @@ Outputs:
     Value: ami-0eb0d9bb7ad1bd1e9
   WorkerInstanceType:
     Value: m5.2xlarge
-  WorkerCloudConfigVersion:
-    Value: v_4_5_0
   VersionBundleVersion:
     Value:
       Ref: VersionBundleVersionParameter

--- a/service/controller/clusterapi/v29/resource/tccpoutputs/create.go
+++ b/service/controller/clusterapi/v29/resource/tccpoutputs/create.go
@@ -14,15 +14,12 @@ import (
 const (
 	DockerVolumeResourceNameKey   = "DockerVolumeResourceName"
 	HostedZoneNameServersKey      = "HostedZoneNameServers"
-	MasterCloudConfigVersionKey   = "MasterCloudConfigVersion"
 	MasterImageIDKey              = "MasterImageID"
 	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
 	MasterInstanceTypeKey         = "MasterInstanceType"
 	VersionBundleVersionKey       = "VersionBundleVersion"
 	VPCIDKey                      = "VPCID"
 	VPCPeeringConnectionIDKey     = "VPCPeeringConnectionID"
-	WorkerASGNameKey              = "WorkerASGName"
-	WorkerCloudConfigVersionKey   = "WorkerCloudConfigVersion"
 	WorkerDockerVolumeSizeKey     = "WorkerDockerVolumeSizeGB"
 	WorkerImageIDKey              = "WorkerImageID"
 	WorkerInstanceTypeKey         = "WorkerInstanceType"
@@ -118,14 +115,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, MasterCloudConfigVersionKey)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		cc.Status.TenantCluster.MasterInstance.CloudConfigVersion = v
-	}
-
-	{
 		v, err := cloudFormation.GetOutputValue(outputs, VersionBundleVersionKey)
 		if err != nil {
 			return microerror.Mask(err)
@@ -147,14 +136,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 		cc.Status.TenantCluster.TCCP.VPC.PeeringConnectionID = v
-	}
-
-	{
-		v, err := cloudFormation.GetOutputValue(outputs, WorkerCloudConfigVersionKey)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		cc.Status.TenantCluster.WorkerInstance.CloudConfigVersion = v
 	}
 
 	{

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/outputs.go
@@ -14,8 +14,6 @@ const Outputs = `
     Value: {{ .Guest.Outputs.Master.Instance.ResourceName }}
   MasterInstanceType:
     Value: {{ .Guest.Outputs.Master.Instance.Type }}
-  MasterCloudConfigVersion:
-    Value: {{ .Guest.Outputs.Master.CloudConfig.Version }}
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:
@@ -28,8 +26,6 @@ const Outputs = `
     Value: {{ .Guest.Outputs.Worker.ImageID }}
   WorkerInstanceType:
     Value: {{ .Guest.Outputs.Worker.InstanceType }}
-  WorkerCloudConfigVersion:
-    Value: {{ .Guest.Outputs.Worker.CloudConfig.Version }}
   VersionBundleVersion:
     Value:
       Ref: VersionBundleVersionParameter


### PR DESCRIPTION
Towards Node Pools. When we later want to update the CF stacks of a Node Pool we need certain information in the stack outputs. In the next steps we need to create a new resource for the stack outputs of the Node Pools. This here is preparation for the upcoming PRs. 