### PR TITLE
set app=aws-operator and version labels

### DIFF
--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -15,7 +16,8 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        app: {{ tpl .Values.resource.default.name  . }}
+        app: {{ .Values.project.name }}
+        version: {{ .Values.project.version }}
     spec:
       volumes:
       - name: {{ .Values.project.name }}-configmap

--- a/helm/aws-operator/templates/service.yaml
+++ b/helm/aws-operator/templates/service.yaml
@@ -4,11 +4,13 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -17,6 +17,7 @@ pod:
     id: 1000
 project:
   name: "aws-operator"
+  version: "[[ .Version ]]"
 # Resource names are truncated to 47 characters. Kubernetes allows 63 characters
 # limit for resource names. When pods for deployments are created they have
 # additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7650

This PR set `app` and `version` labels for service, deployment, and pod resources.

e.g.
```
$ k get all -lapp=aws-operator,version=7.0.0-2a6fc487fbda312293f8efb855b87c0108faf725 -A --show-labels

NAMESPACE    NAME                                              READY   STATUS    RESTARTS   AGE   LABELS
giantswarm   pod/aws-operator-version-label-6d754c844b-sk8vp   1/1     Running   0          87s   app=aws-operator,pod-template-hash=6d754c844b,version=7.0.0-2a6fc487fbda312293f8efb855b87c0108faf725

NAMESPACE    NAME                                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE   LABELS
giantswarm   service/aws-operator-version-label   ClusterIP   172.31.130.194   <none>        8000/TCP   87s   app=aws-operator,version=7.0.0-2a6fc487fbda312293f8efb855b87c0108faf725

NAMESPACE    NAME                                         READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
giantswarm   deployment.apps/aws-operator-version-label   1/1     1            1           87s   app=aws-operator,version=7.0.0-2a6fc487fbda312293f8efb855b87c0108faf725

NAMESPACE    NAME                                                    DESIRED   CURRENT   READY   AGE   LABELS
giantswarm   replicaset.apps/aws-operator-version-label-6d754c844b   1         1         1       87s   app=aws-operator,pod-template-hash=6d754c844b,version=7.0.0-2a6fc487fbda312293f8efb855b87c0108faf725```
This overall idea is to keep the same `app` value for different version of the same operator.