### PR TITLE
add cidr block association to tcnp stack template

### DIFF
--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -331,8 +331,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var regionResource controller.Resource
 	{
 		c := region.Config{
-			CMAClient: config.CMAClient,
-			Logger:    config.Logger,
+			Logger:        config.Logger,
+			ToClusterFunc: key.ToCluster,
 		}
 
 		regionResource, err = region.New(c)

--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -31,6 +31,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/namespace"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/natgatewayaddresses"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/peerrolearn"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/region"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/routetable"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/s3bucket"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/s3object"
@@ -327,6 +328,19 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var regionResource controller.Resource
+	{
+		c := region.Config{
+			CMAClient: config.CMAClient,
+			Logger:    config.Logger,
+		}
+
+		regionResource, err = region.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tccpResource controller.Resource
 	{
 		c := tccp.Config{
@@ -569,6 +583,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		vpcCIDRResource,
 		tccpOutputsResource,
 		tccpSubnetResource,
+		regionResource,
 		asgStatusResource,
 		ipamResource,
 		clusterAZsResource,

--- a/service/controller/clusterapi/v29/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v29/machine_deployment_resource_set.go
@@ -161,8 +161,8 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 	var regionResource controller.Resource
 	{
 		c := region.Config{
-			CMAClient: config.CMAClient,
-			Logger:    config.Logger,
+			Logger:        config.Logger,
+			ToClusterFunc: newMachineDeploymentToClusterFunc(config.CMAClient),
 		}
 
 		regionResource, err = region.New(c)

--- a/service/controller/clusterapi/v29/resource/region/create.go
+++ b/service/controller/clusterapi/v29/resource/region/create.go
@@ -4,15 +4,13 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	md, err := key.ToMachineDeployment(obj)
+	cr, err := r.toClusterFunc(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -21,21 +19,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	// Fetch the cluster for region information.
-	var cl v1alpha1.Cluster
-	{
-		m, err := r.cmaClient.ClusterV1alpha1().Clusters(md.Namespace).Get(key.ClusterID(&md), metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		cl = *m
-	}
-
 	// Simply put the region into the controller context for later use in for
 	// instance the tcnp resource.
 	{
-		cc.Status.TenantCluster.AWS.Region = key.Region(cl)
+		cc.Status.TenantCluster.AWS.Region = key.Region(cr)
 	}
 
 	return nil

--- a/service/controller/clusterapi/v29/resource/region/resource.go
+++ b/service/controller/clusterapi/v29/resource/region/resource.go
@@ -12,7 +12,7 @@ package region
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 const (
@@ -20,26 +20,26 @@ const (
 )
 
 type Config struct {
-	CMAClient clientset.Interface
-	Logger    micrologger.Logger
+	Logger        micrologger.Logger
+	ToClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 type Resource struct {
-	cmaClient clientset.Interface
-	logger    micrologger.Logger
+	logger        micrologger.Logger
+	toClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
 }
 
 func New(config Config) (*Resource, error) {
-	if config.CMAClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.ToClusterFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterFunc must not be empty", config)
+	}
 
 	r := &Resource{
-		cmaClient: config.CMAClient,
-		logger:    config.Logger,
+		logger:        config.Logger,
+		toClusterFunc: config.ToClusterFunc,
 	}
 
 	return r, nil

--- a/service/controller/clusterapi/v29/resource/tcnp/template/params_main.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/params_main.go
@@ -9,4 +9,5 @@ type ParamsMain struct {
 	Outputs             *ParamsMainOutputs
 	SecurityGroups      *ParamsMainSecurityGroups
 	Subnets             *ParamsMainSubnets
+	VPCCIDR             *ParamsMainVPCCIDR
 }

--- a/service/controller/clusterapi/v29/resource/tcnp/template/params_main_vpc_cidr.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/params_main_vpc_cidr.go
@@ -1,0 +1,18 @@
+package template
+
+type ParamsMainVPCCIDR struct {
+	TCCP ParamsMainVPCCIDRTCCP
+	TCNP ParamsMainVPCCIDRTCNP
+}
+
+type ParamsMainVPCCIDRTCCP struct {
+	VPC ParamsMainVPCCIDRTCCPVPC
+}
+
+type ParamsMainVPCCIDRTCCPVPC struct {
+	ID string
+}
+
+type ParamsMainVPCCIDRTCNP struct {
+	CIDR string
+}

--- a/service/controller/clusterapi/v29/resource/tcnp/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/render.go
@@ -16,6 +16,7 @@ func Render(v interface{}) (string, error) {
 		TemplateMainOutputs,
 		TemplateMainSecurityGroups,
 		TemplateMainSubnets,
+		TemplateMainVPCCIDR,
 	}
 
 	s, err := templates.Render(l, v)

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main.go
@@ -13,5 +13,6 @@ Resources:
   {{ template "lifecycle_hooks" . }}
   {{ template "security_groups" . }}
   {{ template "subnets" . }}
+  {{ template "vpc_cidr" . }}
 {{- end -}}
 `

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main.go
@@ -14,5 +14,5 @@ Resources:
   {{ template "security_groups" . }}
   {{ template "subnets" . }}
   {{ template "vpc_cidr" . }}
-{{- end -}}
+{{ end }}
 `

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main_vpc_cidr.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main_vpc_cidr.go
@@ -5,7 +5,7 @@ const TemplateMainVPCCIDR = `
   VpcCidrBlock:
     Type: AWS::EC2::VPCCidrBlock
     Properties:
-      VpcId: {{ .TCCP.VPC.ID }}
-      CidrBlock: {{ .TCNP.CIDR }}
+      VpcId: {{ .VPCCIDR.TCCP.VPC.ID }}
+      CidrBlock: {{ .VPCCIDR.TCNP.CIDR }}
 {{- end -}}
 `

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main_vpc_cidr.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main_vpc_cidr.go
@@ -1,0 +1,11 @@
+package template
+
+const TemplateMainVPCCIDR = `
+{{- define "vpc_cidr" -}}
+  VpcCidrBlock:
+    Type: AWS::EC2::VPCCidrBlock
+    Properties:
+      VpcId: {{ .TCCP.VPC.ID }}
+      CidrBlock: {{ .TCNP.CIDR }}
+{{- end -}}
+`

--- a/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
@@ -284,3 +284,8 @@ Resources:
     Properties:
       RouteTableId: PublicRouteTableEuCentral1b
       SubnetId: validPublicSubnetID-1b
+  VpcCidrBlock:
+    Type: AWS::EC2::VPCCidrBlock
+    Properties:
+      VpcId: imagenary-vpc-id
+      CidrBlock: 10.100.8.0/24


### PR DESCRIPTION
Towards Node Pools. Tenant clusters remain to have one VPC, which is managed within the TCCP stack. Node Pools are managed within the TCNP stacks. Their subnets have to be associated with the VPC so that a tenant cluster has a properly setup network space. 