### PR TITLE
legacy: set app=aws-operator and version labels

### DIFF
--- a/helm/aws-operator-chart/templates/deployment.yaml
+++ b/helm/aws-operator-chart/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: aws-operator
+    version: {{ .Chart.Version }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -16,6 +17,7 @@ spec:
         releasetime: {{ $.Release.Time }}
       labels:
         app: aws-operator
+        version: {{ .Chart.Version }}
     spec:
       volumes:
       - name: aws-operator-configmap

--- a/helm/aws-operator-chart/templates/service.yaml
+++ b/helm/aws-operator-chart/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: aws-operator
+    version: {{ .Chart.Version }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -12,3 +13,4 @@ spec:
   - port: 8000
   selector:
     app: aws-operator
+    version: {{ .Chart.Version }}

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -4,7 +4,8 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -15,7 +16,8 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        app: {{ tpl .Values.resource.default.name  . }}
+        app: {{ .Values.project.name }}
+        version: {{ .Values.project.version }}
     spec:
       volumes:
       - name: {{ .Values.project.name }}-configmap

--- a/helm/aws-operator/templates/service.yaml
+++ b/helm/aws-operator/templates/service.yaml
@@ -4,11 +4,13 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    app: {{ tpl .Values.resource.default.name  . }}
+    app: {{ .Values.project.name }}
+    version: {{ .Values.project.version }}

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -17,6 +17,7 @@ pod:
     id: 1000
 project:
   name: "aws-operator"
+  version: "[[ .Version ]]"
 # Resource names are truncated to 47 characters. Kubernetes allows 63 characters
 # limit for resource names. When pods for deployments are created they have
 # additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have


### PR DESCRIPTION
Towards: giantswarm/giantswarm#7650

This PR set app and version labels for service, deployment, and pod resources.