### PR TITLE
Fix vault encrypter

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "8.3.0-dev"
+	bundleVersion        = "8.1.0-dev"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "8.1.0-dev"
+	bundleVersion        = "8.3.0-dev"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -8,8 +8,8 @@ func NewVersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "todo",
-				Description: "TODO",
+				Component:   "vault",
+				Description: "Fix vault encrypter role with new nodepools iam role names.",
 				Kind:        versionbundle.KindFixed,
 			},
 		},

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -244,13 +244,6 @@ func VPCPeeringRouteName(az string) string {
 	return fmt.Sprintf("VPCPeeringRoute-%s", az)
 }
 
-func baseRoleARN(getter LabelsGetter, region string, accountID string, kind string) string {
-	clusterID := ClusterID(getter)
-	partition := RegionARN(region)
-
-	return fmt.Sprintf("arn:%s:iam::%s:role/%s-%s-%s", partition, accountID, clusterID, kind, EC2RoleK8s)
-}
-
 // imageIDs returns our Container Linux AMIs for each active AWS region. Note
 // that AMIs should always be for HVM virtualisation, not PV. Current Release is
 // CoreOS Container Linux stable 2135.4.0. AMI IDs are copied from the following

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -154,11 +154,17 @@ func RegionARN(region string) string {
 }
 
 func RoleARNMaster(getter LabelsGetter, region string, accountID string) string {
-	return baseRoleARN(getter, region, accountID, "master")
+	clusterID := ClusterID(getter)
+	partition := RegionARN(region)
+
+	return fmt.Sprintf("arn:%s:iam::%s:role/%s-master-%s", partition, accountID, clusterID, EC2RoleK8s)
 }
 
 func RoleARNWorker(getter LabelsGetter, region string, accountID string) string {
-	return baseRoleARN(getter, region, accountID, "worker")
+	clusterID := ClusterID(getter)
+	partition := RegionARN(region)
+
+	return fmt.Sprintf("arn:%s:iam::%s:role/gs-cluster-%s-role-*", partition, accountID, clusterID)
 }
 
 // S3ObjectPathTCCP computes the S3 object path to the cloud config uploaded for


### PR DESCRIPTION
CAPI release introduced new names for nodepools IAM roles. That change broke vault encrypter as there are constraints on master/worker iam role names allowed to authorize in vault for decryption. 

This PR adjusts vault constraints with new worker IAM role name format