### PR TITLE
Label nodes with operator version instead of release version

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -15,5 +15,4 @@ const (
 const (
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
 	OperatorVersion         = "aws-operator.giantswarm.io/version"
-	ReleaseVersion          = "release.giantswarm.io/version"
 )

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -15,6 +15,14 @@ func NewVersionBundle() versionbundle.Bundle {
 					"https://github.com/giantswarm/aws-operator/pull/2059",
 				},
 			},
+			{
+				Component:   "kubelet",
+				Description: "Label nodes with operator instead of release version.",
+				Kind:        versionbundle.KindFixed,
+				URLs: []string{
+					"https://github.com/giantswarm/aws-operator/pull/2064",
+				},
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -17,7 +17,7 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "kubelet",
-				Description: "Label nodes with operator instead of release version.",
+				Description: "Label nodes with operator version instead of release version.",
 				Kind:        versionbundle.KindFixed,
 				URLs: []string{
 					"https://github.com/giantswarm/aws-operator/pull/2064",

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -68,7 +68,7 @@ func KubeletLabelsTCCP(getter LabelsGetter) string {
 	var labels string
 
 	labels = ensureLabel(labels, label.Provider, "aws")
-	labels = ensureLabel(labels, label.ReleaseVersion, ReleaseVersion(getter))
+	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
 
 	return labels
 }
@@ -77,7 +77,7 @@ func KubeletLabelsTCNP(getter LabelsGetter) string {
 	var labels string
 
 	labels = ensureLabel(labels, label.Provider, "aws")
-	labels = ensureLabel(labels, label.ReleaseVersion, ReleaseVersion(getter))
+	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
 	labels = ensureLabel(labels, label.MachineDeployment, MachineDeploymentID(getter))
 
 	return labels
@@ -147,10 +147,6 @@ func RegionARN(region string) string {
 	}
 
 	return regionARN
-}
-
-func ReleaseVersion(getter LabelsGetter) string {
-	return getter.GetLabels()[label.ReleaseVersion]
 }
 
 func RoleARNMaster(getter LabelsGetter, region string, accountID string) string {


### PR DESCRIPTION
Towards fixing https://github.com/giantswarm/giantswarm/issues/7465

This is aws-operator part of the fix. For cluster-operator part of the fix see https://github.com/giantswarm/cluster-operator/pull/772