### PR TITLE
rename spec types

### DIFF
--- a/service/controller/clusterapi/v29/network/allocator.go
+++ b/service/controller/clusterapi/v29/network/allocator.go
@@ -33,7 +33,7 @@ func New(config Config) (Allocator, error) {
 	return r, nil
 }
 
-func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks AllocationCallbacks) (net.IPNet, error) {
+func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks Callbacks) (net.IPNet, error) {
 	i.logger.LogCtx(ctx, "level", "debug", "message", "acquiring lock for IPAM")
 	i.mutex.Lock()
 	i.logger.LogCtx(ctx, "level", "debug", "message", "acquired lock for IPAM")
@@ -49,7 +49,7 @@ func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize n
 	{
 		i.logger.LogCtx(ctx, "level", "debug", "message", "getting allocated subnets")
 
-		reservedSubnets, err = callbacks.GetReservedNetworks(ctx)
+		reservedSubnets, err = callbacks.Collect(ctx)
 		if err != nil {
 			return net.IPNet{}, microerror.Mask(err)
 		}
@@ -72,7 +72,7 @@ func (i *allocator) Allocate(ctx context.Context, fullRange net.IPNet, netSize n
 	{
 		i.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("persisting allocation candidate: %q", subnet.String()))
 
-		err = callbacks.PersistAllocatedNetwork(ctx, subnet)
+		err = callbacks.Persist(ctx, subnet)
 		if err != nil {
 			return net.IPNet{}, microerror.Mask(err)
 		}

--- a/service/controller/clusterapi/v29/network/spec.go
+++ b/service/controller/clusterapi/v29/network/spec.go
@@ -5,33 +5,31 @@ import (
 	"net"
 )
 
-// AllocationCallbacks holds function pointers for two methods that must be
-// called inside a lock when allocating new network range.
-type AllocationCallbacks struct {
-	// GetReservedNetworks implementation must return all networks that are
-	// allocated on any given moment. Failing to do that will result in
-	// overlapping allocations.
-	GetReservedNetworks func(context.Context) ([]net.IPNet, error)
-
-	// PersistAllocatedNetwork must mutate shared persistent state so that on
-	// successful execution persistet network is visible when
-	// GetReservedNetworks() is called.
-	PersistAllocatedNetwork func(context.Context, net.IPNet) error
+type Callbacks struct {
+	Collect Collector
+	Persist Persister
 }
 
 // Allocator is an interface for IPAM implementation that manages network range
 // and subnets for an installation.
 type Allocator interface {
 	// Allocate performs the subnet allocation from given fullRange for a CIDR
-	// block with netSize. It requires function pointers to callbacks that are
-	// used for getting currently reserved networks and persisting allocated
-	// network. These are called within an single lock so given that callbacks
-	// work correctly, this is concurrent safe within single process e.g. when
-	// logic between multiple controllers are allocating networks from the same
-	// pool.
+	// block with netSize. It requires callbacks for getting currently reserved
+	// networks and persisting allocated networks. The callbacks are called within
+	// a single lock. Given that callbacks work correctly, this is concurrent safe
+	// within a single process e.g. when logic between multiple controllers are
+	// allocating networks from the same pool.
 	//
 	// NOTE: This is NOT concurrent safe between distinct processes.
 	//
 	// This returns either allocated network or an error.
-	Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks AllocationCallbacks) (net.IPNet, error)
+	Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks Callbacks) (net.IPNet, error)
 }
+
+// Collector implementation must return all networks that are allocated on any
+// given moment. Failing to do that will result in overlapping allocations.
+type Collector func(context.Context) ([]net.IPNet, error)
+
+// Persister must mutate shared persistent state so that on successful execution
+// persisted networks are visible by Collector implementations.
+type Persister func(context.Context, net.IPNet) error

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		for az, _ := range azsMap {
+		for az := range azsMap {
 			azs = append(azs, az)
 		}
 	}

--- a/service/controller/clusterapi/v29/resource/ipam/create.go
+++ b/service/controller/clusterapi/v29/resource/ipam/create.go
@@ -53,9 +53,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		{
 			r.logger.LogCtx(ctx, "level", "debug", "message", "allocating cluster subnet CIDR")
 
-			callbacks := network.AllocationCallbacks{
-				GetReservedNetworks:     r.getReservedNetworks,
-				PersistAllocatedNetwork: r.persistAllocatedNetwork(cr, key.WorkerAvailabilityZones(cc.Status.TenantCluster.TCCP.MachineDeployment)),
+			callbacks := network.Callbacks{
+				Collect: r.getReservedNetworks,
+				Persist: r.persistAllocatedNetwork(cr, key.WorkerAvailabilityZones(cc.Status.TenantCluster.TCCP.MachineDeployment)),
 			}
 
 			subnetCIDR, err = r.networkAllocator.Allocate(ctx, r.networkRange, r.allocatedSubnetMask, callbacks)


### PR DESCRIPTION
Towards Node Pools. I want to improve the naming of some spec types and define separate types to reuse them later. 