### PR TITLE
fix route table mapping iteration issue

### DIFF
--- a/service/controller/clusterapi/v29/controllercontext/status.go
+++ b/service/controller/clusterapi/v29/controllercontext/status.go
@@ -15,20 +15,13 @@ type ContextStatus struct {
 type ContextStatusControlPlane struct {
 	AWSAccountID string
 	NATGateway   ContextStatusControlPlaneNATGateway
-	RouteTable   ContextStatusControlPlaneRouteTable
+	RouteTables  []*ec2.RouteTable
 	PeerRole     ContextStatusControlPlanePeerRole
 	VPC          ContextStatusControlPlaneVPC
 }
 
 type ContextStatusControlPlaneNATGateway struct {
 	Addresses []*ec2.Address
-}
-
-type ContextStatusControlPlaneRouteTable struct {
-	// Mappings are key value pairs of control plane route table names and their
-	// IDs, where the map keys are route table names and the map values are route
-	// table IDs. The mapping is managed by the routetable resource.
-	Mappings map[string]string
 }
 
 type ContextStatusControlPlanePeerRole struct {

--- a/service/controller/clusterapi/v29/resource/cpf/create.go
+++ b/service/controller/clusterapi/v29/resource/cpf/create.go
@@ -142,10 +142,10 @@ func newRouteTablesParams(ctx context.Context, cr v1alpha1.Cluster, encrypterBac
 
 	var privateRoutes []template.ParamsMainRouteTablesRoute
 	{
-		for _, id := range cc.Status.ControlPlane.RouteTable.Mappings {
+		for _, rt := range cc.Status.ControlPlane.RouteTables {
 			for _, az := range cc.Status.TenantCluster.TCCP.AvailabilityZones {
 				route := template.ParamsMainRouteTablesRoute{
-					RouteTableID: id,
+					RouteTableID: *rt.RouteTableId,
 					// Requester CIDR block, we create the peering connection from the
 					// tenant's private subnets.
 					CidrBlock: az.Subnet.Private.CIDR.String(),
@@ -161,9 +161,9 @@ func newRouteTablesParams(ctx context.Context, cr v1alpha1.Cluster, encrypterBac
 
 	var publicRoutes []template.ParamsMainRouteTablesRoute
 	if encrypterBackend == encrypter.VaultBackend {
-		for _, id := range cc.Status.ControlPlane.RouteTable.Mappings {
+		for _, rt := range cc.Status.ControlPlane.RouteTables {
 			route := template.ParamsMainRouteTablesRoute{
-				RouteTableID: id,
+				RouteTableID: *rt.RouteTableId,
 				// Requester CIDR block, we create the peering connection from the
 				// tenant's CIDR for being able to access Vault's ELB.
 				CidrBlock: key.StatusClusterNetworkCIDR(cr),

--- a/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/cpf/testdata/case-0-basic-test.golden
@@ -46,39 +46,3 @@ Resources:
       RouteTableId: gauss-private-2-id
       DestinationCidrBlock: 10.100.3.128/27
       VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute6:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-1-id
-      DestinationCidrBlock: 10.100.3.0/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute7:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-1-id
-      DestinationCidrBlock: 10.100.3.64/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute8:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-1-id
-      DestinationCidrBlock: 10.100.3.128/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute9:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-2-id
-      DestinationCidrBlock: 10.100.3.0/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute10:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-2-id
-      DestinationCidrBlock: 10.100.3.64/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id
-  PrivateRoute11:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: gauss-public-2-id
-      DestinationCidrBlock: 10.100.3.128/27
-      VpcPeeringConnectionId: imagenary-peering-connection-id

--- a/service/controller/clusterapi/v29/resource/routetable/delete.go
+++ b/service/controller/clusterapi/v29/resource/routetable/delete.go
@@ -2,15 +2,8 @@ package routetable
 
 import (
 	"context"
-
-	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	err := r.addRouteTableMappingsToContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }

--- a/service/controller/clusterapi/v29/unittest/default_controller_context.go
+++ b/service/controller/clusterapi/v29/unittest/default_controller_context.go
@@ -97,12 +97,24 @@ func DefaultContext() context.Context {
 			ControlPlane: controllercontext.ContextStatusControlPlane{
 				AWSAccountID: "control-plane-account",
 				NATGateway:   controllercontext.ContextStatusControlPlaneNATGateway{},
-				RouteTable: controllercontext.ContextStatusControlPlaneRouteTable{
-					Mappings: map[string]string{
-						"gauss-private-1-name": "gauss-private-1-id",
-						"gauss-private-2-name": "gauss-private-2-id",
-						"gauss-public-1-name":  "gauss-public-1-id",
-						"gauss-public-2-name":  "gauss-public-2-id",
+				RouteTables: []*ec2.RouteTable{
+					{
+						RouteTableId: aws.String("gauss-private-1-id"),
+						Tags: []*ec2.Tag{
+							{
+								Key:   aws.String("Name"),
+								Value: aws.String("gauss-private-1-name"),
+							},
+						},
+					},
+					{
+						RouteTableId: aws.String("gauss-private-2-id"),
+						Tags: []*ec2.Tag{
+							{
+								Key:   aws.String("Name"),
+								Value: aws.String("gauss-private-2-name"),
+							},
+						},
 					},
 				},
 				PeerRole: controllercontext.ContextStatusControlPlanePeerRole{


### PR DESCRIPTION
I found out that the route table mapping in the controller context is a map and that the golden file tests flap now because iterating over maps in go is not deterministic in order. Now we use a list of route tables. 