### PR TITLE
main, service: move vesionbundle to pkg/project

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,13 +8,13 @@ import (
 	"github.com/giantswarm/microkit/command"
 	microserver "github.com/giantswarm/microkit/server"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/versionbundle"
 	"github.com/spf13/viper"
 
 	"github.com/giantswarm/aws-operator/flag"
 	"github.com/giantswarm/aws-operator/pkg/project"
 	"github.com/giantswarm/aws-operator/server"
 	"github.com/giantswarm/aws-operator/service"
-	"github.com/giantswarm/aws-operator/service/versionbundle"
 )
 
 var (
@@ -93,7 +93,7 @@ func mainE(ctx context.Context) error {
 			Name:           project.Name(),
 			Source:         project.Source(),
 			Version:        project.Version(),
-			VersionBundles: versionbundle.NewSlice(),
+			VersionBundles: []versionbundle.Bundle{project.NewBundle()},
 		}
 
 		newCommand, err = command.New(c)

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -1,11 +1,10 @@
-package versionbundle
+package project
 
 import (
-	"github.com/giantswarm/aws-operator/pkg/project"
 	"github.com/giantswarm/versionbundle"
 )
 
-func New() versionbundle.Bundle {
+func NewBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
@@ -51,13 +50,7 @@ func New() versionbundle.Bundle {
 				Version: "1.15.5",
 			},
 		},
-		Name:    "aws-operator",
-		Version: project.BundleVersion(),
-	}
-}
-
-func NewSlice() []versionbundle.Bundle {
-	return []versionbundle.Bundle{
-		New(),
+		Name:    Name(),
+		Version: BundleVersion(),
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/client/k8srestconfig"
 	"github.com/giantswarm/statusresource"
+	"github.com/giantswarm/versionbundle"
 	"github.com/spf13/viper"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -26,7 +27,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller"
 	"github.com/giantswarm/aws-operator/service/locker"
 	legacynetwork "github.com/giantswarm/aws-operator/service/network"
-	"github.com/giantswarm/aws-operator/service/versionbundle"
 )
 
 // Config represents the configuration used to create a new service.
@@ -291,7 +291,7 @@ func New(config Config) (*Service, error) {
 			Name:           project.Name(),
 			Source:         project.Source(),
 			Version:        project.Version(),
-			VersionBundles: versionbundle.NewSlice(),
+			VersionBundles: []versionbundle.Bundle{project.NewBundle()},
 		}
 
 		versionService, err = version.New(c)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7345

I relalized versionbundle package is only used in two files:

- main.go
- service/service.go

Resource sets should use `project.BundleVersion()` anyway.

Therefore I think it makes sense to move all that stuff to the project package.