### PR TITLE
add DisableVersionBundleSelection flag

### DIFF
--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Service struct {
-	AWS            aws.AWS
-	Cluster        cluster.Cluster
-	Guest          guest.Guest
-	Installation   installation.Installation
-	Kubernetes     kubernetes.Kubernetes
-	RegistryDomain string
+	AWS                           aws.AWS
+	Cluster                       cluster.Cluster
+	Guest                         guest.Guest
+	Installation                  installation.Installation
+	Kubernetes                    kubernetes.Kubernetes
+	RegistryDomain                string
+	DisableVersionBundleSelection bool
 }

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -16,5 +16,5 @@ type Service struct {
 	Installation                  installation.Installation
 	Kubernetes                    kubernetes.Kubernetes
 	RegistryDomain                string
-	DisableVersionBundleSelection bool
+	DisableVersionBundleSelection string
 }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.AWS.VPCPeerID, "", "Control Plane VPC ID to peer Tenant Clusters with.")
 
 	daemonCommand.PersistentFlags().String(f.Service.RegistryDomain, "quay.io", "Image registry.")
+	daemonCommand.PersistentFlags().Bool(f.Service.DisableVersionBundleSelection, false, "If enabled AWSConfig CRs are selected based on label instead of spec.versionBundle.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Guest.Ignition.Path, "/opt/ignition", "Default path for the ignition base directory.")
 	daemonCommand.PersistentFlags().String(f.Service.Guest.SSH.SSOPublicKey, "", "Public key for trusted SSO CA.")


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6663

Introduces a new flag which will be used disable selection of AWSConfig CRs based on versionBundle.