### PR TITLE
fix finalizer deletion

### DIFF
--- a/service/controller/clusterapi/v29/resource/secretfinalizer/delete.go
+++ b/service/controller/clusterapi/v29/resource/secretfinalizer/delete.go
@@ -49,7 +49,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found secret %#q in namespace %#q", s.Name, s.Namespace))
 		}
 
-		if !containsString(secret.Finalizers, secretFinalizer) {
+		if containsString(secret.Finalizers, secretFinalizer) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing finalizer for secret %#q in namespace %#q", s.Name, s.Namespace))
 
 			secret.Finalizers = filterString(secret.Finalizers, secretFinalizer)


### PR DESCRIPTION
This fix is already ported to the legacy controllers but we missed it apparently in the clusterapi controller. This is the reason why the api cert secrets are left over. The finalizer is never removed so they are kept forever. 