### PR TITLE
Don't release once allocated AZs

### DIFF
--- a/service/controller/clusterapi/v31/resource/tccpazs/create.go
+++ b/service/controller/clusterapi/v31/resource/tccpazs/create.go
@@ -159,11 +159,7 @@ func (r *Resource) ensureAZsAreAssignedWithSubnet(ctx context.Context, tccpSubne
 	var azNames []string
 	{
 		for az := range azMapping {
-			// Drop the AZs that are not needed by Cluster or MachineDeployment
-			// CRs anymore. This will allow freeing up resources for later use.
-			if azMapping[az].RequiredByCR {
-				azNames = append(azNames, az)
-			}
+			azNames = append(azNames, az)
 		}
 
 		sort.Strings(azNames)
@@ -306,11 +302,7 @@ func newAZSpec(azMapping map[string]mapping) []controllercontext.ContextSpecTena
 	var azNames []string
 	{
 		for az := range azMapping {
-			// Drop the AZs that are not needed by Cluster or MachineDeployment
-			// CRs anymore. This will allow freeing up resources for later use.
-			if azMapping[az].RequiredByCR {
-				azNames = append(azNames, az)
-			}
+			azNames = append(azNames, az)
 		}
 
 		sort.Strings(azNames)

--- a/service/controller/clusterapi/v31/resource/tccpazs/create_test.go
+++ b/service/controller/clusterapi/v31/resource/tccpazs/create_test.go
@@ -165,6 +165,17 @@ func Test_EnsureCreated_AZ_Spec(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name: "eu-central-1b",
+					Subnet: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnet{
+						Private: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPrivate{
+							CIDR: mustParseCIDR("10.100.3.96/27"),
+						},
+						Public: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPublic{
+							CIDR: mustParseCIDR("10.100.3.64/27"),
+						},
+					},
+				},
 			},
 			errorMatcher: nil,
 		},


### PR DESCRIPTION
Due to current behavior of AWS CloudFormation / ELB, we can't release AZs that
were once allocated for cluster. Reason for this is that when subnet for freed
AZ is detached from ELBs, the requester-managed network interface (ENI created
by ELB) is not deleted from corresponding subnet and therefore this subnet
cannot be deleted. This keeps allocated network range reserved and it cannot be
used for another AZ.

Thus for now the AZ allocation for cluster / node pool is permanent and cannot
be reverted.