### PR TITLE
Remove component updates from changelog

### DIFF
--- a/service/versionbundle/version_bundle.go
+++ b/service/versionbundle/version_bundle.go
@@ -20,26 +20,6 @@ func New() versionbundle.Bundle {
 				Kind:        versionbundle.KindAdded,
 			},
 			{
-				Component:   "calico",
-				Description: "Updated from v3.8.2 to v3.9.1.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "containerlinux",
-				Description: "Updated from v2135.4.0 to v2191.5.0.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "etcd",
-				Description: "Updated from v3.3.13 to v3.3.15.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "kubernetes",
-				Description: "Updated from v1.14.6 to v1.15.5.",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
 				Component:   "clusterapi",
 				Description: "Add cleanuprecordsets resource to cleanup non-managed route53 records.",
 				Kind:        versionbundle.KindAdded,


### PR DESCRIPTION
I didn't have a clear picture of the final versioning we would use for the node pools release when I originally added these. `aws-operator` `v5.5.0` released in GS v9.0 already includes these updates so I think it doesn't make sense to have them here as well.