### PR TITLE
circleci: remove thiccc specific deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,6 @@ jobs:
         paths:
         - ./aws-operator
 
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "thiccc" ]; then
-            ./architect deploy
-          fi
-
-
 workflows:
   build:
     jobs:


### PR DESCRIPTION
Removing `deploy` step, which would never be trigger because it only executes for `thiccc` branch.