### PR TITLE
rename version fields to align with VOO

### DIFF
--- a/service/controller/clusterapi/v29/adapter/guest_outputs.go
+++ b/service/controller/clusterapi/v29/adapter/guest_outputs.go
@@ -1,20 +1,20 @@
 package adapter
 
 type GuestOutputsAdapter struct {
-	Master         GuestOutputsAdapterMaster
-	Route53Enabled bool
-	VersionBundle  GuestOutputsAdapterVersionBundle
+	Master          GuestOutputsAdapterMaster
+	OperatorVersion string
+	Route53Enabled  bool
 }
 
 func (a *GuestOutputsAdapter) Adapt(config Config) error {
-	a.Route53Enabled = config.Route53Enabled
 	a.Master.DockerVolume.ResourceName = config.StackState.DockerVolumeResourceName
 	a.Master.ImageID = config.StackState.MasterImageID
 	a.Master.Instance.ResourceName = config.StackState.MasterInstanceResourceName
 	a.Master.Instance.Type = config.StackState.MasterInstanceType
-	a.Master.CloudConfig.Version = config.StackState.MasterCloudConfigVersion
 
-	a.VersionBundle.Version = config.StackState.VersionBundleVersion
+	a.OperatorVersion = config.StackState.OperatorVersion
+
+	a.Route53Enabled = config.Route53Enabled
 
 	return nil
 }
@@ -22,7 +22,6 @@ func (a *GuestOutputsAdapter) Adapt(config Config) error {
 type GuestOutputsAdapterMaster struct {
 	ImageID      string
 	Instance     GuestOutputsAdapterMasterInstance
-	CloudConfig  GuestOutputsAdapterMasterCloudConfig
 	DockerVolume GuestOutputsAdapterMasterDockerVolume
 }
 
@@ -31,14 +30,6 @@ type GuestOutputsAdapterMasterInstance struct {
 	Type         string
 }
 
-type GuestOutputsAdapterMasterCloudConfig struct {
-	Version string
-}
-
 type GuestOutputsAdapterMasterDockerVolume struct {
 	ResourceName string
-}
-
-type GuestOutputsAdapterVersionBundle struct {
-	Version string
 }

--- a/service/controller/clusterapi/v29/adapter/spec.go
+++ b/service/controller/clusterapi/v29/adapter/spec.go
@@ -64,11 +64,7 @@ type StackState struct {
 	MasterImageID              string
 	MasterInstanceType         string
 	MasterInstanceResourceName string
-	// TODO the cloud config versions shouldn't be injected here. These should
-	// actually always only be the ones the operator has hard coded. No other
-	// version should be used here ever.
-	MasterCloudConfigVersion string
-	MasterInstanceMonitoring bool
+	MasterInstanceMonitoring   bool
 
-	VersionBundleVersion string
+	OperatorVersion string
 }

--- a/service/controller/clusterapi/v29/changedetection/cluster.go
+++ b/service/controller/clusterapi/v29/changedetection/cluster.go
@@ -81,8 +81,8 @@ func (c *Cluster) ShouldUpdate(ctx context.Context, cl v1alpha1.Cluster, md v1al
 		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should update due to master instance type changes: cc.Status.TenantCluster.MasterInstance.Type is %q while key.MasterInstanceType(cl) is %q", cc.Status.TenantCluster.MasterInstance.Type, key.MasterInstanceType(cl)))
 		return true, nil
 	}
-	if cc.Status.TenantCluster.VersionBundleVersion != key.OperatorVersion(&cl) {
-		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should update due to version bundle version changes: cc.Status.TenantCluster.VersionBundleVersion is %q while key.OperatorVersion(&cl) is %q", cc.Status.TenantCluster.VersionBundleVersion, key.OperatorVersion(&cl)))
+	if cc.Status.TenantCluster.OperatorVersion != key.OperatorVersion(&cl) {
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected the tenant cluster should update due to version bundle version changes: cc.Status.TenantCluster.OperatorVersion is %q while key.OperatorVersion(&cl) is %q", cc.Status.TenantCluster.OperatorVersion, key.OperatorVersion(&cl)))
 		return true, nil
 	}
 

--- a/service/controller/clusterapi/v29/controllercontext/status_types.go
+++ b/service/controller/clusterapi/v29/controllercontext/status_types.go
@@ -39,7 +39,7 @@ type ContextStatusTenantCluster struct {
 	MasterInstance        ContextStatusTenantClusterMasterInstance
 	TCCP                  ContextStatusTenantClusterTCCP
 	TCNP                  ContextStatusTenantClusterTCNP
-	VersionBundleVersion  string
+	OperatorVersion       string
 }
 
 type ContextStatusTenantClusterAWS struct {

--- a/service/controller/clusterapi/v29/resource/tccp/create.go
+++ b/service/controller/clusterapi/v29/resource/tccp/create.go
@@ -160,15 +160,9 @@ func (r *Resource) createStack(ctx context.Context, cr v1alpha1.Cluster) error {
 				aws.String(namedIAMCapability),
 			},
 			EnableTerminationProtection: aws.Bool(true),
-			Parameters: []*cloudformation.Parameter{
-				{
-					ParameterKey:   aws.String(versionBundleVersionParameterKey),
-					ParameterValue: aws.String(key.OperatorVersion(&cr)),
-				},
-			},
-			StackName:    aws.String(key.StackNameTCCP(&cr)),
-			Tags:         r.getCloudFormationTags(cr),
-			TemplateBody: aws.String(templateBody),
+			StackName:                   aws.String(key.StackNameTCCP(&cr)),
+			Tags:                        r.getCloudFormationTags(cr),
+			TemplateBody:                aws.String(templateBody),
 		}
 
 		_, err = cc.Client.TenantCluster.AWS.CloudFormation.CreateStack(i)
@@ -244,12 +238,6 @@ func (r *Resource) ensureStack(ctx context.Context, cr v1alpha1.Cluster, templat
 			Capabilities: []*string{
 				aws.String(namedIAMCapability),
 			},
-			Parameters: []*cloudformation.Parameter{
-				{
-					ParameterKey:   aws.String(versionBundleVersionParameterKey),
-					ParameterValue: aws.String(key.OperatorVersion(&cr)),
-				},
-			},
 			StackName:    aws.String(key.StackNameTCCP(&cr)),
 			TemplateBody: aws.String(templateBody),
 		}
@@ -300,10 +288,9 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.Cluster, tp 
 				MasterImageID:              key.ImageID(cc.Status.TenantCluster.AWS.Region),
 				MasterInstanceResourceName: tp.MasterInstanceResourceName,
 				MasterInstanceType:         key.MasterInstanceType(cr),
-				MasterCloudConfigVersion:   key.CloudConfigVersion,
 				MasterInstanceMonitoring:   r.instanceMonitoring,
 
-				VersionBundleVersion: key.OperatorVersion(&cr),
+				OperatorVersion: key.OperatorVersion(&cr),
 			},
 			TenantClusterAccountID:         cc.Status.TenantCluster.AWS.AccountID,
 			TenantClusterAvailabilityZones: cc.Spec.TenantCluster.TCCP.AvailabilityZones,

--- a/service/controller/clusterapi/v29/resource/tccp/resource.go
+++ b/service/controller/clusterapi/v29/resource/tccp/resource.go
@@ -28,9 +28,6 @@ const (
 	// our Cloud Formation templates. It is required for creating worker policy
 	// IAM roles.
 	namedIAMCapability = "CAPABILITY_NAMED_IAM"
-	// versionBundleVersionParameterKey is the key name of the Cloud Formation
-	// parameter that sets the version bundle version.
-	versionBundleVersionParameterKey = "VersionBundleVersionParameter"
 )
 
 // Config represents the configuration used to create a new cloudformation

--- a/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tccp/testdata/case-0-basic-test.golden
@@ -9,17 +9,12 @@ Outputs:
     Value: rsc-ac0dc01
   MasterInstanceType:
     Value: m5.xlarge
-  VersionBundleVersion:
-    Value:
-      Ref: VersionBundleVersionParameter
+  OperatorVersion:
+    Value: 7.3.0
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:
     Value: !Ref VPCPeeringConnection
-Parameters:
-  VersionBundleVersionParameter:
-    Type: String
-    Description: Sets the VersionBundleVersion used to generate the template.
 Resources:
   MasterRole:
     Type: "AWS::IAM::Role"

--- a/service/controller/clusterapi/v29/resource/tccpoutputs/create.go
+++ b/service/controller/clusterapi/v29/resource/tccpoutputs/create.go
@@ -17,7 +17,7 @@ const (
 	MasterImageIDKey              = "MasterImageID"
 	MasterInstanceResourceNameKey = "MasterInstanceResourceName"
 	MasterInstanceTypeKey         = "MasterInstanceType"
-	VersionBundleVersionKey       = "VersionBundleVersion"
+	OperatorVersion               = "OperatorVersion"
 	VPCIDKey                      = "VPCID"
 	VPCPeeringConnectionIDKey     = "VPCPeeringConnectionID"
 )
@@ -112,11 +112,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, VersionBundleVersionKey)
+		v, err := cloudFormation.GetOutputValue(outputs, OperatorVersion)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		cc.Status.TenantCluster.VersionBundleVersion = v
+		cc.Status.TenantCluster.OperatorVersion = v
 	}
 
 	{

--- a/service/controller/clusterapi/v29/resource/tcnp/create.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/create.go
@@ -271,17 +271,12 @@ func newOutputs(ctx context.Context, cr v1alpha1.MachineDeployment) (*template.P
 	}
 
 	outputs := &template.ParamsMainOutputs{
-		CloudConfig: template.ParamsMainOutputsCloudConfig{
-			Version: key.CloudConfigVersion,
-		},
 		DockerVolumeSizeGB: key.MachineDeploymentDockerVolumeSizeGB(cr),
 		Instance: template.ParamsMainOutputsInstance{
 			Image: key.ImageID(cc.Status.TenantCluster.AWS.Region),
 			Type:  key.MachineDeploymentInstanceType(cr),
 		},
-		VersionBundle: template.ParamsMainOutputsVersionBundle{
-			Version: key.OperatorVersion(&cr),
-		},
+		OperatorVersion: key.OperatorVersion(&cr),
 	}
 
 	return outputs, nil

--- a/service/controller/clusterapi/v29/resource/tcnp/template/params_main_outputs.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/params_main_outputs.go
@@ -1,21 +1,12 @@
 package template
 
 type ParamsMainOutputs struct {
-	CloudConfig        ParamsMainOutputsCloudConfig
 	DockerVolumeSizeGB string
 	Instance           ParamsMainOutputsInstance
-	VersionBundle      ParamsMainOutputsVersionBundle
-}
-
-type ParamsMainOutputsCloudConfig struct {
-	Version string
+	OperatorVersion    string
 }
 
 type ParamsMainOutputsInstance struct {
 	Image string
 	Type  string
-}
-
-type ParamsMainOutputsVersionBundle struct {
-	Version string
 }

--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main_outputs.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main_outputs.go
@@ -4,15 +4,13 @@ const TemplateMainOutputs = `
 {{- define "outputs" -}}
   AutoScalingGroupName:
     Value: !Ref NodePoolAutoScalingGroup
-  CloudConfigVersion:
-    Value: {{ .Outputs.CloudConfig.Version }}
   DockerVolumeSizeGB:
     Value: {{ .Outputs.DockerVolumeSizeGB }}
   InstanceImage:
     Value: {{ .Outputs.Instance.Image }}
   InstanceType:
     Value: {{ .Outputs.Instance.Type }}
-  VersionBundleVersion:
-    Value: {{ .Outputs.VersionBundle.Version }}
+  OperatorVersion:
+    Value: {{ .Outputs.OperatorVersion }}
 {{- end -}}
 `

--- a/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
@@ -3,15 +3,13 @@ Description: Tenant Cluster Node Pool Cloud Formation Stack.
 Outputs:
   AutoScalingGroupName:
     Value: !Ref NodePoolAutoScalingGroup
-  CloudConfigVersion:
-    Value: v_4_6_0
   DockerVolumeSizeGB:
     Value: 100
   InstanceImage:
     Value: ami-0eb0d9bb7ad1bd1e9
   InstanceType:
     Value: m5.2xlarge
-  VersionBundleVersion:
+  OperatorVersion:
     Value: 7.3.0
 Resources:
   NodePoolAutoScalingGroup:

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/main.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/main.go
@@ -6,10 +6,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Control Plane Cloud Formation Stack.
 Outputs:
   {{ template "outputs" . }}
-Parameters:
-  VersionBundleVersionParameter:
-    Type: String
-    Description: Sets the VersionBundleVersion used to generate the template.
 Resources:
   {{ template "iam_policies" . }}
   {{ template "instance" . }}

--- a/service/controller/clusterapi/v29/templates/cloudformation/tccp/outputs.go
+++ b/service/controller/clusterapi/v29/templates/cloudformation/tccp/outputs.go
@@ -14,9 +14,8 @@ const Outputs = `
     Value: {{ .Guest.Outputs.Master.Instance.ResourceName }}
   MasterInstanceType:
     Value: {{ .Guest.Outputs.Master.Instance.Type }}
-  VersionBundleVersion:
-    Value:
-      Ref: VersionBundleVersionParameter
+  OperatorVersion:
+    Value: {{ .Guest.Outputs.OperatorVersion }}
   VPCID:
     Value: !Ref VPC
   VPCPeeringConnectionID:

--- a/service/controller/clusterapi/v29/unittest/default_controller_context.go
+++ b/service/controller/clusterapi/v29/unittest/default_controller_context.go
@@ -139,6 +139,7 @@ func DefaultContext() context.Context {
 				Encryption:            controllercontext.ContextStatusTenantClusterEncryption{},
 				HostedZoneNameServers: "1.1.1.1,8.8.8.8",
 				MasterInstance:        controllercontext.ContextStatusTenantClusterMasterInstance{},
+				OperatorVersion:       "6.3.0",
 				TCCP: controllercontext.ContextStatusTenantClusterTCCP{
 					AvailabilityZones: []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone{
 						{
@@ -226,7 +227,6 @@ func DefaultContext() context.Context {
 				TCNP: controllercontext.ContextStatusTenantClusterTCNP{
 					ASG: controllercontext.ContextStatusTenantClusterTCNPASG{},
 				},
-				VersionBundleVersion: "6.3.0",
 			},
 		},
 	}


### PR DESCRIPTION
This basically renames "VersionBundleVersion" to "OperatorVersion". Better naming suggestions welcome. I just want to get rid of the idea of version bundles as such and later it would be a huge headache to migrate existing node pool clusters. So I wanted to take the opportunity now. 