### PR TITLE
refactor tcnpencryption resource to drop legacy behaviour

### DIFF
--- a/service/controller/clusterapi/v31/cluster_resource_set.go
+++ b/service/controller/clusterapi/v31/cluster_resource_set.go
@@ -190,9 +190,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	var tccpEncryptionResource resource.Interface
 	{
 		c := tccpencryption.Config{
-			Encrypter:     encrypterObject,
-			Logger:        config.Logger,
-			ToClusterFunc: key.ToCluster,
+			Encrypter: encrypterObject,
+			Logger:    config.Logger,
 		}
 
 		tccpEncryptionResource, err = tccpencryption.New(c)

--- a/service/controller/resource/tccpencryption/create.go
+++ b/service/controller/resource/tccpencryption/create.go
@@ -8,16 +8,12 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := r.toClusterFunc(obj)
-	if IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cluster cr not yet availabile")
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-		return nil
-	} else if err != nil {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
 		return microerror.Mask(err)
 	}
 	cc, err := controllercontext.FromContext(ctx)

--- a/service/controller/resource/tccpencryption/delete.go
+++ b/service/controller/resource/tccpencryption/delete.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := r.toClusterFunc(obj)
+	cr, err := key.ToCluster(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/tccpencryption/error.go
+++ b/service/controller/resource/tccpencryption/error.go
@@ -1,9 +1,7 @@
 package tccpencryption
 
 import (
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 var invalidConfigError = &microerror.Error{
@@ -13,30 +11,4 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
-}
-
-var notFoundError = &microerror.Error{
-	Kind: "notFoundError",
-}
-
-// IsNotFound asserts notFoundError.
-func IsNotFound(err error) bool {
-	c := microerror.Cause(err)
-
-	aerr, ok := c.(awserr.Error)
-	if ok {
-		if aerr.Code() == "NotFoundException" {
-			return true
-		}
-	}
-
-	if c == notFoundError {
-		return true
-	}
-
-	if errors.IsNotFound(c) {
-		return true
-	}
-
-	return false
 }

--- a/service/controller/resource/tccpencryption/resource.go
+++ b/service/controller/resource/tccpencryption/resource.go
@@ -3,7 +3,6 @@ package tccpencryption
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/giantswarm/aws-operator/service/controller/clusterapi/v31/encrypter"
 )
@@ -13,24 +12,20 @@ const (
 )
 
 type Config struct {
-	Encrypter     encrypter.Interface
-	Logger        micrologger.Logger
-	ToClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
+	Encrypter encrypter.Interface
+	Logger    micrologger.Logger
 }
 
 // Resource implements the operatorkit Resource interface to fill the operator's
-// controller context with an appropriate encryption key. The controller context
-// structure looks as follows.
+// controller context with an appropriate encryption key. The resource
+// implementation ensures the creation of the Tenant Cluster's encryption key as
+// well as its deletion. The controller context structure looks as follows.
 //
 //     cc.Status.TenantCluster.Encryption.Key
 //
-// The resource may be used by different controllers reconcoling different
-// runtime objects. Therefore toClusterFunc must be configured accordingly. This
-// may be a simple key function or a more complex lookup implementation.
 type Resource struct {
-	encrypter     encrypter.Interface
-	logger        micrologger.Logger
-	toClusterFunc func(v interface{}) (v1alpha1.Cluster, error)
+	encrypter encrypter.Interface
+	logger    micrologger.Logger
 }
 
 func New(config Config) (*Resource, error) {
@@ -40,14 +35,10 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if config.ToClusterFunc == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.ToClusterFunc must not be empty", config)
-	}
 
 	r := &Resource{
-		encrypter:     config.Encrypter,
-		logger:        config.Logger,
-		toClusterFunc: config.ToClusterFunc,
+		encrypter: config.Encrypter,
+		logger:    config.Logger,
 	}
 
 	return r, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7354. Refactoring the resource running in the cluster controller so we get rid of some old code and behaviour since we have the new tcnpencryption resource just added. 