### PR TITLE
Expose version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -345,8 +345,8 @@
   revision = "85e779854c8e1b948bb2551e3750cfdae8ddfdbf"
 
 [[projects]]
-  branch = "add-version"
-  digest = "1:c0699d619f2c3834831b47f48f1c962c24529a8f4bf0497ad137986628247ca5"
+  branch = "master"
+  digest = "1:a2122f2c0fae0df1c4225df3c18e624d712566cb43eabc38c6f0914231cae2bb"
   name = "github.com/giantswarm/microendpoint"
   packages = [
     "endpoint/healthz",
@@ -355,7 +355,7 @@
     "service/version",
   ]
   pruneopts = "UT"
-  revision = "f29ac8858852902659aefecb0d2719b0f4db9154"
+  revision = "2c0b54e888d682445c698d2b2b3544b2001e84ac"
 
 [[projects]]
   branch = "master"
@@ -366,7 +366,7 @@
   revision = "f446cc816a48d6626ddce3ecd966c8b6be3a1985"
 
 [[projects]]
-  branch = "add-version"
+  branch = "master"
   digest = "1:5a83c09d3255d3a9311f988a46068e99f537de547899fa3956ec4c51b439d0b2"
   name = "github.com/giantswarm/microkit"
   packages = [
@@ -386,7 +386,7 @@
     "tls",
   ]
   pruneopts = "UT"
-  revision = "985f1121824067b2f7311654fc9d42fa316229c1"
+  revision = "4eef9bd9640621debcdfa90dee993cb6898d18cf"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -367,7 +367,7 @@
 
 [[projects]]
   branch = "add-version"
-  digest = "1:b393d8caf081af7db00cac06afe4e3c162ef90c10999d05fad689f88c2124084"
+  digest = "1:5a83c09d3255d3a9311f988a46068e99f537de547899fa3956ec4c51b439d0b2"
   name = "github.com/giantswarm/microkit"
   packages = [
     "command",
@@ -386,7 +386,7 @@
     "tls",
   ]
   pruneopts = "UT"
-  revision = "3ba752ebe63e3be2244483af93867d0e08f81caf"
+  revision = "985f1121824067b2f7311654fc9d42fa316229c1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -345,8 +345,8 @@
   revision = "85e779854c8e1b948bb2551e3750cfdae8ddfdbf"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b7f7982da706514dcb15a2d9211d932efb654c33d4ac105d552ae1981702dad4"
+  branch = "add-version"
+  digest = "1:c0699d619f2c3834831b47f48f1c962c24529a8f4bf0497ad137986628247ca5"
   name = "github.com/giantswarm/microendpoint"
   packages = [
     "endpoint/healthz",
@@ -355,7 +355,7 @@
     "service/version",
   ]
   pruneopts = "UT"
-  revision = "f77c569259aef9cea5e38d0d7d94bf1d7d07d136"
+  revision = "f29ac8858852902659aefecb0d2719b0f4db9154"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,8 +366,8 @@
   revision = "f446cc816a48d6626ddce3ecd966c8b6be3a1985"
 
 [[projects]]
-  branch = "master"
-  digest = "1:83013eaf386dd720e63ab59999d7ea22390fae720bc7c7d3fa31a8c07efb9894"
+  branch = "add-version"
+  digest = "1:b393d8caf081af7db00cac06afe4e3c162ef90c10999d05fad689f88c2124084"
   name = "github.com/giantswarm/microkit"
   packages = [
     "command",
@@ -386,7 +386,7 @@
     "tls",
   ]
   pruneopts = "UT"
-  revision = "d6fac43ca97d8630b27d70810b1e1df7b7c1e775"
+  revision = "3ba752ebe63e3be2244483af93867d0e08f81caf"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,7 +97,7 @@ required = [
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  branch = "add-version"
   name = "github.com/giantswarm/microkit"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,7 +89,7 @@ required = [
   name = "github.com/giantswarm/k8scloudconfig"
 
 [[constraint]]
-  branch = "add-version"
+  branch = "master"
   name = "github.com/giantswarm/microendpoint"
 
 [[constraint]]
@@ -97,7 +97,7 @@ required = [
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "add-version"
+  branch = "master"
   name = "github.com/giantswarm/microkit"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -89,7 +89,7 @@ required = [
   name = "github.com/giantswarm/k8scloudconfig"
 
 [[constraint]]
-  branch = "master"
+  branch = "add-version"
   name = "github.com/giantswarm/microendpoint"
 
 [[constraint]]

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func mainE(ctx context.Context) error {
 			GitCommit:      project.GitSHA(),
 			Name:           project.Name(),
 			Source:         project.Source(),
+			Version:        project.Version(),
 			VersionBundles: service.NewVersionBundles(),
 		}
 

--- a/main.go
+++ b/main.go
@@ -11,16 +11,13 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/giantswarm/aws-operator/flag"
+	"github.com/giantswarm/aws-operator/pkg/project"
 	"github.com/giantswarm/aws-operator/server"
 	"github.com/giantswarm/aws-operator/service"
 )
 
 var (
-	description string     = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
-	f           *flag.Flag = flag.New()
-	gitCommit   string     = "n/a"
-	name        string     = "aws-operator"
-	source      string     = "https://github.com/giantswarm/aws-operator"
+	f *flag.Flag = flag.New()
 )
 
 func main() {
@@ -54,10 +51,11 @@ func mainE(ctx context.Context) error {
 				Logger: logger,
 				Viper:  v,
 
-				Description: description,
-				GitCommit:   gitCommit,
-				ProjectName: name,
-				Source:      source,
+				Description: project.Description(),
+				GitCommit:   project.GitSHA(),
+				ProjectName: project.Name(),
+				Source:      project.Source(),
+				Version:     project.Version(),
 			}
 
 			newService, err = service.New(c)
@@ -76,7 +74,7 @@ func mainE(ctx context.Context) error {
 				Service: newService,
 				Viper:   v,
 
-				ProjectName: name,
+				ProjectName: project.Name(),
 			}
 
 			newServer, err = server.New(c)
@@ -95,10 +93,10 @@ func mainE(ctx context.Context) error {
 			Logger:        logger,
 			ServerFactory: serverFactory,
 
-			Description:    description,
-			GitCommit:      gitCommit,
-			Name:           name,
-			Source:         source,
+			Description:    project.Description(),
+			GitCommit:      project.GitSHA(),
+			Name:           project.Name(),
+			Source:         project.Source(),
 			VersionBundles: service.NewVersionBundles(),
 		}
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,29 @@
+package project
+
+var (
+	description        = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
+	gitSHA             = "n/a"
+	name        string = "aws-operator"
+	source      string = "https://github.com/giantswarm/aws-operator"
+	version            = "n/a"
+)
+
+func Description() string {
+	return description
+}
+
+func GitSHA() string {
+	return gitSHA
+}
+
+func Name() string {
+	return name
+}
+
+func Source() string {
+	return source
+}
+
+func Version() string {
+	return version
+}

--- a/service/service.go
+++ b/service/service.go
@@ -39,6 +39,7 @@ type Config struct {
 	GitCommit   string
 	ProjectName string
 	Source      string
+	Version     string
 }
 
 type Service struct {
@@ -398,6 +399,7 @@ func New(config Config) (*Service, error) {
 			GitCommit:      config.GitCommit,
 			Name:           config.ProjectName,
 			Source:         config.Source,
+			Version:        config.Version,
 			VersionBundles: NewVersionBundles(),
 		}
 

--- a/vendor/github.com/giantswarm/microendpoint/LICENSE
+++ b/vendor/github.com/giantswarm/microendpoint/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/giantswarm/microendpoint/endpoint/version/endpoint.go
+++ b/vendor/github.com/giantswarm/microendpoint/endpoint/version/endpoint.go
@@ -66,7 +66,7 @@ func (e *Endpoint) Encoder() kithttp.EncodeResponseFunc {
 
 func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		serviceResponse, err := e.Service.Get(ctx, version.DefaultRequest())
+		serviceResponse, err := e.Service.Get(ctx, version.Request{})
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/vendor/github.com/giantswarm/microendpoint/endpoint/version/endpoint.go
+++ b/vendor/github.com/giantswarm/microendpoint/endpoint/version/endpoint.go
@@ -29,16 +29,6 @@ type Config struct {
 	Service *version.Service
 }
 
-// DefaultConfig provides a default configuration to create a new version
-// endpoint by best effort.
-func DefaultConfig() Config {
-	return Config{
-		// Dependencies.
-		Logger:  nil,
-		Service: nil,
-	}
-}
-
 // New creates a new configured version endpoint.
 func New(config Config) (*Endpoint, error) {
 	// Dependencies.
@@ -81,14 +71,16 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 			return nil, microerror.Mask(err)
 		}
 
-		response := DefaultResponse()
-		response.Description = serviceResponse.Description
-		response.GitCommit = serviceResponse.GitCommit
-		response.GoVersion = serviceResponse.GoVersion
-		response.Name = serviceResponse.Name
-		response.OSArch = serviceResponse.OSArch
-		response.Source = serviceResponse.Source
-		response.VersionBundles = serviceResponse.VersionBundles
+		response := &Response{
+			Description:    serviceResponse.Description,
+			GitCommit:      serviceResponse.GitCommit,
+			GoVersion:      serviceResponse.GoVersion,
+			Name:           serviceResponse.Name,
+			OSArch:         serviceResponse.OSArch,
+			Source:         serviceResponse.Source,
+			Version:        serviceResponse.Version,
+			VersionBundles: serviceResponse.VersionBundles,
+		}
 
 		return response, nil
 	}

--- a/vendor/github.com/giantswarm/microendpoint/endpoint/version/response.go
+++ b/vendor/github.com/giantswarm/microendpoint/endpoint/version/response.go
@@ -10,18 +10,6 @@ type Response struct {
 	Name           string                 `json:"name"`
 	OSArch         string                 `json:"os_arch"`
 	Source         string                 `json:"source"`
+	Version        string                 `json:"version"`
 	VersionBundles []versionbundle.Bundle `json:"version_bundles"`
-}
-
-// DefaultResponse provides a default response object by best effort.
-func DefaultResponse() *Response {
-	return &Response{
-		Description:    "",
-		GitCommit:      "",
-		GoVersion:      "",
-		Name:           "",
-		OSArch:         "",
-		Source:         "",
-		VersionBundles: nil,
-	}
 }

--- a/vendor/github.com/giantswarm/microendpoint/service/version/request.go
+++ b/vendor/github.com/giantswarm/microendpoint/service/version/request.go
@@ -3,8 +3,3 @@ package version
 // Request is the configuration for the service action.
 type Request struct {
 }
-
-// DefaultRequest provides a default request object by best effort.
-func DefaultRequest() Request {
-	return Request{}
-}

--- a/vendor/github.com/giantswarm/microendpoint/service/version/response.go
+++ b/vendor/github.com/giantswarm/microendpoint/service/version/response.go
@@ -10,18 +10,6 @@ type Response struct {
 	Name           string                 `json:"name"`
 	OSArch         string                 `json:"os_arch"`
 	Source         string                 `json:"source"`
+	Version        string                 `json:"version"`
 	VersionBundles []versionbundle.Bundle `json:"version_bundles"`
-}
-
-// DefaultResponse provides a default response object by best effort.
-func DefaultResponse() *Response {
-	return &Response{
-		Description:    "",
-		GitCommit:      "",
-		GoVersion:      "",
-		Name:           "",
-		OSArch:         "",
-		Source:         "",
-		VersionBundles: nil,
-	}
 }

--- a/vendor/github.com/giantswarm/microendpoint/service/version/service.go
+++ b/vendor/github.com/giantswarm/microendpoint/service/version/service.go
@@ -71,6 +71,7 @@ func New(config Config) (*Service, error) {
 
 // Get returns the version response.
 func (s *Service) Get(ctx context.Context, request Request) (*Response, error) {
+
 	response := &Response{
 		Description:    s.description,
 		GitCommit:      s.gitCommit,

--- a/vendor/github.com/giantswarm/microendpoint/service/version/service.go
+++ b/vendor/github.com/giantswarm/microendpoint/service/version/service.go
@@ -15,20 +15,8 @@ type Config struct {
 	GitCommit      string
 	Name           string
 	Source         string
+	Version        string
 	VersionBundles []versionbundle.Bundle
-}
-
-// DefaultConfig provides a default configuration to create a new version service
-// by best effort.
-func DefaultConfig() Config {
-	return Config{
-		// Settings.
-		Description:    "",
-		GitCommit:      "",
-		Name:           "",
-		Source:         "",
-		VersionBundles: nil,
-	}
 }
 
 // Service implements the version service interface.
@@ -37,6 +25,7 @@ type Service struct {
 	gitCommit      string
 	name           string
 	source         string
+	version        string
 	versionBundles []versionbundle.Bundle
 }
 
@@ -55,6 +44,9 @@ func New(config Config) (*Service, error) {
 	if config.Source == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Source must not be empty")
 	}
+	if config.Version == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Version must not be empty")
+	}
 
 	if len(config.VersionBundles) != 0 {
 		err := versionbundle.Bundles(config.VersionBundles).Validate()
@@ -68,6 +60,7 @@ func New(config Config) (*Service, error) {
 		gitCommit:      config.GitCommit,
 		name:           config.Name,
 		source:         config.Source,
+		version:        config.Version,
 		versionBundles: config.VersionBundles,
 	}
 
@@ -78,15 +71,16 @@ func New(config Config) (*Service, error) {
 
 // Get returns the version response.
 func (s *Service) Get(ctx context.Context, request Request) (*Response, error) {
-	response := DefaultResponse()
-
-	response.Description = s.description
-	response.GitCommit = s.gitCommit
-	response.GoVersion = runtime.Version()
-	response.Name = s.name
-	response.OSArch = runtime.GOOS + "/" + runtime.GOARCH
-	response.Source = s.source
-	response.VersionBundles = s.versionBundles
+	response := &Response{
+		Description:    s.description,
+		GitCommit:      s.gitCommit,
+		GoVersion:      runtime.Version(),
+		Name:           s.name,
+		OSArch:         runtime.GOOS + "/" + runtime.GOARCH,
+		Source:         s.source,
+		Version:        s.version,
+		VersionBundles: s.versionBundles,
+	}
 
 	return response, nil
 }

--- a/vendor/github.com/giantswarm/microkit/command/command.go
+++ b/vendor/github.com/giantswarm/microkit/command/command.go
@@ -21,6 +21,7 @@ type Config struct {
 	GitCommit      string
 	Name           string
 	Source         string
+	Version        string
 	VersionBundles []versionbundle.Bundle
 	Viper          *viper.Viper
 }
@@ -54,6 +55,7 @@ func New(config Config) (Command, error) {
 			GitCommit:      config.GitCommit,
 			Name:           config.Name,
 			Source:         config.Source,
+			Version:        config.Version,
 			VersionBundles: config.VersionBundles,
 		}
 

--- a/vendor/github.com/giantswarm/microkit/command/version/command.go
+++ b/vendor/github.com/giantswarm/microkit/command/version/command.go
@@ -16,21 +16,25 @@ type Config struct {
 	GitCommit      string
 	Name           string
 	Source         string
+	Version        string
 	VersionBundles []versionbundle.Bundle
 }
 
 func New(config Config) (Command, error) {
 	if config.Description == "" {
-		return nil, microerror.Maskf(invalidConfigError, "description commit must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Description must not be empty", config)
 	}
 	if config.GitCommit == "" {
-		return nil, microerror.Maskf(invalidConfigError, "git commit must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.GitCommit must not be empty", config)
 	}
 	if config.Name == "" {
-		return nil, microerror.Maskf(invalidConfigError, "name must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Name must not be empty", config)
 	}
 	if config.Source == "" {
-		return nil, microerror.Maskf(invalidConfigError, "source must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Source must not be empty", config)
+	}
+	if config.Version == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Version must not be empty", config)
 	}
 
 	newCommand := &command{
@@ -43,6 +47,7 @@ func New(config Config) (Command, error) {
 		GoVersion:      runtime.Version(),
 		OS:             runtime.GOOS,
 		Arch:           runtime.GOARCH,
+		Version:        config.Version,
 		VersionBundles: config.VersionBundles,
 	}
 
@@ -66,6 +71,7 @@ type command struct {
 	GoVersion      string                 `json:"goVersion" yaml:"goVersion"`
 	OS             string                 `json:"os" yaml:"os"`
 	Arch           string                 `json:"arch" yaml:"arch"`
+	Version        string                 `json:"version" yaml:"version"`
 	VersionBundles []versionbundle.Bundle `json:"versionBundles" yaml:"versionBundles"`
 }
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6559

This PR exposes binary version to version endpoint & command.
Also moved the project information into `pkg/project` package.

```
$ k exec -it aws-operator-59f6bf8686-mm5kq sh
/opt/aws-operator $ ./aws-operator version
description: The aws-operator handles Kubernetes clusters running on a Kubernetes
  cluster inside of AWS.
gitCommit: ae94a1d0eed6dd6b23716737904a1933132d9f01
name: aws-operator
source: https://github.com/giantswarm/aws-operator
goVersion: go1.11.3
os: linux
arch: amd64
version: 0.1.0-ae94a1d0eed6dd6b23716737904a1933132d9f01
versionBundles:
```

```
$ curl -Ss http://localhost:8000/ |jq .
{
  "description": "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS.",
  "git_commit": "ae94a1d0eed6dd6b23716737904a1933132d9f01",
  "go_version": "go1.11.3",
  "name": "aws-operator",
  "os_arch": "linux/amd64",
  "source": "https://github.com/giantswarm/aws-operator",
  "version": "0.1.0-ae94a1d0eed6dd6b23716737904a1933132d9f01",
  "version_bundles": [
```