### PR TITLE
fix vpc ID in golden file

### DIFF
--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -240,7 +240,7 @@ func newLaunchConfiguration(ctx context.Context, cl v1alpha1.Cluster, md v1alpha
 			Type:       key.WorkerInstanceType(md),
 		},
 		SmallCloudConfig: template.ParamsMainLaunchConfigurationSmallCloudConfig{
-			S3URL: key.SmallCloudConfigS3URL(cl, cc.Status.TenantCluster.AWSAccountID, "worker"),
+			S3URL: key.SmallCloudConfigS3URL(&md, cc.Status.TenantCluster.AWSAccountID, "worker"),
 		},
 	}
 

--- a/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
@@ -191,7 +191,7 @@ Resources:
     Type: AWS::EC2::SecurityGroups
     Properties:
       GroupDescription: General Node Pool Security Group For Basic Traffic Rules.
-      VpcId: 
+      VpcId: imagenary-vpc-id
       SecurityGroupIngress:
 
       # Allow traffic from control plane CIDR to 22 for SSH access.

--- a/service/controller/clusterapi/v29/unittest/default_controller_context.go
+++ b/service/controller/clusterapi/v29/unittest/default_controller_context.go
@@ -48,6 +48,7 @@ func DefaultContext() context.Context {
 					IsTransitioning:   false,
 					MachineDeployment: DefaultMachineDeployment(),
 					VPC: controllercontext.ContextStatusTenantClusterTCCPVPC{
+						ID:                  "imagenary-vpc-id",
 						PeeringConnectionID: "imagenary-peering-connection-id",
 					},
 				},


### PR DESCRIPTION
Towards Node Pools. Based on [`fix-tcnp-templates`](https://github.com/giantswarm/aws-operator/pull/1781). 