### PR TITLE
aws-operator: remove v31 from imports and variable names

### DIFF
--- a/integration/setup/error.go
+++ b/integration/setup/error.go
@@ -81,7 +81,7 @@ var stackNotFoundError = &microerror.Error{
 }
 
 // IsStackNotFound asserts stackNotFoundError.
-// Copied from service/controller/v17/cloudformation/error.go.
+// Copied from service/controller/internal/cloudformation/error.go.
 func IsStackNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -96,7 +96,6 @@ func IsStackNotFound(err error) bool {
 	}
 
 	return false
-
 }
 
 var stillExistsError = &microerror.Error{

--- a/integration/test/draining/draining_test.go
+++ b/integration/test/draining/draining_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/giantswarm/aws-operator/integration/env"
-	"github.com/giantswarm/aws-operator/service/controller/legacy/v29/key"
+	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
 const (

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/client/aws"
 	"github.com/giantswarm/aws-operator/pkg/project"
-	v31adapter "github.com/giantswarm/aws-operator/service/controller/internal/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/internal/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/locker"
 )
@@ -213,7 +213,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
-	var resourceSetV31 *controller.ResourceSet
+	var resourceSet *controller.ResourceSet
 	{
 		c := clusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
@@ -228,12 +228,12 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 
 			AccessLogsExpiration:  config.AccessLogsExpiration,
 			AdvancedMonitoringEC2: config.AdvancedMonitoringEC2,
-			APIWhitelist: v31adapter.APIWhitelist{
-				Private: v31adapter.Whitelist{
+			APIWhitelist: adapter.APIWhitelist{
+				Private: adapter.Whitelist{
 					Enabled:    config.APIWhitelist.Private.Enabled,
 					SubnetList: config.APIWhitelist.Private.SubnetList,
 				},
-				Public: v31adapter.Whitelist{
+				Public: adapter.Whitelist{
 					Enabled:    config.APIWhitelist.Public.Enabled,
 					SubnetList: config.APIWhitelist.Public.SubnetList,
 				},
@@ -265,14 +265,14 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			VPCPeerID:                  config.VPCPeerID,
 		}
 
-		resourceSetV31, err = newClusterResourceSet(c)
+		resourceSet, err = newClusterResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resourceSets := []*controller.ResourceSet{
-		resourceSetV31,
+		resourceSet,
 	}
 
 	return resourceSets, nil

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -132,7 +132,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
-	var v31ResourceSet *controller.ResourceSet
+	var resourceSet *controller.ResourceSet
 	{
 		c := drainerResourceSetConfig{
 			CMAClient:              config.CMAClient,
@@ -146,14 +146,14 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Route53Enabled: config.Route53Enabled,
 		}
 
-		v31ResourceSet, err = newDrainerResourceSet(c)
+		resourceSet, err = newDrainerResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resourceSets := []*controller.ResourceSet{
-		v31ResourceSet,
+		resourceSet,
 	}
 
 	return resourceSets, nil

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -185,7 +185,7 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 		}
 	}
 
-	var v31ResourceSet *controller.ResourceSet
+	var resourceSet *controller.ResourceSet
 	{
 		c := machineDeploymentResourceSetConfig{
 			CertsSearcher:          certsSearcher,
@@ -223,14 +223,14 @@ func newMachineDeploymentResourceSets(config MachineDeploymentConfig) ([]*contro
 			VPCPeerID:                  config.VPCPeerID,
 		}
 
-		v31ResourceSet, err = newMachineDeploymentResourceSet(c)
+		resourceSet, err = newMachineDeploymentResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resourceSets := []*controller.ResourceSet{
-		v31ResourceSet,
+		resourceSet,
 	}
 
 	return resourceSets, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7345