### PR TITLE
fix race condition of CIDR Block and VPC PCX

### DIFF
--- a/service/controller/resource/tccp/template/template_main_vpc.go
+++ b/service/controller/resource/tccp/template/template_main_vpc.go
@@ -14,6 +14,7 @@ const TemplateMainVPC = `
         Value: {{ $v.ClusterID }}
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
+    DependsOn: VPCPeeringConnection
     Properties:
       CidrBlock: {{ $v.CIDRBlockAWSCNI }}
       VpcId: !Ref VPC

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-route53-enabled.golden
@@ -928,6 +928,7 @@ Resources:
         Value: 8y5ck
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
+    DependsOn: VPCPeeringConnection
     Properties:
       CidrBlock: 172.17.0.1/16
       VpcId: !Ref VPC

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-route53-enabled.golden
@@ -931,6 +931,7 @@ Resources:
         Value: 8y5ck
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
+    DependsOn: VPCPeeringConnection
     Properties:
       CidrBlock: 172.17.0.1/16
       VpcId: !Ref VPC

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-route53-disabled.golden
@@ -815,6 +815,7 @@ Resources:
         Value: 8y5ck
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
+    DependsOn: VPCPeeringConnection
     Properties:
       CidrBlock: 172.17.0.1/16
       VpcId: !Ref VPC

--- a/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-route53-disabled.golden
@@ -818,6 +818,7 @@ Resources:
         Value: 8y5ck
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
+    DependsOn: VPCPeeringConnection
     Properties:
       CidrBlock: 172.17.0.1/16
       VpcId: !Ref VPC


### PR DESCRIPTION
It seems we just found a race condition right before the release. 