### PR TITLE
Lookup ASG name only from active instances

### DIFF
--- a/service/controller/clusterapi/v30/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v30/resource/asgstatus/create.go
@@ -46,6 +46,15 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 						aws.String(key.StackTCNP),
 					},
 				},
+				{
+					Name: aws.String("instance-state-name"),
+					Values: []*string{
+						aws.String(ec2.InstanceStateNamePending),
+						aws.String(ec2.InstanceStateNameRunning),
+						aws.String(ec2.InstanceStateNameStopped),
+						aws.String(ec2.InstanceStateNameStopping),
+					},
+				},
 			},
 		}
 
@@ -63,19 +72,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		nonTerminatedInstances := o.Reservations[0].Instances[:0]
-		for _, i := range o.Reservations[0].Instances[:0] {
-			if *i.State.Name != ec2.InstanceStateNameTerminated {
-				nonTerminatedInstances = append(nonTerminatedInstances, i)
-			}
-		}
-		if len(nonTerminatedInstances) == 0 {
+		if len(o.Reservations[0].Instances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/clusterapi/v31/resource/asgstatus/create.go
+++ b/service/controller/clusterapi/v31/resource/asgstatus/create.go
@@ -46,6 +46,15 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 						aws.String(key.StackTCNP),
 					},
 				},
+				{
+					Name: aws.String("instance-state-name"),
+					Values: []*string{
+						aws.String(ec2.InstanceStateNamePending),
+						aws.String(ec2.InstanceStateNameRunning),
+						aws.String(ec2.InstanceStateNameStopped),
+						aws.String(ec2.InstanceStateNameStopping),
+					},
+				},
 			},
 		}
 
@@ -63,19 +72,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		nonTerminatedInstances := o.Reservations[0].Instances[:0]
-		for _, i := range o.Reservations[0].Instances[:0] {
-			if *i.State.Name != ec2.InstanceStateNameTerminated {
-				nonTerminatedInstances = append(nonTerminatedInstances, i)
-			}
-		}
-		if len(nonTerminatedInstances) == 0 {
+		if len(o.Reservations[0].Instances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v28/resource/asgstatus/create.go
+++ b/service/controller/legacy/v28/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v28patch1/resource/asgstatus/create.go
+++ b/service/controller/legacy/v28patch1/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v29/resource/asgstatus/create.go
+++ b/service/controller/legacy/v29/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v29patch1/resource/asgstatus/create.go
+++ b/service/controller/legacy/v29patch1/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v30/resource/asgstatus/create.go
+++ b/service/controller/legacy/v30/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group

--- a/service/controller/legacy/v31/resource/asgstatus/create.go
+++ b/service/controller/legacy/v31/resource/asgstatus/create.go
@@ -59,13 +59,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
-		if len(o.Reservations[0].Instances) == 0 {
+		nonTerminatedInstances := o.Reservations[0].Instances[:0]
+		for _, i := range o.Reservations[0].Instances[:0] {
+			if *i.State.Name != ec2.InstanceStateNameTerminated {
+				nonTerminatedInstances = append(nonTerminatedInstances, i)
+			}
+		}
+		if len(nonTerminatedInstances) == 0 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "worker asg not available yet")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}
 
-		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+		asgName = awstags.ValueForKey(nonTerminatedInstances[0].Tags, "aws:autoscaling:groupName")
 	}
 
 	var asg *autoscaling.Group


### PR DESCRIPTION
Towards giantswarm/giantswarm#6302

Cherry-picked from #1964 to make review easier.

This PR is step forward to make aws-operator e2e tests green again.

Cluster recreation (after deletion of initially created tenant cluster) was getting stuck since it would find from terminated instance tag reference to (name of) ASG and expect that it's an existing ASG, while it's actually deleted. PR fixes "recreate cluster" e2e tests by looking up for active instances only, so ignoring any terminated instances from initial ASG/cluster.