### PR TITLE
wire machine deployment ipam resource

### DIFF
--- a/service/controller/clusterapi/machine_deployment.go
+++ b/service/controller/clusterapi/machine_deployment.go
@@ -1,6 +1,8 @@
 package clusterapi
 
 import (
+	"net"
+
 	clusterv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/cluster/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -24,12 +26,16 @@ type MachineDeploymentConfig struct {
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
 
-	EncrypterBackend string
-	HostAWSConfig    aws.Config
-	InstallationName string
-	ProjectName      string
-	Route53Enabled   bool
-	VaultAddress     string
+	EncrypterBackend           string
+	GuestPrivateSubnetMaskBits int
+	GuestPublicSubnetMaskBits  int
+	GuestSubnetMaskBits        int
+	HostAWSConfig              aws.Config
+	InstallationName           string
+	IPAMNetworkRange           net.IPNet
+	ProjectName                string
+	Route53Enabled             bool
+	VaultAddress               string
 }
 
 type MachineDeployment struct {
@@ -132,12 +138,16 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 			K8sClient:              config.K8sClient,
 			Logger:                 config.Logger,
 
-			EncrypterBackend: config.EncrypterBackend,
-			HostAWSConfig:    config.HostAWSConfig,
-			InstallationName: config.InstallationName,
-			ProjectName:      config.ProjectName,
-			Route53Enabled:   config.Route53Enabled,
-			VaultAddress:     config.VaultAddress,
+			EncrypterBackend:           config.EncrypterBackend,
+			GuestPrivateSubnetMaskBits: config.GuestPrivateSubnetMaskBits,
+			GuestPublicSubnetMaskBits:  config.GuestPublicSubnetMaskBits,
+			GuestSubnetMaskBits:        config.GuestSubnetMaskBits,
+			HostAWSConfig:              config.HostAWSConfig,
+			InstallationName:           config.InstallationName,
+			IPAMNetworkRange:           config.IPAMNetworkRange,
+			ProjectName:                config.ProjectName,
+			Route53Enabled:             config.Route53Enabled,
+			VaultAddress:               config.VaultAddress,
 		}
 
 		v29ResourceSet, err = v29.NewMachineDeploymentResourceSet(c)

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set.go
@@ -139,8 +139,8 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 	resources := []controller.Resource{
 		awsClientResource,
 		encryptionResource,
-		ipamResource,
 		machineDeploymentSubnetResource,
+		ipamResource,
 	}
 
 	{

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/awsclient"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/encryption"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ipam"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/machinedeploymentsubnet"
 )
 
@@ -25,6 +26,48 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 	var encrypterObject encrypter.Interface
 	{
 		encrypterObject, err = newEncrypterObject(config)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var machineDeploymentChecker *ipam.MachineDeploymentChecker
+	{
+		c := ipam.MachineDeploymentCheckerConfig{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		machineDeploymentChecker, err = ipam.NewMachineDeploymentChecker(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var subnetCollector *ipam.SubnetCollector
+	{
+		c := ipam.SubnetCollectorConfig{
+			CMAClient: config.CMAClient,
+			G8sClient: config.G8sClient,
+			Logger:    config.Logger,
+
+			NetworkRange: config.IPAMNetworkRange,
+		}
+
+		subnetCollector, err = ipam.NewSubnetCollector(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var machineDeploymentPersister *ipam.MachineDeploymentPersister
+	{
+		c := ipam.MachineDeploymentPersisterConfig{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		machineDeploymentPersister, err = ipam.NewMachineDeploymentPersister(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -60,6 +103,26 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
+	var ipamResource controller.Resource
+	{
+		c := ipam.Config{
+			Checker:   machineDeploymentChecker,
+			Collector: subnetCollector,
+			Logger:    config.Logger,
+			Persister: machineDeploymentPersister,
+
+			AllocatedSubnetMaskBits: config.GuestSubnetMaskBits,
+			NetworkRange:            config.IPAMNetworkRange,
+			PrivateSubnetMaskBits:   config.GuestPrivateSubnetMaskBits,
+			PublicSubnetMaskBits:    config.GuestPublicSubnetMaskBits,
+		}
+
+		ipamResource, err = ipam.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var machineDeploymentSubnetResource controller.Resource
 	{
 		c := machinedeploymentsubnet.Config{
@@ -76,6 +139,7 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 	resources := []controller.Resource{
 		awsClientResource,
 		encryptionResource,
+		ipamResource,
 		machineDeploymentSubnetResource,
 	}
 

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set_config.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set_config.go
@@ -1,6 +1,8 @@
 package v29
 
 import (
+	"net"
+
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/kubernetes"
@@ -16,12 +18,16 @@ type MachineDeploymentResourceSetConfig struct {
 	K8sClient              kubernetes.Interface
 	Logger                 micrologger.Logger
 
-	EncrypterBackend string
-	HostAWSConfig    aws.Config
-	InstallationName string
-	ProjectName      string
-	Route53Enabled   bool
-	VaultAddress     string
+	EncrypterBackend           string
+	GuestPrivateSubnetMaskBits int
+	GuestPublicSubnetMaskBits  int
+	GuestSubnetMaskBits        int
+	HostAWSConfig              aws.Config
+	InstallationName           string
+	IPAMNetworkRange           net.IPNet
+	ProjectName                string
+	Route53Enabled             bool
+	VaultAddress               string
 }
 
 func (c MachineDeploymentResourceSetConfig) GetEncrypterBackend() string {


### PR DESCRIPTION
Towards Node Pools. This wires the `ipam` resource properly configured for `MachineDeployment` types. Just as we have it for `Cluster` types as well. 