### PR TITLE
add asgname resource

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.2.4-xh3b4sd"
+	version            = "8.2.4-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.2.4-dev"
+	version            = "8.2.4-xh3b4sd"
 )
 
 func Description() string {

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -6,6 +6,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
@@ -262,6 +265,19 @@ func StackNameTCNP(getter LabelsGetter) string {
 
 func StackNameTCNPF(getter LabelsGetter) string {
 	return fmt.Sprintf("cluster-%s-tcnpf-%s", ClusterID(getter), MachineDeploymentID(getter))
+}
+
+func ToLabelsGetter(v interface{}) (LabelsGetter, error) {
+	if v == nil {
+		return nil, microerror.Maskf(wrongTypeError, "expected 'LabelsGetter', got '%T'", v)
+	}
+
+	m, err := meta.Accessor(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return m, nil
 }
 
 func VPCPeeringRouteName(az string) string {

--- a/service/controller/resource/asgname/create.go
+++ b/service/controller/resource/asgname/create.go
@@ -1,0 +1,16 @@
+package asgname
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.ensure(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/asgname/delete.go
+++ b/service/controller/resource/asgname/delete.go
@@ -1,0 +1,16 @@
+package asgname
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	err := r.ensure(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/asgname/error.go
+++ b/service/controller/resource/asgname/error.go
@@ -1,0 +1,51 @@
+package asgname
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "does not exist") {
+		return true
+	}
+
+	if c == notFoundError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/resource/asgname/resource.go
+++ b/service/controller/resource/asgname/resource.go
@@ -1,0 +1,133 @@
+package asgname
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/aws-operator/pkg/awstags"
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+const (
+	Name = "asgname"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	TagKey       string
+	TagValueFunc func(cr key.LabelsGetter) string
+}
+
+type Resource struct {
+	logger micrologger.Logger
+
+	tagKey       string
+	tagValueFunc func(cr key.LabelsGetter) string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.TagKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TagKey must not be empty", config)
+	}
+	if config.TagValueFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TagValueFunc must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		tagKey:       config.TagKey,
+		tagValueFunc: config.TagValueFunc,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToLabelsGetter(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var asgName string
+	{
+		i := &ec2.DescribeInstancesInput{
+			Filters: []*ec2.Filter{
+				{
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
+					Values: []*string{
+						aws.String(key.ClusterID(cr)),
+					},
+				},
+				{
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagStack)),
+					Values: []*string{
+						aws.String(key.StackTCNP),
+					},
+				},
+				{
+					Name: aws.String(fmt.Sprintf("tag:%s", r.tagKey)),
+					Values: []*string{
+						aws.String(r.tagValueFunc(cr)),
+					},
+				},
+				{
+					Name: aws.String("instance-state-name"),
+					Values: []*string{
+						aws.String(ec2.InstanceStateNamePending),
+						aws.String(ec2.InstanceStateNameRunning),
+						aws.String(ec2.InstanceStateNameStopped),
+						aws.String(ec2.InstanceStateNameStopping),
+					},
+				},
+			},
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.EC2.DescribeInstances(i)
+		if IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "asg not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(o.Reservations) == 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "asg not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
+		if len(o.Reservations[0].Instances) == 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "asg not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return nil
+		}
+
+		asgName = awstags.ValueForKey(o.Reservations[0].Instances[0].Tags, "aws:autoscaling:groupName")
+	}
+
+	{
+		cc.Status.TenantCluster.ASG.Name = asgName
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is towards Node Pools. Follow up of https://github.com/giantswarm/aws-operator/pull/2272. I want to separate the ASG name lookup from the rest of the ASG status gathering so we can reuse certain parts more easily across different controllers. So we have nice little lego blocks we can reuse configured accordingly. 