### PR TITLE
Reference correct coreOS version in release notes

### DIFF
--- a/service/controller/legacy/v28/version_bundle.go
+++ b/service/controller/legacy/v28/version_bundle.go
@@ -19,7 +19,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "containerlinux",
-				Description: "Update to 2079.5.1. https://github.com/coreos/manifest/releases/tag/v2079.5.1",
+				Description: "Update to 2135.4.0. https://github.com/coreos/manifest/releases/tag/v2135.4.0",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
@@ -40,7 +40,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2079.5.1",
+				Version: "2135.4.0",
 			},
 			{
 				Name:    "docker",


### PR DESCRIPTION
v28 already containes coreOS 2135.4.0 - I missed adding it in this previous PR:
https://github.com/giantswarm/aws-operator/pull/1715