### PR TITLE
Use labels getter in s3 bucket key function

### DIFF
--- a/service/controller/clusterapi/v29/adapter/guest_iam_policies.go
+++ b/service/controller/clusterapi/v29/adapter/guest_iam_policies.go
@@ -31,7 +31,7 @@ func (i *GuestIAMPoliciesAdapter) Adapt(cfg Config) error {
 	i.WorkerRoleName = key.RoleNameWorker(cfg.CustomObject)
 	i.RegionARN = key.RegionARN(cfg.CustomObject)
 	i.KMSKeyARN = cfg.TenantClusterKMSKeyARN
-	i.S3Bucket = key.BucketName(cfg.CustomObject, cfg.TenantClusterAccountID)
+	i.S3Bucket = key.BucketName(&cfg.CustomObject, cfg.TenantClusterAccountID)
 
 	return nil
 }

--- a/service/controller/clusterapi/v29/adapter/guest_instance.go
+++ b/service/controller/clusterapi/v29/adapter/guest_instance.go
@@ -79,7 +79,7 @@ func (i *GuestInstanceAdapter) Adapt(config Config) error {
 
 		c := SmallCloudconfigConfig{
 			InstanceRole: "master",
-			S3URL:        key.SmallCloudConfigS3URL(config.CustomObject, config.TenantClusterAccountID, "master"),
+			S3URL:        key.SmallCloudConfigS3URL(&config.CustomObject, config.TenantClusterAccountID, "master"),
 		}
 		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 		if err != nil {

--- a/service/controller/clusterapi/v29/adapter/guest_launch_configuration.go
+++ b/service/controller/clusterapi/v29/adapter/guest_launch_configuration.go
@@ -116,7 +116,7 @@ func (l *GuestLaunchConfigAdapter) Adapt(config Config) error {
 	// small cloud config field.
 	c := SmallCloudconfigConfig{
 		InstanceRole: "worker",
-		S3URL:        key.SmallCloudConfigS3URL(config.CustomObject, config.TenantClusterAccountID, "worker"),
+		S3URL:        key.SmallCloudConfigS3URL(&config.CustomObject, config.TenantClusterAccountID, "worker"),
 	}
 	rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
 	if err != nil {

--- a/service/controller/clusterapi/v29/key/cluster.go
+++ b/service/controller/clusterapi/v29/key/cluster.go
@@ -61,19 +61,6 @@ const (
 	RefWorkerASG   = "workerAutoScalingGroup"
 )
 
-func BucketName(cluster v1alpha1.Cluster, accountID string) string {
-	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(&cluster))
-}
-
-// BucketObjectName computes the S3 object path to the actual cloud config.
-//
-//     /version/3.4.0/cloudconfig/v_3_2_5/master
-//     /version/3.4.0/cloudconfig/v_3_2_5/worker
-//
-func BucketObjectName(cluster v1alpha1.Cluster, role string) string {
-	return fmt.Sprintf("version/%s/cloudconfig/%s/%s", OperatorVersion(&cluster), CloudConfigVersion, role)
-}
-
 func ClusterAPIEndpoint(cluster v1alpha1.Cluster) string {
 	return fmt.Sprintf("api.%s.k8s.%s", ClusterID(&cluster), ClusterBaseDomain(cluster))
 }
@@ -221,14 +208,6 @@ func RouteTableName(cluster v1alpha1.Cluster, suffix, az string) string {
 
 func SecurityGroupName(cluster v1alpha1.Cluster, groupName string) string {
 	return fmt.Sprintf("%s-%s", ClusterID(&cluster), groupName)
-}
-
-func SmallCloudConfigPath(cluster v1alpha1.Cluster, accountID string, role string) string {
-	return fmt.Sprintf("%s/%s", BucketName(cluster, accountID), BucketObjectName(cluster, role))
-}
-
-func SmallCloudConfigS3URL(cluster v1alpha1.Cluster, accountID string, role string) string {
-	return fmt.Sprintf("s3://%s", SmallCloudConfigPath(cluster, accountID, role))
 }
 
 func StackNameCPF(cluster v1alpha1.Cluster) string {

--- a/service/controller/clusterapi/v29/key/common.go
+++ b/service/controller/clusterapi/v29/key/common.go
@@ -21,6 +21,19 @@ func AWSTags(getter LabelsGetter, installationName string) map[string]string {
 	return tags
 }
 
+func BucketName(getter LabelsGetter, accountID string) string {
+	return fmt.Sprintf("%s-g8s-%s", accountID, ClusterID(getter))
+}
+
+// BucketObjectName computes the S3 object path to the actual cloud config.
+//
+//     /version/3.4.0/cloudconfig/v_3_2_5/master
+//     /version/3.4.0/cloudconfig/v_3_2_5/worker
+//
+func BucketObjectName(getter LabelsGetter, role string) string {
+	return fmt.Sprintf("version/%s/cloudconfig/%s/%s", OperatorVersion(getter), CloudConfigVersion, role)
+}
+
 func ClusterCloudProviderTag(getter LabelsGetter) string {
 	return fmt.Sprintf("kubernetes.io/cluster/%s", ClusterID(getter))
 }
@@ -117,6 +130,14 @@ func SanitizeCFResourceName(v string) string {
 	}
 
 	return string(rs)
+}
+
+func SmallCloudConfigPath(getter LabelsGetter, accountID string, role string) string {
+	return fmt.Sprintf("%s/%s", BucketName(getter, accountID), BucketObjectName(getter, role))
+}
+
+func SmallCloudConfigS3URL(getter LabelsGetter, accountID string, role string) string {
+	return fmt.Sprintf("s3://%s", SmallCloudConfigPath(getter, accountID, role))
 }
 
 func StackNameTCNP(getter LabelsGetter) string {

--- a/service/controller/clusterapi/v29/resource/s3bucket/current.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/current.go
@@ -27,7 +27,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	bucketStateNames := []string{
 		key.TargetLogBucketName(cr),
-		key.BucketName(cr, cc.Status.TenantCluster.AWSAccountID),
+		key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
 	}
 
 	var currentBucketState []BucketState

--- a/service/controller/clusterapi/v29/resource/s3bucket/desired.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/desired.go
@@ -29,7 +29,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			IsLoggingEnabled: true,
 		},
 		{
-			Name:             key.BucketName(cr, cc.Status.TenantCluster.AWSAccountID),
+			Name:             key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
 			IsLoggingBucket:  false,
 			IsLoggingEnabled: true,
 		},

--- a/service/controller/clusterapi/v29/resource/s3object/current.go
+++ b/service/controller/clusterapi/v29/resource/s3object/current.go
@@ -42,7 +42,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		}
 	}
 
-	bucketName := key.BucketName(cr, cc.Status.TenantCluster.AWSAccountID)
+	bucketName := key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID)
 
 	var objects []*s3.Object
 	{

--- a/service/controller/clusterapi/v29/resource/s3object/desired.go
+++ b/service/controller/clusterapi/v29/resource/s3object/desired.go
@@ -66,9 +66,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			}
 
 			m.Lock()
-			k := key.BucketObjectName(cr, "master")
+			k := key.BucketObjectName(&cr, "master")
 			output[k] = BucketObjectState{
-				Bucket: key.BucketName(cr, cc.Status.TenantCluster.AWSAccountID),
+				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
 				Body:   b,
 				Key:    k,
 			}
@@ -84,9 +84,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			}
 
 			m.Lock()
-			k := key.BucketObjectName(cr, "worker")
+			k := key.BucketObjectName(&cr, "worker")
 			output[k] = BucketObjectState{
-				Bucket: key.BucketName(cr, cc.Status.TenantCluster.AWSAccountID),
+				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
 				Body:   b,
 				Key:    k,
 			}

--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -209,7 +209,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cl v1alpha1.Cluster, md v
 			ID: key.MachineDeploymentID(&md),
 		},
 		RegionARN: key.RegionARN(cl),
-		S3Bucket:  key.BucketName(&cl, cc.Status.TenantCluster.AWSAccountID),
+		S3Bucket:  key.BucketName(&md, cc.Status.TenantCluster.AWSAccountID),
 	}
 
 	return iamPolicies, nil

--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -209,7 +209,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cl v1alpha1.Cluster, md v
 			ID: key.MachineDeploymentID(&md),
 		},
 		RegionARN: key.RegionARN(cl),
-		S3Bucket:  key.BucketName(cl, cc.Status.TenantCluster.AWSAccountID),
+		S3Bucket:  key.BucketName(&cl, cc.Status.TenantCluster.AWSAccountID),
 	}
 
 	return iamPolicies, nil


### PR DESCRIPTION
We use this function for the cluster CR and machinedeployment CR - both have the correct labels needed for this, so there is no need to keep this typed to the cluster CR.