### PR TITLE
Fix ignition files location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM golang:1.13 AS builder
 ENV GO111MODULE=on
 COPY go.mod /etc/go.mod
 RUN cat /etc/go.mod | grep k8scloudconfig | awk '{print $1"/...@"$2}' | xargs -I{} go get {}
+# This is needed to extract the versioned catalog name, e.g. v6@6.0.1
+RUN ls /go/pkg/mod/github.com/giantswarm/k8scloudconfig/ | head -n1
+RUN ln -s /go/pkg/mod/github.com/giantswarm/k8scloudconfig/$(ls /go/pkg/mod/github.com/giantswarm/k8scloudconfig/ | head -n1) /opt/k8scloudconfig
 
 FROM alpine:3.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/aws-operator
 ADD ./aws-operator /opt/aws-operator/aws-operator
 
 RUN mkdir -p /opt/ignition
-COPY --from=builder /go/pkg/mod/cache/download/github.com/giantswarm/k8scloudconfig /opt/ignition
+COPY --from=builder /opt/k8scloudconfig /opt/ignition
 
 WORKDIR /opt/aws-operator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13 AS builder
 ENV GO111MODULE=on
 COPY go.mod /etc/go.mod
-RUN cat /etc/go.mod | grep k8scloudconfig | awk '{print $1"@"$2}' | xargs -I{} go get {}
+RUN cat /etc/go.mod | grep k8scloudconfig | awk '{print $1"/...@"$2}' | xargs -I{} go get {}
 
 FROM alpine:3.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ENV GO111MODULE=on
 COPY go.mod /etc/go.mod
 RUN cat /etc/go.mod | grep k8scloudconfig | awk '{print $1"/...@"$2}' | xargs -I{} go get {}
 # This is needed to extract the versioned catalog name, e.g. v6@6.0.1
-RUN ls /go/pkg/mod/github.com/giantswarm/k8scloudconfig/ | head -n1
 RUN ln -s /go/pkg/mod/github.com/giantswarm/k8scloudconfig/$(ls /go/pkg/mod/github.com/giantswarm/k8scloudconfig/ | head -n1) /opt/k8scloudconfig
 
 FROM alpine:3.8

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.2.2-dev"
+	version            = "666.0.0"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "666.0.0"
+	version            = "8.2.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Did a little investigation - `cache` folder was not right, it should have been `/go/pkg/mod`.

Also (I found it interesting), the last path segment is versioned, i.e `v6@6.0.1` instead of `v6` found in repository. Added some bash magic to copy it properly. Tested it on _gauss_ by creating a cluster and it works.