### PR TITLE
Rm tccpoutputs from cluster

### DIFF
--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -52,7 +52,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpf"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpi"
-	"github.com/giantswarm/aws-operator/service/controller/resource/tccpoutputs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpvpcid"
@@ -437,21 +436,6 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		}
 	}
 
-	var tccpOutputsResource resource.Interface
-	{
-		c := tccpoutputs.Config{
-			Logger: config.Logger,
-
-			Route53Enabled: config.Route53Enabled,
-			ToClusterFunc:  key.ToCluster,
-		}
-
-		tccpOutputsResource, err = tccpoutputs.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tccpSubnetsResource resource.Interface
 	{
 		c := tccpsubnets.Config{
@@ -658,7 +642,6 @@ func newClusterResourceSet(config clusterResourceSetConfig) (*controller.Resourc
 		cpRouteTablesResource,
 		cpVPCResource,
 		tccpVPCIDResource,
-		tccpOutputsResource,
 		tccpSubnetsResource,
 		regionResource,
 		tenantClientsResource,

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -806,6 +806,7 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane cloud formation stack")
 	}
+
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the update of the tenant cluster's control plane cloud formation stack")
 

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -806,7 +806,6 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane cloud formation stack")
 	}
-
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the update of the tenant cluster's control plane cloud formation stack")
 


### PR DESCRIPTION
this caused issues with updates as the update did not proceed since  the new tccpoutputs were not available and that caused cancellign the reconcilation

 i don't see any reason why `tccpoutputs` should be in the cluster resource as none of the values is used there so removing 