### PR TITLE
Duplicate etcd record backport to v29patch1

### DIFF
--- a/service/controller/legacy/v29patch1/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29patch1/templates/cloudformation/tccp/record_sets.go
@@ -37,7 +37,7 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
-  EtcdRecordSet:
+  EtcdInternalRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
@@ -46,6 +46,16 @@ const RecordSets = `
         EvaluateTargetHealth: false
       Name: '{{ $v.EtcdDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
+      Type: A
+  EtcdRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt EtcdLoadBalancer.DNSName
+        HostedZoneId: !GetAtt EtcdLoadBalancer.CanonicalHostedZoneNameID
+        EvaluateTargetHealth: false
+      Name: '{{ $v.EtcdDomain }}.'
+      HostedZoneId: !Ref 'HostedZone'
       Type: A
   IngressRecordSet:
     Type: AWS::Route53::RecordSet

--- a/service/controller/legacy/v29patch1/version_bundle.go
+++ b/service/controller/legacy/v29patch1/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "cloudformation",
+				Description: "Duplicate etcd record set into public hosted zone.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
Porting the changes made in https://github.com/giantswarm/aws-operator/pull/1941 inside the legacy controller from `v30` back to `v29patch1`

cc @corest 