### PR TITLE
Add internal LB in ASG too

### DIFF
--- a/service/controller/legacy/v29patch1/templates/cloudformation/tccp/auto_scaling_group.go
+++ b/service/controller/legacy/v29patch1/templates/cloudformation/tccp/auto_scaling_group.go
@@ -20,6 +20,7 @@ const AutoScalingGroup = `
       LaunchConfigurationName: !Ref {{ $v.ASGType }}LaunchConfiguration
       LoadBalancerNames:
         - !Ref IngressLoadBalancer
+        - !Ref IngressInternalLoadBalancer
       HealthCheckGracePeriod: {{ $v.HealthCheckGracePeriod }}
       MetricsCollection:
         - Granularity: "1Minute"

--- a/service/controller/legacy/v29patch1/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v29patch1/templates/cloudformation/tccp/record_sets.go
@@ -37,7 +37,7 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
-  EtcdInternalRecordSet:
+  EtcdRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
@@ -47,7 +47,7 @@ const RecordSets = `
       Name: '{{ $v.EtcdDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
-  EtcdRecordSet:
+  EtcdExternalRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:


### PR DESCRIPTION
As we have an internal ingress controller too, we need to add it into the auto scaling group, otherwise, LB instances will be empty