### PR TITLE
'add-all-ec2-permissions-as-in-old-tccp-role'

### DIFF
--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -23,25 +23,8 @@ const TemplateMainIAMPolicies = `
         Version: "2012-10-17"
         Statement:
           - Effect: "Allow"
-            Action: "ec2:Describe*"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:AttachVolume"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:DetachVolume"
-            Resource: "*"
-          - Effect: Allow
-            Action: 
-             - "ec2:AuthorizeSecurityGroupIngress"
-             - "ec2:CreateSecurityGroup"
-             - "ec2:CreateTags"
-             - "ec2:DeleteTags"
-             - "ec2:DeleteSecurityGroup"
-             - "ec2:ModifyInstanceAttribute"
-             - "ec2:ModifyNetworkInterfaceAttribute"
-             - "ec2:RevokeSecurityGroupIngress"
-            Resource: "*"
+            Action: "ec2:*"
+            Resource: "*"          
           {{- if .IAMPolicies.KMSKeyARN }}
           - Effect: "Allow"
             Action: "kms:Decrypt"

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -103,24 +103,7 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: "Allow"
-            Action: "ec2:Describe*"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:AttachVolume"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:DetachVolume"
-            Resource: "*"
-          - Effect: Allow
-            Action: 
-             - "ec2:AuthorizeSecurityGroupIngress"
-             - "ec2:CreateSecurityGroup"
-             - "ec2:CreateTags"
-             - "ec2:DeleteTags"
-             - "ec2:DeleteSecurityGroup"
-             - "ec2:ModifyInstanceAttribute"
-             - "ec2:ModifyNetworkInterfaceAttribute"
-             - "ec2:RevokeSecurityGroupIngress"
+            Action: "ec2:*"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -103,24 +103,7 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: "Allow"
-            Action: "ec2:Describe*"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:AttachVolume"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:DetachVolume"
-            Resource: "*"
-          - Effect: Allow
-            Action: 
-             - "ec2:AuthorizeSecurityGroupIngress"
-             - "ec2:CreateSecurityGroup"
-             - "ec2:CreateTags"
-             - "ec2:DeleteTags"
-             - "ec2:DeleteSecurityGroup"
-             - "ec2:ModifyInstanceAttribute"
-             - "ec2:ModifyNetworkInterfaceAttribute"
-             - "ec2:RevokeSecurityGroupIngress"
+            Action: "ec2:*"
             Resource: "*"
           - Effect: "Allow"
             Action:


### PR DESCRIPTION
just making it's same as we had in the tccp IAM role, to avoid any surprise that something won't work
https://github.com/giantswarm/aws-operator/blob/master/service/controller/resource/tccp/template/template_main_iam_policies.go#L26-L28
