### PR TITLE
Change recordet names

### DIFF
--- a/service/controller/legacy/v30/templates/cloudformation/tccp/record_sets.go
+++ b/service/controller/legacy/v30/templates/cloudformation/tccp/record_sets.go
@@ -47,7 +47,7 @@ const RecordSets = `
       Name: 'api.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
-  EtcdInternalRecordSet:
+  EtcdRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:
@@ -57,7 +57,7 @@ const RecordSets = `
       Name: '{{ $v.EtcdDomain }}.'
       HostedZoneId: !Ref 'InternalHostedZone'
       Type: A
-  EtcdRecordSet:
+  EtcdExternalRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
       AliasTarget:


### PR DESCRIPTION
I have realized it was breaking the upgrade (from `8.4.0` to `8.4.1`) as it was trying to update the recordset with the same name but in a different zone
```
[Tried to create resource record set [name='etcd.0cuut.k8s.ginger.eu-central-1.aws.gigantic.io.', type='A'] but it already exists]
```
We need to keep the internal the same