### PR TITLE
Cherry pick short e2e cluster ID algorithm

### DIFF
--- a/integration/env/common.go
+++ b/integration/env/common.go
@@ -95,29 +95,29 @@ func init() {
 		panic("version bundle version  must not be empty")
 	}
 	os.Setenv(EnvVarVersionBundleVersion, VersionBundleVersion())
+
+	// ClusterID returns a cluster ID unique to a run integration test. It might
+	// look like ci-wip-3cc75-5e958.
+	//
+	//     ci is a static identifier stating a CI run of the aws-operator.
+	//     wip is a version reference which can also be cur for the current version.
+	//     3cc75 is the Git SHA.
+	//     5e958 is a hash of the integration test dir, if any.
+	//
+	var parts []string
+	parts = append(parts, "ci-")
+	parts = append(parts, TestedVersion()[0:1])
+	parts = append(parts, CircleSHA()[0:1])
+	parts = append(parts, generateID())
+	clusterID = strings.Join(parts, "")
 }
 
 func CircleSHA() string {
 	return circleSHA
 }
 
-// ClusterID returns a cluster ID unique to a run integration test. It might
-// look like ci-wip-3cc75-5e958.
-//
-//     ci is a static identifier stating a CI run of the aws-operator.
-//     wip is a version reference which can also be cur for the current version.
-//     3cc75 is the Git SHA.
-//     5e958 is a hash of the integration test dir, if any.
-//
 func ClusterID() string {
-	var parts []string
-
-	parts = append(parts, "ci")
-	parts = append(parts, TestedVersion()[0:1])
-	parts = append(parts, CircleSHA()[0:2])
-	parts = append(parts, generateID())
-
-	return strings.Join(parts, "-")
+	return clusterID
 }
 
 func KeepResources() bool {


### PR DESCRIPTION
Cherry pick of new cluster ID generation algorithm from `use-kind` branch. Testing if this fixes failing e2e tests.