### PR TITLE
rename encryption resource

### DIFF
--- a/service/controller/clusterapi/v31/cluster_resource_set.go
+++ b/service/controller/clusterapi/v31/cluster_resource_set.go
@@ -25,7 +25,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/cleanupsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/cproutetables"
 	"github.com/giantswarm/aws-operator/service/controller/resource/cpvpccidr"
-	"github.com/giantswarm/aws-operator/service/controller/resource/encryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/endpoints"
 	"github.com/giantswarm/aws-operator/service/controller/resource/ipam"
 	"github.com/giantswarm/aws-operator/service/controller/resource/natgatewayaddresses"
@@ -37,6 +36,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/service"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccp"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
+	"github.com/giantswarm/aws-operator/service/controller/resource/tccpencryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpf"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpi"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpoutputs"
@@ -187,15 +187,15 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var encryptionResource resource.Interface
+	var tccpEncryptionResource resource.Interface
 	{
-		c := encryption.Config{
+		c := tccpencryption.Config{
 			Encrypter:     encrypterObject,
 			Logger:        config.Logger,
 			ToClusterFunc: key.ToCluster,
 		}
 
-		encryptionResource, err = encryption.New(c)
+		tccpEncryptionResource, err = tccpencryption.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -548,7 +548,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		// the information given in the controller context.
 		ipamResource,
 		bridgeZoneResource,
-		encryptionResource,
+		tccpEncryptionResource,
 		s3BucketResource,
 		s3ObjectResource,
 		tccpAZsResource,

--- a/service/controller/clusterapi/v31/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v31/machine_deployment_resource_set.go
@@ -23,11 +23,11 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/awsclient"
 	"github.com/giantswarm/aws-operator/service/controller/resource/cproutetables"
 	"github.com/giantswarm/aws-operator/service/controller/resource/cpvpccidr"
-	"github.com/giantswarm/aws-operator/service/controller/resource/encryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/ipam"
 	"github.com/giantswarm/aws-operator/service/controller/resource/region"
 	"github.com/giantswarm/aws-operator/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
+	"github.com/giantswarm/aws-operator/service/controller/resource/tccpencryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpnatgateways"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
@@ -188,15 +188,15 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
-	var encryptionResource resource.Interface
+	var tccpEncryptionResource resource.Interface
 	{
-		c := encryption.Config{
+		c := tccpencryption.Config{
 			Encrypter:     encrypterObject,
 			Logger:        config.Logger,
 			ToClusterFunc: newMachineDeploymentToClusterFunc(config.CMAClient),
 		}
 
-		encryptionResource, err = encryption.New(c)
+		tccpEncryptionResource, err = tccpencryption.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -424,7 +424,7 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 
 		// All these resources implement certain business logic and operate based on
 		// the information given in the controller context.
-		encryptionResource,
+		tccpEncryptionResource,
 		s3ObjectResource,
 		ipamResource,
 		tcnpResource,

--- a/service/controller/resource/tccpencryption/create.go
+++ b/service/controller/resource/tccpencryption/create.go
@@ -1,4 +1,4 @@
-package encryption
+package tccpencryption
 
 import (
 	"context"

--- a/service/controller/resource/tccpencryption/delete.go
+++ b/service/controller/resource/tccpencryption/delete.go
@@ -1,4 +1,4 @@
-package encryption
+package tccpencryption
 
 import (
 	"context"

--- a/service/controller/resource/tccpencryption/error.go
+++ b/service/controller/resource/tccpencryption/error.go
@@ -1,4 +1,4 @@
-package encryption
+package tccpencryption
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/service/controller/resource/tccpencryption/resource.go
+++ b/service/controller/resource/tccpencryption/resource.go
@@ -1,4 +1,4 @@
-package encryption
+package tccpencryption
 
 import (
 	"github.com/giantswarm/microerror"
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	name = "encryptionv31"
+	name = "tccpencryptionv31"
 )
 
 type Config struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7354. Renaming the resource running in the cluster controller so we can have another encryption resource running in the machine deployment controller. The new resource should then only put the encryption key into the controller context and NOT delete the encryption key of the cluster when a Node Pool is deleted. 