### PR TITLE
Fix push-to-catalog name on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ workflows:
             tags:
               only: /^v.*/
       - architect/push-to-app-catalog:
-          name: push-aws-operator-to-app-catalog
+          name: push-aws-operator-to-control-plane-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-operator"
@@ -178,7 +178,7 @@ workflows:
           app_name: "aws-operator"
           app_collection_repo: "aws-app-collection"
           requires:
-            - push-aws-operator-to-app-catalog
+            - push-aws-operator-to-control-plane-app-catalog
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Same fix as https://github.com/giantswarm/cluster-operator/pull/894

We fix master branch but not the legacy branch for wrong push-to-catalog job name. 

This hangs app deployment.

```
opsctl deploy -i ginger --jumphost-user jhbok aws-operator@legacy
Initializing deployment .................................................................
```