### PR TITLE
Create ingress wildcard for internal resolution

### DIFF
--- a/service/controller/resource/tccp/template/template_main_record_sets.go
+++ b/service/controller/resource/tccp/template/template_main_record_sets.go
@@ -76,6 +76,15 @@ const TemplateMainRecordSets = `
       Type: CNAME
       ResourceRecords:
         - 'ingress.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+  IngressWildcardInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      TTL: '300'
+      Type: CNAME
+      ResourceRecords:
+        - 'ingress.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
 {{- end -}}
 {{- end -}}
 `

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-when-encrypter-backend-kms-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-when-encrypter-backend-kms-route53-enabled.golden
@@ -466,6 +466,15 @@ Resources:
       Type: CNAME
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+  IngressWildcardInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      TTL: '300'
+      Type: CNAME
+      ResourceRecords:
+        - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-when-encrypter-backend-kms-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-when-encrypter-backend-kms-route53-enabled.golden
@@ -469,6 +469,15 @@ Resources:
       Type: CNAME
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+  IngressWildcardInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      TTL: '300'
+      Type: CNAME
+      ResourceRecords:
+        - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-when-encrypter-backend-vault-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-when-encrypter-backend-vault-route53-enabled.golden
@@ -460,6 +460,15 @@ Resources:
       Type: CNAME
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+  IngressWildcardInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      TTL: '300'
+      Type: CNAME
+      ResourceRecords:
+        - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable

--- a/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-when-encrypter-backend-vault-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-when-encrypter-backend-vault-route53-enabled.golden
@@ -460,6 +460,15 @@ Resources:
       Type: CNAME
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+  IngressWildcardInternalRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: '*.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
+      HostedZoneId: !Ref 'InternalHostedZone'
+      TTL: '300'
+      Type: CNAME
+      ResourceRecords:
+        - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable


### PR DESCRIPTION
If we want to resolver ingress domain from inside the cluster itself, we will need to add a wildcard to the ingress domain in the internal DNS records.

This issue appeared when trying to issue certificates with cert-manager.

More info in https://gigantic.slack.com/archives/C7865GLSY/p1580723650001300
