### PR TITLE
Setup private hosted zone for api/etcd internal elbs

### DIFF
--- a/service/controller/clusterapi/v29/adapter/guest_load_balancers.go
+++ b/service/controller/clusterapi/v29/adapter/guest_load_balancers.go
@@ -19,8 +19,10 @@ const (
 type GuestLoadBalancersAdapter struct {
 	APIElbHealthCheckTarget          string
 	APIElbName                       string
+	APIInternalElbName               string
 	APIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
 	APIElbScheme                     string
+	APIInternalElbScheme             string
 	APIElbSecurityGroupID            string
 	EtcdElbHealthCheckTarget         string
 	EtcdElbName                      string
@@ -49,6 +51,7 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 	// API load balancer settings.
 	a.APIElbHealthCheckTarget = heathCheckTarget(key.KubernetesSecurePort)
 	a.APIElbName = key.ELBNameAPI(&cfg.CustomObject)
+	a.APIInternalElbName = key.InternalELBNameAPI(&cfg.CustomObject)
 	a.APIElbPortsToOpen = []GuestLoadBalancersAdapterPortPair{
 		{
 			PortELB:      key.KubernetesSecurePort,
@@ -56,6 +59,7 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 		},
 	}
 	a.APIElbScheme = externalELBScheme
+	a.APIInternalElbScheme = internalELBScheme
 
 	// etcd load balancer settings.
 	a.EtcdElbHealthCheckTarget = heathCheckTarget(key.EtcdPort)

--- a/service/controller/clusterapi/v29/adapter/guest_record_sets.go
+++ b/service/controller/clusterapi/v29/adapter/guest_record_sets.go
@@ -10,6 +10,7 @@ type GuestRecordSetsAdapter struct {
 	ClusterID                  string
 	MasterInstanceResourceName string
 	Route53Enabled             bool
+	VPCRegion                  string
 }
 
 func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
@@ -18,6 +19,7 @@ func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
 	a.ClusterID = key.ClusterID(&config.CustomObject)
 	a.MasterInstanceResourceName = config.StackState.MasterInstanceResourceName
 	a.Route53Enabled = config.Route53Enabled
+	a.VPCRegion = key.Region(config.CustomObject)
 
 	return nil
 }

--- a/service/controller/clusterapi/v29/key/common.go
+++ b/service/controller/clusterapi/v29/key/common.go
@@ -65,6 +65,10 @@ func ELBNameIngress(getter LabelsGetter) string {
 	return fmt.Sprintf("%s-ingress", ClusterID(getter))
 }
 
+func InternalELBNameAPI(getter LabelsGetter) string {
+	return fmt.Sprintf("%s-api-internal", ClusterID(getter))
+}
+
 func IsDeleted(getter DeletionTimestampGetter) bool {
 	return getter.GetDeletionTimestamp() != nil
 }

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -261,7 +261,7 @@ Resources:
         - !Ref PublicSubnetEuCentral1c
       
 
-  EtcdInternalLoadBalancer:
+  EtcdLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -194,6 +194,39 @@ Resources:
       GatewayId:
         Ref: InternetGateway
   
+  ApiInternalLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn:
+      - VPCGatewayAttachment
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: 1200
+      HealthCheck:
+        HealthyThreshold: 2
+        Interval: 5
+        Target: TCP:443
+        Timeout: 3
+        UnhealthyThreshold: 2
+      Instances:
+      - !Ref rsc-ac0dc01
+      Listeners:
+      
+      - InstancePort: 443
+        InstanceProtocol: TCP
+        LoadBalancerPort: 443
+        Protocol: TCP
+      
+      LoadBalancerName: 8y5ck-api-internal
+      Scheme: internal
+      SecurityGroups:
+        - !Ref MasterSecurityGroup
+      Subnets:
+        - !Ref PublicSubnetEuCentral1a
+      
+        - !Ref PublicSubnetEuCentral1b
+      
+        - !Ref PublicSubnetEuCentral1c
+      
   ApiLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     DependsOn:
@@ -228,7 +261,7 @@ Resources:
         - !Ref PublicSubnetEuCentral1c
       
 
-  EtcdLoadBalancer:
+  EtcdInternalLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/load_balancers.go
@@ -3,6 +3,36 @@ package tccp
 const LoadBalancers = `
 {{- define "load_balancers" -}}
 {{- $v := .Guest.LoadBalancers }}
+  ApiInternalLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn:
+      - VPCGatewayAttachment
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: 1200
+      HealthCheck:
+        HealthyThreshold: {{ $v.ELBHealthCheckHealthyThreshold }}
+        Interval: {{ $v.ELBHealthCheckInterval }}
+        Target: {{ $v.APIElbHealthCheckTarget }}
+        Timeout: {{ $v.ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ $v.ELBHealthCheckUnhealthyThreshold }}
+      Instances:
+      - !Ref {{ $v.MasterInstanceResourceName }}
+      Listeners:
+      {{ range $v.APIElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ $v.APIInternalElbName }}
+      Scheme: {{ $v.APIInternalElbScheme }}
+      SecurityGroups:
+        - !Ref MasterSecurityGroup
+      Subnets:
+      {{- range $s := $v.PublicSubnets }}
+        - !Ref {{ $s }}
+      {{end}}
   ApiLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     DependsOn:
@@ -34,7 +64,7 @@ const LoadBalancers = `
         - !Ref {{ $s }}
       {{end}}
 
-  EtcdLoadBalancer:
+  EtcdInternalLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/load_balancers.go
@@ -64,7 +64,7 @@ const LoadBalancers = `
         - !Ref {{ $s }}
       {{end}}
 
-  EtcdInternalLoadBalancer:
+  EtcdLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/record_sets.go
@@ -41,8 +41,8 @@ const RecordSets = `
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
-        DNSName: !GetAtt EtcdInternalLoadBalancer.DNSName
-        HostedZoneId: !GetAtt EtcdInternalLoadBalancer.CanonicalHostedZoneNameID
+        DNSName: !GetAtt EtcdLoadBalancer.DNSName
+        HostedZoneId: !GetAtt EtcdLoadBalancer.CanonicalHostedZoneNameID
         EvaluateTargetHealth: false
       Name: '{{ $v.EtcdDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/record_sets.go
@@ -8,6 +8,15 @@ const RecordSets = `
     Type: 'AWS::Route53::HostedZone'
     Properties:
       Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+  InternalHostedZone:
+    Type: 'AWS::Route53::HostedZone'
+    Properties:
+      Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneConfig:
+        Comment: "Internal hosted zone for internal network"
+      VPCs:
+        - VPCId: !Ref VPC
+          VPCRegion: '{{ $v.VPCRegion }}'
   ApiRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -18,15 +27,25 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'HostedZone'
       Type: A
+  ApiInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt ApiInternalLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApiInternalLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      Type: A
   EtcdRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
-        DNSName: !GetAtt EtcdLoadBalancer.DNSName
-        HostedZoneId: !GetAtt EtcdLoadBalancer.CanonicalHostedZoneNameID
+        DNSName: !GetAtt EtcdInternalLoadBalancer.DNSName
+        HostedZoneId: !GetAtt EtcdInternalLoadBalancer.CanonicalHostedZoneNameID
         EvaluateTargetHealth: false
       Name: '{{ $v.EtcdDomain }}.'
-      HostedZoneId: !Ref 'HostedZone'
+      HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
   IngressRecordSet:
     Type: AWS::Route53::RecordSet

--- a/service/controller/clusterapi/v29/version_bundle.go
+++ b/service/controller/clusterapi/v29/version_bundle.go
@@ -17,6 +17,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Introduce explicit resource reservation for OS resources and container runtime.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "cloudformation",
+				Description: "Setup private hosted zone for internal api/etcd load-balancers.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/legacy/v29/adapter/guest_load_balancers.go
+++ b/service/controller/legacy/v29/adapter/guest_load_balancers.go
@@ -21,6 +21,7 @@ type GuestLoadBalancersAdapter struct {
 	APIElbName                       string
 	APIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
 	APIElbScheme                     string
+	APIElbSchemeInternal             string
 	APIElbSecurityGroupID            string
 	EtcdElbHealthCheckTarget         string
 	EtcdElbName                      string
@@ -63,6 +64,7 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 		},
 	}
 	a.APIElbScheme = externalELBScheme
+	a.APIElbSchemeInternal = internalELBScheme
 
 	// etcd load balancer settings.
 	etcdElbName, err := key.LoadBalancerName(key.EtcdDomain(cfg.CustomObject), cfg.CustomObject)

--- a/service/controller/legacy/v29/adapter/guest_load_balancers.go
+++ b/service/controller/legacy/v29/adapter/guest_load_balancers.go
@@ -19,9 +19,10 @@ const (
 type GuestLoadBalancersAdapter struct {
 	APIElbHealthCheckTarget          string
 	APIElbName                       string
+	APIInternalElbName               string
 	APIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
 	APIElbScheme                     string
-	APIElbSchemeInternal             string
+	APIInternalElbScheme             string
 	APIElbSecurityGroupID            string
 	EtcdElbHealthCheckTarget         string
 	EtcdElbName                      string
@@ -55,8 +56,15 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 		return microerror.Mask(err)
 	}
 
+	// Internal API load balancer settings.
+	apiInternalElbName, err := key.InternalLoadBalancerName(cfg.CustomObject.Spec.Cluster.Kubernetes.API.Domain, cfg.CustomObject)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	a.APIElbHealthCheckTarget = heathCheckTarget(cfg.CustomObject.Spec.Cluster.Kubernetes.API.SecurePort)
 	a.APIElbName = apiElbName
+	a.APIInternalElbName = apiInternalElbName
 	a.APIElbPortsToOpen = []GuestLoadBalancersAdapterPortPair{
 		{
 			PortELB:      key.KubernetesAPISecurePort(cfg.CustomObject),
@@ -64,7 +72,7 @@ func (a *GuestLoadBalancersAdapter) Adapt(cfg Config) error {
 		},
 	}
 	a.APIElbScheme = externalELBScheme
-	a.APIElbSchemeInternal = internalELBScheme
+	a.APIInternalElbScheme = internalELBScheme
 
 	// etcd load balancer settings.
 	etcdElbName, err := key.LoadBalancerName(key.EtcdDomain(cfg.CustomObject), cfg.CustomObject)

--- a/service/controller/legacy/v29/adapter/guest_load_balancers_test.go
+++ b/service/controller/legacy/v29/adapter/guest_load_balancers_test.go
@@ -18,9 +18,10 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 		expectedAPIElbName                       string
 		expectedAPIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
 		expectedAPIElbScheme                     string
-		expectedAPIElbSchemeInternal             string
+		expectedAPIInternalElbScheme             string
 		expectedAPIElbSecurityGroupID            string
 		expectedAPIElbSubnetID                   string
+		expectedAPIInternalElbName               string
 		expectedEtcdElbName                      string
 		expectedEtcdElbPortsToOpen               []GuestLoadBalancersAdapterPortPair
 		expectedEtcdElbScheme                    string
@@ -100,7 +101,8 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 				},
 			},
 			expectedAPIElbScheme:         "internet-facing",
-			expectedAPIElbSchemeInternal: "internal",
+			expectedAPIInternalElbScheme: "internal",
+			expectedAPIInternalElbName:   "test-cluster-api-internal",
 			expectedEtcdElbName:          "test-cluster-etcd",
 			expectedEtcdElbPortsToOpen: []GuestLoadBalancersAdapterPortPair{
 				{
@@ -158,8 +160,8 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 				t.Errorf("expected API ELB Scheme, got %q, want %q", a.Guest.LoadBalancers.APIElbScheme, tc.expectedAPIElbScheme)
 			}
 
-			if tc.expectedAPIElbSchemeInternal != a.Guest.LoadBalancers.APIElbSchemeInternal {
-				t.Errorf("expected API ELB Scheme Internal, got %q, want %q", a.Guest.LoadBalancers.APIElbSchemeInternal, tc.expectedAPIElbSchemeInternal)
+			if tc.expectedAPIInternalElbScheme != a.Guest.LoadBalancers.APIInternalElbScheme {
+				t.Errorf("expected API ELB Scheme Internal, got %q, want %q", a.Guest.LoadBalancers.APIInternalElbScheme, tc.expectedAPIInternalElbScheme)
 			}
 
 			if tc.expectedEtcdElbName != a.Guest.LoadBalancers.EtcdElbName {

--- a/service/controller/legacy/v29/adapter/guest_load_balancers_test.go
+++ b/service/controller/legacy/v29/adapter/guest_load_balancers_test.go
@@ -18,6 +18,7 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 		expectedAPIElbName                       string
 		expectedAPIElbPortsToOpen                []GuestLoadBalancersAdapterPortPair
 		expectedAPIElbScheme                     string
+		expectedAPIElbSchemeInternal             string
 		expectedAPIElbSecurityGroupID            string
 		expectedAPIElbSubnetID                   string
 		expectedEtcdElbName                      string
@@ -98,8 +99,9 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 					PortInstance: 443,
 				},
 			},
-			expectedAPIElbScheme: "internet-facing",
-			expectedEtcdElbName:  "test-cluster-etcd",
+			expectedAPIElbScheme:         "internet-facing",
+			expectedAPIElbSchemeInternal: "internal",
+			expectedEtcdElbName:          "test-cluster-etcd",
 			expectedEtcdElbPortsToOpen: []GuestLoadBalancersAdapterPortPair{
 				{
 					PortELB:      2379,
@@ -154,6 +156,10 @@ func TestAdapterLoadBalancersRegularFields(t *testing.T) {
 
 			if tc.expectedAPIElbScheme != a.Guest.LoadBalancers.APIElbScheme {
 				t.Errorf("expected API ELB Scheme, got %q, want %q", a.Guest.LoadBalancers.APIElbScheme, tc.expectedAPIElbScheme)
+			}
+
+			if tc.expectedAPIElbSchemeInternal != a.Guest.LoadBalancers.APIElbSchemeInternal {
+				t.Errorf("expected API ELB Scheme Internal, got %q, want %q", a.Guest.LoadBalancers.APIElbSchemeInternal, tc.expectedAPIElbSchemeInternal)
 			}
 
 			if tc.expectedEtcdElbName != a.Guest.LoadBalancers.EtcdElbName {

--- a/service/controller/legacy/v29/adapter/guest_record_sets.go
+++ b/service/controller/legacy/v29/adapter/guest_record_sets.go
@@ -8,6 +8,7 @@ type GuestRecordSetsAdapter struct {
 	ClusterID                  string
 	MasterInstanceResourceName string
 	Route53Enabled             bool
+	VPCRegion                  string
 }
 
 func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
@@ -16,6 +17,7 @@ func (a *GuestRecordSetsAdapter) Adapt(config Config) error {
 	a.ClusterID = key.ClusterID(config.CustomObject)
 	a.MasterInstanceResourceName = config.StackState.MasterInstanceResourceName
 	a.Route53Enabled = config.Route53Enabled
+	a.VPCRegion = key.Region(config.CustomObject)
 
 	return nil
 }

--- a/service/controller/legacy/v29/adapter/guest_record_sets_test.go
+++ b/service/controller/legacy/v29/adapter/guest_record_sets_test.go
@@ -15,6 +15,7 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 		expectedBaseDomain     string
 		expectedClusterID      string
 		expectedRoute53Enabled bool
+		expectedVPCRegion      string
 	}{
 		{
 			description: "basic matching, all fields present",
@@ -41,6 +42,7 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 								Name: "installation.aws.eu-central-1.gigantic.io",
 							},
 						},
+						Region: "eu-central-1",
 					},
 				},
 			},
@@ -48,6 +50,7 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 			expectedRoute53Enabled: true,
 			expectedClusterID:      "test-cluster",
 			expectedBaseDomain:     "installation.aws.eu-central-1.gigantic.io",
+			expectedVPCRegion:      "eu-central-1",
 		},
 	}
 
@@ -71,6 +74,9 @@ func TestAdapterRecordSetsRegularFields(t *testing.T) {
 			}
 			if a.Guest.RecordSets.Route53Enabled != tc.expectedRoute53Enabled {
 				t.Fatalf("Route53Enabled == %v, want %v", a.Guest.RecordSets.Route53Enabled, tc.expectedRoute53Enabled)
+			}
+			if a.Guest.RecordSets.VPCRegion != tc.expectedVPCRegion {
+				t.Fatalf("VPCRegion == %v, want %v", a.Guest.RecordSets.VPCRegion, tc.expectedVPCRegion)
 			}
 		})
 	}

--- a/service/controller/legacy/v29/key/key.go
+++ b/service/controller/legacy/v29/key/key.go
@@ -269,6 +269,21 @@ func InstanceProfileName(customObject v1alpha1.AWSConfig, profileType string) st
 	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), profileType, ProfileNameTemplate)
 }
 
+func InternalLoadBalancerName(domainName string, cluster v1alpha1.AWSConfig) (string, error) {
+	if ClusterID(cluster) == "" {
+		return "", microerror.Maskf(missingCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	componentName, err := componentName(domainName)
+	if err != nil {
+		return "", microerror.Maskf(malformedCloudConfigKeyError, "spec.cluster.id")
+	}
+
+	lbName := fmt.Sprintf("%s-%s-internal", ClusterID(cluster), componentName)
+
+	return lbName, nil
+}
+
 func IsChinaRegion(customObject v1alpha1.AWSConfig) bool {
 	return strings.HasPrefix(Region(customObject), "cn-")
 }

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
@@ -33,7 +33,7 @@ const LoadBalancers = `
       {{- range $s := $v.PublicSubnets }}
         - !Ref {{ $s }}
       {{end}}
-  ApiLoadBalancerPrivate:
+  ApiInternalLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     DependsOn:
       - VPCGatewayAttachment
@@ -55,8 +55,8 @@ const LoadBalancers = `
         LoadBalancerPort: {{ .PortELB }}
         Protocol: TCP
       {{ end }}
-      LoadBalancerName: {{ $v.APIElbName }}
-      Scheme: {{ $v.APIElbSchemeInternal }}
+      LoadBalancerName: {{ $v.APIInternalElbName }}
+      Scheme: {{ $v.APIInternalElbScheme }}
       SecurityGroups:
         - !Ref MasterSecurityGroup
       Subnets:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
@@ -33,6 +33,36 @@ const LoadBalancers = `
       {{- range $s := $v.PublicSubnets }}
         - !Ref {{ $s }}
       {{end}}
+  ApiLoadBalancerPrivate:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    DependsOn:
+      - VPCGatewayAttachment
+    Properties:
+      ConnectionSettings:
+        IdleTimeout: 1200
+      HealthCheck:
+        HealthyThreshold: {{ $v.ELBHealthCheckHealthyThreshold }}
+        Interval: {{ $v.ELBHealthCheckInterval }}
+        Target: {{ $v.APIElbHealthCheckTarget }}
+        Timeout: {{ $v.ELBHealthCheckTimeout }}
+        UnhealthyThreshold: {{ $v.ELBHealthCheckUnhealthyThreshold }}
+      Instances:
+      - !Ref {{ $v.MasterInstanceResourceName }}
+      Listeners:
+      {{ range $v.APIElbPortsToOpen}}
+      - InstancePort: {{ .PortInstance }}
+        InstanceProtocol: TCP
+        LoadBalancerPort: {{ .PortELB }}
+        Protocol: TCP
+      {{ end }}
+      LoadBalancerName: {{ $v.APIElbName }}
+      Scheme: {{ $v.APIElbSchemeInternal }}
+      SecurityGroups:
+        - !Ref MasterSecurityGroup
+      Subnets:
+      {{- range $s := $v.PublicSubnets }}
+        - !Ref {{ $s }}
+      {{end}}
 
   EtcdLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
@@ -64,7 +64,7 @@ const LoadBalancers = `
         - !Ref {{ $s }}
       {{end}}
 
-  EtcdInternalLoadBalancer:
+  EtcdLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/load_balancers.go
@@ -64,7 +64,7 @@ const LoadBalancers = `
         - !Ref {{ $s }}
       {{end}}
 
-  EtcdLoadBalancer:
+  EtcdInternalLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       ConnectionSettings:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -8,6 +8,15 @@ const RecordSets = `
     Type: 'AWS::Route53::HostedZone'
     Properties:
       Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+  HostedZonePrivate:
+    Type: 'AWS::Route53::HostedZone'
+    Properties:
+      Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+	  HostedZoneConfig:
+	    Comment: "Private hosted zone for internal network"
+	  VPCs:
+        - VPCId: !Ref VPC
+          VPCRegion: '{{ $v.VPCRegion }}'
   ApiRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -41,8 +41,8 @@ const RecordSets = `
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
-        DNSName: !GetAtt EtcdInternalLoadBalancer.DNSName
-        HostedZoneId: !GetAtt EtcdInternalLoadBalancer.CanonicalHostedZoneNameID
+        DNSName: !GetAtt EtcdLoadBalancer.DNSName
+        HostedZoneId: !GetAtt EtcdLoadBalancer.CanonicalHostedZoneNameID
         EvaluateTargetHealth: false
       Name: '{{ $v.EtcdDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -41,11 +41,11 @@ const RecordSets = `
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
-        DNSName: !GetAtt EtcdLoadBalancer.DNSName
-        HostedZoneId: !GetAtt EtcdLoadBalancer.CanonicalHostedZoneNameID
+        DNSName: !GetAtt EtcdInternalLoadBalancer.DNSName
+        HostedZoneId: !GetAtt EtcdInternalLoadBalancer.CanonicalHostedZoneNameID
         EvaluateTargetHealth: false
       Name: '{{ $v.EtcdDomain }}.'
-      HostedZoneId: !Ref 'HostedZone'
+      HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
   IngressRecordSet:
     Type: AWS::Route53::RecordSet

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -12,9 +12,9 @@ const RecordSets = `
     Type: 'AWS::Route53::HostedZone'
     Properties:
       Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
-	  HostedZoneConfig:
-	    Comment: "Private hosted zone for internal network"
-	  VPCs:
+      HostedZoneConfig:
+        Comment: "Private hosted zone for internal network"
+      VPCs:
         - VPCId: !Ref VPC
           VPCRegion: '{{ $v.VPCRegion }}'
   ApiRecordSet:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -27,6 +27,16 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'HostedZone'
       Type: A
+  ApiRecordSetPrivate:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt ApiLoadBalancerPrivate.DNSName
+        HostedZoneId: !GetAtt ApiLoadBalancerPrivate.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'HostedZonePrivate'
+      Type: A
   EtcdRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:

--- a/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29/templates/cloudformation/tccp/record_sets.go
@@ -8,12 +8,12 @@ const RecordSets = `
     Type: 'AWS::Route53::HostedZone'
     Properties:
       Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
-  HostedZonePrivate:
+  InternalHostedZone:
     Type: 'AWS::Route53::HostedZone'
     Properties:
       Name: '{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneConfig:
-        Comment: "Private hosted zone for internal network"
+        Comment: "Internal hosted zone for internal network"
       VPCs:
         - VPCId: !Ref VPC
           VPCRegion: '{{ $v.VPCRegion }}'
@@ -27,15 +27,15 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'HostedZone'
       Type: A
-  ApiRecordSetPrivate:
+  ApiInternalRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
-        DNSName: !GetAtt ApiLoadBalancerPrivate.DNSName
-        HostedZoneId: !GetAtt ApiLoadBalancerPrivate.CanonicalHostedZoneNameID
+        DNSName: !GetAtt ApiInternalLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApiInternalLoadBalancer.CanonicalHostedZoneNameID
         EvaluateTargetHealth: false
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
-      HostedZoneId: !Ref 'HostedZonePrivate'
+      HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
   EtcdRecordSet:
     Type: AWS::Route53::RecordSet

--- a/service/controller/legacy/v29/version_bundle.go
+++ b/service/controller/legacy/v29/version_bundle.go
@@ -22,6 +22,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Introduce explicit resource reservation for OS resources and container runtime.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "cloudformation",
+				Description: "Setup private hosted zone for internal api/etcd load-balancers.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6499

This changes adds:
  - added private hosted zone (same as public)
  - added private k8s api load balancer
  - dns records for internal api/etcd elbs moved into private hosted zone

This change creates split horizone dns, where external queries to api resolved into public lb and internal - into private