### PR TITLE
add ipam resource spec for future use

### DIFF
--- a/service/controller/clusterapi/v29/resource/ipam/spec.go
+++ b/service/controller/clusterapi/v29/resource/ipam/spec.go
@@ -1,0 +1,25 @@
+package ipam
+
+import (
+	"context"
+	"net"
+)
+
+// Checker determines whether a subnet has to be allocated. This decision is
+// being made based on the status of the Kubernetes runtime object defined by
+// namespace and name.
+type Checker interface {
+	Check(ctx context.Context, namespace string, name string) (bool, error)
+}
+
+// Collector implementation must return all networks that are allocated on any
+// given moment. Failing to do that will result in overlapping allocations.
+type Collector interface {
+	Collect(ctx context.Context) ([]net.IPNet, error)
+}
+
+// Persister must mutate shared persistent state so that on successful execution
+// persisted networks are visible by Collector implementations.
+type Persister interface {
+	Persist(ctx context.Context, subnet net.IPNet, namespace string, name string) error
+}


### PR DESCRIPTION
Towards Node Pools. I am planning to inline the network allocation magic in the `ipam` resource. Goal is to get rid of the callback thingy. The code is then also flatly structured and simple interfaces are configured to the resource which makes the whole thing straight forward and maybe even testable. The latter has to be seen though as we just dropped some tests because the code was too complicated. The godoc here will also be polished and extended with more concrete examples later. I want to wire everything accordingly and make it work. 