### PR TITLE
Move bundle version to pkg/project

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,17 @@
 package project
 
 var (
-	description        = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
-	gitSHA             = "n/a"
-	name        string = "aws-operator"
-	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "n/a"
+	bundleVersion        = "6.4.0"
+	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
+	gitSHA               = "n/a"
+	name          string = "aws-operator"
+	source        string = "https://github.com/giantswarm/aws-operator"
+	version              = "n/a"
 )
+
+func BundleVersion() string {
+	return bundleVersion
+}
 
 func Description() string {
 	return description

--- a/service/controller/clusterapi/v31/version_bundle.go
+++ b/service/controller/clusterapi/v31/version_bundle.go
@@ -1,6 +1,7 @@
 package v31
 
 import (
+	"github.com/giantswarm/aws-operator/pkg/project"
 	"github.com/giantswarm/versionbundle"
 )
 
@@ -35,7 +36,7 @@ func VersionBundle() versionbundle.Bundle {
 				Version: "1.14.6",
 			},
 		},
-		Name:    "aws-operator",
-		Version: "6.4.0",
+		Name:    project.Name(),
+		Version: project.BundleVersion(),
 	}
 }


### PR DESCRIPTION
Towards: giantswarm/giantswarm#7337

This PR moves the versionbundle.Version under `pkg/project.bundleVersion` in order to make it available at runtime.

The idea is to later be able to exposes to prometheus and build alerts based on this to detect when there's more than 1 operator reconciling 1 bundle version.