### PR TITLE
handle service creation more gracefully in case namespace does not yet exist

### DIFF
--- a/service/controller/resource/service/create.go
+++ b/service/controller/resource/service/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -21,19 +22,25 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	if serviceToCreate != nil {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating service")
 
 		namespace := key.ClusterNamespace(cr)
 		_, err = r.k8sClient.CoreV1().Services(namespace).Create(serviceToCreate)
 		if apierrors.IsAlreadyExists(err) {
 			// fall through
+		} else if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create service")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "namespace not found yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: created")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created service")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: already created")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not create service")
 	}
 
 	return nil

--- a/service/controller/resource/service/current.go
+++ b/service/controller/resource/service/current.go
@@ -17,7 +17,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master service in the Kubernetes API")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the service in the Kubernetes API")
 
 	namespace := key.ClusterNamespace(cr)
 
@@ -26,12 +26,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	{
 		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(masterServiceName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master service in the Kubernetes API")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the service in the Kubernetes API")
 			// fall through
 		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master service in the Kubernetes API")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the service in the Kubernetes API")
 			service = manifest
 		}
 	}

--- a/service/controller/resource/service/update.go
+++ b/service/controller/resource/service/update.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
@@ -24,8 +23,9 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updated services")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to update services")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not update service")
 	}
+
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be updated")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the service has to be updated")
 
 	if isServiceModified(desiredService, currentService) {
 		// Make a copy and set the resource version so the service can be updated.
@@ -67,12 +67,12 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
 			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found service '%s' that has to be updated", desiredService.GetName()))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the service has to be updated")
 
 		return serviceToUpdate, nil
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no services needs update")
-
-		return nil, nil
 	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "the service does not have to be updated")
+
+	return nil, nil
 }


### PR DESCRIPTION
During testing I found an edge case we do not yet cover. The service is actually managed in `cluster-operator` and while it is catching up `aws-operator` may be too fast but should not throw errors. Instead we check for the error and try on the next reconciliation loop. 

> {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource.go:161","controller":"aws-operator-cluster-controller","event":"update","function":"ApplyCreateChange","level":"warning","loop":"6","message":"retrying due to error","object":"/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/awsclusters/swt6m","resource":"service","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource.go:154: } {/go/src/github.com/giantswarm/aws-operator/service/controller/resource/service/create.go:31: } {namespaces \"swt6m\" not found}]","time":"2020-03-05T09:09:03.445095+00:00","version":"12350527"}