### PR TITLE
Tag tenant cluster control plane resources

### DIFF
--- a/service/controller/clusterapi/v29/adapter/guest_subnets.go
+++ b/service/controller/clusterapi/v29/adapter/guest_subnets.go
@@ -14,6 +14,7 @@ type Subnet struct {
 	Name                  string
 	MapPublicIPOnLaunch   bool
 	RouteTableAssociation RouteTableAssociation
+	Type                  string
 }
 
 type RouteTableAssociation struct {
@@ -56,6 +57,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 				RouteTableName: "PublicRouteTable",
 				SubnetName:     snetName,
 			},
+			Type: "public",
 		}
 		s.PublicSubnets = append(s.PublicSubnets, snet)
 
@@ -70,6 +72,7 @@ func (s *GuestSubnetsAdapter) Adapt(cfg Config) error {
 				RouteTableName: key.PrivateRouteTableName(i),
 				SubnetName:     snetName,
 			},
+			Type: "private",
 		}
 		s.PrivateSubnets = append(s.PrivateSubnets, snet)
 	}

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -526,6 +526,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PublicSubnet
+      - Key: giantswarm.io/subnet-type
+        Value: public
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/elb"
@@ -548,6 +550,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PublicSubnet01
+      - Key: giantswarm.io/subnet-type
+        Value: public
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/elb"
@@ -570,6 +574,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnet
+      - Key: giantswarm.io/subnet-type
+        Value: private
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/internal-elb"
@@ -591,6 +597,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnet01
+      - Key: giantswarm.io/subnet-type
+        Value: private
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/internal-elb"

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -49,6 +49,8 @@ Resources:
         Value: 8y5ck
       - Key: Installation
         Value: 
+      - Key: giantswarm.io/tccp
+        Value: true
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -59,6 +61,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+        - Key: giantswarm.io/tccp
+          Value: true
   VPCS3Endpoint:
     Type: 'AWS::EC2::VPCEndpoint'
     Properties:
@@ -274,6 +278,8 @@ Resources:
       Tags:
         - Key: Name
           Value:  8y5ck-master
+        - Key: giantswarm.io/tccp
+          Value: true
 
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -349,6 +355,8 @@ Resources:
       Tags:
         - Key: Name
           Value:  8y5ck-worker
+        - Key: giantswarm.io/tccp
+          Value: true
 
   IngressSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -372,6 +380,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-ingress
+        - Key: giantswarm.io/tccp
+          Value: true
 
   EtcdELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -395,6 +405,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-etcd-elb
+        - Key: giantswarm.io/tccp
+          Value: true
 
   # Allow all access between masters and workers for calico. This is done after
   # the other rules to avoid circular dependencies.
@@ -469,6 +481,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-public
+      - Key: giantswarm.io/tccp
+        Value: true
   PrivateRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -476,6 +490,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-private
+      - Key: giantswarm.io/tccp
+        Value: true
 
   VPCPeeringRoute:
     Type: AWS::EC2::Route
@@ -492,6 +508,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-private01
+      - Key: giantswarm.io/tccp
+        Value: true
 
   VPCPeeringRoute01:
     Type: AWS::EC2::Route
@@ -512,6 +530,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PublicSubnet
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/elb"
         Value: "1"
       VpcId: !Ref VPC
@@ -532,6 +552,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PublicSubnet01
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/elb"
         Value: "1"
       VpcId: !Ref VPC
@@ -552,6 +574,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnet
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/internal-elb"
         Value: "1"
       VpcId: !Ref VPC
@@ -571,6 +595,8 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnet01
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/internal-elb"
         Value: "1"
       VpcId: !Ref VPC
@@ -589,6 +615,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+        - Key: giantswarm.io/tccp
+          Value: true
 
   VPCGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -625,6 +653,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+        - Key: giantswarm.io/tccp
+          Value: true
   NATEIP:
     Type: AWS::EC2::EIP
     Properties:
@@ -650,6 +680,8 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+        - Key: giantswarm.io/tccp
+          Value: true
   NATEIP01:
     Type: AWS::EC2::EIP
     Properties:
@@ -684,6 +716,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-master
+      - Key: giantswarm.io/tccp
+        Value: true
   rsc-abbacd01:
     Type: AWS::EC2::Volume
     Properties:
@@ -696,6 +730,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-docker
+      - Key: giantswarm.io/tccp
+        Value: true
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
@@ -708,6 +744,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-etcd
+      - Key: giantswarm.io/tccp
+        Value: true
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
@@ -720,6 +758,8 @@ Resources:
       Tags:
       - Key: Name
         Value: 8y5ck-log
+      - Key: giantswarm.io/tccp
+        Value: true
   rsc-ac0dc01DockerMountPoint:
     Type: AWS::EC2::VolumeAttachment
     Properties:
@@ -920,6 +960,9 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-worker
+          PropagateAtLaunch: true
+        - Key: giantswarm.io/tccp
+          Value: true
           PropagateAtLaunch: true
         - Key: k8s.io/cluster-autoscaler/enabled
           Value: true

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/auto_scaling_group.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/auto_scaling_group.go
@@ -27,6 +27,9 @@ const AutoScalingGroup = `
         - Key: Name
           Value: {{ $v.ClusterID }}-{{ $v.ASGType }}
           PropagateAtLaunch: true
+        - Key: giantswarm.io/tccp
+          Value: true
+          PropagateAtLaunch: true
         - Key: k8s.io/cluster-autoscaler/enabled
           Value: true
           PropagateAtLaunch: false

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/instance.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/instance.go
@@ -23,6 +23,8 @@ const Instance = `
       Tags:
       - Key: Name
         Value: {{ $v.Cluster.ID }}-master
+      - Key: giantswarm.io/tccp
+        Value: true
   {{ $v.Master.DockerVolume.ResourceName }}:
     Type: AWS::EC2::Volume
     Properties:
@@ -35,6 +37,8 @@ const Instance = `
       Tags:
       - Key: Name
         Value: {{ $v.Master.DockerVolume.Name }}
+      - Key: giantswarm.io/tccp
+        Value: true
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
@@ -47,6 +51,8 @@ const Instance = `
       Tags:
       - Key: Name
         Value: {{ $v.Master.EtcdVolume.Name }}
+      - Key: giantswarm.io/tccp
+        Value: true
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
@@ -59,6 +65,8 @@ const Instance = `
       Tags:
       - Key: Name
         Value: {{ $v.Master.LogVolume.Name }}
+      - Key: giantswarm.io/tccp
+        Value: true
   {{ $v.Master.Instance.ResourceName }}DockerMountPoint:
     Type: AWS::EC2::VolumeAttachment
     Properties:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/internet_gateway.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/internet_gateway.go
@@ -9,6 +9,8 @@ const InternetGateway = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}
+        - Key: giantswarm.io/tccp
+          Value: true
 
   VPCGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/nat_gateway.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/nat_gateway.go
@@ -17,6 +17,8 @@ const NatGateway = `
       Tags:
         - Key: Name
           Value: {{ .ClusterID }}
+        - Key: giantswarm.io/tccp
+          Value: true
   {{ .NATEIPName }}:
     Type: AWS::EC2::EIP
     Properties:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/route_tables.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/route_tables.go
@@ -10,6 +10,8 @@ const RouteTables = `
       Tags:
       - Key: Name
         Value: {{ $v.PublicRouteTableName.TagName }}
+      - Key: giantswarm.io/tccp
+        Value: true
 
   {{- range $v.PrivateRouteTableNames }}
   {{ .ResourceName }}:
@@ -19,6 +21,8 @@ const RouteTables = `
       Tags:
       - Key: Name
         Value: {{ .TagName }}
+      - Key: giantswarm.io/tccp
+        Value: true
 
   {{ .VPCPeeringRouteName }}:
     Type: AWS::EC2::Route

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/security_groups.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/security_groups.go
@@ -31,6 +31,8 @@ const SecurityGroups = `
       Tags:
         - Key: Name
           Value:  {{ $v.MasterSecurityGroupName }}
+        - Key: giantswarm.io/tccp
+          Value: true
 
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -52,6 +54,8 @@ const SecurityGroups = `
       Tags:
         - Key: Name
           Value:  {{ $v.WorkerSecurityGroupName }}
+        - Key: giantswarm.io/tccp
+          Value: true
 
   IngressSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -69,6 +73,8 @@ const SecurityGroups = `
       Tags:
         - Key: Name
           Value: {{ $v.IngressSecurityGroupName }}
+        - Key: giantswarm.io/tccp
+          Value: true
 
   EtcdELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -86,6 +92,8 @@ const SecurityGroups = `
       Tags:
         - Key: Name
           Value: {{ $v.EtcdELBSecurityGroupName }}
+        - Key: giantswarm.io/tccp
+          Value: true
 
   # Allow all access between masters and workers for calico. This is done after
   # the other rules to avoid circular dependencies.

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/subnets.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/subnets.go
@@ -13,6 +13,8 @@ const Subnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
+      - Key: giantswarm.io/subnet-type
+        Value: {{ .Type }}
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/elb"
@@ -37,6 +39,8 @@ const Subnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
+      - Key: giantswarm.io/subnet-type
+        Value: {{ .Type }}
       - Key: giantswarm.io/tccp
         Value: true
       - Key: "kubernetes.io/role/internal-elb"

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/subnets.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/subnets.go
@@ -13,6 +13,8 @@ const Subnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/elb"
         Value: "1"
       VpcId: !Ref VPC
@@ -35,6 +37,8 @@ const Subnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
+      - Key: giantswarm.io/tccp
+        Value: true
       - Key: "kubernetes.io/role/internal-elb"
         Value: "1"
       VpcId: !Ref VPC

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/vpc.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/vpc.go
@@ -14,6 +14,8 @@ const VPC = `
         Value: {{ $v.ClusterID }}
       - Key: Installation
         Value: {{ $v.InstallationName }}
+      - Key: giantswarm.io/tccp
+        Value: true
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -24,6 +26,8 @@ const VPC = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}
+        - Key: giantswarm.io/tccp
+          Value: true
   VPCS3Endpoint:
     Type: 'AWS::EC2::VPCEndpoint'
     Properties:


### PR DESCRIPTION
Add `giantswarm.io/tccp` tag to AWS resources that belong to tenant cluster
control plane.

This is needed e.g. for gathering only subnets that below to TCCP (in contrast
to all tenant cluster subnets where most of them belong to distinct node
pools).