### PR TITLE
improve diff comparison in unit tests

### DIFF
--- a/service/controller/clusterapi/v29/resource/cpf/create_test.go
+++ b/service/controller/clusterapi/v29/resource/cpf/create_test.go
@@ -69,7 +69,7 @@ func Test_Controller_Resource_CPF_Template_Render(t *testing.T) {
 			}
 
 			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(templateBody, string(goldenFile)))
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
 			}
 		})
 	}

--- a/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template_render_test.go
@@ -111,7 +111,7 @@ func Test_newTemplateBody(t *testing.T) {
 			}
 
 			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(templateBody, string(goldenFile)))
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
 			}
 		})
 	}

--- a/service/controller/clusterapi/v29/resource/tcnp/create_test.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create_test.go
@@ -65,7 +65,7 @@ func Test_Controller_Resource_TCNP_Template_Render(t *testing.T) {
 			}
 
 			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(templateBody, string(goldenFile)))
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
 			}
 		})
 	}


### PR DESCRIPTION
When `na-eu-central-1a` and `na-eu-central-1c` are the removed values and `nat-gateway-id-eu-central-1a` and `nat-gateway-id-eu-central-1c` are the added values, the diff looks like below. This was the other way around and confusing. 

```
go test ./service/controller/clusterapi/v29/resource/tcnp
--- FAIL: Test_Controller_Resource_TCNP_Template_Render (0.00s)
    --- FAIL: Test_Controller_Resource_TCNP_Template_Render/0 (0.00s)
        create_test.go:68:

              strings.Join({
              	... // 214 identical lines
              	"      RouteTableId: !Ref PrivateRouteTableEuCentral1a",
              	"      DestinationCidrBlock: 0.0.0.0/0",
            - 	"      NatGatewayId: na-eu-central-1a",
            + 	"      NatGatewayId: nat-gateway-id-eu-central-1a",
              	"  PrivateRouteTableEuCentral1c:",
              	"    Type: AWS::EC2::RouteTable",
              	... // 14 identical lines
              	"      RouteTableId: !Ref PrivateRouteTableEuCentral1c",
              	"      DestinationCidrBlock: 0.0.0.0/0",
            - 	"      NatGatewayId: na-eu-central-1c",
            + 	"      NatGatewayId: nat-gateway-id-eu-central-1c",
              	"  GeneralSecurityGroup:",
              	"    Type: AWS::EC2::SecurityGroup",
              	... // 143 identical lines
              }, "\n")

FAIL
FAIL	github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/tcnp	0.029s
```