### PR TITLE
fix ingress load balancer name in tcnp stack template

### DIFF
--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -199,7 +199,10 @@ func newAutoScalingGroup(ctx context.Context, cl v1alpha1.Cluster, md v1alpha1.M
 		Cluster: template.ParamsMainAutoScalingGroupCluster{
 			ID: key.ClusterID(&md),
 		},
-		DesiredCapacity:       minDesiredNodes,
+		DesiredCapacity: minDesiredNodes,
+		LoadBalancer: template.ParamsMainAutoScalingGroupLoadBalancer{
+			Name: key.ELBNameIngress(&md),
+		},
 		MaxBatchSize:          workerCountRatio(minDesiredNodes, 0.3),
 		MaxSize:               key.WorkerScalingMax(md),
 		MinInstancesInService: workerCountRatio(minDesiredNodes, 0.7),

--- a/service/controller/clusterapi/v29/resource/tcnp/template/params_main_auto_scaling_group.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/params_main_auto_scaling_group.go
@@ -4,6 +4,7 @@ type ParamsMainAutoScalingGroup struct {
 	AvailabilityZones     []string
 	Cluster               ParamsMainAutoScalingGroupCluster
 	DesiredCapacity       int
+	LoadBalancer          ParamsMainAutoScalingGroupLoadBalancer
 	MaxBatchSize          string
 	MaxSize               int
 	MinInstancesInService string
@@ -14,4 +15,8 @@ type ParamsMainAutoScalingGroup struct {
 
 type ParamsMainAutoScalingGroupCluster struct {
 	ID string
+}
+
+type ParamsMainAutoScalingGroupLoadBalancer struct {
+	Name string
 }

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main_auto_scaling_group.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main_auto_scaling_group.go
@@ -18,7 +18,7 @@ const TemplateMainAutoScalingGroup = `
       MaxSize: {{ .AutoScalingGroup.MaxSize }}
       LaunchConfigurationName: !Ref NodePoolLaunchConfiguration
       LoadBalancerNames:
-        - !Ref IngressLoadBalancer
+        - {{ .AutoScalingGroup.LoadBalancer.Name }}
 
       # 10 seconds after a new node comes into service, the ASG checks the new
       # instance's health.

--- a/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
@@ -28,7 +28,7 @@ Resources:
       MaxSize: 5
       LaunchConfigurationName: !Ref NodePoolLaunchConfiguration
       LoadBalancerNames:
-        - !Ref IngressLoadBalancer
+        - 8y5ck-ingress
 
       # 10 seconds after a new node comes into service, the ASG checks the new
       # instance's health.


### PR DESCRIPTION
Towards Node Pools. Based on [`fix-tcnp-templates`](https://github.com/giantswarm/aws-operator/pull/1781). 