### PR TITLE
remove order sensitivity from comparison of tccp az

### DIFF
--- a/service/controller/internal/changedetection/tccp.go
+++ b/service/controller/internal/changedetection/tccp.go
@@ -81,13 +81,24 @@ func availabilityZonesEqual(spec []controllercontext.ContextSpecTenantClusterTCC
 		return false
 	}
 
-	for i, az := range spec {
-		if !availabilityZoneEqual(az, status[i]) {
+	for _, az := range spec {
+		// alternatively could sort the slice and compare as before.
+		if !containsAZ(az, status) {
 			return false
 		}
 	}
 
 	return true
+}
+
+// true if status slice has an AZ that is equal to target.
+func containsAZ(target controllercontext.ContextSpecTenantClusterTCCPAvailabilityZone, status []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone) bool {
+	for _, az := range status {
+		if availabilityZoneEqual(target, az) {
+			return true
+		}
+	}
+	return false
 }
 
 func availabilityZoneEqual(spec controllercontext.ContextSpecTenantClusterTCCPAvailabilityZone, status controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone) bool {

--- a/service/controller/internal/changedetection/tccp_test.go
+++ b/service/controller/internal/changedetection/tccp_test.go
@@ -229,6 +229,66 @@ func Test_Detection_availabilityZonesEqual(t *testing.T) {
 			},
 			matches: false,
 		},
+		{
+			name: "case 9, different order",
+			spec: []controllercontext.ContextSpecTenantClusterTCCPAvailabilityZone{
+				{
+					Name: "eu-central-1a",
+					Subnet: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnet{
+						Private: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPrivate{
+							CIDR: mustParseCIDR("10.1.4.0/27"),
+							ID:   "subnet-0854f0e4c66e3ef10",
+						},
+						Public: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPublic{
+							CIDR: mustParseCIDR("10.1.4.32/27"),
+							ID:   "subnet-0854f0e4c66e3ef10",
+						},
+					},
+				},
+				{
+					Name: "eu-central-1b",
+					Subnet: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnet{
+						Private: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPrivate{
+							CIDR: mustParseCIDR("10.1.4.64/27"),
+							ID:   "subnet-0934681f126016726",
+						},
+						Public: controllercontext.ContextSpecTenantClusterTCCPAvailabilityZoneSubnetPublic{
+							CIDR: mustParseCIDR("10.1.4.96/27"),
+							ID:   "subnet-0debe88c7b8120cb4",
+						},
+					},
+				},
+			},
+			status: []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone{
+				{
+					Name: "eu-central-1b",
+					Subnet: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnet{
+						Private: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnetPrivate{
+							CIDR: mustParseCIDR("10.1.4.64/27"),
+							ID:   "subnet-0934681f126016726",
+						},
+						Public: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnetPublic{
+							CIDR: mustParseCIDR("10.1.4.96/27"),
+							ID:   "subnet-0debe88c7b8120cb4",
+						},
+					},
+				},
+				{
+					Name: "eu-central-1a",
+					Subnet: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnet{
+						Private: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnetPrivate{
+							CIDR: mustParseCIDR("10.1.4.0/27"),
+							ID:   "subnet-0854f0e4c66e3ef10",
+						},
+						Public: controllercontext.ContextStatusTenantClusterTCCPAvailabilityZoneSubnetPublic{
+							CIDR: mustParseCIDR("10.1.4.32/27"),
+							ID:   "subnet-0854f0e4c66e3ef10",
+						},
+					},
+				},
+			},
+			matches: true,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/service/controller/internal/changedetection/tccp_test.go
+++ b/service/controller/internal/changedetection/tccp_test.go
@@ -230,7 +230,7 @@ func Test_Detection_availabilityZonesEqual(t *testing.T) {
 			matches: false,
 		},
 		{
-			name: "case 9, different order",
+			name: "case 8, different order",
 			spec: []controllercontext.ContextSpecTenantClusterTCCPAvailabilityZone{
 				{
 					Name: "eu-central-1a",


### PR DESCRIPTION
Not sure if ordering of AZ's could cause a problem, but thought this would be a good 'practice' PR even if it is unneccessary @xh3b4sd 