### PR TITLE
Add host k8s client to guest framework for compatibility with e2e-harness

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -309,8 +309,8 @@
   revision = "776376d011031615b44d4080a0f2efaa301d6ddd"
 
 [[projects]]
-  branch = "master"
-  digest = "1:9040e13234b3f2d9aacb9f8f4cdaca5f108b334196cf17d1518d52307a7444b1"
+  branch = "update-guest"
+  digest = "1:1c0ae6a96700e4cc0813367998b4282ffd6b599e0d710e17d9829609ce4d95c5"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
     "internal/filelogger",
@@ -319,7 +319,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "b527706db0fd20a025f0134ce19cc56bdb5921cd"
+  revision = "3bb66ad27e2e53301f0480edf3883149b7bd0bb0"
 
 [[projects]]
   branch = "master"
@@ -350,7 +350,7 @@
   revision = "11c30c63f167e8b027926eea81ad4ca513becf20"
 
 [[projects]]
-  branch = "master"
+  branch = "update-guest"
   digest = "1:0020f60d83964a8b6e968615d5e27fd4248f6f452b2871dcab65bb03f0ea5286"
   name = "github.com/giantswarm/e2etests"
   packages = [
@@ -364,7 +364,7 @@
     "update/provider",
   ]
   pruneopts = "UT"
-  revision = "0a92296f4027610eda21acb3651031bf1a3c202f"
+  revision = "221dc04f9064ae5f1d4b9a0a03c69a7459f93fbc"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -309,8 +309,8 @@
   revision = "776376d011031615b44d4080a0f2efaa301d6ddd"
 
 [[projects]]
-  branch = "update-guest"
-  digest = "1:1c0ae6a96700e4cc0813367998b4282ffd6b599e0d710e17d9829609ce4d95c5"
+  branch = "master"
+  digest = "1:8fb1e299495dee85dc466313ce7cca959f8f4077fca3a1a6c7ef2f42b048aa20"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
     "internal/filelogger",
@@ -319,7 +319,7 @@
     "pkg/release",
   ]
   pruneopts = "UT"
-  revision = "3bb66ad27e2e53301f0480edf3883149b7bd0bb0"
+  revision = "f54d8a266f15340b465463a8b8b972f1f430a69c"
 
 [[projects]]
   branch = "master"
@@ -350,7 +350,7 @@
   revision = "11c30c63f167e8b027926eea81ad4ca513becf20"
 
 [[projects]]
-  branch = "update-guest"
+  branch = "master"
   digest = "1:0020f60d83964a8b6e968615d5e27fd4248f6f452b2871dcab65bb03f0ea5286"
   name = "github.com/giantswarm/e2etests"
   packages = [
@@ -364,7 +364,7 @@
     "update/provider",
   ]
   pruneopts = "UT"
-  revision = "221dc04f9064ae5f1d4b9a0a03c69a7459f93fbc"
+  revision = "4725599ab01a636085874e4999d1d318b59923bf"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/certs"
 
 [[constraint]]
-  branch = "update-guest"
+  branch = "master"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "update-guest"
+  branch = "master"
   name = "github.com/giantswarm/e2etests"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ required = [
   name = "github.com/giantswarm/certs"
 
 [[constraint]]
-  branch = "master"
+  branch = "update-guest"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]
@@ -65,7 +65,7 @@ required = [
   name = "github.com/giantswarm/e2etemplates"
 
 [[constraint]]
-  branch = "master"
+  branch = "update-guest"
   name = "github.com/giantswarm/e2etests"
 
 [[constraint]]

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -56,10 +56,25 @@ func NewConfig() (Config, error) {
 		}
 	}
 
+	var cpK8sClients *k8sclient.Clients
+	{
+		c := k8sclient.ClientsConfig{
+			Logger: logger,
+
+			KubeConfigPath: harness.DefaultKubeConfig,
+		}
+
+		cpK8sClients, err = k8sclient.NewClients(c)
+		if err != nil {
+			return Config{}, microerror.Mask(err)
+		}
+	}
+
 	var guest *framework.Guest
 	{
 		c := framework.GuestConfig{
-			Logger: logger,
+			HostK8sClient: cpK8sClients.K8sClient(),
+			Logger:        logger,
 
 			ClusterID:    env.ClusterID(),
 			CommonDomain: env.CommonDomain(),
@@ -80,20 +95,6 @@ func NewConfig() (Config, error) {
 		}
 
 		host, err = framework.NewHost(c)
-		if err != nil {
-			return Config{}, microerror.Mask(err)
-		}
-	}
-
-	var cpK8sClients *k8sclient.Clients
-	{
-		c := k8sclient.ClientsConfig{
-			Logger: logger,
-
-			KubeConfigPath: harness.DefaultKubeConfig,
-		}
-
-		cpK8sClients, err = k8sclient.NewClients(c)
 		if err != nil {
 			return Config{}, microerror.Mask(err)
 		}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/framework/guest.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/framework/guest.go
@@ -9,13 +9,10 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/giantswarm/e2e-harness/pkg/harness"
 )
 
 const (
@@ -27,6 +24,8 @@ const (
 type GuestConfig struct {
 	Logger micrologger.Logger
 
+	HostK8sClient kubernetes.Interface
+
 	ClusterID    string
 	CommonDomain string
 }
@@ -34,15 +33,19 @@ type GuestConfig struct {
 type Guest struct {
 	logger micrologger.Logger
 
-	g8sClient  versioned.Interface
-	k8sClient  kubernetes.Interface
-	restConfig *rest.Config
+	g8sClient     versioned.Interface
+	hostK8sClient kubernetes.Interface
+	k8sClient     kubernetes.Interface
+	restConfig    *rest.Config
 
 	clusterID    string
 	commonDomain string
 }
 
 func NewGuest(config GuestConfig) (*Guest, error) {
+	if config.HostK8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostK8sClient must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -57,9 +60,7 @@ func NewGuest(config GuestConfig) (*Guest, error) {
 	g := &Guest{
 		logger: config.Logger,
 
-		g8sClient:  nil,
-		k8sClient:  nil,
-		restConfig: nil,
+		hostK8sClient: config.HostK8sClient,
 
 		clusterID:    config.ClusterID,
 		commonDomain: config.CommonDomain,
@@ -91,24 +92,13 @@ func (g *Guest) RestConfig() *rest.Config {
 
 // Initialize sets up the Guest fields that are not directly injected.
 func (g *Guest) Initialize() error {
-	var hostK8sClient kubernetes.Interface
-	{
-		c, err := clientcmd.BuildConfigFromFlags("", harness.DefaultKubeConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		hostK8sClient, err = kubernetes.NewForConfig(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
 
 	var guestG8sClient versioned.Interface
 	var guestK8sClient kubernetes.Interface
 	var guestRestConfig *rest.Config
 	{
 		n := fmt.Sprintf("%s-api", g.clusterID)
-		s, err := hostK8sClient.CoreV1().Secrets("default").Get(n, metav1.GetOptions{})
+		s, err := g.hostK8sClient.CoreV1().Secrets("default").Get(n, metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/vendor/github.com/giantswarm/e2e-harness/pkg/framework/guest.go
+++ b/vendor/github.com/giantswarm/e2e-harness/pkg/framework/guest.go
@@ -21,6 +21,10 @@ const (
 	minimumNodesReady = 3
 )
 
+var (
+	namespaces = []string{"giantswarm"}
+)
+
 type GuestConfig struct {
 	Logger micrologger.Logger
 
@@ -211,6 +215,11 @@ func (g *Guest) WaitForGuestReady(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
+	err = g.EnsureNamespacesExists(ctx, namespaces)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = g.WaitForNodesReady(ctx, minimumNodesReady)
 	if err != nil {
 		return microerror.Mask(err)
@@ -252,5 +261,27 @@ func (g *Guest) WaitForNodesReady(ctx context.Context, expectedNodes int) error 
 	}
 
 	g.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for %d k8s nodes to be in %#q state", expectedNodes, v1.NodeReady))
+	return nil
+}
+
+func (g *Guest) EnsureNamespacesExists(ctx context.Context, namespaces []string) error {
+	g.logger.Log("level", "debug", "message", "ensuring needed namespaces exist")
+	for _, name := range namespaces {
+		// check for existing namespace with this name
+		existing, _ := g.K8sClient().CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+
+		if existing == nil || existing.Name != name {
+			g.logger.Log("level", "debug", "message", fmt.Sprintf("Creating namespace %s", name))
+			nsSpec := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			_, err := g.K8sClient().CoreV1().Namespaces().Create(nsSpec)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			g.logger.Log("level", "debug", "message", fmt.Sprintf("Created namespace %s", name))
+		}
+	}
+
+	g.logger.Log("level", "debug", "message", "ensured needed namespaces exist")
+
 	return nil
 }

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/apiextensions_aws_config_e2e.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/apiextensions_aws_config_e2e.go
@@ -29,6 +29,7 @@ type APIExtensionsAWSConfigE2EConfigAWS struct {
 	Region           string
 	RouteTable0      string
 	RouteTable1      string
+	VPCPeerID        string
 }
 
 // NewAPIExtensionsAWSConfigE2E renders values required by apiextensions-aws-config-e2e-chart.
@@ -65,6 +66,9 @@ func NewAPIExtensionsAWSConfigE2E(config APIExtensionsAWSConfigE2EConfig) (strin
 	}
 	if config.AWS.RouteTable1 == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.RouteTable1 must not be empty", config)
+	}
+	if config.AWS.VPCPeerID == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.AWS.VPCPeerID must not be empty", config)
 	}
 
 	values, err := render.Render(apiExtensionsAWSConfigE2ETemplate, config)

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/apiextensions_aws_config_e2e_template.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/apiextensions_aws_config_e2e_template.go
@@ -13,4 +13,5 @@ aws:
   ingressHostedZone: {{ .AWS.IngressHostedZone }}
   routeTable0: {{ .AWS.RouteTable0 }}
   routeTable1: {{ .AWS.RouteTable1 }}
+  vpcPeerId: {{ .AWS.VPCPeerID }}
 `

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/aws_operator.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/aws_operator.go
@@ -11,7 +11,6 @@ const (
 )
 
 type AWSOperatorConfig struct {
-	InstallationName   string
 	Provider           AWSOperatorConfigProvider
 	RegistryPullSecret string
 	Secret             AWSOperatorConfigSecret
@@ -26,6 +25,7 @@ type AWSOperatorConfigProviderAWS struct {
 	Encrypter       string
 	Region          string
 	RouteTableNames string
+	VPCPeerID       string
 }
 
 type AWSOperatorConfigSecret struct {
@@ -61,9 +61,6 @@ type AWSOperatorConfigSSH struct {
 
 // NewAWSOperator renders values required by aws-operator-chart.
 func NewAWSOperator(config AWSOperatorConfig) (string, error) {
-	if config.InstallationName == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
-	}
 	if config.Provider.AWS.Encrypter == "" {
 		config.Provider.AWS.Encrypter = defaultEncrypter
 	}
@@ -72,6 +69,9 @@ func NewAWSOperator(config AWSOperatorConfig) (string, error) {
 	}
 	if config.Provider.AWS.RouteTableNames == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.Provider.AWS.RouteTableNames must not be empty", config)
+	}
+	if config.Provider.AWS.VPCPeerID == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.Provider.AWS.VPCPeerID must not be empty", config)
 	}
 	if config.RegistryPullSecret == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.RegistryPullSecret must not be empty", config)

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/aws_operator_template.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/chartvalues/aws_operator_template.go
@@ -33,7 +33,7 @@ const awsOperatorTemplate = `Installation:
         UserList: '{{ .SSH.UserList }}'
       Update:
         Enabled: true
-    Name: '{{ .InstallationName }}'
+    Name: ci-aws-operator
     Provider:
       AWS:
         AvailabilityZones:
@@ -49,6 +49,7 @@ const awsOperatorTemplate = `Installation:
         Encrypter: '{{ .Provider.AWS.Encrypter }}'
         TrustedAdvisor:
           Enabled: false
+        VPCPeerID: '{{ .Provider.AWS.VPCPeerID }}'
     Registry:
       Domain: quay.io
     Secret:

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_host_peer_stack_template.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_host_peer_stack_template.go
@@ -2,7 +2,7 @@ package e2etemplates
 
 const awsHostPeerStackTemplate = `
 AWSTemplateFormatVersion: 2010-09-09
-Description: Control Plane Peer Stack with VPC peering and route tables for testing purposes
+Description: Host Peer Stack with VPC peering and route tables for testing purposes
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -11,8 +11,6 @@ Resources:
       Tags:
       - Key: Name
         Value: {{ .Stack.Name }}
-      - Key: giantswarm.io/installation
-        Value: cp-peer-{{ .Stack.Name }}
   PeerRouteTable0:
     Type: AWS::EC2::RouteTable
     Properties:

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_host_vpc_stack.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_host_vpc_stack.go
@@ -15,8 +15,6 @@ Resources:
       Tags:
       - Key: Name
         Value: ${CLUSTER_NAME}
-      - Key: giantswarm.io/installation
-        Value: cp-peer-${CLUSTER_NAME}
   PeerRouteTable0:
     Type: AWS::EC2::RouteTable
     Properties:

--- a/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/vendor/github.com/giantswarm/e2etemplates/pkg/e2etemplates/aws_operator_chart_values.go
@@ -39,8 +39,6 @@ const AWSOperatorChartValues = `Installation:
           Enabled: false
     Registry:
       Domain: quay.io
-    Installation:
-      Name: cp-peer-${CLUSTER_NAME}
     Secret:
       AWSOperator:
         IDRSAPub: ${IDRSA_PUB}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4606

As part of the migration to kind @MarcelMue created https://github.com/giantswarm/e2e-harness/pull/207 which is needed to improve the k8s client handling.

I want to merge this PR to move forward. PRs also prepared for the legacy branch and azure-operator. No other projects are affected.