### PR TITLE
Add network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add common labels to our managed components.
 - Disable profiling for Controller Manager and Scheduler.
 - Add network policy.
-- Move containerPort values to `values.yaml`.
+- Move containerPort values from deployment to `values.yaml`.
 
 ## [8.4.0] 2020-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add common labels to our managed components.
 - Disable profiling for Controller Manager and Scheduler.
+- Add network policy.
+- Move containerPort values to `values.yaml`.
 
 ## [8.4.0] 2020-04-23
 

--- a/helm/aws-operator/templates/_resource.tpl
+++ b/helm/aws-operator/templates/_resource.tpl
@@ -11,12 +11,12 @@ room for such suffix.
 {{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "resource.psp.name" -}}
-{{- include "resource.default.name" . -}}-psp
-{{- end -}}
-
 {{- define "resource.networkPolicy.name" -}}
 {{- include "resource.default.name" . -}}-network-policy
+{{- end -}}
+
+{{- define "resource.psp.name" -}}
+{{- include "resource.default.name" . -}}-psp
 {{- end -}}
 
 {{- define "resource.pullSecret.name" -}}

--- a/helm/aws-operator/templates/_resource.tpl
+++ b/helm/aws-operator/templates/_resource.tpl
@@ -15,6 +15,10 @@ room for such suffix.
 {{- include "resource.default.name" . -}}-psp
 {{- end -}}
 
+{{- define "resource.networkPolicy.name" -}}
+{{- include "resource.default.name" . -}}-network-policy
+{{- end -}}
+
 {{- define "resource.pullSecret.name" -}}
 {{- include "resource.default.name" . -}}-pull-secret
 {{- end -}}

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -51,9 +51,14 @@ spec:
           readOnly: true
         - name: certs
           mountPath: /etc/ssl/certs/ca-certificates.crt
+        {{- if .Values.ports.ingress }}
         ports:
-        - name: http
-          containerPort: 8000
+        {{- range .Values.ports.ingress }}
+        - name: {{ .name }}
+          containerPort: {{ .port }}
+          protocol: {{ .protocol }}
+        {{- end }}
+        {{- end }}
         args:
         - daemon
         - --config.dirs=/var/run/{{ .Chart.Name }}/configmap/

--- a/helm/aws-operator/templates/network-policy.yaml
+++ b/helm/aws-operator/templates/network-policy.yaml
@@ -1,0 +1,26 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "resource.networkPolicy.name" . }}
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  {{- if .Values.ports.ingress }}
+  ingress:
+  - ports:
+  {{- range .Values.ports.ingress }}
+    - port: {{ .port }}
+      protocol: {{ .protocol }}
+  {{- end }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  egress:
+  - {}
+  policyTypes:
+  - Egress
+  - Ingress

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -18,6 +18,11 @@ pod:
     id: 1000
   group:
     id: 1000
+ports:
+  ingress:
+    - name: "http"
+      port: 8000
+      protocol: "TCP"
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/4383

tcpdump shows ingress is required to port 8000:

```
13:16:54.878524 IP 10.0.5.139.41218 > 10.100.2.71.8000: Flags [S], seq 1087225694, win 62727, options [mss 8961,nop,nop,sackOK,nop,wscale 7], length 0
13:16:54.878549 IP 10.100.2.71.8000 > 10.0.5.139.41218: Flags [S.], seq 2940511237, ack 1087225695, win 62727, options [mss 8961,nop,nop,sackOK,nop,wscale 7], length 0
13:16:54.878569 IP 10.0.5.139.41218 > 10.100.2.71.8000: Flags [.], ack 1, win 491, length 0
13:16:54.878768 IP 10.0.5.139.41218 > 10.100.2.71.8000: Flags [P.], seq 1:121, ack 1, win 491, length 120
```