### PR TITLE
make error handling for temporary dependency violations more graceful

### DIFF
--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
@@ -63,7 +63,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			}
 
 			_, err := cc.Client.TenantCluster.AWS.EC2.DeleteSecurityGroup(i)
-			if err != nil {
+			if IsDependencyViolation(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("security group %#q for tenant cluster %#q still has dependency", *g.GroupId, key.ClusterID(&cr)))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("skipping security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+				continue
+
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
@@ -56,6 +56,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if len(groups) > 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
 
+		var deleted int
 		for _, g := range groups {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
 
@@ -77,10 +78,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
+			deleted++
+
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", len(groups), key.ClusterID(&cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %d security groups for tenant cluster %#q", deleted, key.ClusterID(&cr)))
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no security groups to be deleted for tenant cluster %#q", key.ClusterID(&cr)))
 	}

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
@@ -66,6 +67,10 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			if IsDependencyViolation(err) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("security group %#q for tenant cluster %#q still has dependency", *g.GroupId, key.ClusterID(&cr)))
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("skipping security group %#q for tenant cluster %#q", *g.GroupId, key.ClusterID(&cr)))
+
+				r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+				finalizerskeptcontext.SetKept(ctx)
+
 				continue
 
 			} else if err != nil {

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
@@ -1,6 +1,11 @@
 package cleanupsecuritygroups
 
-import "github.com/giantswarm/microerror"
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/giantswarm/microerror"
+)
 
 // executionFailedError is an error type for situations where Resource execution
 // cannot continue and must always fall back to operatorkit.
@@ -14,11 +19,44 @@ var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
 
+var dependencyViolationError = &microerror.Error{
+	Kind: "dependencyViolationError",
+}
+
+// IsDependencyViolation asserts dependencyViolationError.
+func IsDependencyViolation(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == dependencyViolationError {
+		return true
+	}
+
+	aerr, ok := c.(awserr.Error)
+	if !ok {
+		return false
+	}
+	fmt.Printf("\n")
+	fmt.Printf("\n")
+	fmt.Printf("\n")
+	fmt.Printf("code: %#v\n", aerr.Code())
+	fmt.Printf("erro: %#v\n", aerr.Error())
+	fmt.Printf("mess: %#v\n", aerr.Message())
+	fmt.Printf("orig: %#v\n", aerr.OrigErr())
+	fmt.Printf("\n")
+	fmt.Printf("\n")
+	fmt.Printf("\n")
+	if aerr.Code() == "DependencyViolation" {
+		return true
+	}
+
+	return false
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
 
-// IsInsserts invalidConfigError.
+// IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }

--- a/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
+++ b/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/error.go
@@ -1,8 +1,6 @@
 package cleanupsecuritygroups
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/giantswarm/microerror"
 )
@@ -23,7 +21,11 @@ var dependencyViolationError = &microerror.Error{
 	Kind: "dependencyViolationError",
 }
 
-// IsDependencyViolation asserts dependencyViolationError.
+// IsDependencyViolation asserts dependencyViolationError. Additionally it
+// asserts AWS errors which may look like the following.
+//
+//     DependencyViolation: resource sg-07423aeb02946f323 has a dependent object\n\tstatus code: 400, request id: c16da859-433c-4e59-b598-ef17f9faa770
+//
 func IsDependencyViolation(err error) bool {
 	c := microerror.Cause(err)
 
@@ -35,16 +37,6 @@ func IsDependencyViolation(err error) bool {
 	if !ok {
 		return false
 	}
-	fmt.Printf("\n")
-	fmt.Printf("\n")
-	fmt.Printf("\n")
-	fmt.Printf("code: %#v\n", aerr.Code())
-	fmt.Printf("erro: %#v\n", aerr.Error())
-	fmt.Printf("mess: %#v\n", aerr.Message())
-	fmt.Printf("orig: %#v\n", aerr.OrigErr())
-	fmt.Printf("\n")
-	fmt.Printf("\n")
-	fmt.Printf("\n")
 	if aerr.Code() == "DependencyViolation" {
 		return true
 	}


### PR DESCRIPTION
During deletions of Node Pools clusters we see errors like these. 

> {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:222","controller":"aws-operator-cluster-controller","event":"delete","level":"error","loop":"20","message":"stop reconciliation due to error","object":"/apis/cluster.k8s.io/v1alpha1/namespaces/default/clusters/cl029","resource":"cleanupsecuritygroupsv29","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:489: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/resource_wrapper.go:56: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:103: } {/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:91: } {/go/src/github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/cleanupsecuritygroups/delete.go:67: } {DependencyViolation: resource sg-0548bf486ca5ce537 has a dependent object\n\tstatus code: 400, request id: 8bc5346d-4cf5-4bfb-a7c9-da96e9832335}]","time":"2019-08-08T14:42:16.238488+00:00","version":"143653753"}