### PR TITLE
move template rendering to pkg

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,4 +1,4 @@
-package templates
+package template
 
 import (
 	"bytes"

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,12 +1,10 @@
-package templates_test
+package template
 
 import (
 	"testing"
-
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
 )
 
-func TestRender(t *testing.T) {
+func Test_Template_Render(t *testing.T) {
 	t.Parallel()
 	tpl := "some string <{{.Value}}> another string"
 	d := struct {
@@ -14,7 +12,7 @@ func TestRender(t *testing.T) {
 	}{"myvalue"}
 	expected := "some string <myvalue> another string"
 
-	actual, err := templates.Render([]string{tpl}, d)
+	actual, err := Render([]string{tpl}, d)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}

--- a/service/controller/clusterapi/v29/adapter/guest_instance.go
+++ b/service/controller/clusterapi/v29/adapter/guest_instance.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/aws-operator/pkg/template"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
 )
 
 type GuestInstanceAdapter struct {
@@ -86,7 +86,7 @@ func (i *GuestInstanceAdapter) Adapt(config Config) error {
 		c := SmallCloudconfigConfig{
 			S3URL: key.SmallCloudConfigS3URL(&config.CustomObject, config.TenantClusterAccountID, "master"),
 		}
-		rendered, err := templates.Render(key.CloudConfigSmallTemplates(), c)
+		rendered, err := template.Render(key.CloudConfigSmallTemplates(), c)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/clusterapi/v29/resource/tccp/create.go
+++ b/service/controller/clusterapi/v29/resource/tccp/create.go
@@ -10,12 +10,12 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
+	"github.com/giantswarm/aws-operator/pkg/template"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/encrypter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -278,7 +278,7 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.Cluster, tp 
 			return "", microerror.Mask(err)
 		}
 
-		templateBody, err = templates.Render(key.CloudFormationGuestTemplates(), a)
+		templateBody, err = template.Render(key.CloudFormationGuestTemplates(), a)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}

--- a/service/controller/clusterapi/v29/resource/tccpf/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tccpf/template/render.go
@@ -3,7 +3,7 @@ package template
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
+	"github.com/giantswarm/aws-operator/pkg/template"
 )
 
 func Render(v interface{}) (string, error) {
@@ -13,7 +13,7 @@ func Render(v interface{}) (string, error) {
 		TemplateMainRouteTables,
 	}
 
-	s, err := templates.Render(l, v)
+	s, err := template.Render(l, v)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v29/resource/tccpi/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tccpi/template/render.go
@@ -3,7 +3,7 @@ package template
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
+	"github.com/giantswarm/aws-operator/pkg/template"
 )
 
 func Render(v interface{}) (string, error) {
@@ -12,7 +12,7 @@ func Render(v interface{}) (string, error) {
 		TemplateMainIAMRoles,
 	}
 
-	s, err := templates.Render(l, v)
+	s, err := template.Render(l, v)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v29/resource/tcnp/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tcnp/template/render.go
@@ -3,7 +3,7 @@ package template
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
+	"github.com/giantswarm/aws-operator/pkg/template"
 )
 
 func Render(v interface{}) (string, error) {
@@ -20,7 +20,7 @@ func Render(v interface{}) (string, error) {
 		TemplateMainVPC,
 	}
 
-	s, err := templates.Render(l, v)
+	s, err := template.Render(l, v)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/v29/resource/tcnpf/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tcnpf/template/render.go
@@ -3,7 +3,7 @@ package template
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates"
+	"github.com/giantswarm/aws-operator/pkg/template"
 )
 
 func Render(v interface{}) (string, error) {
@@ -12,7 +12,7 @@ func Render(v interface{}) (string, error) {
 		TemplateMainRouteTables,
 	}
 
-	s, err := templates.Render(l, v)
+	s, err := template.Render(l, v)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards cleaning up the adapter packages and associated templates folders we move the rendering into `pkg`. Next step would be to move templates and align rendering and package structures. 