### PR TITLE
add new region resource

### DIFF
--- a/service/controller/clusterapi/v29/controllercontext/status.go
+++ b/service/controller/clusterapi/v29/controllercontext/status.go
@@ -38,13 +38,18 @@ type ContextStatusControlPlaneVPC struct {
 }
 
 type ContextStatusTenantCluster struct {
-	AWSAccountID          string
+	AWS                   ContextStatusTenantClusterAWS
 	Encryption            ContextStatusTenantClusterEncryption
 	HostedZoneNameServers string
 	MasterInstance        ContextStatusTenantClusterMasterInstance
 	TCCP                  ContextStatusTenantClusterTCCP
 	VersionBundleVersion  string
 	WorkerInstance        ContextStatusTenantClusterWorkerInstance
+}
+
+type ContextStatusTenantClusterAWS struct {
+	AccountID string
+	Region    string
 }
 
 type ContextStatusTenantClusterEncryption struct {

--- a/service/controller/clusterapi/v29/encrypter/vault/vault.go
+++ b/service/controller/clusterapi/v29/encrypter/vault/vault.go
@@ -160,8 +160,8 @@ func (e *Encrypter) EnsureCreatedAuthorizedIAMRoles(ctx context.Context, customO
 	var masterRoleARN string
 	var workerRoleARN string
 	{
-		masterRoleARN = key.RoleARNMaster(customObject, cc.Status.TenantCluster.AWSAccountID)
-		workerRoleARN = key.RoleARNWorker(customObject, cc.Status.TenantCluster.AWSAccountID)
+		masterRoleARN = key.RoleARNMaster(customObject, cc.Status.TenantCluster.AWS.AccountID)
+		workerRoleARN = key.RoleARNWorker(customObject, cc.Status.TenantCluster.AWS.AccountID)
 	}
 
 	var roleData *AWSAuthRole
@@ -262,8 +262,8 @@ func (e *Encrypter) EnsureDeletedAuthorizedIAMRoles(ctx context.Context, customO
 	var masterRoleARN string
 	var workerRoleARN string
 	{
-		masterRoleARN = key.RoleARNMaster(customObject, cc.Status.TenantCluster.AWSAccountID)
-		workerRoleARN = key.RoleARNWorker(customObject, cc.Status.TenantCluster.AWSAccountID)
+		masterRoleARN = key.RoleARNMaster(customObject, cc.Status.TenantCluster.AWS.AccountID)
+		workerRoleARN = key.RoleARNWorker(customObject, cc.Status.TenantCluster.AWS.AccountID)
 	}
 
 	var roleData *AWSAuthRole

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/clusterazs"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/encryption"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ipam"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/region"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/tcnp"
 )
 
@@ -139,6 +140,19 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
+	var regionResource controller.Resource
+	{
+		c := region.Config{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		regionResource, err = region.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tcnpResource controller.Resource
 	{
 		c := tcnp.Config{
@@ -156,6 +170,7 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 
 	resources := []controller.Resource{
 		awsClientResource,
+		regionResource,
 		encryptionResource,
 		ipamResource,
 		clusterAZsResource,

--- a/service/controller/clusterapi/v29/resource/accountid/resource.go
+++ b/service/controller/clusterapi/v29/resource/accountid/resource.go
@@ -89,7 +89,7 @@ func (r *Resource) addAccountIDToContext(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 
-		cc.Status.TenantCluster.AWSAccountID = accountID
+		cc.Status.TenantCluster.AWS.AccountID = accountID
 	}
 
 	return nil

--- a/service/controller/clusterapi/v29/resource/cpi/create.go
+++ b/service/controller/clusterapi/v29/resource/cpi/create.go
@@ -131,7 +131,7 @@ func (r *Resource) newIAMRolesParams(ctx context.Context, cr v1alpha1.Cluster) (
 		Tenant: template.ParamsMainIAMRolesTenant{
 			AWS: template.ParamsMainIAMRolesTenantAWS{
 				Account: template.ParamsMainIAMRolesTenantAWSAccount{
-					ID: cc.Status.TenantCluster.AWSAccountID,
+					ID: cc.Status.TenantCluster.AWS.AccountID,
 				},
 			},
 		},

--- a/service/controller/clusterapi/v29/resource/region/create.go
+++ b/service/controller/clusterapi/v29/resource/region/create.go
@@ -1,0 +1,42 @@
+package region
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	md, err := key.ToMachineDeployment(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Fetch the cluster for region information.
+	var cl v1alpha1.Cluster
+	{
+		m, err := r.cmaClient.ClusterV1alpha1().Clusters(md.Namespace).Get(key.ClusterID(&md), metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		cl = *m
+	}
+
+	// Simply put the region into the controller context for later use in for
+	// instance the tcnp resource.
+	{
+		cc.Status.TenantCluster.AWS.Region = key.Region(cl)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/region/delete.go
+++ b/service/controller/clusterapi/v29/resource/region/delete.go
@@ -1,0 +1,9 @@
+package region
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/region/error.go
+++ b/service/controller/clusterapi/v29/resource/region/error.go
@@ -1,0 +1,14 @@
+package region
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v29/resource/region/resource.go
+++ b/service/controller/clusterapi/v29/resource/region/resource.go
@@ -1,0 +1,41 @@
+package region
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+const (
+	Name = "regionv29"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	cmaClient clientset.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/clusterapi/v29/resource/region/resource.go
+++ b/service/controller/clusterapi/v29/resource/region/resource.go
@@ -1,3 +1,12 @@
+// Package region implements an operatorkit resource that addresses a problem
+// where the tcnp resource would need to fetch the Cluster CR even though the
+// MachineDeployment CR is reconciled. This is only because we need the AWS
+// region to lookup S3 bucket names and EC2 image IDs and the like. So in order
+// to free the tcnp resource from that hustle we implement a separate region
+// resource which does the lookup and puts the region into the controller
+// context. The controller context information are then simply used by the tcnp
+// resource as this is our state of the art primitive for information
+// distribution within a controller's reconciliation.
 package region
 
 import (

--- a/service/controller/clusterapi/v29/resource/s3bucket/current.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/current.go
@@ -27,7 +27,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	bucketStateNames := []string{
 		key.TargetLogBucketName(cr),
-		key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
+		key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
 	}
 
 	var currentBucketState []BucketState

--- a/service/controller/clusterapi/v29/resource/s3bucket/desired.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/desired.go
@@ -29,7 +29,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			IsLoggingEnabled: true,
 		},
 		{
-			Name:             key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
+			Name:             key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
 			IsLoggingBucket:  false,
 			IsLoggingEnabled: true,
 		},

--- a/service/controller/clusterapi/v29/resource/s3bucket/desired_test.go
+++ b/service/controller/clusterapi/v29/resource/s3bucket/desired_test.go
@@ -78,7 +78,9 @@ func testContextWithAccountID(id string) controllercontext.Context {
 	return controllercontext.Context{
 		Status: controllercontext.ContextStatus{
 			TenantCluster: controllercontext.ContextStatusTenantCluster{
-				AWSAccountID: id,
+				AWS: controllercontext.ContextStatusTenantClusterAWS{
+					AccountID: id,
+				},
 			},
 		},
 	}

--- a/service/controller/clusterapi/v29/resource/s3object/current.go
+++ b/service/controller/clusterapi/v29/resource/s3object/current.go
@@ -42,7 +42,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		}
 	}
 
-	bucketName := key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID)
+	bucketName := key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID)
 
 	var objects []*s3.Object
 	{

--- a/service/controller/clusterapi/v29/resource/s3object/current_test.go
+++ b/service/controller/clusterapi/v29/resource/s3object/current_test.go
@@ -116,7 +116,9 @@ func Test_CurrentState(t *testing.T) {
 				},
 				Status: controllercontext.ContextStatus{
 					TenantCluster: controllercontext.ContextStatusTenantCluster{
-						AWSAccountID: "myaccountid",
+						AWS: controllercontext.ContextStatusTenantClusterAWS{
+							AccountID: "myaccountid",
+						},
 					},
 				},
 			}

--- a/service/controller/clusterapi/v29/resource/s3object/desired.go
+++ b/service/controller/clusterapi/v29/resource/s3object/desired.go
@@ -68,7 +68,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			m.Lock()
 			k := key.BucketObjectName(&cr, "master")
 			output[k] = BucketObjectState{
-				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
+				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
 				Body:   b,
 				Key:    k,
 			}
@@ -86,7 +86,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			m.Lock()
 			k := key.BucketObjectName(&cr, "worker")
 			output[k] = BucketObjectState{
-				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWSAccountID),
+				Bucket: key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
 				Body:   b,
 				Key:    k,
 			}

--- a/service/controller/clusterapi/v29/resource/s3object/desired_test.go
+++ b/service/controller/clusterapi/v29/resource/s3object/desired_test.go
@@ -95,7 +95,9 @@ func Test_DesiredState(t *testing.T) {
 				},
 				Status: controllercontext.ContextStatus{
 					TenantCluster: controllercontext.ContextStatusTenantCluster{
-						AWSAccountID: "myaccountid",
+						AWS: controllercontext.ContextStatusTenantClusterAWS{
+							AccountID: "myaccountid",
+						},
 					},
 				},
 			})

--- a/service/controller/clusterapi/v29/resource/tccp/create.go
+++ b/service/controller/clusterapi/v29/resource/tccp/create.go
@@ -326,7 +326,7 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.Cluster, tp 
 
 				VersionBundleVersion: key.OperatorVersion(&cr),
 			},
-			TenantClusterAccountID:         cc.Status.TenantCluster.AWSAccountID,
+			TenantClusterAccountID:         cc.Status.TenantCluster.AWS.AccountID,
 			TenantClusterAvailabilityZones: cc.Spec.TenantCluster.TCCP.AvailabilityZones,
 		}
 

--- a/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
@@ -161,7 +161,9 @@ func defaultControllerContext() controllercontext.Context {
 				},
 			},
 			TenantCluster: controllercontext.ContextStatusTenantCluster{
-				AWSAccountID:          "tenant-account",
+				AWS: controllercontext.ContextStatusTenantClusterAWS{
+					AccountID: "tenant-account",
+				},
 				Encryption:            controllercontext.ContextStatusTenantClusterEncryption{},
 				HostedZoneNameServers: "1.1.1.1,8.8.8.8",
 				MasterInstance:        controllercontext.ContextStatusTenantClusterMasterInstance{},

--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -209,7 +209,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cl v1alpha1.Cluster, md v
 			ID: key.MachineDeploymentID(&md),
 		},
 		RegionARN: key.RegionARN(cl),
-		S3Bucket:  key.BucketName(&md, cc.Status.TenantCluster.AWSAccountID),
+		S3Bucket:  key.BucketName(&md, cc.Status.TenantCluster.AWS.AccountID),
 	}
 
 	return iamPolicies, nil


### PR DESCRIPTION
Towards Node Pools. Addressing a little rabbit hole here. The `tcnp` resource does an ugly thing right now, where it fetches the `Cluster` even though the `MachineDeployment` is reconciled. This is only because we need the region to lookup bucket names and image IDs and the like. So in order to free the `tcnp` resource from that hustle we suggest a separate region resource which does the lookup and puts the region into the controller context. 