### PR TITLE
Allow not found error for new outputs

### DIFF
--- a/service/controller/resource/tccpoutputs/create.go
+++ b/service/controller/resource/tccpoutputs/create.go
@@ -73,7 +73,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		{
 			v, err := cloudFormation.GetOutputValue(outputs, HostedZoneID)
 			// migration code to dont throw error  when the old C dont yet have the new output value
-			// TODO
+			// TODO https://github.com/giantswarm/giantswarm/issues/10139
 			// after migration we can remove the check for IsOutputNotFound
 			if cloudformation.IsOutputNotFound(err) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "did not found the tenant cluster's control plane hostedZoneID output")
@@ -97,7 +97,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		{
 			v, err := cloudFormation.GetOutputValue(outputs, InternalHostedZoneID)
 			// migration code to dont throw error  when the old C dont yet have the new output value
-			// TODO
+			// TODO https://github.com/giantswarm/giantswarm/issues/10139
 			// after migration we can remove the check for IsOutputNotFound
 			if cloudformation.IsOutputNotFound(err) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "did not found the tenant cluster's control plane internalHostedZoneID output")

--- a/service/controller/resource/tccpoutputs/create.go
+++ b/service/controller/resource/tccpoutputs/create.go
@@ -72,10 +72,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if r.route53Enabled {
 		{
 			v, err := cloudFormation.GetOutputValue(outputs, HostedZoneID)
-			if err != nil {
-				return microerror.Mask(err)
+			// migration code to dont throw error  when the old C dont yet have the new output value
+			// TODO
+			// after migration we can remove the check for IsOutputNotFound
+			if cloudformation.IsOutputNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "did not found the tenant cluster's control plane hostedZoneID output")
+			} else {
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				cc.Status.TenantCluster.DNS.HostedZoneID = v
 			}
-			cc.Status.TenantCluster.DNS.HostedZoneID = v
+
 		}
 
 		{
@@ -88,10 +96,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		{
 			v, err := cloudFormation.GetOutputValue(outputs, InternalHostedZoneID)
-			if err != nil {
-				return microerror.Mask(err)
+			// migration code to dont throw error  when the old C dont yet have the new output value
+			// TODO
+			// after migration we can remove the check for IsOutputNotFound
+			if cloudformation.IsOutputNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "did not found the tenant cluster's control plane internalHostedZoneID output")
+			} else {
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				cc.Status.TenantCluster.DNS.InternalHostedZoneID = v
 			}
-			cc.Status.TenantCluster.DNS.InternalHostedZoneID = v
 		}
 
 	}


### PR DESCRIPTION
allow error OutputNotFoundError for tccpoutputs for migration

this accidentally break update as during update the expected new values are not available in old CF 

TODO issue https://github.com/giantswarm/giantswarm/issues/10139

