### PR TITLE
fix tag filters to not fetch master instances

### DIFF
--- a/service/controller/clusterapi/v29/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v29/resource/asgstatus/create.go
@@ -34,6 +34,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 						aws.String(key.ClusterID(&cr)),
 					},
 				},
+				{
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagStack)),
+					Values: []*string{
+						aws.String(key.StackTCNP),
+					},
+				},
 			},
 		}
 

--- a/service/controller/legacy/v28/resource/asgstatus/create.go
+++ b/service/controller/legacy/v28/resource/asgstatus/create.go
@@ -31,6 +31,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		i := &ec2.DescribeInstancesInput{
 			Filters: []*ec2.Filter{
 				{
+					Name: aws.String("tag:Name"),
+					Values: []*string{
+						aws.String(fmt.Sprintf("%s-worker", key.ClusterID(cr))),
+					},
+				},
+				{
 					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
 					Values: []*string{
 						aws.String(key.ClusterID(cr)),

--- a/service/controller/legacy/v28patch1/resource/asgstatus/create.go
+++ b/service/controller/legacy/v28patch1/resource/asgstatus/create.go
@@ -31,6 +31,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		i := &ec2.DescribeInstancesInput{
 			Filters: []*ec2.Filter{
 				{
+					Name: aws.String("tag:Name"),
+					Values: []*string{
+						aws.String(fmt.Sprintf("%s-worker", key.ClusterID(cr))),
+					},
+				},
+				{
 					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
 					Values: []*string{
 						aws.String(key.ClusterID(cr)),

--- a/service/controller/legacy/v29/resource/asgstatus/create.go
+++ b/service/controller/legacy/v29/resource/asgstatus/create.go
@@ -31,6 +31,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		i := &ec2.DescribeInstancesInput{
 			Filters: []*ec2.Filter{
 				{
+					Name: aws.String("tag:Name"),
+					Values: []*string{
+						aws.String(fmt.Sprintf("%s-worker", key.ClusterID(cr))),
+					},
+				},
+				{
 					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
 					Values: []*string{
 						aws.String(key.ClusterID(cr)),


### PR DESCRIPTION
So we only want to list worker instances running in ASGs and not master instances. 