### PR TITLE
separate stopping ec2 instance from ebs service implementation

### DIFF
--- a/service/controller/clusterapi/v31/resource/tccp/create.go
+++ b/service/controller/clusterapi/v31/resource/tccp/create.go
@@ -99,6 +99,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if update {
+			err = r.stopMasterInstance(ctx, cr)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			err = r.detachVolumes(ctx, cr)
 			if err != nil {
 				return microerror.Mask(err)
@@ -203,11 +208,9 @@ func (r *Resource) detachVolumes(ctx context.Context, cr v1alpha1.Cluster) error
 			return microerror.Mask(err)
 		}
 
-		// First shutdown the instances and wait for it to be stopped. Then detach
-		// the etcd and docker volume without forcing.
 		force := false
-		shutdown := true
-		wait := true
+		shutdown := false
+		wait := false
 
 		for _, v := range volumes {
 			for _, a := range v.Attachments {

--- a/service/controller/clusterapi/v31/resource/tccp/create_test.go
+++ b/service/controller/clusterapi/v31/resource/tccp/create_test.go
@@ -36,17 +36,12 @@ func Test_Controller_Resource_TCCP_Template_Render(t *testing.T) {
 		name         string
 		cr           v1alpha1.Cluster
 		ctx          context.Context
-		tp           templateParams
 		errorMatcher func(error) bool
 	}{
 		{
-			name: "case 0: basic test",
-			cr:   unittest.DefaultCluster(),
-			ctx:  unittest.DefaultContext(),
-			tp: templateParams{
-				DockerVolumeResourceName:   "rsc-abbacd01",
-				MasterInstanceResourceName: "rsc-ac0dc01",
-			},
+			name:         "case 0: basic test",
+			cr:           unittest.DefaultCluster(),
+			ctx:          unittest.DefaultContext(),
 			errorMatcher: nil,
 		},
 	}


### PR DESCRIPTION
This PR is mainly about moving code for preparation of several things. The EBS service implementation in general is tightly coupled with the EC2 Instance management. We do not want this as it makes reconciliation cumbersome. As such we have problems with long running reconciliation loops because of tightly coupled functionality and its implications of error handling. Later we want to have multi master support which would make things even more complicated. Functionality should be resembled and the code starts to be separated more, which is finally what we want. 