### PR TITLE
'fix route53Enabled propagation'

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -219,6 +219,7 @@ func New(config Config) (*Service, error) {
 			InstallationName:          config.Viper.GetString(config.Flag.Service.Installation.Name),
 			NetworkSetupDockerImage:   config.Viper.GetString(config.Flag.Service.Cluster.Kubernetes.NetworkSetup.Docker.Image),
 			PodInfraContainerImage:    config.Viper.GetString(config.Flag.Service.AWS.PodInfraContainerImage),
+			Route53Enabled:            config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RegistryDomain:            config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			SSHUserList:               config.Viper.GetString(config.Flag.Service.Cluster.Kubernetes.SSH.UserList),
 			SSOPublicKey:              config.Viper.GetString(config.Flag.Service.Guest.SSH.SSOPublicKey),


### PR DESCRIPTION
I missed  one line for setting the route53Enabled value for control plane resource set 

this caused that route53 role was not created and exernal-dns did not worked
