### PR TITLE
move tccp templates

### DIFF
--- a/service/controller/clusterapi/v29/key/legacy.go
+++ b/service/controller/clusterapi/v29/key/legacy.go
@@ -4,7 +4,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates/cloudconfig"
-	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/templates/cloudformation/tccp"
 )
 
 // NOTE that code below is deprecated and needs refactoring.
@@ -12,23 +11,6 @@ import (
 func CloudConfigSmallTemplates() []string {
 	return []string{
 		cloudconfig.Small,
-	}
-}
-
-func CloudFormationGuestTemplates() []string {
-	return []string{
-		tccp.IAMPolicies,
-		tccp.Instance,
-		tccp.InternetGateway,
-		tccp.LoadBalancers,
-		tccp.Main,
-		tccp.NatGateway,
-		tccp.Outputs,
-		tccp.RecordSets,
-		tccp.RouteTables,
-		tccp.SecurityGroups,
-		tccp.Subnets,
-		tccp.VPC,
 	}
 }
 

--- a/service/controller/clusterapi/v29/resource/tccp/create.go
+++ b/service/controller/clusterapi/v29/resource/tccp/create.go
@@ -10,12 +10,12 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
-	"github.com/giantswarm/aws-operator/pkg/template"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/ebs"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/encrypter"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/resource/tccp/template"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -273,12 +273,12 @@ func (r *Resource) newTemplateBody(ctx context.Context, cr v1alpha1.Cluster, tp 
 			c.TenantClusterKMSKeyARN = cc.Status.TenantCluster.Encryption.Key
 		}
 
-		a, err := adapter.NewGuest(c)
+		params, err := adapter.NewGuest(c)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
 
-		templateBody, err = template.Render(key.CloudFormationGuestTemplates(), a)
+		templateBody, err = template.Render(params)
 		if err != nil {
 			return "", microerror.Mask(err)
 		}

--- a/service/controller/clusterapi/v29/resource/tccp/template/render.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/render.go
@@ -1,0 +1,31 @@
+package template
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/pkg/template"
+)
+
+func Render(v interface{}) (string, error) {
+	l := []string{
+		TemplateMain,
+		TemplateMainIAMPolicies,
+		TemplateMainInstance,
+		TemplateMainInternetGateway,
+		TemplateMainLoadBalancers,
+		TemplateMainNatGateway,
+		TemplateMainOutputs,
+		TemplateMainRecordSets,
+		TemplateMainRouteTables,
+		TemplateMainSecurityGroups,
+		TemplateMainSubnets,
+		TemplateMainVPC,
+	}
+
+	s, err := template.Render(l, v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return s, nil
+}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const Main = `
+const TemplateMain = `
 {{- define "main" -}}
 AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Control Plane Cloud Formation Stack.

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_iam_policies.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_iam_policies.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const IAMPolicies = `
+const TemplateMainIAMPolicies = `
 {{- define "iam_policies" -}}
 {{- $v := .Guest.IAMPolicies -}}
   MasterRole:

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_instance.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_instance.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const Instance = `
+const TemplateMainInstance = `
 {{- define "instance" -}}
 {{- $v := .Guest.Instance -}}
   {{ $v.Master.Instance.ResourceName }}:

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_internet_gateway.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_internet_gateway.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const InternetGateway = `
+const TemplateMainInternetGateway = `
 {{- define "internet_gateway" -}}
 {{- $v := .Guest.InternetGateway -}}
   InternetGateway:

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_load_balancers.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_load_balancers.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const LoadBalancers = `
+const TemplateMainLoadBalancers = `
 {{- define "load_balancers" -}}
 {{- $v := .Guest.LoadBalancers }}
   ApiInternalLoadBalancer:

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_nat_gateway.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_nat_gateway.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const NatGateway = `
+const TemplateMainNatGateway = `
 {{- define "nat_gateway" -}}
   {{- $v := .Guest.NATGateway -}}
   {{- range $v.Gateways }}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_outputs.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_outputs.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const Outputs = `
+const TemplateMainOutputs = `
 {{- define "outputs" -}}
   DockerVolumeResourceName:
     Value: {{ .Guest.Outputs.Master.DockerVolume.ResourceName }}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_record_sets.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_record_sets.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const RecordSets = `
+const TemplateMainRecordSets = `
 {{- define "record_sets" -}}
 {{- $v := .Guest.RecordSets }}
 {{- if $v.Route53Enabled -}}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_route_tables.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_route_tables.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const RouteTables = `
+const TemplateMainRouteTables = `
 {{- define "route_tables" -}}
 {{- $v := .Guest.RouteTables -}}
   {{- range $v.PublicRouteTableNames }}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_security_groups.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_security_groups.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const SecurityGroups = `
+const TemplateMainSecurityGroups = `
 {{- define "security_groups" -}}
 {{- $v := .Guest.SecurityGroups -}}
   MasterSecurityGroup:

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_subnets.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_subnets.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const Subnets = `
+const TemplateMainSubnets = `
 {{- define "subnets" -}}
 {{- $v := .Guest.Subnets }}
   {{- range $v.PublicSubnets }}

--- a/service/controller/clusterapi/v29/resource/tccp/template/template_main_vpc.go
+++ b/service/controller/clusterapi/v29/resource/tccp/template/template_main_vpc.go
@@ -1,6 +1,6 @@
-package tccp
+package template
 
-const VPC = `
+const TemplateMainVPC = `
 {{- define "vpc" -}}
 {{- $v := .Guest.VPC }}
   VPC:


### PR DESCRIPTION
One step closer to dropping the adapter package. Now the templates are in their own place like with all the other stack managing resource implementations. 