### PR TITLE
aws-operator: remove v31 from imports and variable names

### DIFF
--- a/integration/setup/error.go
+++ b/integration/setup/error.go
@@ -81,7 +81,7 @@ var stackNotFoundError = &microerror.Error{
 }
 
 // IsStackNotFound asserts stackNotFoundError.
-// Copied from service/controller/v17/cloudformation/error.go.
+// Copied from service/controller/internal/cloudformation/error.go.
 func IsStackNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -96,7 +96,6 @@ func IsStackNotFound(err error) bool {
 	}
 
 	return false
-
 }
 
 var stillExistsError = &microerror.Error{

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	awsclient "github.com/giantswarm/aws-operator/client/aws"
-	v31adapter "github.com/giantswarm/aws-operator/service/controller/internal/adapter"
-	v31cloudconfig "github.com/giantswarm/aws-operator/service/controller/internal/cloudconfig"
+	"github.com/giantswarm/aws-operator/service/controller/internal/adapter"
+	"github.com/giantswarm/aws-operator/service/controller/internal/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 
 	"github.com/giantswarm/aws-operator/service/network"
@@ -213,7 +213,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
-	var resourceSetV31 *controller.ResourceSet
+	var resourceSet *controller.ResourceSet
 	{
 		c := clusterResourceSetConfig{
 			CertsSearcher:          certsSearcher,
@@ -233,12 +233,12 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 
 			AccessLogsExpiration:  config.AccessLogsExpiration,
 			AdvancedMonitoringEC2: config.AdvancedMonitoringEC2,
-			APIWhitelist: v31adapter.APIWhitelist{
-				Private: v31adapter.Whitelist{
+			APIWhitelist: adapter.APIWhitelist{
+				Private: adapter.Whitelist{
 					Enabled:    config.APIWhitelist.Private.Enabled,
 					SubnetList: config.APIWhitelist.Private.SubnetList,
 				},
-				Public: v31adapter.Whitelist{
+				Public: adapter.Whitelist{
 					Enabled:    config.APIWhitelist.Public.Enabled,
 					SubnetList: config.APIWhitelist.Public.SubnetList,
 				},
@@ -256,7 +256,7 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			IncludeTags:                config.IncludeTags,
 			InstallationName:           config.InstallationName,
 			IPAMNetworkRange:           config.IPAMNetworkRange,
-			OIDC: v31cloudconfig.OIDCConfig{
+			OIDC: cloudconfig.OIDCConfig{
 				ClientID:      config.OIDC.ClientID,
 				IssuerURL:     config.OIDC.IssuerURL,
 				UsernameClaim: config.OIDC.UsernameClaim,
@@ -270,14 +270,14 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			VPCPeerID:      config.VPCPeerID,
 		}
 
-		resourceSetV31, err = newClusterResourceSet(c)
+		resourceSet, err = newClusterResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resourceSets := []*controller.ResourceSet{
-		resourceSetV31,
+		resourceSet,
 	}
 
 	return resourceSets, nil

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -21,7 +21,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/internal/adapter"
 	"github.com/giantswarm/aws-operator/service/controller/internal/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/controller/key"
-
 	"github.com/giantswarm/aws-operator/service/network"
 )
 

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -138,7 +138,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
-	var v31ResourceSet *controller.ResourceSet
+	var resourceSet *controller.ResourceSet
 	{
 		c := drainerResourceSetConfig{
 			ControlPlaneAWSClients: controlPlaneAWSClients,
@@ -156,14 +156,14 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Route53Enabled: config.Route53Enabled,
 		}
 
-		v31ResourceSet, err = newDrainerResourceSet(c)
+		resourceSet, err = newDrainerResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resourceSets := []*controller.ResourceSet{
-		v31ResourceSet,
+		resourceSet,
 	}
 
 	return resourceSets, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7345