### PR TITLE
cleanup security groups

### DIFF
--- a/service/controller/clusterapi/v29/cluster_resource_set.go
+++ b/service/controller/clusterapi/v29/cluster_resource_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/awsclient"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cproutetables"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cpvpccidr"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ebsvolume"
@@ -180,6 +181,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		awsClientResource, err = awsclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -610,7 +623,6 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		encryptionResource,
 		s3BucketResource,
 		s3ObjectResource,
-		loadBalancerResource,
 		ebsVolumeResource,
 		tccpAZsResource,
 		tccpiResource,
@@ -620,6 +632,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		serviceResource,
 		endpointsResource,
 		secretFinalizerResource,
+		loadBalancerResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/legacy/v25/cluster_resource_set.go
+++ b/service/controller/legacy/v25/cluster_resource_set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/resource/ebsvolume"
@@ -209,6 +210,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -611,6 +624,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		namespaceResource,
 		serviceResource,
 		endpointsResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/delete.go
@@ -8,12 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v25/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	var groups []*ec2.SecurityGroup
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(cr)))
 
 		i := &ec2.DescribeSecurityGroupsInput{
 			Filters: []*ec2.Filter{
@@ -34,7 +34,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				// customers might not cleanup properly when the whole tenant cluster is
 				// torn down.
 				{
-					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(cr))),
 					Values: []*string{
 						aws.String("owned"),
 					},
@@ -49,14 +49,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 		groups = o.SecurityGroups
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	if len(groups) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 
 		for _, g := range groups {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 
 			i := &ec2.DeleteSecurityGroupInput{
 				GroupId: g.GroupId,
@@ -67,12 +67,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	return nil

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "cleanupsecuritygroupsv29"
+	Name = "cleanupsecuritygroupsv25"
 )
 
 type Config struct {

--- a/service/controller/legacy/v25/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v25/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/legacy/v26/cluster_resource_set.go
+++ b/service/controller/legacy/v26/cluster_resource_set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/resource/ebsvolume"
@@ -209,6 +210,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -611,6 +624,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		namespaceResource,
 		serviceResource,
 		endpointsResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/delete.go
@@ -8,12 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v26/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	var groups []*ec2.SecurityGroup
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(cr)))
 
 		i := &ec2.DescribeSecurityGroupsInput{
 			Filters: []*ec2.Filter{
@@ -34,7 +34,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				// customers might not cleanup properly when the whole tenant cluster is
 				// torn down.
 				{
-					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(cr))),
 					Values: []*string{
 						aws.String("owned"),
 					},
@@ -49,14 +49,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 		groups = o.SecurityGroups
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	if len(groups) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 
 		for _, g := range groups {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 
 			i := &ec2.DeleteSecurityGroupInput{
 				GroupId: g.GroupId,
@@ -67,12 +67,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	return nil

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "cleanupsecuritygroupsv29"
+	Name = "cleanupsecuritygroupsv26"
 )
 
 type Config struct {

--- a/service/controller/legacy/v26/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v26/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/legacy/v27/cluster_resource_set.go
+++ b/service/controller/legacy/v27/cluster_resource_set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/resource/ebsvolume"
@@ -210,6 +211,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -615,6 +628,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		serviceResource,
 		endpointsResource,
 		secretFinalizerResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/delete.go
@@ -8,12 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v27/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	var groups []*ec2.SecurityGroup
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(cr)))
 
 		i := &ec2.DescribeSecurityGroupsInput{
 			Filters: []*ec2.Filter{
@@ -34,7 +34,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				// customers might not cleanup properly when the whole tenant cluster is
 				// torn down.
 				{
-					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(cr))),
 					Values: []*string{
 						aws.String("owned"),
 					},
@@ -49,14 +49,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 		groups = o.SecurityGroups
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	if len(groups) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 
 		for _, g := range groups {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 
 			i := &ec2.DeleteSecurityGroupInput{
 				GroupId: g.GroupId,
@@ -67,12 +67,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	return nil

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "cleanupsecuritygroupsv29"
+	Name = "cleanupsecuritygroupsv27"
 )
 
 type Config struct {

--- a/service/controller/legacy/v27/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v27/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/legacy/v28/cluster_resource_set.go
+++ b/service/controller/legacy/v28/cluster_resource_set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v28/resource/ebsvolume"
@@ -210,6 +211,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -615,6 +628,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		serviceResource,
 		endpointsResource,
 		secretFinalizerResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/legacy/v28/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/legacy/v28/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/legacy/v28/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v28/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/legacy/v28/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/legacy/v28/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/legacy/v28/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v28/resource/cleanupsecuritygroups/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "cleanupsecuritygroupsv29"
+	Name = "cleanupsecuritygroupsv28"
 )
 
 type Config struct {

--- a/service/controller/legacy/v28/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v28/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/legacy/v29/cluster_resource_set.go
+++ b/service/controller/legacy/v29/cluster_resource_set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/accountid"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/bridgezone"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/cpf"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/cpi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/resource/ebsvolume"
@@ -215,6 +216,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 
 		asgStatusResource, err = asgstatus.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupSecurityGroups controller.Resource
+	{
+		c := cleanupsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		cleanupSecurityGroups, err = cleanupsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -620,6 +633,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		serviceResource,
 		endpointsResource,
 		secretFinalizerResource,
+		cleanupSecurityGroups,
 	}
 
 	{

--- a/service/controller/legacy/v29/resource/cleanupsecuritygroups/create.go
+++ b/service/controller/legacy/v29/resource/cleanupsecuritygroups/create.go
@@ -1,0 +1,9 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/legacy/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v29/resource/cleanupsecuritygroups/delete.go
@@ -8,12 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	var groups []*ec2.SecurityGroup
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(cr)))
 
 		i := &ec2.DescribeSecurityGroupsInput{
 			Filters: []*ec2.Filter{
@@ -34,7 +34,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				// customers might not cleanup properly when the whole tenant cluster is
 				// torn down.
 				{
-					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(cr))),
 					Values: []*string{
 						aws.String("owned"),
 					},
@@ -49,14 +49,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 		groups = o.SecurityGroups
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	if len(groups) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 
 		for _, g := range groups {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 
 			i := &ec2.DeleteSecurityGroupInput{
 				GroupId: g.GroupId,
@@ -67,12 +67,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(cr)))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(cr)))
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(cr)))
 	}
 
 	return nil

--- a/service/controller/legacy/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/legacy/v29/resource/cleanupsecuritygroups/delete.go
@@ -1,0 +1,79 @@
+package cleanupsecuritygroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var groups []*ec2.SecurityGroup
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding security groups for tenant cluster %#q", key.ClusterID(&cr)))
+
+		i := &ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				// The filter here matches all security groups managed by ingress
+				// controllers running within the tenant cluster. The cluster deletion
+				// process might not be perfect and the ingress controllers ran by
+				// customers might not cleanup properly when the whole tenant cluster is
+				// torn down.
+				{
+					Name: aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", key.ClusterID(&cr))),
+					Values: []*string{
+						aws.String("owned"),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeSecurityGroups(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		groups = o.SecurityGroups
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found security groups for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	if len(groups) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+
+		for _, g := range groups {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+			i := &ec2.DeleteSecurityGroupInput{
+				GroupId: g.GroupId,
+			}
+
+			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
+	}
+
+	return nil
+}

--- a/service/controller/legacy/v29/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/legacy/v29/resource/cleanupsecuritygroups/error.go
@@ -1,0 +1,24 @@
+package cleanupsecuritygroups
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/legacy/v29/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/legacy/v29/resource/cleanupsecuritygroups/resource.go
@@ -1,0 +1,34 @@
+package cleanupsecuritygroups
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "cleanupsecuritygroupsv29"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6443. Explored and discussed with Vaclav. Theory here is that our tenant cluster deletion is not graceful enough to let apps running within it cleanup once the cluster is deleted. Thus we see security groups being left over in `seal/4tjmw`. The security group left there appears to be from an ingress controller. I deploy this to `seal` and see if it works. Note that this approach is actually a recommended way the AWS support told me. We already do the same thing with load balancers. 