### PR TITLE
adding private dns name to ec2 metrics

### DIFF
--- a/service/collector/ec2_instances.go
+++ b/service/collector/ec2_instances.go
@@ -31,6 +31,9 @@ const (
 	// labelInstanceType will contain the instance type name
 	labelInstanceType = "instance_type"
 
+	// labelPrivateDNS will contain the private dns name
+	labelPrivateDNS = "private_dns"
+
 	// subsystemEC2 will become the second part of the metric name, right after namespace.
 	subsystemEC2 = "ec2"
 )
@@ -47,6 +50,7 @@ var (
 			labelOrganization,
 			labelAvailabilityZone,
 			labelInstanceType,
+			labelPrivateDNS,
 			labelInstanceState,
 			labelInstanceStatus,
 		},
@@ -209,7 +213,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 			continue
 		}
 
-		var az, cluster, instanceType, installation, organization, state, status string
+		var az, cluster, instanceType, installation, organization, privateDNS, state, status string
 		for _, tag := range instances[instanceID].Tags {
 			switch *tag.Key {
 			case tagCluster:
@@ -222,6 +226,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 		}
 
 		instanceType = *instances[instanceID].InstanceType
+		privateDNS = *instances[instanceID].PrivateDnsName
 
 		up := 0
 		if statuses.InstanceState.Name != nil {
@@ -248,6 +253,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 			organization,
 			az,
 			instanceType,
+			privateDNS,
 			state,
 			status,
 		)


### PR DESCRIPTION
I just saw that the `node` tag in our ec2 metrics does not map to what we need to make this inhibition rule work: https://github.com/giantswarm/g8s-prometheus/pull/779 
To find the ec2 instance that belongs to a node from kubelet related alerts (eg https://github.com/giantswarm/giantswarm/blob/master/ops-recipes/kubelet-condition-not-ready.md), I want to add the private dns name as a tag there.