### PR TITLE
Add route53manager role

### DIFF
--- a/service/controller/clusterapi/v31/resource/tccp/template/template_main_iam_policies.go
+++ b/service/controller/clusterapi/v31/resource/tccp/template/template_main_iam_policies.go
@@ -84,7 +84,36 @@ const TemplateMainIAMPolicies = `
           Effect: "Allow"
           Action: "sts:AssumeRole"
           Resource: "*"
-
+  Route53ManagerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: {{ $v.ClusterID }}-Route53Manager-Role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            AWS: !GetAtt IAMManagerRole.Arn
+          Action: "sts:AssumeRole"
+  Route53ManagerRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: {{ $v.ClusterID }}-Route53Manager-Policy
+      Roles:
+        - Ref: "Route53ManagerRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "route53:ChangeResourceRecordSets"
+            Resource:
+              - "arn:aws:route53:::hostedzone/!Ref 'HostedZone'"
+              - "arn:aws:route53:::hostedzone/!Ref 'InternalHostedZone'"
+          - Effect: "Allow"
+            Action:
+			  - "route53:ListHostedZones"
+			  - "route53:ListResourceRecordSets"
+            Resource: "*"
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/clusterapi/v31/resource/tccp/template/template_main_iam_policies.go
+++ b/service/controller/clusterapi/v31/resource/tccp/template/template_main_iam_policies.go
@@ -111,8 +111,8 @@ const TemplateMainIAMPolicies = `
               - "arn:aws:route53:::hostedzone/!Ref 'InternalHostedZone'"
           - Effect: "Allow"
             Action:
-			  - "route53:ListHostedZones"
-			  - "route53:ListResourceRecordSets"
+			        - "route53:ListHostedZones"
+			        - "route53:ListResourceRecordSets"
             Resource: "*"
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"

--- a/service/controller/clusterapi/v31/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v31/resource/tccp/testdata/case-0-basic-test.golden
@@ -119,8 +119,8 @@ Resources:
               - "arn:aws:route53:::hostedzone/!Ref 'InternalHostedZone'"
           - Effect: "Allow"
             Action:
-			  - "route53:ListHostedZones"
-			  - "route53:ListResourceRecordSets"
+			        - "route53:ListHostedZones"
+			        - "route53:ListResourceRecordSets"
             Resource: "*"
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"

--- a/service/controller/clusterapi/v31/resource/tccp/testdata/case-0-basic-test.golden
+++ b/service/controller/clusterapi/v31/resource/tccp/testdata/case-0-basic-test.golden
@@ -92,7 +92,36 @@ Resources:
           Effect: "Allow"
           Action: "sts:AssumeRole"
           Resource: "*"
-
+  Route53ManagerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: 8y5ck-Route53Manager-Role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Principal:
+            AWS: !GetAtt IAMManagerRole.Arn
+          Action: "sts:AssumeRole"
+  Route53ManagerRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: 8y5ck-Route53Manager-Policy
+      Roles:
+        - Ref: "Route53ManagerRole"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "route53:ChangeResourceRecordSets"
+            Resource:
+              - "arn:aws:route53:::hostedzone/!Ref 'HostedZone'"
+              - "arn:aws:route53:::hostedzone/!Ref 'InternalHostedZone'"
+          - Effect: "Allow"
+            Action:
+			  - "route53:ListHostedZones"
+			  - "route53:ListResourceRecordSets"
+            Resource: "*"
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4795

Required for external-dns app.
Only kiam server-role is allowed to assume this