### PR TITLE
drop asg name from tcnp stack outputs

### DIFF
--- a/service/controller/clusterapi/v29/resource/tcnp/template/template_main_outputs.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/template_main_outputs.go
@@ -2,8 +2,6 @@ package template
 
 const TemplateMainOutputs = `
 {{- define "outputs" -}}
-  AutoScalingGroupName:
-    Value: !Ref NodePoolAutoScalingGroup
   DockerVolumeSizeGB:
     Value: {{ .Outputs.DockerVolumeSizeGB }}
   InstanceImage:

--- a/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v29/resource/tcnp/testdata/case-0-basic-test.golden
@@ -1,8 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Node Pool Cloud Formation Stack.
 Outputs:
-  AutoScalingGroupName:
-    Value: !Ref NodePoolAutoScalingGroup
   DockerVolumeSizeGB:
     Value: 100
   InstanceImage:


### PR DESCRIPTION
We gather the ASG name together with more information in the `asgstatus` resource. This is more reliable during stack transitions anyway. Just dropping the unused outputs from the tcnp stack. 