### PR TITLE
helm: Ensure proper labels on all resources

### DIFF
--- a/helm/aws-operator/Chart.yaml
+++ b/helm/aws-operator/Chart.yaml
@@ -1,2 +1,3 @@
 name: aws-operator
 version: [[ .Version ]]
+appVersion: [[ .Version ]]

--- a/helm/aws-operator/templates/_helpers.tpl
+++ b/helm/aws-operator/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-operator.name" -}}
+{{- default .Chart.Name .Values.project.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-operator.labels" -}}
+helm.sh/chart: {{ include "aws-operator.chart" . }}
+{{ include "aws-operator.selectorLabels" . }}
+{{ include "aws-operator.name" . }}.giantswarm.io/branch: {{ .Values.project.branch }}
+{{ include "aws-operator.name" . }}.giantswarm.io/commit: {{ .Values.project.commit }}
+app.kubernetes.io/name: {{ include "aws-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-operator.selectorLabels" -}}
+app: {{ include "aws-operator.name" . }}
+{{ include "aws-operator.name" . }}.giantswarm.io/version: {{ .Chart.AppVersion }}
+{{- end -}}

--- a/helm/aws-operator/templates/configmap.yaml
+++ b/helm/aws-operator/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 data:
   config.yaml: |
     server:

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -4,15 +4,13 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "aws-operator.labels" . | nindent 4 }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: {{ .Values.project.name }}
-      version: {{ .Values.project.version }}
+      {{- include "aws-operator.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
@@ -20,8 +18,7 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        app: {{ .Values.project.name }}
-        version: {{ .Values.project.version }}
+        {{- include "aws-operator.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
       - name: {{ .Values.project.name }}-configmap

--- a/helm/aws-operator/templates/psp.yaml
+++ b/helm/aws-operator/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/aws-operator/templates/pull-secret.yaml
+++ b/helm/aws-operator/templates/pull-secret.yaml
@@ -4,5 +4,7 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ tpl .Values.resource.pullSecret.name . }}
   namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/aws-operator/templates/rbac.yaml
+++ b/helm/aws-operator/templates/rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - infrastructure.giantswarm.io
@@ -127,6 +129,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}
@@ -140,6 +144,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions
@@ -154,6 +160,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}

--- a/helm/aws-operator/templates/secret.yaml
+++ b/helm/aws-operator/templates/secret.yaml
@@ -4,5 +4,7 @@ type: Opaque
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}
 data:
   secret.yaml: {{ .Values.Installation.V1.Secret.AWSOperator.SecretYaml | b64enc | quote }}

--- a/helm/aws-operator/templates/service-account.yaml
+++ b/helm/aws-operator/templates/service-account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "aws-operator.labels" . | nindent 4 }}

--- a/helm/aws-operator/templates/service.yaml
+++ b/helm/aws-operator/templates/service.yaml
@@ -4,13 +4,11 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "aws-operator.labels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "aws-operator.selectorLabels" . | nindent 4 }}

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -21,6 +21,8 @@ pod:
 project:
   name: "aws-operator"
   version: "[[ .Version ]]"
+  branch: "[[ .Branch ]]"
+  commit: "[[ .SHA ]]"
 # Resource names are truncated to 47 characters. Kubernetes allows 63 characters
 # limit for resource names. When pods for deployments are created they have
 # additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8632

Refactor labels out into a template helper to be able to maintain them
in one place and use on multiple objects. This borrows from a structure
of a default chart template in upstream Helm.

Ensure all resources created when the chart is installed have proper
labels, i.e. `$OPERATOR.giantswarm.io/` + `version` - used as selector
together with `app`, as well as `branch` and `commit` - purely
informational.

Also add common labels advocated by Kubernetes
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
so that resources can be queried and visualised by shared tooling.