### PR TITLE
Legacy: Release 9.1.0 with Kubernetes 1.16.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ workflows:
             tags:
               only: /^v.*/
       - architect/push-to-app-catalog:
-          name: push-aws-operator-to-app-catalog
+          name: push-aws-operator-to-control-plane-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-operator"
@@ -174,11 +174,11 @@ workflows:
             tags:
               only: /^v.*/
       - architect/push-to-app-collection:
-          name: push-to-aws-app-collection
+          name: push-aws-operator-to-aws-app-collection
           app_name: "aws-operator"
           app_collection_repo: "aws-app-collection"
           requires:
-            - push-aws-operator-to-app-catalog
+            - push-aws-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -416,14 +416,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:34f4559474d1b3d0fd14f3fe235bd624a9d737106cca6ec9fb9406c99d5b0762"
+  digest = "1:b9d558aa4abc2da053057de4f7a62fc181cab37d0cf976335be4d48dbaa9b1e1"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "ignition/v_2_2_0",
     "v_5_0_0",
   ]
   pruneopts = "T"
-  revision = "c43b36807bdd4c5ba4ac96f50b434b57ae348213"
+  revision = "48d270782f3789e0f625b18b10f0d577641ce956"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -416,14 +416,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8fcac04170acd9c50dc24e7f5c330c1ff9a1c68184252812d0e7d13b4531b9cc"
+  digest = "1:34f4559474d1b3d0fd14f3fe235bd624a9d737106cca6ec9fb9406c99d5b0762"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "ignition/v_2_2_0",
-    "v_4_9_0",
+    "v_5_0_0",
   ]
   pruneopts = "T"
-  revision = "fd74eac277875634cd16f098c7ed020a96a87808"
+  revision = "c43b36807bdd4c5ba4ac96f50b434b57ae348213"
 
 [[projects]]
   branch = "master"
@@ -2114,7 +2114,7 @@
     "github.com/giantswarm/k8sclient/k8scrdclient",
     "github.com/giantswarm/k8sclient/k8srestconfig",
     "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0",
-    "github.com/giantswarm/k8scloudconfig/v_4_9_0",
+    "github.com/giantswarm/k8scloudconfig/v_5_0_0",
     "github.com/giantswarm/kubelock",
     "github.com/giantswarm/microendpoint/endpoint/healthz",
     "github.com/giantswarm/microendpoint/endpoint/version",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -416,14 +416,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b9d558aa4abc2da053057de4f7a62fc181cab37d0cf976335be4d48dbaa9b1e1"
+  digest = "1:6a3f00998009fd4e9fbbc3050d8f8d5c5d82b5aeeb88e2cb7ae73be6d925ed66"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "ignition/v_2_2_0",
     "v_5_0_0",
   ]
   pruneopts = "T"
-  revision = "48d270782f3789e0f625b18b10f0d577641ce956"
+  revision = "ead4746e4fdaa113c56755a0e291c9274722b8d8"
 
 [[projects]]
   branch = "master"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "6.0.0"
+	bundleVersion        = "5.6.0"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "5.5.1-dev"
+	bundleVersion        = "6.0.0"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,38 +9,53 @@ func NewBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Updated to support Kubernetes 1.16.",
+				Description: "Update to support Kubernetes 1.16.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/aws-operator/pull/2090",
+				},
 			},
 			{
 				Component:   "calico",
-				Description: "Updated from v3.8.2 to v3.9.1.",
+				Description: "Update from v3.9.1 to v3.10.1.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/k8scloudconfig/pull/615",
+				},
 			},
 			{
 				Component:   "containerlinux",
-				Description: "Updated from v2135.4.0 to v2191.5.0.",
+				Description: "Update from v2191.5.0 to 2247.6.0.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/k8scloudconfig/pull/615",
+				},
 			},
 			{
 				Component:   "etcd",
-				Description: "Updated from v3.3.13 to v3.3.15.",
+				Description: "Update from v3.3.15 to v3.3.17.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/k8scloudconfig/pull/615",
+				},
 			},
 			{
 				Component:   "kubernetes",
-				Description: "Updated from v1.14.6 to v1.15.5.",
+				Description: "Update from v1.15.5 to v1.16.3.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/k8scloudconfig/pull/615",
+				},
 			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "calico",
-				Version: "3.9.1",
+				Version: "3.10.1",
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2191.5.0",
+				Version: "2247.6.0",
 			},
 			{
 				Name:    "docker",
@@ -48,11 +63,11 @@ func NewBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "etcd",
-				Version: "3.3.15",
+				Version: "3.3.17",
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.15.5",
+				Version: "1.16.3",
 			},
 		},
 		Name:    Name(),

--- a/service/controller/internal/cloudconfig/cloud_config_test.go
+++ b/service/controller/internal/cloudconfig/cloud_config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
 	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_9_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_0_0"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/randomkeys"

--- a/service/controller/internal/cloudconfig/master_template.go
+++ b/service/controller/internal/cloudconfig/master_template.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_9_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_0_0"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeys"
 

--- a/service/controller/internal/cloudconfig/worker_template.go
+++ b/service/controller/internal/cloudconfig/worker_template.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_9_0"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_0_0"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -20,7 +20,7 @@ import (
 const (
 	// CloudConfigVersion defines the version of k8scloudconfig in use.
 	// It is used in the main stack output and S3 object paths.
-	CloudConfigVersion = "v_4_9_0"
+	CloudConfigVersion = "v_5_0_0"
 
 	// CloudProviderTagName is used to add Cloud Provider tags to AWS resources.
 	CloudProviderTagName = "kubernetes.io/cluster/%s"

--- a/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
@@ -9,13 +9,22 @@ The latest version is considered WIP and it is a subject of change. All other
 versions are frozen. To freeze current version all files are copied to a new
 version directory, and  then changes are introduced.
 
-## [v5.0.0] - 2019-11-12
+## [v5.0.0] - 2020-01-02
 
 ### Changed
 
 - Moved kubelet from container to host process (`--containerized` flag is removed in Kubernetes 1.16).
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
+- Update Kubernetes to `1.16.3`.
+- Update Calico to `3.10.1` along with corresponding RBAC rules.
+- Update etcd to `3.3.17`.
+- Update `calicoctl` (debug tool) to `3.10.1`.
+- Update `crictl` (debug tool) to `1.16.1`.
+- Clean up k8s-addons (use system `kubectl`, avoid `kubectl get cs`).
+- Apply kubelet restricted role labels using new systemd service.
 - Increase `fs.inotify.max_user_instances` to 8192.
+- Change Priority Class for `calico-node` to `system-node-critical`.
+- Use registry domain for k8s-api-healthz and wait for domains script for AWS China.
 
 ### Added
 

--- a/vendor/github.com/giantswarm/k8scloudconfig/Gopkg.lock
+++ b/vendor/github.com/giantswarm/k8scloudconfig/Gopkg.lock
@@ -15,7 +15,7 @@
   name = "github.com/giantswarm/apiextensions"
   packages = ["pkg/apis/provider/v1alpha1"]
   pruneopts = "UT"
-  revision = "a4fd7939e26e7e2cd681af032963a1597ffae781"
+  revision = "29482fb3d774cedee3578619809e04274372bf9b"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
@@ -13,8 +13,8 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.15.5"
-	etcdImage                        = "giantswarm/etcd:v3.3.15"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3"
+	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )
 

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/install-debug-tools
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/install-debug-tools
@@ -4,13 +4,13 @@ set -eu
 mkdir -p /opt/bin
 
 # download calicoctl
-CALICOCTL_VERSION=v3.9.1
+CALICOCTL_VERSION=v3.10.1
 wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
 mv calicoctl-linux-amd64 /opt/bin/calicoctl
 chmod +x /opt/bin/calicoctl
 
 # download crictl
-CRICTL_VERSION=v1.15.0
+CRICTL_VERSION=v1.16.1
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 tar xvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 mv crictl /opt/bin/crictl

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/install-debug-tools
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/install-debug-tools
@@ -5,13 +5,13 @@ mkdir -p /opt/bin
 
 # download calicoctl
 CALICOCTL_VERSION=v3.10.1
-wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
+wget --timeout=600 --no-dns-cache --retry-connrefused https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
 mv calicoctl-linux-amd64 /opt/bin/calicoctl
 chmod +x /opt/bin/calicoctl
 
 # download crictl
 CRICTL_VERSION=v1.16.1
-wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+wget --timeout=600 --no-dns-cache --retry-connrefused https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 tar xvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 mv crictl /opt/bin/crictl
 chmod +x /opt/bin/crictl

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/k8s-addons
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/k8s-addons
@@ -1,21 +1,18 @@
 #!/bin/bash
 
 export KUBECONFIG=/etc/kubernetes/kubeconfig/addons.yaml
-# kubectl 1.12.2
-KUBECTL={{ .RegistryDomain }}/giantswarm/docker-kubectl:f5cae44c480bd797dc770dd5f62d40b74063c0d7
-
-/usr/bin/docker pull $KUBECTL
+export KUBECTL="/opt/bin/hyperkube kubectl"
 
 # wait for healthy master
-while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
+while [ "$($KUBECTL get nodes $(hostname) -o jsonpath='{.metadata.name}')" != "$(hostname)" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
 # label namespaces (required for network egress policies)
 NAMESPACES="default kube-system" 
 for namespace in ${NAMESPACES}
 do
-    if ! /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get namespaces -l name=${namespace} | grep ${namespace}; then
+    if ! $KUBECTL get namespaces -l name=${namespace} | grep ${namespace}; then
         while
-            /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL label namespace ${namespace} name=${namespace}
+            $KUBECTL label namespace ${namespace} name=${namespace}
             [ "$?" -ne "0" ]
         do
             echo "failed to label namespace ${namespace}, retrying in 5 sec"
@@ -35,7 +32,7 @@ SECURITY_FILES="${SECURITY_FILES} psp_binding.yaml"
 for manifest in $SECURITY_FILES
 do
     while
-        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        $KUBECTL apply -f /srv/$manifest
         [ "$?" -ne "0" ]
     do
         echo "failed to apply /srv/$manifest, retrying in 5 sec"
@@ -45,10 +42,10 @@ done
 
 # check for other master and remove it
 THIS_MACHINE=$(cat /etc/hostname)
-for master in $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get nodes --no-headers=true --selector role=master | awk '{print $1}')
+for master in $($KUBECTL get nodes --no-headers=true --selector role=master | awk '{print $1}')
 do
     if [ "$master" != "$THIS_MACHINE" ]; then
-        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL delete node $master
+        $KUBECTL delete node $master
     fi
 done
 
@@ -64,8 +61,7 @@ done
 
 # create kube-proxy configmap
 while
-    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv $KUBECTL create configmap kube-proxy --from-file=kube-proxy.yaml=/srv/kube-proxy-config.yaml -o yaml --dry-run \
-    | /usr/bin/docker run  -i --log-driver=none -a stdin -a stdout -a stderr -e KUBECONFIG=${KUBECONFIG} -v /etc/kubernetes:/etc/kubernetes --net=host --rm $KUBECTL apply -n kube-system -f -
+    $KUBECTL create configmap kube-proxy --from-file=kube-proxy.yaml=/srv/kube-proxy-config.yaml -o yaml --dry-run | $KUBECTL apply -n kube-system -f -
     [ "$?" -ne "0" ]
 do
     echo "failed to configure kube-proxy from /srv/kube-proxy-config.yaml, retrying in 5 sec"
@@ -77,7 +73,7 @@ PROXY_MANIFESTS="kube-proxy-sa.yaml kube-proxy-ds.yaml"
 for manifest in $PROXY_MANIFESTS
 do
     while
-        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        $KUBECTL apply -f /srv/$manifest
         [ "$?" -ne "0" ]
     do
         echo "failed to apply /srv/$manifest, retrying in 5 sec"
@@ -87,7 +83,7 @@ done
 echo "kube-proxy successfully installed"
 
 # restart ds to apply config from configmap
-/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL delete pods -l k8s-app=kube-proxy -n kube-system
+$KUBECTL delete pods -l k8s-app=kube-proxy -n kube-system
 
 {{ if not .DisableCalico -}}
 
@@ -95,7 +91,7 @@ echo "kube-proxy successfully installed"
 CALICO_FILE="calico-all.yaml"
 
 while
-    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$CALICO_FILE
+    $KUBECTL apply -f /srv/$CALICO_FILE
     [ "$?" -ne "0" ]
 do
     echo "failed to apply /srv/$manifest, retrying in 5 sec"
@@ -105,9 +101,9 @@ done
 # wait for healthy calico - we check for pods - desired vs ready
 while
     # result of this is 'eval [ "$DESIRED_POD_COUNT" -eq "$READY_POD_COUNT" ]'
-    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
+    $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
     RET_CODE_1=$?
-    eval $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
+    eval $($KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
     RET_CODE_2=$?
     [ "$RET_CODE_1" -ne "0" ] || [ "$RET_CODE_2" -ne "0" ]
 do
@@ -120,7 +116,7 @@ done
 # apply default storage class
 if [ -f /srv/default-storage-class.yaml ]; then
     while
-        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/default-storage-class.yaml
+        $KUBECTL apply -f /srv/default-storage-class.yaml
         [ "$?" -ne "0" ]
     do
         echo "failed to apply /srv/default-storage-class.yaml, retrying in 5 sec"
@@ -134,7 +130,7 @@ fi
 PRIORITY_CLASSES_FILE="priority_classes.yaml"
 
 while
-    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$PRIORITY_CLASSES_FILE
+    $KUBECTL apply -f /srv/$PRIORITY_CLASSES_FILE
     [ "$?" -ne "0" ]
 do
     echo "failed to apply /srv/$PRIORITY_CLASSES_FILE, retrying in 5 sec"
@@ -146,7 +142,7 @@ NETWORK_POLICIES_FILE="network_policies.yaml"
 NAMESPACES="kube-system giantswarm"
 for namespace in ${NAMESPACES}; do
     while
-      /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$NETWORK_POLICIES_FILE -n $namespace
+      $KUBECTL apply -f /srv/$NETWORK_POLICIES_FILE -n $namespace
       [ "$?" -ne "0" ]
     do
       echo "failed to apply /srv/$NETWORK_POLICIES_FILE, retrying in 5 sec"
@@ -166,7 +162,7 @@ MANIFESTS="${MANIFESTS} ingress-controller-svc.yaml"
 for manifest in $MANIFESTS
 do
     while
-        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        $KUBECTL apply -f /srv/$manifest
         [ "$?" -ne "0" ]
     do
         echo "failed to apply /srv/$manifest, retrying in 5 sec"

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/wait-for-domains
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} {{ .RegistryDomain }}"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/calico-all.yaml
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/calico-all.yaml
@@ -563,7 +563,7 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/calico-all.yaml
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/calico-all.yaml
@@ -5,14 +5,14 @@
 # Extra changes:
 #  - Added resource limits to calico-node and calico-kube-controller.
 #  - Added resource limits to install-cni.
-#  - Added 'priorityClassName: system-cluster-critical' to calico daemonset.
+#  - Added 'priorityClassName: system-node-critical' to calico daemonset.
 #
-# Calico Version v3.9.1
-# https://docs.projectcalico.org/v3.9/release-notes/
+# Calico Version v3.10.1
+# https://docs.projectcalico.org/v3.10/release-notes/
 # This manifest includes the following component versions:
-#   calico/node:v3.9.1
-#   calico/cni:v3.9.1
-#   calico/kube-controllers:v3.9.1
+#   calico/node:v3.10.1
+#   calico/cni:v3.10.1
+#   calico/kube-controllers:v3.10.1
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -70,6 +70,7 @@ data:
         }
       ]
     }
+
 ---
 # Source: calico/templates/kdd-crds.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -265,6 +266,21 @@ spec:
     singular: networkpolicy
 
 ---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset
+
+---
 # This manifest installs the calico-node container, as well
 # as the CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
@@ -312,12 +328,12 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       initContainers:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .RegistryDomain }}/giantswarm/cni:v3.9.1
+          image: {{ .RegistryDomain }}/giantswarm/cni:v3.10.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -363,7 +379,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .RegistryDomain }}/giantswarm/node:v3.9.1
+          image: {{ .RegistryDomain }}/giantswarm/node:v3.10.1
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -470,8 +486,9 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-            - mountPath: /calico-secrets
-              name: etcd-certs
+            - name: etcd-certs
+              mountPath: /calico-secrets
+              readOnly: true
       volumes:
         # Used by calico-node.
         - name: lib-modules
@@ -538,7 +555,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/role: master
+        node.kubernetes.io/master: ''
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
@@ -546,13 +563,13 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.9.1
+          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.10.1
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -612,7 +629,6 @@ metadata:
   name: calico-kube-controllers
   namespace: kube-system
 ---
----
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
@@ -620,51 +636,47 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
 rules:
-- apiGroups:
-  - ""
+- apiGroups: [""]
   resources:
-  - nodes
-  - pods
-  - namespaces
-  - serviceaccounts
+    - nodes
+    - pods
+    - namespaces
+    - serviceaccounts
   verbs:
-  - watch
-  - list
-  - get
-- apiGroups:
-  - networking.k8s.io
+    - watch
+    - list
+    - get
+- apiGroups: ["networking.k8s.io"]
   resources:
-  - networkpolicies
+    - networkpolicies
   verbs:
-  - watch
-  - list
-  # IPAM resources are manipulated when nodes are deleted.
-- apiGroups:
-  - crd.projectcalico.org
+    - watch
+    - list
+# IPAM resources are manipulated when nodes are deleted.
+- apiGroups: ["crd.projectcalico.org"]
   resources:
-  - ippools
+    - ippools
   verbs:
-  - list
-- apiGroups:
-  - crd.projectcalico.org
+    - list
+- apiGroups: ["crd.projectcalico.org"]
   resources:
-  - blockaffinities
-  - ipamblocks
-  - ipamhandles
+    - blockaffinities
+    - ipamblocks
+    - ipamhandles
   verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-- apiGroups:
-  - crd.projectcalico.org
+    - get
+    - list
+    - create
+    - update
+    - delete
+# Needs access to update clusterinformations.
+- apiGroups: ["crd.projectcalico.org"]
   resources:
-  - clusterinformations
+    - clusterinformations
   verbs:
-  - get
-  - create
-  - update
+    - get
+    - create
+    - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/kube-proxy-ds.yaml
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/kube-proxy-ds.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: kube-proxy
   namespace: kube-system

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/psp_policies.yaml
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/k8s-resource/psp_policies.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
@@ -27,7 +27,7 @@ spec:
     max: 65536
 ---
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/manifests/k8s-api-healthz.yaml
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/files/manifests/k8s-api-healthz.yaml
@@ -18,7 +18,7 @@ spec:
       command:
         - /k8s-api-healthz
         - --api-endpoint="https://$(HOST_IP):443/healthz"
-      image: quay.io/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      image:  {{ .RegistryDomain }}/giantswarm/k8s-api-healthz:0999549a4c334b646288d08bd2c781c6aae2e12f
       resources:
         requests:
           cpu: 50m

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/master_template.go
@@ -290,7 +290,7 @@ systemd:
         --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
         --network-plugin=cni \
         --register-node=true \
-        --register-with-taints=node.kubernetes.io/master=:NoSchedule \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
         --node-labels="node.kubernetes.io/master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
         --v=2

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/master_template.go
@@ -290,9 +290,9 @@ systemd:
         --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
         --network-plugin=cni \
         --register-node=true \
-        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+        --register-with-taints=node.kubernetes.io/master=:NoSchedule \
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
-        --node-labels="node.kubernetes.io/master,node-role.kubernetes.io/master,kubernetes.io/role=master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+        --node-labels="node.kubernetes.io/master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
         --v=2
       [Install]
       WantedBy=multi-user.target
@@ -317,6 +317,23 @@ systemd:
   - name: systemd-networkd-wait-online.service
     enabled: false
     mask: true
+  - name: k8s-label-node.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Adds labels to the node after kubelet startup
+      After=k8s-kubelet.service
+      Wants=k8s-kubelet.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
+      ExecStart=/bin/sh -c '\
+        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
+        $KUBECTL label nodes --overwrite $(hostname) node-role.kubernetes.io/master=""; \
+        $KUBECTL label nodes --overwrite $(hostname) kubernetes.io/role=master'
+      [Install]
+      WantedBy=multi-user.target
   - name: k8s-addons.service
     enabled: true
     contents: |


### PR DESCRIPTION
Legacy version of `master` release 11.0.0 (https://github.com/giantswarm/aws-operator/pull/2084) for non-node pool clusters.

Includes master cherry-pick of https://github.com/giantswarm/aws-operator/pull/2105 to allow `opsctl deploy` e2e checks to succeed.