### PR TITLE
Fix PSP api version

### DIFF
--- a/helm/aws-operator/templates/psp.yaml
+++ b/helm/aws-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}


### PR DESCRIPTION
Same as https://github.com/giantswarm/cluster-operator/pull/931 

> Coming from https://gigantic.slack.com/archives/C76JX6YLQ/p1582535793004300. The CP got updated and we missed to bump cluster-operator.