### PR TITLE
add tcnpencryption resource to simply put encryption keys into the controller context

### DIFF
--- a/service/controller/clusterapi/v31/machine_deployment_resource_set.go
+++ b/service/controller/clusterapi/v31/machine_deployment_resource_set.go
@@ -27,7 +27,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/region"
 	"github.com/giantswarm/aws-operator/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
-	"github.com/giantswarm/aws-operator/service/controller/resource/tccpencryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpnatgateways"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
@@ -35,6 +34,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpvpcpcx"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnp"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnpazs"
+	"github.com/giantswarm/aws-operator/service/controller/resource/tcnpencryption"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnpf"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnpoutputs"
 )
@@ -188,15 +188,15 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		}
 	}
 
-	var tccpEncryptionResource resource.Interface
+	var tcnpEncryptionResource resource.Interface
 	{
-		c := tccpencryption.Config{
-			Encrypter:     encrypterObject,
-			Logger:        config.Logger,
-			ToClusterFunc: newMachineDeploymentToClusterFunc(config.CMAClient),
+		c := tcnpencryption.Config{
+			CMAClient: config.CMAClient,
+			Encrypter: encrypterObject,
+			Logger:    config.Logger,
 		}
 
-		tccpEncryptionResource, err = tccpencryption.New(c)
+		tcnpEncryptionResource, err = tcnpencryption.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -421,10 +421,10 @@ func NewMachineDeploymentResourceSet(config MachineDeploymentResourceSetConfig) 
 		tcnpASGStatusResource,
 		tcnpAZsResource,
 		tcnpOutputsResource,
+		tcnpEncryptionResource,
 
 		// All these resources implement certain business logic and operate based on
 		// the information given in the controller context.
-		tccpEncryptionResource,
 		s3ObjectResource,
 		ipamResource,
 		tcnpResource,

--- a/service/controller/resource/tcnpencryption/create.go
+++ b/service/controller/resource/tcnpencryption/create.go
@@ -1,0 +1,69 @@
+package tcnpencryption
+
+import (
+	"context"
+	"time"
+
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var cl v1alpha1.Cluster
+	{
+		md, err := key.ToMachineDeployment(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		m, err := r.cmaClient.ClusterV1alpha1().Clusters(md.Namespace).Get(key.ClusterID(&md), metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cluster cr not yet availabile")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		cl = *m
+	}
+
+	// For some obscure reasons the encryption key is not immediately available
+	// when creating it. On each cluster creation we saw the retry resource
+	// kicking in once because of a not found error. To prevent the error, instead
+	// we backoff silently upfront where we know we have to.
+	{
+		var encryptionKey string
+
+		o := func() error {
+			encryptionKey, err = r.encrypter.EncryptionKey(ctx, cl)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(3, 1*time.Second)
+
+		err := backoff.Retry(o, b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		cc.Status.TenantCluster.Encryption.Key = encryptionKey
+	}
+
+	return nil
+}

--- a/service/controller/resource/tcnpencryption/delete.go
+++ b/service/controller/resource/tcnpencryption/delete.go
@@ -1,0 +1,12 @@
+package tcnpencryption
+
+import (
+	"context"
+)
+
+// EnsureDeleted is a noop because we do not want to delete anything when Node
+// Pools are deleted. Deletion of the Tenant Cluster's KMS key is managed in the
+// tccpencryption resource.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/tcnpencryption/error.go
+++ b/service/controller/resource/tcnpencryption/error.go
@@ -1,0 +1,14 @@
+package tcnpencryption
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/tcnpencryption/resource.go
+++ b/service/controller/resource/tcnpencryption/resource.go
@@ -1,0 +1,55 @@
+package tcnpencryption
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+
+	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/encrypter"
+)
+
+const (
+	name = "tcnpencryptionv31"
+)
+
+type Config struct {
+	CMAClient clientset.Interface
+	Encrypter encrypter.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the operatorkit Resource interface to fill the operator's
+// controller context with an appropriate encryption key. The controller context
+// structure looks as follows.
+//
+//     cc.Status.TenantCluster.Encryption.Key
+//
+type Resource struct {
+	cmaClient clientset.Interface
+	encrypter encrypter.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CMAClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CMAClient must not be empty", config)
+	}
+	if config.Encrypter == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Encrypter must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		cmaClient: config.CMAClient,
+		encrypter: config.Encrypter,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return name
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7354. Adding another encryption resource running in the machine deployment controller. The new resource does only put the encryption key into the controller context and NOT delete the encryption key of the cluster when a Node Pool is deleted. 