### PR TITLE
legacy: Bump to next WIP version

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	bundleVersion        = "5.6.0"
+	bundleVersion        = "5.6.1-dev"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -9,42 +9,10 @@ func NewBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "aws-operator",
-				Description: "Update to support Kubernetes 1.16.",
+				Description: "TODO.",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"https://github.com/giantswarm/aws-operator/pull/2090",
-				},
-			},
-			{
-				Component:   "calico",
-				Description: "Update from v3.9.1 to v3.10.1.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/k8scloudconfig/pull/615",
-				},
-			},
-			{
-				Component:   "containerlinux",
-				Description: "Update from v2191.5.0 to 2247.6.0.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/k8scloudconfig/pull/615",
-				},
-			},
-			{
-				Component:   "etcd",
-				Description: "Update from v3.3.15 to v3.3.17.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/k8scloudconfig/pull/615",
-				},
-			},
-			{
-				Component:   "kubernetes",
-				Description: "Update from v1.15.5 to v1.16.3.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/k8scloudconfig/pull/615",
+					"https://github.com/giantswarm/aws-operator/pull/X",
 				},
 			},
 		},


### PR DESCRIPTION
v5.6.0 is out. This moves to v5.6.1-dev and clears changelogs.