### PR TITLE
Set vethpreffix to eni

### DIFF
--- a/service/controller/internal/cloudconfig/template/aws-cni.go
+++ b/service/controller/internal/cloudconfig/template/aws-cni.go
@@ -118,8 +118,6 @@ spec:
           env:
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG
-            - name: AWS_VPC_K8S_CNI_VETHPREFIX
-              value: cali
             - name: AWS_VPC_ENI_MTU
               value: "9001"
             ## Deviation from original manifest - 2
@@ -144,6 +142,10 @@ spec:
             ## disable SNAT as we setup NATGW in the route tables
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
               value: "true"
+            ## Deviation from original manifest - 6
+            ## Explicit interface naming
+            - name: AWS_VPC_K8S_CNI_VETHPREFIX
+              value: eni
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
There are some iptables rules with `eni+` hardcoded in aws cni https://github.com/aws/amazon-vpc-cni-k8s/blob/b0286f121f6996fbdc06f701c31b908bc214c2fa/pkg/networkutils/network.go#L411