### PR TITLE
'remove-encryption-from-master-volume'

### DIFF
--- a/service/controller/resource/tccp/template/template_main_instance.go
+++ b/service/controller/resource/tccp/template/template_main_instance.go
@@ -26,9 +26,6 @@ const TemplateMainInstance = `
   {{ $v.Master.DockerVolume.ResourceName }}:
     Type: AWS::EC2::Volume
     Properties:
-{{ if eq $v.Master.EncrypterBackend "kms" }}
-      Encrypted: true
-{{ end }}
       Size: 50
       VolumeType: gp2
       AvailabilityZone: {{ $v.Master.AZ }}
@@ -38,9 +35,6 @@ const TemplateMainInstance = `
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-{{ if eq $v.Master.EncrypterBackend "kms" }}
-      Encrypted: true
-{{ end }}
       Size: 100
       VolumeType: gp2
       AvailabilityZone: {{ $v.Master.AZ }}
@@ -50,9 +44,6 @@ const TemplateMainInstance = `
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-{{ if eq $v.Master.EncrypterBackend "kms" }}
-      Encrypted: true
-{{ end }}
       Size: 100
       VolumeType: gp2
       AvailabilityZone: {{ $v.Master.AZ }}

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-without-encryption-key-route53-enabled.golden
@@ -186,7 +186,6 @@ Resources:
   DockerVolume8Y5CK78968:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 50
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -196,7 +195,6 @@ Resources:
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -206,7 +204,6 @@ Resources:
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-with-encryption-key-route53-enabled.golden
@@ -189,7 +189,6 @@ Resources:
   DockerVolume8Y5CK78968:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 50
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -199,7 +198,6 @@ Resources:
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -209,7 +207,6 @@ Resources:
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-without-encryption-key-route53-disabled.golden
@@ -153,7 +153,6 @@ Resources:
   DockerVolume8Y5CK78968:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 50
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -163,7 +162,6 @@ Resources:
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -173,7 +171,6 @@ Resources:
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b

--- a/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-3-basic-test-with-encryption-key-route53-disabled.golden
@@ -156,7 +156,6 @@ Resources:
   DockerVolume8Y5CK78968:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 50
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -166,7 +165,6 @@ Resources:
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -176,7 +174,6 @@ Resources:
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b

--- a/service/controller/resource/tccp/testdata/case-4-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-4-basic-test-with-api-whitelist-enabled.golden
@@ -153,7 +153,6 @@ Resources:
   DockerVolume8Y5CK78968:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 50
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -163,7 +162,6 @@ Resources:
   EtcdVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b
@@ -173,7 +171,6 @@ Resources:
   LogVolume:
     Type: AWS::EC2::Volume
     Properties:
-
       Size: 100
       VolumeType: gp2
       AvailabilityZone: eu-central-1b


### PR DESCRIPTION
because of some unforesson issue we did not have properly set encryption for master volumes, and with removing o vault encryptor this is  render volumes  with encryption flag and causes trouble with update.

We will address this issue when we migrate  to ASG masters, as we migrate etcd volume via snapshot to new volume.
