### PR TITLE
drop CRD management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Control Plane drainer controller.
 
+### Changed
+
+- Drop CRD management to not ensure CRDs in operators anymore.
+
 ### Fixed
 
 - Fix aws operator policy for latest node pools version.

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -102,7 +102,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          infrastructurev1alpha2.NewAWSClusterCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -38,7 +38,6 @@ func NewControlPlane(config ControlPlaneConfig) (*ControlPlane, error) {
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          infrastructurev1alpha2.NewAWSControlPlaneCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,

--- a/service/controller/control_plane_drainer.go
+++ b/service/controller/control_plane_drainer.go
@@ -44,7 +44,6 @@ func NewControlPlaneDrainer(config ControlPlaneDrainerConfig) (*ControlPlaneDrai
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          infrastructurev1alpha2.NewAWSControlPlaneCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -73,7 +73,6 @@ func NewMachineDeployment(config MachineDeploymentConfig) (*MachineDeployment, e
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          infrastructurev1alpha2.NewAWSMachineDeploymentCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,

--- a/service/controller/machine_deployment_drainer.go
+++ b/service/controller/machine_deployment_drainer.go
@@ -44,7 +44,6 @@ func NewMachineDeploymentDrainer(config MachineDeploymentDrainerConfig) (*Machin
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          infrastructurev1alpha2.NewAWSMachineDeploymentCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,


### PR DESCRIPTION
With https://github.com/giantswarm/opsctl/pull/596 we do not want to ensure CRDs in the operators. This is because of complications with the CRD update mechanism, which we work around by having a single authority managing CRDs. 

## Checklist

- [x] Update changelog in CHANGELOG.md.
