### PR TITLE
add lock package

### DIFF
--- a/service/lock/error.go
+++ b/service/lock/error.go
@@ -1,0 +1,14 @@
+package lock
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/lock/mutex_lock.go
+++ b/service/lock/mutex_lock.go
@@ -1,0 +1,46 @@
+package lock
+
+import (
+	"context"
+	"sync"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type MutexLockConfig struct {
+	Logger micrologger.Logger
+}
+
+// MutexLock implements Interface using sync.Mutex. For now we use a shared
+// instance of *MutexLock for all IPAM related activity of network packages in
+// the legacy controllers and ipam resources in the clusterapi controllers.
+type MutexLock struct {
+	logger micrologger.Logger
+
+	mutex sync.Mutex
+}
+
+func New(config MutexLockConfig) (*MutexLock, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	l := &MutexLock{
+		logger: config.Logger,
+
+		mutex: sync.Mutex{},
+	}
+
+	return l, nil
+}
+
+func (l *MutexLock) Lock(ctx context.Context) error {
+	l.mutex.Lock()
+	return nil
+}
+
+func (l *MutexLock) Unlock(ctx context.Context) error {
+	l.mutex.Unlock()
+	return nil
+}

--- a/service/lock/spec.go
+++ b/service/lock/spec.go
@@ -1,0 +1,10 @@
+package lock
+
+import "context"
+
+// Interface is some form of lock implementation like achieved for in process
+// locking using sync.Mutex.
+type Interface interface {
+	Lock(ctx context.Context) error
+	Unlock(ctx context.Context) error
+}


### PR DESCRIPTION
Towards Node Pools. We figured out that we need locking which I dropped in my other PRs. This here is an implementation we will use in all IPAM related code to lock allocation. The package abstraction will also be beneficial once we flatten the operators in the scope of VOO. 