### PR TITLE
rename controllers

### DIFF
--- a/service/controller/machine_deployment_drainer.go
+++ b/service/controller/machine_deployment_drainer.go
@@ -12,32 +12,32 @@ import (
 	"github.com/giantswarm/aws-operator/pkg/project"
 )
 
-type DrainerConfig struct {
+type MachineDeploymentDrainerConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
 	HostAWSConfig  aws.Config
-	LabelSelector  DrainerConfigLabelSelector
+	LabelSelector  MachineDeploymentDrainerConfigLabelSelector
 	Route53Enabled bool
 }
 
-type DrainerConfigLabelSelector struct {
+type MachineDeploymentDrainerConfigLabelSelector struct {
 	Enabled          bool
 	OverridenVersion string
 }
 
-type Drainer struct {
+type MachineDeploymentDrainer struct {
 	*controller.Controller
 }
 
-func NewDrainer(config DrainerConfig) (*Drainer, error) {
+func NewMachineDeploymentDrainer(config MachineDeploymentDrainerConfig) (*MachineDeploymentDrainer, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 
 	var err error
 
-	resourceSets, err := newDrainerResourceSets(config)
+	resourceSets, err := newMachineDeploymentDrainerResourceSets(config)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -64,19 +64,19 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 		}
 	}
 
-	d := &Drainer{
+	d := &MachineDeploymentDrainer{
 		Controller: operatorkitController,
 	}
 
 	return d, nil
 }
 
-func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, error) {
+func newMachineDeploymentDrainerResourceSets(config MachineDeploymentDrainerConfig) ([]*controller.ResourceSet, error) {
 	var err error
 
 	var resourceSet *controller.ResourceSet
 	{
-		c := drainerResourceSetConfig{
+		c := machineDeploymentDrainerResourceSetConfig{
 			G8sClient: config.K8sClient.G8sClient(),
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
@@ -86,7 +86,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 			Route53Enabled: config.Route53Enabled,
 		}
 
-		resourceSet, err = newDrainerResourceSet(c)
+		resourceSet, err = newMachineDeploymentDrainerResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/machine_deployment_drainer_resource_set.go
+++ b/service/controller/machine_deployment_drainer_resource_set.go
@@ -23,7 +23,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/drainfinisher"
 )
 
-type drainerResourceSetConfig struct {
+type machineDeploymentDrainerResourceSetConfig struct {
 	G8sClient versioned.Interface
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
@@ -33,7 +33,7 @@ type drainerResourceSetConfig struct {
 	Route53Enabled bool
 }
 
-func newDrainerResourceSet(config drainerResourceSetConfig) (*controller.ResourceSet, error) {
+func newMachineDeploymentDrainerResourceSet(config machineDeploymentDrainerResourceSetConfig) (*controller.ResourceSet, error) {
 	var err error
 
 	var asgNameResource resource.Interface

--- a/service/service.go
+++ b/service/service.go
@@ -37,12 +37,12 @@ type Config struct {
 type Service struct {
 	Version *version.Service
 
-	bootOnce                    sync.Once
-	clusterController           *controller.Cluster
-	controlPlaneController      *controller.ControlPlane
-	drainerController           *controller.Drainer
-	machineDeploymentController *controller.MachineDeployment
-	operatorCollector           *collector.Set
+	bootOnce                           sync.Once
+	clusterController                  *controller.Cluster
+	controlPlaneController             *controller.ControlPlane
+	machineDeploymentController        *controller.MachineDeployment
+	machineDeploymentDrainerController *controller.MachineDeploymentDrainer
+	operatorCollector                  *collector.Set
 }
 
 // New creates a new configured service object.
@@ -207,26 +207,6 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
-	var drainerController *controller.Drainer
-	{
-		c := controller.DrainerConfig{
-			K8sClient: k8sClient,
-			Logger:    config.Logger,
-
-			HostAWSConfig: awsConfig,
-			LabelSelector: controller.DrainerConfigLabelSelector{
-				Enabled:          config.Viper.GetBool(config.Flag.Service.Feature.LabelSelector.Enabled),
-				OverridenVersion: config.Viper.GetString(config.Flag.Service.Test.LabelSelector.Version),
-			},
-			Route53Enabled: config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
-		}
-
-		drainerController, err = controller.NewDrainer(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var machineDeploymentController *controller.MachineDeployment
 	{
 		c := controller.MachineDeploymentConfig{
@@ -275,6 +255,26 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var machineDeploymentDrainerController *controller.MachineDeploymentDrainer
+	{
+		c := controller.MachineDeploymentDrainerConfig{
+			K8sClient: k8sClient,
+			Logger:    config.Logger,
+
+			HostAWSConfig: awsConfig,
+			LabelSelector: controller.MachineDeploymentDrainerConfigLabelSelector{
+				Enabled:          config.Viper.GetBool(config.Flag.Service.Feature.LabelSelector.Enabled),
+				OverridenVersion: config.Viper.GetString(config.Flag.Service.Test.LabelSelector.Version),
+			},
+			Route53Enabled: config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
+		}
+
+		machineDeploymentDrainerController, err = controller.NewMachineDeploymentDrainer(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var operatorCollector *collector.Set
 	{
 		c := collector.SetConfig{
@@ -313,12 +313,12 @@ func New(config Config) (*Service, error) {
 	s := &Service{
 		Version: versionService,
 
-		bootOnce:                    sync.Once{},
-		clusterController:           clusterController,
-		controlPlaneController:      controlPlaneController,
-		drainerController:           drainerController,
-		machineDeploymentController: machineDeploymentController,
-		operatorCollector:           operatorCollector,
+		bootOnce:                           sync.Once{},
+		clusterController:                  clusterController,
+		controlPlaneController:             controlPlaneController,
+		machineDeploymentController:        machineDeploymentController,
+		machineDeploymentDrainerController: machineDeploymentDrainerController,
+		operatorCollector:                  operatorCollector,
 	}
 
 	return s, nil
@@ -330,7 +330,7 @@ func (s *Service) Boot(ctx context.Context) {
 
 		go s.clusterController.Boot(ctx)
 		go s.controlPlaneController.Boot(ctx)
-		go s.drainerController.Boot(ctx)
 		go s.machineDeploymentController.Boot(ctx)
+		go s.machineDeploymentDrainerController.Boot(ctx)
 	})
 }


### PR DESCRIPTION
We are about to get a new drainer controller for the Control Plane CRs because this is where the new ASGs for the HA Masters will be managed. They need draining as well. So we sort the naming and make space for the new controllers. 