### PR TITLE
add structure for new machinedeploymentazs resource

### DIFF
--- a/service/controller/clusterapi/v29/resource/machinedeploymentazs/create.go
+++ b/service/controller/clusterapi/v29/resource/machinedeploymentazs/create.go
@@ -1,0 +1,9 @@
+package machinedeploymentazs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/machinedeploymentazs/delete.go
+++ b/service/controller/clusterapi/v29/resource/machinedeploymentazs/delete.go
@@ -1,0 +1,9 @@
+package machinedeploymentazs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/machinedeploymentazs/error.go
+++ b/service/controller/clusterapi/v29/resource/machinedeploymentazs/error.go
@@ -1,0 +1,12 @@
+package machinedeploymentazs
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalid config",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v29/resource/machinedeploymentazs/resource.go
+++ b/service/controller/clusterapi/v29/resource/machinedeploymentazs/resource.go
@@ -1,5 +1,12 @@
 // Package machinedeploymentazs implements a resource to gather all private
-// subnets for the configured availability zones of a node pool.
+// subnets for the configured availability zones of a node pool. Like the
+// clusterazs resource, we need logic to take the node pool subnet allocated by
+// the ipam resource and split it according to the configured availability
+// zones. We then have 1, 2 or 4 private subnet CIDRs we put into the controller
+// context for further use in the tcnp resource. Note that the availability
+// zones of a node pool cannot be updated upon creation due to the network
+// splitting. In order to change availability zones one must delete and create
+// node pools accordingly.
 package machinedeploymentazs
 
 import (

--- a/service/controller/clusterapi/v29/resource/machinedeploymentazs/resource.go
+++ b/service/controller/clusterapi/v29/resource/machinedeploymentazs/resource.go
@@ -1,0 +1,43 @@
+// Package machinedeploymentazs implements a resource to gather all private
+// subnets for the configured availability zones of a node pool.
+package machinedeploymentazs
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "machinedeploymentazsv29"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards Node Pools. Like the `clusterazs` resource, we need logic to take the node pool subnet allocated by the `ipam` resource and split it according to the configured availability zones. We then have 1, 2 or 4 private subnet CIDRs we put into the controller context for further use in the `tcnp` resource. 