### PR TITLE
Use apps/v1 for deployment

### DIFF
--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.project.name }}
-      version: {{ .Values.project.version }
+      version: {{ .Values.project.version }}
   strategy:
     type: RollingUpdate
   template:

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.project.name }}
+      version: {{ .Values.project.version }
   strategy:
     type: RollingUpdate
   template:

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
@@ -9,6 +9,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ .Values.project.name }}
   strategy:
     type: RollingUpdate
   template:

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "7.0.1"
+	bundleVersion        = "7.0.1-dev"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "7.0.1-dev-rossf7"
+	bundleVersion        = "7.0.1"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "7.0.1-dev"
+	bundleVersion        = "7.0.1-dev-rossf7"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7355

I'm unclear why its started happening now but this fixes deployment of the PR from @anvddriesch  https://github.com/giantswarm/aws-operator/pull/2068

Since we need to upgrade the API version for K8s 1.16 this updates the helm chart.

```
status:
  appVersion: ""
  reason: 'Upgrade "aws-operator-remove-adapter" failed: Deployment.apps "aws-operator-remove-adapter"
    is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"aws-operator",
    "version":"7.0.0-8ffb529e4a11578553a7f802bfc8fdf20cd4deb3"}: `selector` does not
    match template `labels`'
```