### PR TITLE
switch deployment from master to thiccc branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
     - deploy:
         command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+          if [ "${CIRCLE_BRANCH}" == "thiccc" ]; then
             ./architect deploy
           fi
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6882

Stop deploying `master` branch to all installations, and instead deploy `thiccc` branch (see https://github.com/giantswarm/aws-operator/pull/1988)