### PR TITLE
improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 aws-operator
+!helm/aws-operator
 TODO
 *.swp
 !vendor/**


### PR DESCRIPTION
I have the problem in Atom that the new helm chart directory is considered being ignored by git. We actually only want to ignore the binary. 