### PR TITLE
Disable Route53 recordset cleanup when Route53 is disabled

### DIFF
--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -339,6 +339,8 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 	{
 		c := cleanuprecordsets.Config{
 			Logger: config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
 		}
 
 		cleanupRecordSets, err = cleanuprecordsets.New(c)

--- a/service/controller/resource/cleanuprecordsets/delete.go
+++ b/service/controller/resource/cleanuprecordsets/delete.go
@@ -22,6 +22,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if !r.route53Enabled {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "route53 disabled")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	var hostedZones []*route53.HostedZone
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding hosted zones")

--- a/service/controller/resource/cleanuprecordsets/resource.go
+++ b/service/controller/resource/cleanuprecordsets/resource.go
@@ -11,10 +11,14 @@ const (
 
 type Config struct {
 	Logger micrologger.Logger
+
+	Route53Enabled bool
 }
 
 type Resource struct {
 	logger micrologger.Logger
+
+	route53Enabled bool
 }
 
 func New(config Config) (*Resource, error) {
@@ -24,6 +28,8 @@ func New(config Config) (*Resource, error) {
 
 	r := &Resource{
 		logger: config.Logger,
+
+		route53Enabled: config.Route53Enabled,
 	}
 
 	return r, nil


### PR DESCRIPTION
In China there's no (fully functional) Route53 so it is disabled there
and DNS management is done differently.