### PR TITLE
copy entityid package from api for CR name generation

### DIFF
--- a/service/controller/resource/ensurecpcrs/entityid/generator.go
+++ b/service/controller/resource/ensurecpcrs/entityid/generator.go
@@ -1,0 +1,48 @@
+package entityid
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+const (
+	// idChars represents the character set used to generate cluster IDs.
+	// (does not contain 1 and l, to avoid confusion)
+	idChars = "023456789abcdefghijkmnopqrstuvwxyz"
+
+	// idLength represents the number of characters used to create a cluster ID.
+	idLength = 5
+)
+
+var (
+	// Use local instance of RNG. Can be overwritten with fixed seed in tests
+	// if needed.
+	localRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+func New() string {
+	for {
+		letterRunes := []rune(idChars)
+		b := make([]rune, idLength)
+		for i := range b {
+			b[i] = letterRunes[localRng.Intn(len(letterRunes))]
+		}
+
+		id := string(b)
+
+		if _, err := strconv.Atoi(id); err == nil {
+			// string is numbers only, which we want to avoid
+			continue
+		}
+
+		matched, err := regexp.MatchString("^[a-z]+$", id)
+		if err == nil && matched == true {
+			// strings is letters only, which we also avoid
+			continue
+		}
+
+		return id
+	}
+}


### PR DESCRIPTION
This is shamelessly copied from https://github.com/giantswarm/api/tree/08ffe0e96d0df349754e62af40c138cd58187f3c/pkg/entityid. This should be ok enough for the time being as this is all about a temporary migration. The idea is just to generate the Control Plane IDs randomly instead of reusing the cluster IDs for them, which would be super weird. 