### PR TITLE
Remove extraneous slice casts and convert slice to string for diffs

### DIFF
--- a/service/controller/clusterapi/v30/cloudconfig/tccp_test.go
+++ b/service/controller/clusterapi/v30/cloudconfig/tccp_test.go
@@ -105,8 +105,8 @@ func Test_Controller_CloudConfig_TCCP_Template_Render(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
+			if !bytes.Equal(templateBody, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(templateBody)))
 			}
 		})
 	}

--- a/service/controller/clusterapi/v30/cloudconfig/tcnp_test.go
+++ b/service/controller/clusterapi/v30/cloudconfig/tcnp_test.go
@@ -102,8 +102,8 @@ func Test_Controller_CloudConfig_TCNP_Template_Render(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
+			if !bytes.Equal(templateBody, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(templateBody)))
 			}
 		})
 	}

--- a/service/controller/clusterapi/v31/cloudconfig/tccp_test.go
+++ b/service/controller/clusterapi/v31/cloudconfig/tccp_test.go
@@ -105,8 +105,8 @@ func Test_Controller_CloudConfig_TCCP_Template_Render(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
+			if !bytes.Equal(templateBody, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(templateBody)))
 			}
 		})
 	}

--- a/service/controller/clusterapi/v31/cloudconfig/tcnp_test.go
+++ b/service/controller/clusterapi/v31/cloudconfig/tcnp_test.go
@@ -102,8 +102,8 @@ func Test_Controller_CloudConfig_TCNP_Template_Render(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal([]byte(templateBody), goldenFile) {
-				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), templateBody))
+			if !bytes.Equal(templateBody, goldenFile) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(goldenFile), string(templateBody)))
 			}
 		})
 	}


### PR DESCRIPTION
I noticed [in a recent build](https://circleci.com/gh/giantswarm/aws-operator/24189) that v30 and v31 node pool controllers render cloud configs as `[]byte` instead of `string` now, but use the same comparison logic in the unit tests. This makes golden diffs totally unreadable.