### PR TITLE
add cluster checker for ipam resource refactoring

### DIFF
--- a/service/controller/clusterapi/v29/network/cluster_checker.go
+++ b/service/controller/clusterapi/v29/network/cluster_checker.go
@@ -1,0 +1,56 @@
+package network
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+type ClusterCheckerConfig struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type ClusterChecker struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func NewClusterChecker(config ClusterCheckerConfig) (*ClusterChecker, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	a := &ClusterChecker{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return a, nil
+}
+
+func (c *ClusterChecker) Check(ctx context.Context, namespace string, name string) (bool, error) {
+	cr, err := c.cmaClient.ClusterV1alpha1().Clusters(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	// We check the subnet we want to ensure in the CR status. In case there is no
+	// subnet tracked so far, we want to proceed with the allocation process. Thus
+	// we return true.
+	if key.StatusClusterNetworkCIDR(*cr) == "" {
+		return true, nil
+	}
+
+	// At this point the subnet is already allocated for the CR we check here. So
+	// we do not want to proceed further and return false.
+	return false, nil
+}

--- a/service/controller/clusterapi/v29/network/spec.go
+++ b/service/controller/clusterapi/v29/network/spec.go
@@ -26,6 +26,13 @@ type Allocator interface {
 	Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks Callbacks) (net.IPNet, error)
 }
 
+// Checker implementation determines whether a subnet has to be allocated. This
+// decision is being made based on the status of the Kubernetes runtime object
+// defined by namespace and name.
+type Checker interface {
+	Check(ctx context.Context, namespace string, name string) (bool, error)
+}
+
 // Collector implementation must return all networks that are allocated on any
 // given moment. Failing to do that will result in overlapping allocations.
 type Collector func(context.Context) ([]net.IPNet, error)

--- a/service/controller/clusterapi/v29/network/spec.go
+++ b/service/controller/clusterapi/v29/network/spec.go
@@ -26,7 +26,7 @@ type Allocator interface {
 	Allocate(ctx context.Context, fullRange net.IPNet, netSize net.IPMask, callbacks Callbacks) (net.IPNet, error)
 }
 
-// Checker implementation determines whether a subnet has to be allocated. This
+// Checker determines whether a subnet has to be allocated. This
 // decision is being made based on the status of the Kubernetes runtime object
 // defined by namespace and name.
 type Checker interface {


### PR DESCRIPTION
Towards Node Pools. Here is another step towards making the `ipam` resource working for multiple types. In this PR we add a "cluster checker" implementation which aims to check if the `ipam` resource should proceed with the subnet allocation or cancel. One of the next steps is also to provide a "machine deployment checker", so we get that working for different types through the interface implementations. 