### PR TITLE
do not execute PR job on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
             branches:
               ignore: master
             tags:
-              only: /^v.*/
+              ignore: /^v.*/
 
       - architect/push-to-app-catalog:
           name: push-to-app-catalog-master

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The aws-operator manages Kubernetes clusters running on AWS.
     - Contains only the latest version of controllers (reconciling cluster API
       objects).
 
+
+
 ## Getting the Project
 
 Download the latest release:


### PR DESCRIPTION
<img width="1182" alt="Screenshot 2020-04-23 at 16 43 31" src="https://user-images.githubusercontent.com/552769/80112835-d770f100-8581-11ea-99dd-74f3584bd149.png">

Follow up of https://github.com/giantswarm/aws-operator/pull/2347. Screenshot taken from [the last build on tag push](https://app.circleci.com/pipelines/github/giantswarm/aws-operator/3349/workflows/4726f066-f33b-4686-8845-067e03eb9fe7). The `push-to-aliyun-pr` job should not be run when tags are pushed. 