### PR TITLE
pkg, service: replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion        = "8.1.2-dev"
-	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
-	gitSHA               = "n/a"
-	name          string = "aws-operator"
-	source        string = "https://github.com/giantswarm/aws-operator"
-	version              = "n/a"
+	description        = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
+	gitSHA             = "n/a"
+	name        string = "aws-operator"
+	source      string = "https://github.com/giantswarm/aws-operator"
+	version            = "8.1.2-dev"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -39,6 +39,6 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    Name(),
-		Version: BundleVersion(),
+		Version: Version(),
 	}
 }

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -637,7 +637,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/drainer_resource_set.go
+++ b/service/controller/drainer_resource_set.go
@@ -124,7 +124,7 @@ func newDrainerResourceSet(config drainerResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/machine_deployment_resource_set.go
+++ b/service/controller/machine_deployment_resource_set.go
@@ -473,7 +473,7 @@ func newMachineDeploymentResourceSet(config machineDeploymentResourceSetConfig) 
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.BundleVersion() {
+		if key.OperatorVersion(&cr) == project.Version() {
 			return true
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and now that
it isn't injected during the build from git data, we can remove the
separate concept of _bundle version_ and replace it with just _version_.
