### PR TITLE
legacy: Remove CRD management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch from dep to Go modules.
 - Use release.Revision in Helm chart for Helm 3 support.
 
+### Removed
+
+- Management of AWSConfig CRD.
 
 ## [5.6.0] - 2020-01-29
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ go build github.com/giantswarm/aws-operator
 
 ## Architecture
 
+The operator uses our [operatorkit][1] framework.
+
 The operator provisions guest Kubernetes clusters running on AWS. It runs in a
 host Kubernetes cluster also running on AWS.
 
 [1]:https://github.com/giantswarm/operatorkit
-[2]:https://github.com/giantswarm/apiextensions
-[3]:https://github.com/giantswarm/versionbundle
 
 ### CloudFormation
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ go build github.com/giantswarm/aws-operator
 
 ## Architecture
 
-The operator uses our [operatorkit][1] framework. It manages an `awsconfig`
-CRD using a generated client stored in our [apiextensions][2] repo. Releases
-are versioned using [version bundles][3].
-
 The operator provisions guest Kubernetes clusters running on AWS. It runs in a
 host Kubernetes cluster also running on AWS.
 

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -238,6 +238,17 @@ func installResources(ctx context.Context, config Config) error {
 		}
 	}
 
+	// Install AWSConfig CRD since it is no longer installed by the operator.
+	// If the CRD doesn't exist it fails.
+	{
+		b := backoff.NewMaxRetries(5, 2*time.Second)
+
+		err := config.CPCRDClient.EnsureCreated(ctx, providerv1alpha1.NewAWSConfigCRD(), b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	// Install AWSCluster CRD for IPAM resource. It checks clusters objects
 	// for allocated ranges. If the CRD doesn't exist it fails.
 	{

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -99,7 +99,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 	var clusterController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          v1alpha1.NewAWSConfigCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -50,7 +50,6 @@ func NewDrainer(config DrainerConfig) (*Drainer, error) {
 	var drainerController *controller.Controller
 	{
 		c := controller.Config{
-			CRD:          v1alpha1.NewAWSConfigCRD(),
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,


### PR DESCRIPTION
Based on this https://github.com/giantswarm/aws-operator/pull/2291#issuecomment-612899936, since `legacy` is now using `k8sclient` with go modules, we should remove CRD management and allow them to be installed with `opsctl ensure crds` instead.

## Checklist

- [x] Update changelog in CHANGELOG.md.
