### PR TITLE
circleci: remove master specific deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,6 @@ jobs:
         paths:
         - ./aws-operator
 
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
-
   master:
     docker:
       - image: busybox


### PR DESCRIPTION
Removing `deploy` step, which would never be trigger because it only executes for `master` branch.