### PR TITLE
fix unexpected end of json input error on nil byte slice

### DIFF
--- a/service/controller/clusterapi/v29/resource/ipam/cluster_persister.go
+++ b/service/controller/clusterapi/v29/resource/ipam/cluster_persister.go
@@ -50,6 +50,9 @@ func (p *ClusterPersister) Persist(ctx context.Context, subnet net.IPNet, namesp
 		if cr.Status.ProviderStatus == nil {
 			cr.Status.ProviderStatus = &runtime.RawExtension{}
 		}
+		if cr.Status.ProviderStatus.Raw == nil {
+			cr.Status.ProviderStatus.Raw = []byte{}
+		}
 
 		err := json.Unmarshal(cr.Status.ProviderStatus.Raw, &providerStatus)
 		if err != nil {


### PR DESCRIPTION
When `cluster-operator` and `aws-operator` are not synchronized due to whatever reason we see errors like these. Initializing the raw extension properly fixes this. 

> {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:74","controller":"aws-operator-cluster-controller","event":"update","level":"warning","loop":"8","message":"retrying due to error","object":"/apis/cluster.k8s.io/v1alpha1/namespaces/default/clusters/cl034","resource":"ipamv29","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/resource_wrapper.go:67: } {/go/src/github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ipam/create.go:81: } {/go/src/github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/ipam/cluster_persister.go:56: } {unexpected end of JSON input}]","time":"2019-08-09T14:09:00.311468+00:00","underlyingResource":"ipamv29","version":"143881679"}