### PR TITLE
unify controller context structure for multiple ASGs

### DIFF
--- a/service/controller/controllercontext/status_funcs.go
+++ b/service/controller/controllercontext/status_funcs.go
@@ -1,5 +1,5 @@
 package controllercontext
 
-func (a ContextStatusTenantClusterTCNPASG) IsEmpty() bool {
+func (a ContextStatusTenantClusterASG) IsEmpty() bool {
 	return a.DesiredCapacity == 0 && a.MaxSize == 0 && a.MinSize == 0
 }

--- a/service/controller/controllercontext/status_types.go
+++ b/service/controller/controllercontext/status_types.go
@@ -43,6 +43,13 @@ type ContextStatusTenantCluster struct {
 	OperatorVersion       string
 }
 
+type ContextStatusTenantClusterASG struct {
+	DesiredCapacity int
+	MaxSize         int
+	MinSize         int
+	Name            string
+}
+
 type ContextStatusTenantClusterAWS struct {
 	AccountID string
 	Region    string
@@ -109,13 +116,6 @@ type ContextStatusTenantClusterTCCPVPC struct {
 type ContextStatusTenantClusterTCNP struct {
 	SecurityGroupIDs []string
 	WorkerInstance   ContextStatusTenantClusterTCNPWorkerInstance
-}
-
-type ContextStatusTenantClusterASG struct {
-	DesiredCapacity int
-	MaxSize         int
-	MinSize         int
-	Name            string
 }
 
 type ContextStatusTenantClusterTCNPWorkerInstance struct {

--- a/service/controller/controllercontext/status_types.go
+++ b/service/controller/controllercontext/status_types.go
@@ -33,6 +33,7 @@ type ContextStatusControlPlaneVPC struct {
 }
 
 type ContextStatusTenantCluster struct {
+	ASG                   ContextStatusTenantClusterASG
 	AWS                   ContextStatusTenantClusterAWS
 	Encryption            ContextStatusTenantClusterEncryption
 	HostedZoneNameServers string
@@ -106,12 +107,11 @@ type ContextStatusTenantClusterTCCPVPC struct {
 }
 
 type ContextStatusTenantClusterTCNP struct {
-	ASG              ContextStatusTenantClusterTCNPASG
 	SecurityGroupIDs []string
 	WorkerInstance   ContextStatusTenantClusterTCNPWorkerInstance
 }
 
-type ContextStatusTenantClusterTCNPASG struct {
+type ContextStatusTenantClusterASG struct {
 	DesiredCapacity int
 	MaxSize         int
 	MinSize         int

--- a/service/controller/internal/changedetection/tcnp.go
+++ b/service/controller/internal/changedetection/tcnp.go
@@ -49,16 +49,16 @@ func (t *TCNP) ShouldScale(ctx context.Context, md infrastructurev1alpha2.AWSMac
 		return false, microerror.Mask(err)
 	}
 
-	asgEmpty := cc.Status.TenantCluster.TCNP.ASG.IsEmpty()
-	asgMaxEqual := cc.Status.TenantCluster.TCNP.ASG.MaxSize == key.MachineDeploymentScalingMax(md)
-	asgMinEqual := cc.Status.TenantCluster.TCNP.ASG.MinSize == key.MachineDeploymentScalingMin(md)
+	asgEmpty := cc.Status.TenantCluster.ASG.IsEmpty()
+	asgMaxEqual := cc.Status.TenantCluster.ASG.MaxSize == key.MachineDeploymentScalingMax(md)
+	asgMinEqual := cc.Status.TenantCluster.ASG.MinSize == key.MachineDeploymentScalingMin(md)
 
 	if !asgEmpty && !asgMaxEqual {
-		t.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected tenant cluster node pool should scale up due to scaling max changes from %d to %d", cc.Status.TenantCluster.TCNP.ASG.MaxSize, key.MachineDeploymentScalingMax(md)))
+		t.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected tenant cluster node pool should scale up due to scaling max changes from %d to %d", cc.Status.TenantCluster.ASG.MaxSize, key.MachineDeploymentScalingMax(md)))
 		return true, nil
 	}
 	if !asgEmpty && !asgMinEqual {
-		t.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected tenant cluster node pool should scale down due to scaling min changes from %d to %d", cc.Status.TenantCluster.TCNP.ASG.MinSize, key.MachineDeploymentScalingMin(md)))
+		t.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("detected tenant cluster node pool should scale down due to scaling min changes from %d to %d", cc.Status.TenantCluster.ASG.MinSize, key.MachineDeploymentScalingMin(md)))
 		return true, nil
 	}
 

--- a/service/controller/internal/unittest/default_controller_context.go
+++ b/service/controller/internal/unittest/default_controller_context.go
@@ -228,9 +228,6 @@ func DefaultContext() context.Context {
 						PeeringConnectionID: "peering-connection-id",
 					},
 				},
-				TCNP: controllercontext.ContextStatusTenantClusterTCNP{
-					ASG: controllercontext.ContextStatusTenantClusterTCNPASG{},
-				},
 			},
 		},
 	}
@@ -455,9 +452,6 @@ func DefaultContextChina() context.Context {
 						ID:                  "vpc-id",
 						PeeringConnectionID: "peering-connection-id",
 					},
-				},
-				TCNP: controllercontext.ContextStatusTenantClusterTCNP{
-					ASG: controllercontext.ContextStatusTenantClusterTCNPASG{},
 				},
 			},
 		},

--- a/service/controller/resource/asgstatus/resource.go
+++ b/service/controller/resource/asgstatus/resource.go
@@ -168,10 +168,10 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		cc.Status.TenantCluster.TCNP.ASG.DesiredCapacity = desiredCapacity
-		cc.Status.TenantCluster.TCNP.ASG.MaxSize = maxSize
-		cc.Status.TenantCluster.TCNP.ASG.MinSize = minSize
-		cc.Status.TenantCluster.TCNP.ASG.Name = asgName
+		cc.Status.TenantCluster.ASG.DesiredCapacity = desiredCapacity
+		cc.Status.TenantCluster.ASG.MaxSize = maxSize
+		cc.Status.TenantCluster.ASG.MinSize = minSize
+		cc.Status.TenantCluster.ASG.Name = asgName
 	}
 
 	return nil

--- a/service/controller/resource/drainer/resource.go
+++ b/service/controller/resource/drainer/resource.go
@@ -121,7 +121,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCNP.ASG.Name
+	workerASGName := cc.Status.TenantCluster.ASG.Name
 	if workerASGName == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/resource/drainfinisher/resource.go
+++ b/service/controller/resource/drainfinisher/resource.go
@@ -108,7 +108,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	workerASGName := cc.Status.TenantCluster.TCNP.ASG.Name
+	workerASGName := cc.Status.TenantCluster.ASG.Name
 	if workerASGName == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "worker ASG name is not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -268,7 +268,7 @@ func newAutoScalingGroup(ctx context.Context, cr infrastructurev1alpha2.AWSMachi
 		subnets = append(subnets, key.SanitizeCFResourceName(key.PrivateSubnetName(az.Name)))
 	}
 
-	minDesiredNodes := minDesiredWorkers(key.MachineDeploymentScalingMin(cr), key.MachineDeploymentScalingMax(cr), cc.Status.TenantCluster.TCNP.ASG.DesiredCapacity)
+	minDesiredNodes := minDesiredWorkers(key.MachineDeploymentScalingMin(cr), key.MachineDeploymentScalingMax(cr), cc.Status.TenantCluster.ASG.DesiredCapacity)
 
 	autoScalingGroup := &template.ParamsMainAutoScalingGroup{
 		AvailabilityZones: key.MachineDeploymentAvailabilityZones(cr),


### PR DESCRIPTION
The idea here is to transport ASG information across different controllers. For now we only had ASGs in the machine deployment controller. With HA Masters we also have ASGs in the control plane controller. We want to reuse as much functionality as possible and therefore align the internal data structure used to transport information between resource implementations. 