### PR TITLE
Explicitly detach unused subnets before dropping it via CloudFormation

### DIFF
--- a/service/controller/clusterapi/v31/cluster_resource_set.go
+++ b/service/controller/clusterapi/v31/cluster_resource_set.go
@@ -37,6 +37,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/service"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccp"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccpazs"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccpf"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccpi"
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/resource/tccpoutputs"
@@ -414,6 +415,18 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
+	var tccpdetachlbsubnetResource resource.Interface
+	{
+		c := tccpdetachlbsubnet.Config{
+			Logger: config.Logger,
+		}
+
+		tccpdetachlbsubnetResource, err = tccpdetachlbsubnet.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tccpVPCIDResource resource.Interface
 	{
 		c := tccpvpcid.Config{
@@ -552,6 +565,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		s3BucketResource,
 		s3ObjectResource,
 		tccpAZsResource,
+		tccpdetachlbsubnetResource,
 		tccpiResource,
 		tccpResource,
 		tccpfResource,

--- a/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/create.go
+++ b/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/create.go
@@ -1,0 +1,21 @@
+package tccpdetachlbsubnet
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.ensureUnusedAZsAreDetachedFromLBs(ctx, obj)
+	if IsVPCNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane vpc id is not yet available")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/delete.go
+++ b/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/delete.go
@@ -1,0 +1,21 @@
+package tccpdetachlbsubnet
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := r.ensureUnusedAZsAreDetachedFromLBs(ctx, obj)
+	if IsVPCNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane vpc id is not available any more")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/error.go
+++ b/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/error.go
@@ -1,0 +1,35 @@
+package tccpdetachlbsubnet
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInsserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var vpcNotFoundError = &microerror.Error{
+	Kind: "vpcNotFoundError",
+}
+
+// IsVPCNotFound asserts vpcNotFoundError.
+func IsVPCNotFound(err error) bool {
+	return microerror.Cause(err) == vpcNotFoundError
+}

--- a/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/resource.go
+++ b/service/controller/clusterapi/v31/resource/tccpdetachlbsubnet/resource.go
@@ -1,0 +1,168 @@
+package tccpdetachlbsubnet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/controllercontext"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "tccpdetachlbsubnetv31"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ensureUnusedAZsAreDetachedFromLBs(ctx context.Context, obj interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// The tenant cluster VPC is a requirement to find its associated load
+	// balancers. In case the VPC ID is not yet tracked in the controller
+	// context we return an error and cause the resource to be canceled.
+	if cc.Status.TenantCluster.TCCP.VPC.ID == "" {
+		return microerror.Mask(vpcNotFoundError)
+	}
+
+	// Collect all LBs from current TCCP VPC.
+	var elbs []*elb.LoadBalancerDescription
+	{
+		i := &elb.DescribeLoadBalancersInput{}
+
+		var o *elb.DescribeLoadBalancersOutput
+
+		for o == nil || (o.NextMarker != nil && *o.NextMarker != "") {
+			o, err = cc.Client.TenantCluster.AWS.ELB.DescribeLoadBalancers(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if o == nil {
+				return microerror.Maskf(executionFailedError, "DescribeLoadBalancersOutput is nil")
+			}
+
+			// Copy marker in case there's next page.
+			i.Marker = o.NextMarker
+
+			for _, lb := range o.LoadBalancerDescriptions {
+				if lb == nil {
+					continue
+				}
+
+				if lb.VPCId == nil || *lb.VPCId != cc.Status.TenantCluster.TCCP.VPC.ID {
+					// This LB doesn't belong to our VPC.
+					continue
+				}
+
+				elbs = append(elbs, lb)
+			}
+		}
+	}
+
+	// Collect all existing subnets that should be detached.
+	var subnetsToDetach []*ec2.Subnet
+	{
+		for _, snet := range cc.Status.TenantCluster.TCCP.Subnets {
+			if snet == nil {
+				continue
+			}
+
+			var found bool
+			for _, az := range cc.Spec.TenantCluster.TCCP.AvailabilityZones {
+				if snet.AvailabilityZone != nil && *snet.AvailabilityZone == az.Name {
+					found = true
+					break
+				}
+			}
+
+			// Subnet's AZ is not in TCCP AZs Spec. This means that this AZ is
+			// not needed anymore and therefore this subnet must be detached
+			// from LBs as well.
+			if !found {
+				subnetsToDetach = append(subnetsToDetach, snet)
+			}
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if there are subnets to detach from load balancers")
+
+	// Collect all LB detachments.
+	var lbDetachments []*elb.DetachLoadBalancerFromSubnetsInput
+	{
+		for _, lb := range elbs {
+			lbDetachment := &elb.DetachLoadBalancerFromSubnetsInput{
+				LoadBalancerName: lb.LoadBalancerName,
+			}
+
+			// Iterate over LB subnets in case it contains a subnet that must
+			// be detached. If that is the case, we add it to LB detachments.
+			for _, snetID := range lb.Subnets {
+				for _, snet := range subnetsToDetach {
+					if *snet.SubnetId == *snetID {
+						lbDetachment.Subnets = append(lbDetachment.Subnets, snet.SubnetId)
+					}
+				}
+			}
+
+			if len(lbDetachment.Subnets) > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found subnets %#q to be detached from load balancer %#q", aws.StringValueSlice(lbDetachment.Subnets), aws.StringValue(lbDetachment.LoadBalancerName)))
+
+				lbDetachments = append(lbDetachments, lbDetachment)
+			}
+		}
+	}
+
+	if len(lbDetachments) == 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find subnets to detach from load balancers")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
+	}
+
+	// Perform the actual detachment.
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "detaching subnets from load balancers")
+
+		for _, i := range lbDetachments {
+			_, err := cc.Client.TenantCluster.AWS.ELB.DetachLoadBalancerFromSubnets(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detached subnets %#q from load balancer %#q", aws.StringValueSlice(i.Subnets), aws.StringValue(i.LoadBalancerName)))
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finished detaching from load balancers")
+	}
+
+	return nil
+}


### PR DESCRIPTION
When cluster's availability zone configuration changes as a result of node pool
deletion, an availability zone might become unused (as it's not required by any
CR for the cluster anymore).

To release network allocation for corresponding AZ's public subnet (to be
available for further use on another AZ) it's resources must be torn down. For
most parts this happens via tccp CloudFormation stack update but it has been
found out that for some reason ELB doesn't delete its requester-managed network
interfaces (ENIs) on disassociated subnet and this leads TCCP CloudFormation
stack to be blocked in cleanup phase and allocated public subnet network to be
reserved.

In order to workaround this shortcoming, this resource explicitly detaches
unused subnet from all relevant ELBs before TCCP CloudFormation stack update
takes place.