### PR TITLE
thiccc: set app=aws-operator and version labels

### DIFF
--- a/helm/aws-operator-chart/templates/deployment.yaml
+++ b/helm/aws-operator-chart/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: aws-operator
+    version: {{ .Chart.Version }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -16,6 +17,7 @@ spec:
         releasetime: {{ $.Release.Time }}
       labels:
         app: aws-operator
+        version: {{ .Chart.Version }}
     spec:
       volumes:
       - name: aws-operator-configmap

--- a/helm/aws-operator-chart/templates/service.yaml
+++ b/helm/aws-operator-chart/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: aws-operator
+    version: {{ .Chart.Version }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -12,3 +13,4 @@ spec:
   - port: 8000
   selector:
     app: aws-operator
+    version: {{ .Chart.Version }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7650

This PR set app and version labels for service, deployment, and pod resources.