### PR TITLE
rename controller context structure to adjust for node pools

### DIFF
--- a/service/controller/clusterapi/v29/changedetection/cluster.go
+++ b/service/controller/clusterapi/v29/changedetection/cluster.go
@@ -46,12 +46,12 @@ func (c *Cluster) ShouldScale(ctx context.Context, md v1alpha1.MachineDeployment
 		return false, microerror.Mask(err)
 	}
 
-	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MaxSize != key.MachineDeploymentScalingMax(md) {
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should scale due to scaling max changes: cc.Status.TenantCluster.TCCP.ASG.MaxSize is %d while key.MachineDeploymentScalingMax(md) is %d", cc.Status.TenantCluster.TCCP.ASG.MaxSize, key.MachineDeploymentScalingMax(md)))
+	if !cc.Status.TenantCluster.TCNP.ASG.IsEmpty() && cc.Status.TenantCluster.TCNP.ASG.MaxSize != key.MachineDeploymentScalingMax(md) {
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should scale due to scaling max changes: cc.Status.TenantCluster.TCNP.ASG.MaxSize is %d while key.MachineDeploymentScalingMax(md) is %d", cc.Status.TenantCluster.TCNP.ASG.MaxSize, key.MachineDeploymentScalingMax(md)))
 		return true, nil
 	}
-	if !cc.Status.TenantCluster.TCCP.ASG.IsEmpty() && cc.Status.TenantCluster.TCCP.ASG.MinSize != key.MachineDeploymentScalingMin(md) {
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should scale due to scaling min changes: cc.Status.TenantCluster.TCCP.ASG.MinSize is %d while key.MachineDeploymentScalingMin(md) is %d", cc.Status.TenantCluster.TCCP.ASG.MinSize, key.MachineDeploymentScalingMin(md)))
+	if !cc.Status.TenantCluster.TCNP.ASG.IsEmpty() && cc.Status.TenantCluster.TCNP.ASG.MinSize != key.MachineDeploymentScalingMin(md) {
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should scale due to scaling min changes: cc.Status.TenantCluster.TCNP.ASG.MinSize is %d while key.MachineDeploymentScalingMin(md) is %d", cc.Status.TenantCluster.TCNP.ASG.MinSize, key.MachineDeploymentScalingMin(md)))
 		return true, nil
 	}
 

--- a/service/controller/clusterapi/v29/controllercontext/status_funcs.go
+++ b/service/controller/clusterapi/v29/controllercontext/status_funcs.go
@@ -1,5 +1,5 @@
 package controllercontext
 
-func (a ContextStatusTenantClusterTCCPASG) IsEmpty() bool {
+func (a ContextStatusTenantClusterTCNPASG) IsEmpty() bool {
 	return a.DesiredCapacity == 0 && a.MaxSize == 0 && a.MinSize == 0
 }

--- a/service/controller/clusterapi/v29/controllercontext/status_types.go
+++ b/service/controller/clusterapi/v29/controllercontext/status_types.go
@@ -38,6 +38,7 @@ type ContextStatusTenantCluster struct {
 	HostedZoneNameServers string
 	MasterInstance        ContextStatusTenantClusterMasterInstance
 	TCCP                  ContextStatusTenantClusterTCCP
+	TCNP                  ContextStatusTenantClusterTCNP
 	VersionBundleVersion  string
 }
 
@@ -58,7 +59,6 @@ type ContextStatusTenantClusterMasterInstance struct {
 }
 
 type ContextStatusTenantClusterTCCP struct {
-	ASG               ContextStatusTenantClusterTCCPASG
 	AvailabilityZones []ContextStatusTenantClusterTCCPAvailabilityZone
 	IsTransitioning   bool
 	MachineDeployment v1alpha1.MachineDeployment
@@ -67,13 +67,6 @@ type ContextStatusTenantClusterTCCP struct {
 	SecurityGroups    []*ec2.SecurityGroup
 	Subnets           []*ec2.Subnet
 	VPC               ContextStatusTenantClusterTCCPVPC
-}
-
-type ContextStatusTenantClusterTCCPASG struct {
-	DesiredCapacity int
-	MaxSize         int
-	MinSize         int
-	Name            string
 }
 
 type ContextStatusTenantClusterTCCPAvailabilityZone struct {
@@ -108,4 +101,15 @@ type ContextStatusTenantClusterTCCPAvailabilityZoneRouteTablePublic struct {
 type ContextStatusTenantClusterTCCPVPC struct {
 	ID                  string
 	PeeringConnectionID string
+}
+
+type ContextStatusTenantClusterTCNP struct {
+	ASG ContextStatusTenantClusterTCNPASG
+}
+
+type ContextStatusTenantClusterTCNPASG struct {
+	DesiredCapacity int
+	MaxSize         int
+	MinSize         int
+	Name            string
 }

--- a/service/controller/clusterapi/v29/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v29/resource/asgstatus/create.go
@@ -117,10 +117,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		cc.Status.TenantCluster.TCCP.ASG.DesiredCapacity = desiredCapacity
-		cc.Status.TenantCluster.TCCP.ASG.MaxSize = maxSize
-		cc.Status.TenantCluster.TCCP.ASG.MinSize = minSize
-		cc.Status.TenantCluster.TCCP.ASG.Name = asgName
+		cc.Status.TenantCluster.TCNP.ASG.DesiredCapacity = desiredCapacity
+		cc.Status.TenantCluster.TCNP.ASG.MaxSize = maxSize
+		cc.Status.TenantCluster.TCNP.ASG.MinSize = minSize
+		cc.Status.TenantCluster.TCNP.ASG.Name = asgName
 	}
 
 	return nil

--- a/service/controller/clusterapi/v29/resource/drainer/create.go
+++ b/service/controller/clusterapi/v29/resource/drainer/create.go
@@ -32,7 +32,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCCP.ASG.Name
+	workerASGName := cc.Status.TenantCluster.TCNP.ASG.Name
 	if workerASGName == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/clusterapi/v29/resource/drainfinisher/create.go
+++ b/service/controller/clusterapi/v29/resource/drainfinisher/create.go
@@ -30,7 +30,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCCP.ASG.Name
+	workerASGName := cc.Status.TenantCluster.TCNP.ASG.Name
 	if workerASGName == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -180,7 +180,7 @@ func newAutoScalingGroup(ctx context.Context, cr v1alpha1.MachineDeployment) (*t
 		subnets = append(subnets, key.SanitizeCFResourceName(key.PrivateSubnetName(az.Name)))
 	}
 
-	minDesiredNodes := minDesiredWorkers(key.MachineDeploymentScalingMin(cr), key.MachineDeploymentScalingMax(cr), cc.Status.TenantCluster.TCCP.ASG.DesiredCapacity)
+	minDesiredNodes := minDesiredWorkers(key.MachineDeploymentScalingMin(cr), key.MachineDeploymentScalingMax(cr), cc.Status.TenantCluster.TCNP.ASG.DesiredCapacity)
 
 	autoScalingGroup := &template.ParamsMainAutoScalingGroup{
 		AvailabilityZones: key.MachineDeploymentAvailabilityZones(cr),

--- a/service/controller/clusterapi/v29/unittest/default_controller_context.go
+++ b/service/controller/clusterapi/v29/unittest/default_controller_context.go
@@ -140,7 +140,6 @@ func DefaultContext() context.Context {
 				HostedZoneNameServers: "1.1.1.1,8.8.8.8",
 				MasterInstance:        controllercontext.ContextStatusTenantClusterMasterInstance{},
 				TCCP: controllercontext.ContextStatusTenantClusterTCCP{
-					ASG: controllercontext.ContextStatusTenantClusterTCCPASG{},
 					AvailabilityZones: []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone{
 						{
 							Name: "eu-central-1a",
@@ -223,6 +222,9 @@ func DefaultContext() context.Context {
 						ID:                  "vpc-id",
 						PeeringConnectionID: "peering-connection-id",
 					},
+				},
+				TCNP: controllercontext.ContextStatusTenantClusterTCNP{
+					ASG: controllercontext.ContextStatusTenantClusterTCNPASG{},
 				},
 				VersionBundleVersion: "6.3.0",
 			},


### PR DESCRIPTION
The ASGs are in the TCNP stack now, not the TCCP stack anymore. Towards implementing update mechanisms for node pools we are going to move the `asgstatus` resource to the `clusterapi` controllers soon. This PR is one of the prerequisites. 