### PR TITLE
configure lookup function for clusterazs resource

### DIFF
--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -185,8 +185,9 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var clusterAZsResource controller.Resource
 	{
 		c := clusterazs.Config{
-			CMAClient: config.CMAClient,
-			Logger:    config.Logger,
+			CMAClient:     config.CMAClient,
+			Logger:        config.Logger,
+			ToClusterFunc: key.ToCluster,
 		}
 
 		clusterAZsResource, err = clusterazs.New(c)

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/encrypter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/awsclient"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/clusterazs"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/encryption"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/machinedeploymentsubnet"
 )
@@ -91,6 +92,20 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
+	var clusterAZsResource controller.Resource
+	{
+		c := clusterazs.Config{
+			CMAClient:     config.CMAClient,
+			Logger:        config.Logger,
+			ToClusterFunc: newMachineDeploymentToClusterFunc(config.CMAClient),
+		}
+
+		clusterAZsResource, err = clusterazs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var encryptionResource controller.Resource
 	{
 		c := encryption.Config{
@@ -146,6 +161,7 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		encryptionResource,
 		machineDeploymentSubnetResource,
 		//ipamResource,
+		clusterAZsResource,
 	}
 
 	{

--- a/service/controller/clusterapi/v29/resource/clusterazs/create.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := r.toClusterFunc(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v29/resource/clusterazs/create_test.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/create_test.go
@@ -176,8 +176,9 @@ func Test_ensureAZsAreAssignedWithSubnet(t *testing.T) {
 		var err error
 
 		c := Config{
-			CMAClient: fake.NewSimpleClientset(),
-			Logger:    microloggertest.New(),
+			CMAClient:     fake.NewSimpleClientset(),
+			Logger:        microloggertest.New(),
+			ToClusterFunc: key.ToCluster,
 		}
 
 		r, err = New(c)

--- a/service/controller/clusterapi/v29/resource/clusterazs/resource.go
+++ b/service/controller/clusterapi/v29/resource/clusterazs/resource.go
@@ -5,6 +5,7 @@ package clusterazs
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
@@ -13,13 +14,15 @@ const (
 )
 
 type Config struct {
-	CMAClient clientset.Interface
-	Logger    micrologger.Logger
+	CMAClient     clientset.Interface
+	Logger        micrologger.Logger
+	ToClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 type Resource struct {
-	cmaClient clientset.Interface
-	logger    micrologger.Logger
+	cmaClient     clientset.Interface
+	logger        micrologger.Logger
+	toClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 func New(config Config) (*Resource, error) {
@@ -29,10 +32,14 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.ToClusterFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterFunc must not be empty", config)
+	}
 
 	r := &Resource{
-		cmaClient: config.CMAClient,
-		logger:    config.Logger,
+		cmaClient:     config.CMAClient,
+		logger:        config.Logger,
+		toClusterFunc: config.ToClusterFunc,
 	}
 
 	return r, nil


### PR DESCRIPTION
Towards Node Pools. We need to have the deterministic information of availability zones and their subnets in the controller context for different controllers. Here we make the `Cluster` type lookup function configurable so it also works in the machine deployment controller. 