### PR TITLE
helm/aws-operator: fix rbac for {clusters,machinedeployments}/status

### DIFF
--- a/helm/aws-operator/templates/rbac.yaml
+++ b/helm/aws-operator/templates/rbac.yaml
@@ -24,6 +24,7 @@ rules:
       - cluster.k8s.io
     resources:
       - machinedeployments
+      - machinedeployments/status
     verbs:
       - delete
       - get

--- a/helm/aws-operator/templates/rbac.yaml
+++ b/helm/aws-operator/templates/rbac.yaml
@@ -13,6 +13,7 @@ rules:
       - cluster.k8s.io
     resources:
       - clusters
+      - clusters/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7276

We noticed that when testing flattened version. We don't know why it
works for non-flattened one.