### PR TITLE
drop project name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ contribution workflow as well as reporting bugs.
 aws-operator is under the Apache 2.0 license. See the [LICENSE](LICENSE) file
 for details.
 
+
+
 ## Credit
 - https://golang.org
 - https://github.com/giantswarm/microkit

--- a/main.go
+++ b/main.go
@@ -53,7 +53,6 @@ func mainE(ctx context.Context) error {
 
 				Description: project.Description(),
 				GitCommit:   project.GitSHA(),
-				ProjectName: project.Name(),
 				Source:      project.Source(),
 				Version:     project.Version(),
 			}

--- a/service/controller/clusterapi/cluster.go
+++ b/service/controller/clusterapi/cluster.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/project"
 	v29 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29"
 	v29adapter "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/adapter"
 	v29cloudconfig "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29/cloudconfig"
@@ -28,7 +29,6 @@ import (
 	v31 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31"
 	v31adapter "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/adapter"
 	v31cloudconfig "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/cloudconfig"
-
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/locker"
 )
@@ -66,7 +66,6 @@ type ClusterConfig struct {
 	NetworkSetupDockerImage    string
 	OIDC                       ClusterConfigOIDC
 	PodInfraContainerImage     string
-	ProjectName                string
 	RegistryDomain             string
 	Route53Enabled             bool
 	RouteTables                string
@@ -162,7 +161,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/aws-operator-cluster-controller.
-			Name: config.ProjectName + "-cluster-controller",
+			Name: project.Name() + "-cluster-controller",
 		}
 
 		operatorkitController, err = controller.New(c)

--- a/service/controller/clusterapi/drainer.go
+++ b/service/controller/clusterapi/drainer.go
@@ -17,10 +17,10 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/project"
 	v29 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29"
 	v30 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v30"
 	v31 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31"
-
 	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
@@ -33,7 +33,6 @@ type DrainerConfig struct {
 
 	HostAWSConfig  aws.Config
 	LabelSelector  DrainerConfigLabelSelector
-	ProjectName    string
 	Route53Enabled bool
 }
 
@@ -102,7 +101,7 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/aws-operator-drainer-controller.
-			Name: config.ProjectName + "-drainer-controller",
+			Name: project.Name() + "-drainer-controller",
 		}
 
 		operatorkitController, err = controller.New(c)
@@ -146,7 +145,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Logger:                 config.Logger,
 
 			HostAWSConfig:  config.HostAWSConfig,
-			ProjectName:    config.ProjectName,
+			ProjectName:    project.Name(),
 			Route53Enabled: config.Route53Enabled,
 		}
 
@@ -166,7 +165,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Logger:                 config.Logger,
 
 			HostAWSConfig:  config.HostAWSConfig,
-			ProjectName:    config.ProjectName,
+			ProjectName:    project.Name(),
 			Route53Enabled: config.Route53Enabled,
 		}
 
@@ -186,7 +185,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Logger:                 config.Logger,
 
 			HostAWSConfig:  config.HostAWSConfig,
-			ProjectName:    config.ProjectName,
+			ProjectName:    project.Name(),
 			Route53Enabled: config.Route53Enabled,
 		}
 

--- a/service/controller/clusterapi/machine_deployment.go
+++ b/service/controller/clusterapi/machine_deployment.go
@@ -19,12 +19,12 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/giantswarm/aws-operator/client/aws"
+	"github.com/giantswarm/aws-operator/pkg/project"
 	v29 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v29"
 	v30 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v30"
 	v30cloudconfig "github.com/giantswarm/aws-operator/service/controller/clusterapi/v30/cloudconfig"
 	v31 "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31"
 	v31cloudconfig "github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/cloudconfig"
-
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/locker"
 )
@@ -56,7 +56,6 @@ type MachineDeploymentConfig struct {
 	NetworkSetupDockerImage    string
 	OIDC                       ClusterConfigOIDC
 	PodInfraContainerImage     string
-	ProjectName                string
 	RegistryDomain             string
 	Route53Enabled             bool
 	RouteTables                string
@@ -131,7 +130,7 @@ func NewMachineDeployment(config MachineDeploymentConfig) (*MachineDeployment, e
 
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/aws-operator-machine-deployment-controller.
-			Name: config.ProjectName + "-machine-deployment-controller",
+			Name: project.Name() + "-machine-deployment-controller",
 		}
 
 		operatorkitController, err = controller.New(c)
@@ -208,7 +207,7 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 			HostAWSConfig:              config.HostAWSConfig,
 			InstallationName:           config.InstallationName,
 			IPAMNetworkRange:           config.IPAMNetworkRange,
-			ProjectName:                config.ProjectName,
+			ProjectName:                project.Name(),
 			Route53Enabled:             config.Route53Enabled,
 			RouteTables:                config.RouteTables,
 			VaultAddress:               config.VaultAddress,
@@ -255,7 +254,7 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 				GroupsClaim:   config.OIDC.GroupsClaim,
 			},
 			PodInfraContainerImage: config.PodInfraContainerImage,
-			ProjectName:            config.ProjectName,
+			ProjectName:            project.Name(),
 			RegistryDomain:         config.RegistryDomain,
 			Route53Enabled:         config.Route53Enabled,
 			RouteTables:            config.RouteTables,
@@ -305,7 +304,7 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 				GroupsClaim:   config.OIDC.GroupsClaim,
 			},
 			PodInfraContainerImage: config.PodInfraContainerImage,
-			ProjectName:            config.ProjectName,
+			ProjectName:            project.Name(),
 			RegistryDomain:         config.RegistryDomain,
 			Route53Enabled:         config.Route53Enabled,
 			RouteTables:            config.RouteTables,

--- a/service/service.go
+++ b/service/service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/flag"
+	"github.com/giantswarm/aws-operator/pkg/project"
 	"github.com/giantswarm/aws-operator/service/collector"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi"
 	"github.com/giantswarm/aws-operator/service/controller/legacy"
@@ -37,7 +38,6 @@ type Config struct {
 
 	Description string
 	GitCommit   string
-	ProjectName string
 	Source      string
 	Version     string
 }
@@ -209,7 +209,6 @@ func New(config Config) (*Service, error) {
 				GroupsClaim:   config.Viper.GetString(config.Flag.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim),
 			},
 			PodInfraContainerImage: config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
-			ProjectName:            config.ProjectName,
 			RegistryDomain:         config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RouteTables:            config.Viper.GetString(config.Flag.Service.AWS.RouteTables),
@@ -239,7 +238,6 @@ func New(config Config) (*Service, error) {
 				Enabled:          config.Viper.GetBool(config.Flag.Service.Feature.LabelSelector.Enabled),
 				OverridenVersion: config.Viper.GetString(config.Flag.Service.Test.LabelSelector.Version),
 			},
-			ProjectName:    config.ProjectName,
 			Route53Enabled: config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 		}
 
@@ -286,7 +284,6 @@ func New(config Config) (*Service, error) {
 				GroupsClaim:   config.Viper.GetString(config.Flag.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim),
 			},
 			PodInfraContainerImage: config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
-			ProjectName:            config.ProjectName,
 			RegistryDomain:         config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RouteTables:            config.Viper.GetString(config.Flag.Service.AWS.RouteTables),
@@ -364,7 +361,7 @@ func New(config Config) (*Service, error) {
 			},
 
 			PodInfraContainerImage: config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
-			ProjectName:            config.ProjectName,
+			ProjectName:            project.Name(),
 			RegistryDomain:         config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			Route53Enabled:         config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RouteTables:            config.Viper.GetString(config.Flag.Service.AWS.RouteTables),
@@ -403,7 +400,7 @@ func New(config Config) (*Service, error) {
 				Enabled:          config.Viper.GetBool(config.Flag.Service.Feature.LabelSelector.Enabled),
 				OverridenVersion: config.Viper.GetString(config.Flag.Service.Test.LabelSelector.Version),
 			},
-			ProjectName:    config.ProjectName,
+			ProjectName:    project.Name(),
 			Route53Enabled: config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 		}
 
@@ -449,7 +446,7 @@ func New(config Config) (*Service, error) {
 		c := version.Config{
 			Description:    config.Description,
 			GitCommit:      config.GitCommit,
-			Name:           config.ProjectName,
+			Name:           project.Name(),
 			Source:         config.Source,
 			Version:        config.Version,
 			VersionBundles: NewVersionBundles(),


### PR DESCRIPTION
Since inception of `pkg/project` we do not need to wire project name configuration all over the place. `project.Name()` is globally available and we should transition towards its usage. This PR is one step into this direction. 