### PR TITLE
 add golden file test for cpf stack

### DIFF
--- a/service/controller/clusterapi/v29/resource/cpf/create_test.go
+++ b/service/controller/clusterapi/v29/resource/cpf/create_test.go
@@ -1,0 +1,72 @@
+package cpf
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cpf/template"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/unittest"
+)
+
+var update = flag.Bool("update", false, "update .golden CF template file")
+
+// Test_Controller_Resource_TCNP_Template_Render tests tenant cluster
+// CloudFormation template rendering. It is meant to be used as a tool to easily
+// check resulting CF template and prevent from accidental CF template changes.
+//
+// It uses golden file as reference template and when changes to template are
+// intentional, they can be updated by providing -update flag for go test.
+//
+//  go test ./service/controller/clusterapi/v29/resource/cpf -run Test_Controller_Resource_CPF_Template_Render -update
+//
+func Test_Controller_Resource_CPF_Template_Render(t *testing.T) {
+	testCases := []struct {
+		name string
+		ctx  context.Context
+		cl   v1alpha1.Cluster
+	}{
+		{
+			name: "case 0: basic test",
+			ctx:  unittest.DefaultContext(),
+			cl:   unittest.DefaultCluster(),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			params, err := newTemplateParams(tc.ctx, tc.cl, "kms", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			templateBody, err := template.Render(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p := filepath.Join("testdata", unittest.NormalizeFileName(tc.name)+".golden")
+
+			if *update {
+				err := ioutil.WriteFile(p, []byte(templateBody), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			goldenFile, err := ioutil.ReadFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal([]byte(templateBody), goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(templateBody, string(goldenFile)))
+			}
+		})
+	}
+}

--- a/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
@@ -1,0 +1,89 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Control Plane Finalizer Cloud Formation Stack.
+Resources:
+  
+
+
+  GuestNSRecordSet:
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      HostedZoneName: 'guux.eu-central-1.aws.gigantic.io.'
+      Name: '8y5ck.k8s.guux.eu-central-1.aws.gigantic.io.'
+      Type: 'NS'
+      TTL: '300'
+      ResourceRecords: !Split [ ',', '1.1.1.1,8.8.8.8' ]
+
+
+  
+  PrivateRoute0:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-2-id
+      DestinationCidrBlock: 10.100.3.0/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-2-id
+      DestinationCidrBlock: 10.100.3.64/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-2-id
+      DestinationCidrBlock: 10.100.3.128/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute3:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-1-id
+      DestinationCidrBlock: 10.100.3.0/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute4:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-1-id
+      DestinationCidrBlock: 10.100.3.64/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute5:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-1-id
+      DestinationCidrBlock: 10.100.3.128/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute6:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-2-id
+      DestinationCidrBlock: 10.100.3.0/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute7:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-2-id
+      DestinationCidrBlock: 10.100.3.64/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute8:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-private-2-id
+      DestinationCidrBlock: 10.100.3.128/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute9:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-1-id
+      DestinationCidrBlock: 10.100.3.0/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute10:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-1-id
+      DestinationCidrBlock: 10.100.3.64/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id
+  PrivateRoute11:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: gauss-public-1-id
+      DestinationCidrBlock: 10.100.3.128/27
+      VpcPeeringConnectionId: imagenary-peering-connection-id

--- a/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
@@ -1,3 +1,4 @@
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: Control Plane Finalizer Cloud Formation Stack.
 Resources:
@@ -15,75 +16,91 @@ Resources:
 
 
   
+  
   PrivateRoute0:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-2-id
+      RouteTableId: gauss-private-1-id
       DestinationCidrBlock: 10.100.3.0/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute1:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-2-id
+      RouteTableId: gauss-private-1-id
       DestinationCidrBlock: 10.100.3.64/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute2:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-2-id
+      RouteTableId: gauss-private-1-id
       DestinationCidrBlock: 10.100.3.128/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute3:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-1-id
+      RouteTableId: gauss-private-2-id
       DestinationCidrBlock: 10.100.3.0/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute4:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-1-id
+      RouteTableId: gauss-private-2-id
       DestinationCidrBlock: 10.100.3.64/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute5:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-1-id
+      RouteTableId: gauss-private-2-id
       DestinationCidrBlock: 10.100.3.128/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute6:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-2-id
+      RouteTableId: gauss-public-1-id
       DestinationCidrBlock: 10.100.3.0/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute7:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-2-id
+      RouteTableId: gauss-public-1-id
       DestinationCidrBlock: 10.100.3.64/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute8:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-private-2-id
+      RouteTableId: gauss-public-1-id
       DestinationCidrBlock: 10.100.3.128/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute9:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-1-id
+      RouteTableId: gauss-public-2-id
       DestinationCidrBlock: 10.100.3.0/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute10:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-1-id
+      RouteTableId: gauss-public-2-id
       DestinationCidrBlock: 10.100.3.64/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
   PrivateRoute11:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: gauss-public-1-id
+      RouteTableId: gauss-public-2-id
       DestinationCidrBlock: 10.100.3.128/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
+  
+
+  
+

--- a/service/controller/clusterapi/v29/unittest/default_controller_context.go
+++ b/service/controller/clusterapi/v29/unittest/default_controller_context.go
@@ -97,7 +97,14 @@ func DefaultContext() context.Context {
 			ControlPlane: controllercontext.ContextStatusControlPlane{
 				AWSAccountID: "control-plane-account",
 				NATGateway:   controllercontext.ContextStatusControlPlaneNATGateway{},
-				RouteTable:   controllercontext.ContextStatusControlPlaneRouteTable{},
+				RouteTable: controllercontext.ContextStatusControlPlaneRouteTable{
+					Mappings: map[string]string{
+						"gauss-private-1-name": "gauss-private-1-id",
+						"gauss-private-2-name": "gauss-private-2-id",
+						"gauss-public-1-name":  "gauss-public-1-id",
+						"gauss-public-2-name":  "gauss-public-2-id",
+					},
+				},
 				PeerRole: controllercontext.ContextStatusControlPlanePeerRole{
 					ARN: "imaginary-cp-peer-role-arn",
 				},


### PR DESCRIPTION
Towards Node Pools. When sorting out the VPC Peering connections for Node Pools we need to work with the CPF stack. I also want to do some improvements to the templates. First, I want to have a golden file test to see that my changes don't mess with functionality in unintended ways. Here is only the test without changing functionality. 