### PR TITLE
resource: strip v31 suffix from resource names

### DIFF
--- a/service/controller/resource/accountid/resource.go
+++ b/service/controller/resource/accountid/resource.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Name = "accountidv31"
+	Name = "accountid"
 )
 
 type Config struct {

--- a/service/controller/resource/asgstatus/resource.go
+++ b/service/controller/resource/asgstatus/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "asgstatusv31"
+	Name = "asgstatus"
 )
 
 type Config struct {

--- a/service/controller/resource/awsclient/resource.go
+++ b/service/controller/resource/awsclient/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Name = "awsclientv31"
+	Name = "awsclient"
 )
 
 type Config struct {

--- a/service/controller/resource/bridgezone/resource.go
+++ b/service/controller/resource/bridgezone/resource.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	name = "bridgezonev31"
+	name = "bridgezone"
 )
 
 type Config struct {

--- a/service/controller/resource/cleanupebsvolumes/resource.go
+++ b/service/controller/resource/cleanupebsvolumes/resource.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "cleanupebsvolumesv31"
+	Name = "cleanupebsvolumes"
 )
 
 // Config represents the configuration used to create a new ebsvolume resource.

--- a/service/controller/resource/cleanuploadbalancers/resource.go
+++ b/service/controller/resource/cleanuploadbalancers/resource.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "cleanuploadbalancersv31"
+	Name = "cleanuploadbalancers"
 )
 
 // Config represents the configuration used to create a new loadbalancer resource.

--- a/service/controller/resource/cleanupsecuritygroups/resource.go
+++ b/service/controller/resource/cleanupsecuritygroups/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "cleanupsecuritygroupsv31"
+	Name = "cleanupsecuritygroups"
 )
 
 type Config struct {

--- a/service/controller/resource/cproutetables/resource.go
+++ b/service/controller/resource/cproutetables/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Name = "cproutetablesv31"
+	Name = "cproutetables"
 )
 
 type Config struct {

--- a/service/controller/resource/cpvpccidr/resource.go
+++ b/service/controller/resource/cpvpccidr/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Name = "cpvpccidrv31"
+	Name = "cpvpccidr"
 )
 
 type Config struct {

--- a/service/controller/resource/drainer/resource.go
+++ b/service/controller/resource/drainer/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "drainerv31"
+	Name = "drainer"
 )
 
 type ResourceConfig struct {

--- a/service/controller/resource/drainfinisher/resource.go
+++ b/service/controller/resource/drainfinisher/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "drainfinisherv31"
+	Name = "drainfinisher"
 )
 
 type ResourceConfig struct {

--- a/service/controller/resource/endpoints/resource.go
+++ b/service/controller/resource/endpoints/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "endpointsv31"
+	Name = "endpoints"
 )
 
 const (

--- a/service/controller/resource/ipam/resource.go
+++ b/service/controller/resource/ipam/resource.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	Name = "ipamv31"
+	Name = "ipam"
 )
 
 const (

--- a/service/controller/resource/natgatewayaddresses/resource.go
+++ b/service/controller/resource/natgatewayaddresses/resource.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	Name = "natgatewayaddressesv31"
+	Name = "natgatewayaddresses"
 )
 
 type Config struct {

--- a/service/controller/resource/peerrolearn/resource.go
+++ b/service/controller/resource/peerrolearn/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Name = "peerrolearnv31"
+	Name = "peerrolearn"
 )
 
 type Config struct {

--- a/service/controller/resource/region/resource.go
+++ b/service/controller/resource/region/resource.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	Name = "regionv31"
+	Name = "region"
 )
 
 type Config struct {

--- a/service/controller/resource/s3bucket/resource.go
+++ b/service/controller/resource/s3bucket/resource.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "s3bucketv31"
+	Name = "s3bucket"
 	// LifecycleLoggingBucketID is the Lifecycle ID for the logging bucket
 	LifecycleLoggingBucketID = "ExpirationLogs"
 )

--- a/service/controller/resource/s3object/resource.go
+++ b/service/controller/resource/s3object/resource.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "s3objectv31"
+	Name = "s3object"
 )
 
 // Config represents the configuration used to create a new cloudformation resource.

--- a/service/controller/resource/secretfinalizer/resource.go
+++ b/service/controller/resource/secretfinalizer/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "secretfinalizerv31"
+	Name = "secretfinalizer"
 )
 
 const (

--- a/service/controller/resource/service/resource.go
+++ b/service/controller/resource/service/resource.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "servicev31"
+	Name = "service"
 )
 
 const (

--- a/service/controller/resource/tccp/resource.go
+++ b/service/controller/resource/tccp/resource.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "tccpv31"
+	Name = "tccp"
 )
 
 const (

--- a/service/controller/resource/tccpazs/resource.go
+++ b/service/controller/resource/tccpazs/resource.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	Name = "tccpazsv31"
+	Name = "tccpazs"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpencryption/resource.go
+++ b/service/controller/resource/tccpencryption/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	name = "tccpencryptionv31"
+	name = "tccpencryption"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpf/resource.go
+++ b/service/controller/resource/tccpf/resource.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "tccpfv31"
+	Name = "tccpf"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpi/resource.go
+++ b/service/controller/resource/tccpi/resource.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "tccpiv31"
+	Name = "tccpi"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpnatgateways/resource.go
+++ b/service/controller/resource/tccpnatgateways/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "tccpnatgatewaysv31"
+	Name = "tccpnatgateways"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpoutputs/resource.go
+++ b/service/controller/resource/tccpoutputs/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "tccpoutputsv31"
+	Name = "tccpoutputs"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpsecuritygroups/resource.go
+++ b/service/controller/resource/tccpsecuritygroups/resource.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	Name = "tccpsecuritygroupsv31"
+	Name = "tccpsecuritygroups"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpsubnets/resource.go
+++ b/service/controller/resource/tccpsubnets/resource.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Name = "tccpsubnetsv31"
+	Name = "tccpsubnets"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpvpcid/resource.go
+++ b/service/controller/resource/tccpvpcid/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "tccpvpcidv31"
+	Name = "tccpvpcid"
 )
 
 type Config struct {

--- a/service/controller/resource/tccpvpcpcx/resource.go
+++ b/service/controller/resource/tccpvpcpcx/resource.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Name = "tccpvpcpcxv31"
+	Name = "tccpvpcpcx"
 )
 
 type Config struct {

--- a/service/controller/resource/tcnp/resource.go
+++ b/service/controller/resource/tcnp/resource.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "tcnpv31"
+	Name = "tcnp"
 )
 
 type Config struct {

--- a/service/controller/resource/tcnpazs/resource.go
+++ b/service/controller/resource/tcnpazs/resource.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	Name = "tcnpazsv31"
+	Name = "tcnpazs"
 )
 
 type Config struct {

--- a/service/controller/resource/tcnpencryption/resource.go
+++ b/service/controller/resource/tcnpencryption/resource.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	name = "tcnpencryptionv31"
+	name = "tcnpencryption"
 )
 
 type Config struct {

--- a/service/controller/resource/tcnpf/resource.go
+++ b/service/controller/resource/tcnpf/resource.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "tcnpfv31"
+	Name = "tcnpf"
 )
 
 type Config struct {

--- a/service/controller/resource/tcnpoutputs/resource.go
+++ b/service/controller/resource/tcnpoutputs/resource.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	Name = "tcnpoutputsv31"
+	Name = "tcnpoutputs"
 )
 
 type Config struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7345