### PR TITLE
drop machine deployment

### DIFF
--- a/service/controller/clusterapi/v29/adapter/adapter.go
+++ b/service/controller/clusterapi/v29/adapter/adapter.go
@@ -45,7 +45,6 @@ type Config struct {
 	EncrypterBackend                string
 	GuestAccountID                  string
 	InstallationName                string
-	MachineDeployment               v1alpha1.MachineDeployment
 	PublicRouteTables               string
 	Route53Enabled                  bool
 	StackState                      StackState

--- a/service/controller/clusterapi/v29/resource/tccp/create.go
+++ b/service/controller/clusterapi/v29/resource/tccp/create.go
@@ -278,7 +278,6 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.Cluster, tp 
 			CustomObject:                    cr,
 			EncrypterBackend:                r.encrypterBackend,
 			InstallationName:                r.installationName,
-			MachineDeployment:               cc.Status.TenantCluster.TCCP.MachineDeployment,
 			PublicRouteTables:               r.publicRouteTables,
 			Route53Enabled:                  r.route53Enabled,
 			StackState: adapter.StackState{


### PR DESCRIPTION
The machine deployment is not used anymore in the adapter package so we can drop it there. 