### PR TITLE
fetch aws-cni security group

### DIFF
--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -46,6 +46,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpf"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpi"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpoutputs"
+	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpvpcid"
 )
@@ -214,6 +215,18 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		}
 
 		tccpEncryptionResource, err = tccpencryption.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var tccpSecurityGroupsResource resource.Interface
+	{
+		c := tccpsecuritygroups.Config{
+			Logger: config.Logger,
+		}
+
+		tccpSecurityGroupsResource, err = tccpsecuritygroups.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -608,6 +621,7 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		ipamResource,
 		bridgeZoneResource,
 		tccpEncryptionResource,
+		tccpSecurityGroupsResource,
 		s3BucketResource,
 		s3ObjectResource,
 		tccpAZsResource,

--- a/service/controller/resource/tccpsecuritygroups/resource.go
+++ b/service/controller/resource/tccpsecuritygroups/resource.go
@@ -57,6 +57,7 @@ func (r *Resource) addInfoToCtx(ctx context.Context, cr infrastructurev1alpha2.A
 				{
 					Name: aws.String("tag:Name"),
 					Values: []*string{
+						aws.String(key.SecurityGroupName(&cr, "aws-cni")),
 						aws.String(key.SecurityGroupName(&cr, "internal-api")),
 						aws.String(key.SecurityGroupName(&cr, "master")),
 					},
@@ -71,11 +72,11 @@ func (r *Resource) addInfoToCtx(ctx context.Context, cr infrastructurev1alpha2.A
 
 		groups = o.SecurityGroups
 
-		if len(groups) > 2 {
+		if len(groups) > 3 {
 			return microerror.Maskf(executionFailedError, "expected two security groups, got %d", len(groups))
 		}
 
-		if len(groups) < 2 {
+		if len(groups) < 3 {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find security groups for tenant cluster %#q yet", key.ClusterID(&cr)))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9259. We need to configure the `ENIConfig` CRs with the subnet ID we create for the AWS CNI. Thus we fetch the security group when reconciling the TCCP stack. 