### PR TITLE
move network package to version bundle

### DIFF
--- a/service/controller/clusterapi/cluster.go
+++ b/service/controller/clusterapi/cluster.go
@@ -21,16 +21,14 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29"
 	v29adapter "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/adapter"
 	v29cloudconfig "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/network"
 )
 
 type ClusterConfig struct {
-	CMAClient        clientset.Interface
-	G8sClient        versioned.Interface
-	K8sClient        kubernetes.Interface
-	K8sExtClient     apiextensionsclient.Interface
-	Logger           micrologger.Logger
-	NetworkAllocator network.Allocator
+	CMAClient    clientset.Interface
+	G8sClient    versioned.Interface
+	K8sClient    kubernetes.Interface
+	K8sExtClient apiextensionsclient.Interface
+	Logger       micrologger.Logger
 
 	AccessLogsExpiration       int
 	AdvancedMonitoringEC2      bool
@@ -207,7 +205,6 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			HostAWSConfig:          config.HostAWSConfig,
 			K8sClient:              config.K8sClient,
 			Logger:                 config.Logger,
-			NetworkAllocator:       config.NetworkAllocator,
 			RandomKeysSearcher:     randomKeysSearcher,
 
 			AccessLogsExpiration:  config.AccessLogsExpiration,

--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/detection"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/encrypter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/network"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/awsclient"
@@ -99,6 +100,17 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var networkAllocator network.Allocator
+	{
+		c := network.Config{
+			Logger: config.Logger,
+		}
+		networkAllocator, err = network.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var accountIDResource controller.Resource
 	{
 		c := accountid.Config{
@@ -173,7 +185,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			CMAClient:        config.CMAClient,
 			G8sClient:        config.G8sClient,
 			Logger:           config.Logger,
-			NetworkAllocator: config.NetworkAllocator,
+			NetworkAllocator: networkAllocator,
 
 			AllocatedSubnetMaskBits: config.GuestSubnetMaskBits,
 			AvailabilityZones:       config.GuestAvailabilityZones,

--- a/service/controller/clusterapi/v29/cluster_resource_set_config.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/network"
 )
 
 type ClusterResourceSetConfig struct {
@@ -24,7 +23,6 @@ type ClusterResourceSetConfig struct {
 	HostAWSConfig          aws.Config
 	K8sClient              kubernetes.Interface
 	Logger                 micrologger.Logger
-	NetworkAllocator       network.Allocator
 	RandomKeysSearcher     randomkeys.Interface
 
 	AccessLogsExpiration       int

--- a/service/controller/clusterapi/v29/key/machine_deployment.go
+++ b/service/controller/clusterapi/v29/key/machine_deployment.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/pkg/label"
-	"github.com/giantswarm/aws-operator/service/network"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/network"
 )
 
 func WorkerClusterID(cr v1alpha1.MachineDeployment) string {

--- a/service/controller/clusterapi/v29/network/allocator.go
+++ b/service/controller/clusterapi/v29/network/allocator.go
@@ -1,0 +1,84 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/giantswarm/ipam"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type allocator struct {
+	logger micrologger.Logger
+	mutex  *sync.Mutex
+}
+
+func New(config Config) (Allocator, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &allocator{
+		logger: config.Logger,
+		mutex:  &sync.Mutex{},
+	}
+
+	return r, nil
+}
+
+func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks AllocationCallbacks) (net.IPNet, error) {
+	i.logger.LogCtx(ctx, "level", "debug", "message", "acquiring lock for IPAM")
+	i.mutex.Lock()
+	i.logger.LogCtx(ctx, "level", "debug", "message", "acquired lock for IPAM")
+
+	defer func() {
+		i.logger.LogCtx(ctx, "level", "debug", "message", "releasing lock for IPAM")
+		i.mutex.Unlock()
+		i.logger.LogCtx(ctx, "level", "debug", "message", "released lock for IPAM")
+	}()
+
+	var err error
+	var reservedSubnets []net.IPNet
+	{
+		i.logger.LogCtx(ctx, "level", "debug", "message", "getting allocated subnets")
+
+		reservedSubnets, err = callbacks.GetReservedNetworks(ctx)
+		if err != nil {
+			return net.IPNet{}, microerror.Mask(err)
+		}
+
+		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("got allocated subnets: %q", reservedSubnets))
+	}
+
+	var subnet net.IPNet
+	{
+		i.logger.LogCtx(ctx, "level", "debug", "message", "finding free subnet")
+
+		subnet, err = ipam.Free(fullRange, netSize, reservedSubnets)
+		if err != nil {
+			return net.IPNet{}, microerror.Maskf(err, "networkRange: %s, allocatedSubnetMask: %s, reservedSubnets: %#v", fullRange.String(), netSize.String(), reservedSubnets)
+		}
+
+		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found free subnet %#q", subnet.String()))
+	}
+
+	{
+		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("persisting allocation candidate: %q", subnet.String()))
+
+		err = callbacks.PersistAllocatedNetwork(ctx, subnet)
+		if err != nil {
+			return net.IPNet{}, microerror.Mask(err)
+		}
+
+		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("persisted allocation candidate: %q", subnet.String()))
+	}
+
+	return subnet, nil
+}

--- a/service/controller/clusterapi/v29/network/allocator_test.go
+++ b/service/controller/clusterapi/v29/network/allocator_test.go
@@ -1,0 +1,257 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+var errArtificial = errors.New("artificial error")
+
+func mustParseCIDR(val string) net.IPNet {
+	_, n, err := net.ParseCIDR(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return *n
+}
+
+func Test_Allocator(t *testing.T) {
+	testCases := []struct {
+		name           string
+		callbacks      AllocationCallbacks
+		networkRange   net.IPNet
+		subnetSize     net.IPMask
+		expectedSubnet net.IPNet
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: allocate first subnet",
+			callbacks: AllocationCallbacks{
+				GetReservedNetworks:     func(_ context.Context) ([]net.IPNet, error) { return []net.IPNet{}, nil },
+				PersistAllocatedNetwork: func(_ context.Context, _ net.IPNet) error { return nil },
+			},
+			networkRange:   mustParseCIDR("10.100.0.0/16"),
+			subnetSize:     net.CIDRMask(24, 32),
+			expectedSubnet: mustParseCIDR("10.100.0.0/24"),
+			errorMatcher:   nil,
+		},
+		{
+			name: "case 1: allocate fourth subnet",
+			callbacks: AllocationCallbacks{
+				GetReservedNetworks: func(_ context.Context) ([]net.IPNet, error) {
+					reservedNetworks := []net.IPNet{
+						mustParseCIDR("10.100.0.0/24"),
+						mustParseCIDR("10.100.1.0/24"),
+						mustParseCIDR("10.100.3.0/24"),
+					}
+					return reservedNetworks, nil
+				},
+				PersistAllocatedNetwork: func(_ context.Context, _ net.IPNet) error { return nil },
+			},
+			networkRange:   mustParseCIDR("10.100.0.0/16"),
+			subnetSize:     net.CIDRMask(24, 32),
+			expectedSubnet: mustParseCIDR("10.100.2.0/24"),
+			errorMatcher:   nil,
+		},
+		{
+			name: "case 2: handle error from getting reserved networks",
+			callbacks: AllocationCallbacks{
+				GetReservedNetworks:     func(_ context.Context) ([]net.IPNet, error) { return nil, errArtificial },
+				PersistAllocatedNetwork: func(_ context.Context, _ net.IPNet) error { return nil },
+			},
+			networkRange:   mustParseCIDR("10.100.0.0/16"),
+			subnetSize:     net.CIDRMask(24, 32),
+			expectedSubnet: net.IPNet{},
+			errorMatcher:   func(err error) bool { return microerror.Cause(err) == errArtificial },
+		},
+		{
+			name: "case 3: handle error from persisting allocated network",
+			callbacks: AllocationCallbacks{
+				GetReservedNetworks:     func(_ context.Context) ([]net.IPNet, error) { return []net.IPNet{}, nil },
+				PersistAllocatedNetwork: func(_ context.Context, _ net.IPNet) error { return errArtificial },
+			},
+			networkRange:   mustParseCIDR("10.100.0.0/16"),
+			subnetSize:     net.CIDRMask(24, 32),
+			expectedSubnet: net.IPNet{},
+			errorMatcher:   func(err error) bool { return microerror.Cause(err) == errArtificial },
+		},
+	}
+
+	svc, err := New(Config{Logger: microloggertest.New()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			net, err := svc.Allocate(context.Background(), tc.networkRange, tc.subnetSize, tc.callbacks)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(net, tc.expectedSubnet) {
+				t.Fatalf("Allocated subnet == %q, want %q", net.String(), tc.expectedSubnet.String())
+			}
+		})
+	}
+}
+
+func Test_Allocator_Locking(t *testing.T) {
+	svc, err := New(Config{Logger: microloggertest.New()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	/*
+		This is how this test is expected to execute:
+		  * Create a channel that is used to signal from thread #1 when it is
+		    inside a lock in Allocate().
+		  * In thread #2 wait for that signal before calling Allocate().
+		  * When thread #1 has sent signal, it sleeps for a little while so that it
+		    guarantees that thread #2 is waiting for mutex.
+		  * Each thread then performs subnet allocation and verifies that allocated
+		    subnet matches the expectation.
+	*/
+
+	fullRange := mustParseCIDR("10.100.0.0/16")
+	netSize := net.CIDRMask(24, 32)
+
+	reservedNetworksMutex := &sync.Mutex{}
+	var reservedNetworks *[]net.IPNet
+	{
+		// Take a pointer to slice so that behaviour is correct between
+		// goroutines during re-allocations in slice.
+		slice := make([]net.IPNet, 0)
+		reservedNetworks = &slice
+	}
+
+	// signal is the channel that is used from thread #2 to signal that thread
+	// #1 can call Allocate().
+	signal := make(chan struct{})
+
+	// wg is a WaitGroup for this test to wait until both threads have
+	// executed.
+	wg := &sync.WaitGroup{}
+
+	// Thread #1
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		callbacks := AllocationCallbacks{
+			GetReservedNetworks: func(_ context.Context) ([]net.IPNet, error) {
+				// Allow second thread to call AllocateNetwork.
+				signal <- struct{}{}
+
+				// Add a bit of delay to let it catch up.
+				time.Sleep(100 * time.Millisecond)
+
+				reservedNetworksMutex.Lock()
+				networks := *reservedNetworks
+				reservedNetworksMutex.Unlock()
+				return networks, nil
+			},
+			PersistAllocatedNetwork: func(_ context.Context, n net.IPNet) error {
+				reservedNetworksMutex.Lock()
+				*reservedNetworks = append(*reservedNetworks, n)
+				reservedNetworksMutex.Unlock()
+				return nil
+			},
+		}
+
+		reservedNetworksMutex.Lock()
+		numReservedNetworks := len(*reservedNetworks)
+		reservedNetworksMutex.Unlock()
+		numExpectedReservedNetworks := 0
+		if numReservedNetworks != numExpectedReservedNetworks {
+			t.Errorf("expected len(reservedNetworks) == %d, got %d", numExpectedReservedNetworks, numReservedNetworks)
+		}
+		_, err := svc.Allocate(context.Background(), fullRange, netSize, callbacks)
+		if err != nil {
+			t.Error(err)
+		}
+
+		reservedNetworksMutex.Lock()
+		numReservedNetworks = len(*reservedNetworks)
+		reservedNetworksMutex.Unlock()
+		numExpectedReservedNetworks = 1
+		if numReservedNetworks != numExpectedReservedNetworks {
+			t.Errorf("expected len(reservedNetworks) == %d, got %d", numExpectedReservedNetworks, numReservedNetworks)
+		}
+
+		expectedNetwork := mustParseCIDR("10.100.0.0/24")
+		reservedNetworksMutex.Lock()
+		gotNetwork := (*reservedNetworks)[0]
+		reservedNetworksMutex.Unlock()
+		if !reflect.DeepEqual(gotNetwork, expectedNetwork) {
+			t.Errorf("expected subnet %q to be allocated, got %q", expectedNetwork.String(), gotNetwork.String())
+		}
+	}()
+
+	// Thread #2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		callbacks := AllocationCallbacks{
+			GetReservedNetworks: func(_ context.Context) ([]net.IPNet, error) {
+				fmt.Printf("reservedNetworks: %#v\n", *reservedNetworks)
+
+				reservedNetworksMutex.Lock()
+				networks := *reservedNetworks
+				reservedNetworksMutex.Unlock()
+				return networks, nil
+			},
+			PersistAllocatedNetwork: func(_ context.Context, n net.IPNet) error {
+				reservedNetworksMutex.Lock()
+				*reservedNetworks = append(*reservedNetworks, n)
+				reservedNetworksMutex.Unlock()
+				return nil
+			},
+		}
+
+		// Wait for signal from first thread before getting into allocation.
+		<-signal
+
+		_, err := svc.Allocate(context.Background(), fullRange, netSize, callbacks)
+		if err != nil {
+			t.Error(err)
+		}
+
+		reservedNetworksMutex.Lock()
+		numReservedNetworks := len(*reservedNetworks)
+		reservedNetworksMutex.Unlock()
+		numExpectedReservedNetworks := 2
+		if numReservedNetworks != numExpectedReservedNetworks {
+			t.Errorf("expected len(reservedNetworks) == %d, got %d", numExpectedReservedNetworks, numReservedNetworks)
+		}
+
+		expectedNetwork := mustParseCIDR("10.100.1.0/24")
+		reservedNetworksMutex.Lock()
+		gotNetwork := (*reservedNetworks)[1]
+		reservedNetworksMutex.Unlock()
+		if !reflect.DeepEqual(gotNetwork, expectedNetwork) {
+			t.Errorf("expected subnet %q to be allocated, got %q", expectedNetwork.String(), gotNetwork.String())
+		}
+	}()
+
+	wg.Wait()
+}

--- a/service/controller/clusterapi/v29/network/error.go
+++ b/service/controller/clusterapi/v29/network/error.go
@@ -1,0 +1,21 @@
+package network
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidParameterError = &microerror.Error{
+	Kind: "invalid parameter",
+}
+
+// IsInvalidParameter asserts invalidParameterError.
+func IsInvalidParameter(err error) bool {
+	return microerror.Cause(err) == invalidParameterError
+}

--- a/service/controller/clusterapi/v29/network/spec.go
+++ b/service/controller/clusterapi/v29/network/spec.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"context"
+	"net"
+)
+
+// AllocationCallbacks holds function pointers for two methods that must be
+// called inside a lock when allocating new network range.
+type AllocationCallbacks struct {
+	// GetReservedNetworks implementation must return all networks that are
+	// allocated on any given moment. Failing to do that will result in
+	// overlapping allocations.
+	GetReservedNetworks func(context.Context) ([]net.IPNet, error)
+
+	// PersistAllocatedNetwork must mutate shared persistent state so that on
+	// successful execution persistet network is visible when
+	// GetReservedNetworks() is called.
+	PersistAllocatedNetwork func(context.Context, net.IPNet) error
+}
+
+// Allocator is an interface for IPAM implementation that manages network range
+// and subnets for an installation.
+type Allocator interface {
+	// Allocate performs the subnet allocation from given fullRange for a CIDR
+	// block with netSize. It requires function pointers to callbacks that are
+	// used for getting currently reserved networks and persisting allocated
+	// network. These are called within an single lock so given that callbacks
+	// work correctly, this is concurrent safe within single process e.g. when
+	// logic between multiple controllers are allocating networks from the same
+	// pool.
+	//
+	// NOTE: This is NOT concurrent safe between distinct processes.
+	//
+	// This returns either allocated network or an error.
+	Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks AllocationCallbacks) (net.IPNet, error)
+}

--- a/service/controller/clusterapi/v29/network/splitter.go
+++ b/service/controller/clusterapi/v29/network/splitter.go
@@ -1,0 +1,46 @@
+package network
+
+import (
+	"math/bits"
+	"net"
+
+	"github.com/giantswarm/ipam"
+	"github.com/giantswarm/microerror"
+)
+
+// CalculateSubnetMask calculates new subnet mask to accommodate n subnets.
+func CalculateSubnetMask(networkMask net.IPMask, n uint) (net.IPMask, error) {
+	if n == 0 {
+		return nil, microerror.Maskf(invalidParameterError, "divide by zero")
+	}
+
+	// Calculate amount of bits needed to accommodate at least N subnets.
+	subnetBitsNeeded := bits.Len(n - 1)
+
+	maskOnes, maskBits := networkMask.Size()
+	if subnetBitsNeeded > maskBits-maskOnes {
+		return nil, microerror.Maskf(invalidParameterError, "no room in network mask %s to accommodate %d subnets", networkMask.String(), n)
+	}
+
+	return net.CIDRMask(maskOnes+subnetBitsNeeded, maskBits), nil
+}
+
+// Split returns n subnets from network.
+func Split(network net.IPNet, n uint) ([]net.IPNet, error) {
+	mask, err := CalculateSubnetMask(network.Mask, n)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var subnets []net.IPNet
+	for i := uint(0); i < n; i++ {
+		subnet, err := ipam.Free(network, mask, subnets)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		subnets = append(subnets, subnet)
+	}
+
+	return subnets, nil
+}

--- a/service/controller/clusterapi/v29/network/splitter_test.go
+++ b/service/controller/clusterapi/v29/network/splitter_test.go
@@ -1,0 +1,172 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func Test_CalculateSubnetMask(t *testing.T) {
+	testCases := []struct {
+		name         string
+		mask         net.IPMask
+		n            uint
+		expectedMask net.IPMask
+		errorMatcher func(error) bool
+	}{
+		{
+			name:         "case 0: split /24 into one network",
+			mask:         net.CIDRMask(24, 32),
+			n:            1,
+			expectedMask: net.CIDRMask(24, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 1: split /24 into two networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            2,
+			expectedMask: net.CIDRMask(25, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 2: split /24 into three networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            3,
+			expectedMask: net.CIDRMask(26, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 3: split /24 into four networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            4,
+			expectedMask: net.CIDRMask(26, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 4: split /24 into five networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            5,
+			expectedMask: net.CIDRMask(27, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 5: split /22 into 7 networks",
+			mask:         net.CIDRMask(22, 32),
+			n:            7,
+			expectedMask: net.CIDRMask(25, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 6: split /31 into 8 networks (no room)",
+			mask:         net.CIDRMask(31, 32),
+			n:            7,
+			expectedMask: nil,
+			errorMatcher: IsInvalidParameter,
+		},
+		{
+			name:         "case 7: IPv6 masks (split /31 for seven networks)",
+			mask:         net.CIDRMask(31, 128),
+			n:            7,
+			expectedMask: net.CIDRMask(34, 128),
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mask, err := CalculateSubnetMask(tc.mask, tc.n)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(mask, tc.expectedMask) {
+				t.Fatalf("Mask == %q, want %q", mask, tc.expectedMask)
+			}
+		})
+	}
+}
+
+func Test_Split(t *testing.T) {
+	testCases := []struct {
+		name            string
+		network         net.IPNet
+		n               uint
+		expectedSubnets []net.IPNet
+		errorMatcher    func(error) bool
+	}{
+		{
+			name:    "case 0: split /24 into four networks",
+			network: mustParseCIDR("192.168.8.0/24"),
+			n:       4,
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.8.0/26"),
+				mustParseCIDR("192.168.8.64/26"),
+				mustParseCIDR("192.168.8.128/26"),
+				mustParseCIDR("192.168.8.192/26"),
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:    "case 1: split /22 into 7 networks",
+			network: mustParseCIDR("10.100.0.0/22"),
+			n:       7,
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("10.100.0.0/25"),
+				mustParseCIDR("10.100.0.128/25"),
+				mustParseCIDR("10.100.1.0/25"),
+				mustParseCIDR("10.100.1.128/25"),
+				mustParseCIDR("10.100.2.0/25"),
+				mustParseCIDR("10.100.2.128/25"),
+				mustParseCIDR("10.100.3.0/25"),
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:            "case 2: split /31 into 8 networks (no room)",
+			network:         mustParseCIDR("192.168.8.128/31"),
+			n:               7,
+			expectedSubnets: nil,
+			errorMatcher:    IsInvalidParameter,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subnets, err := Split(tc.network, tc.n)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(subnets, tc.expectedSubnets) {
+				msg := "expected: {\n"
+				for _, n := range tc.expectedSubnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}\n\ngot: {\n"
+				for _, n := range subnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}"
+				t.Fatal(msg)
+
+			}
+		})
+	}
+}

--- a/service/controller/clusterapi/v29/resource/ipam/create.go
+++ b/service/controller/clusterapi/v29/resource/ipam/create.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
-	"github.com/giantswarm/aws-operator/service/network"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/network"
 )
 
 // EnsureCreated allocates guest cluster network segment. It gathers existing

--- a/service/controller/clusterapi/v29/resource/ipam/resource.go
+++ b/service/controller/clusterapi/v29/resource/ipam/resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
-	"github.com/giantswarm/aws-operator/service/network"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/network"
 )
 
 const (

--- a/service/service.go
+++ b/service/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/collector"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy"
-	"github.com/giantswarm/aws-operator/service/network"
+	legacynetwork "github.com/giantswarm/aws-operator/service/network"
 )
 
 // Config represents the configuration used to create a new service.
@@ -121,12 +121,12 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
-	var networkAllocator network.Allocator
+	var legacyNetworkAllocator legacynetwork.Allocator
 	{
-		c := network.Config{
+		c := legacynetwork.Config{
 			Logger: config.Logger,
 		}
-		networkAllocator, err = network.New(c)
+		legacyNetworkAllocator, err = legacynetwork.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -140,12 +140,11 @@ func New(config Config) (*Service, error) {
 		}
 
 		c := clusterapi.ClusterConfig{
-			CMAClient:        cmaClient,
-			G8sClient:        g8sClient,
-			K8sClient:        k8sClient,
-			K8sExtClient:     k8sExtClient,
-			Logger:           config.Logger,
-			NetworkAllocator: networkAllocator,
+			CMAClient:    cmaClient,
+			G8sClient:    g8sClient,
+			K8sClient:    k8sClient,
+			K8sExtClient: k8sExtClient,
+			Logger:       config.Logger,
 
 			AccessLogsExpiration:  config.Viper.GetInt(config.Flag.Service.AWS.S3AccessLogsExpiration),
 			AdvancedMonitoringEC2: config.Viper.GetBool(config.Flag.Service.AWS.AdvancedMonitoringEC2),
@@ -249,7 +248,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:        k8sClient,
 			K8sExtClient:     k8sExtClient,
 			Logger:           config.Logger,
-			NetworkAllocator: networkAllocator,
+			NetworkAllocator: legacyNetworkAllocator,
 
 			APIWhitelist: legacy.FrameworkConfigAPIWhitelistConfig{
 				Enabled:    config.Viper.GetBool(config.Flag.Service.Installation.Guest.Kubernetes.API.Security.Whitelist.Enabled),


### PR DESCRIPTION
Towards Node Pools. I started to make the `ipam` resource work with `Cluster` as well as `MachineDeployment` types. There are a couple of things I want to adapt and chunk changes. I thought it makes a lot of sense to have the network package versioned. Otherwise every change has to be done in all versions, because the operators are not flattened via VOO. So here it is only copying code and making the clusterapi controller work with the versioned package. 