### PR TITLE
Set PropagateAtLaunch prop for Name tag of NP ASG

### DIFF
--- a/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
+++ b/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
@@ -27,6 +27,7 @@ const TemplateMainAutoScalingGroup = `
       Tags:
         - Key: Name
           Value: {{ .AutoScalingGroup.Cluster.ID }}-worker
+          PropagateAtLaunch: false
         - Key: k8s.io/cluster-autoscaler/enabled
           Value: true
           PropagateAtLaunch: false

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -33,6 +33,7 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-worker
+          PropagateAtLaunch: false
         - Key: k8s.io/cluster-autoscaler/enabled
           Value: true
           PropagateAtLaunch: false


### PR DESCRIPTION
While testing fix for https://github.com/giantswarm/giantswarm/issues/7465, test cluster's nodepool cloudformation stack was failing to create with:

```
NodePoolAutoScalingGroup	CREATE_FAILED	PropagateAtLaunch not found in properties
```

This PR fixes recently introduced Name tag of NodePool ASG, by setting [required](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-tags.html#cfn-as-tags-PropagateAtLaunch) `PropagateAtLaunch` property of the tag.

See https://github.com/giantswarm/aws-operator/pull/2059