### PR TITLE
drop deletion logic from machindeployment resource

### DIFF
--- a/service/controller/clusterapi/v29/resource/machinedeployment/delete.go
+++ b/service/controller/clusterapi/v29/resource/machinedeployment/delete.go
@@ -2,54 +2,8 @@ package machinedeployment
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/giantswarm/aws-operator/pkg/label"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding machine deployment for cluster")
-
-		in := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", label.Cluster, key.ClusterID(&cr)),
-		}
-
-		out, err := r.cmaClient.ClusterV1alpha1().MachineDeployments(metav1.NamespaceAll).List(in)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		if len(out.Items) == 0 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find machine deployment for cluster")
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-			reconciliationcanceledcontext.SetCanceled(ctx)
-
-			return nil
-		}
-		if len(out.Items) != 1 {
-			return microerror.Maskf(executionFailedError, "expected 1 machine deployment got %d", len(out.Items))
-		}
-
-		cc.Status.TenantCluster.TCCP.MachineDeployment = out.Items[0]
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found machine deployment for cluster")
-	}
-
 	return nil
 }


### PR DESCRIPTION
We noticed that the deletion of Node Pool clusters is not reliable and the TCCP stacks sometimes stay even when the CRs are gone. Reason is that the temporary machinedeployment resource did not keep finalizers. I checked and decided to remove the logic for `EnsureDeleted` as it is not of any use. 