### PR TITLE
Add release resource

### DIFF
--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -130,7 +130,7 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 	{
 		c := release.Config{
 			G8sClient: config.G8sClient,
-			Logger: config.Logger,
+			Logger:    config.Logger,
 		}
 
 		releaseResource, err = release.New(c)

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -29,6 +29,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/cpvpc"
 	"github.com/giantswarm/aws-operator/service/controller/resource/encryptionsearcher"
 	"github.com/giantswarm/aws-operator/service/controller/resource/region"
+	"github.com/giantswarm/aws-operator/service/controller/resource/release"
 	"github.com/giantswarm/aws-operator/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/resource/snapshotid"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
@@ -120,6 +121,19 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		}
 
 		encrypterObject, err = kms.NewEncrypter(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var releaseResource resource.Interface
+	{
+		c := release.Config{
+			G8sClient: config.G8sClient,
+			Logger: config.Logger,
+		}
+
+		releaseResource, err = release.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -363,6 +377,7 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		awsClientResource,
 		accountIDResource,
 		encryptionSearcherResource,
+		releaseResource,
 		tccpnOutputsResource,
 		snapshotIDResource,
 		tccpAZsResource,

--- a/service/controller/controllercontext/spec.go
+++ b/service/controller/controllercontext/spec.go
@@ -2,6 +2,8 @@ package controllercontext
 
 import (
 	"net"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 )
 
 type ContextSpec struct {
@@ -9,8 +11,9 @@ type ContextSpec struct {
 }
 
 type ContextSpecTenantCluster struct {
-	TCCP ContextSpecTenantClusterTCCP
-	TCNP ContextSpecTenantClusterTCNP
+	Release v1alpha1.Release
+	TCCP    ContextSpecTenantClusterTCCP
+	TCNP    ContextSpecTenantClusterTCNP
 }
 
 type ContextSpecTenantClusterTCCP struct {

--- a/service/controller/machine_deployment_resource_set.go
+++ b/service/controller/machine_deployment_resource_set.go
@@ -35,6 +35,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/encryptionsearcher"
 	"github.com/giantswarm/aws-operator/service/controller/resource/ipam"
 	"github.com/giantswarm/aws-operator/service/controller/resource/region"
+	"github.com/giantswarm/aws-operator/service/controller/resource/release"
 	"github.com/giantswarm/aws-operator/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpnatgateways"
@@ -190,6 +191,19 @@ func newMachineDeploymentResourceSet(config machineDeploymentResourceSetConfig) 
 		}
 
 		accountIDResource, err = accountid.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var releaseResource resource.Interface
+	{
+		c := release.Config{
+			G8sClient: config.K8sClient.G8sClient(),
+			Logger:    config.Logger,
+		}
+
+		releaseResource, err = release.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -516,6 +530,7 @@ func newMachineDeploymentResourceSet(config machineDeploymentResourceSetConfig) 
 		// into the controller context.
 		awsClientResource,
 		accountIDResource,
+		releaseResource,
 		encryptionSearcherResource,
 		regionResource,
 		cpRouteTablesResource,

--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -1,4 +1,4 @@
-package accountid
+package release
 
 import (
 	"context"

--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -1,0 +1,23 @@
+package accountid
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.addReleaseToContext(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -14,7 +14,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	err = r.addReleaseToContext(ctx, cr)
+	err = r.addReleaseToContext(ctx, &cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -4,17 +4,16 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-
-	"github.com/giantswarm/aws-operator/service/controller/key"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCluster(obj)
+	cr, err := meta.Accessor(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = r.addReleaseToContext(ctx, &cr)
+	err = r.addReleaseToContext(ctx, cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/release/delete.go
+++ b/service/controller/resource/release/delete.go
@@ -1,4 +1,4 @@
-package accountid
+package release
 
 import (
 	"context"

--- a/service/controller/resource/release/delete.go
+++ b/service/controller/resource/release/delete.go
@@ -1,0 +1,9 @@
+package accountid
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/release/error.go
+++ b/service/controller/resource/release/error.go
@@ -1,0 +1,14 @@
+package accountid
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/release/error.go
+++ b/service/controller/resource/release/error.go
@@ -1,4 +1,4 @@
-package accountid
+package release
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -1,4 +1,4 @@
-package accountid
+package release
 
 import (
 	"context"

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -51,7 +51,7 @@ func (r *Resource) addReleaseToContext(ctx context.Context, cr metav1.Object) er
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	
+
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
 

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -29,12 +29,16 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
 	r := &Resource{
-		logger: config.Logger,
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
 	}
 
 	return r, nil

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -2,9 +2,7 @@ package release
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -48,7 +46,7 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) addReleaseToContext(ctx context.Context, cr *v1alpha2.AWSCluster) error {
+func (r *Resource) addReleaseToContext(ctx context.Context, cr metav1.Object) error {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
@@ -60,7 +58,7 @@ func (r *Resource) addReleaseToContext(ctx context.Context, cr *v1alpha2.AWSClus
 		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
 
 		releaseVersion := key.ReleaseVersion(cr)
-		releaseName := fmt.Sprintf("v%s", releaseVersion)
+		releaseName := key.ReleaseName(releaseVersion)
 		release, err := r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -51,9 +51,7 @@ func (r *Resource) addReleaseToContext(ctx context.Context, cr metav1.Object) er
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	// Here we take the STS client scoped to the control plane AWS account to
-	// lookup its ID. The ID is then set to the controller context.
+	
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
 

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -1,0 +1,71 @@
+package accountid
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+)
+
+const (
+	Name = "release"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) addReleaseToContext(ctx context.Context, cr v1alpha2.AWSCluster) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Here we take the STS client scoped to the control plane AWS account to
+	// lookup its ID. The ID is then set to the controller context.
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
+
+		releaseVersion := cr.Labels[label.Release]
+		releaseName := fmt.Sprintf("v%s", releaseVersion)
+		release, err := r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		cc.Spec.TenantCluster.Release = *release
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
+	}
+
+	return nil
+}

--- a/service/controller/resource/release/resource.go
+++ b/service/controller/resource/release/resource.go
@@ -10,8 +10,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
 const (
@@ -44,7 +44,7 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func (r *Resource) addReleaseToContext(ctx context.Context, cr v1alpha2.AWSCluster) error {
+func (r *Resource) addReleaseToContext(ctx context.Context, cr *v1alpha2.AWSCluster) error {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
@@ -55,7 +55,7 @@ func (r *Resource) addReleaseToContext(ctx context.Context, cr v1alpha2.AWSClust
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the tenant cluster release label")
 
-		releaseVersion := cr.Labels[label.Release]
+		releaseVersion := key.ReleaseVersion(cr)
 		releaseName := fmt.Sprintf("v%s", releaseVersion)
 		release, err := r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Since release will be accessed in multiple places, it should be set in a separate resource. This is ported from recent work on the `legacy` branch.
