### PR TITLE
Release v5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [5.7.1] - 2020-05-07
+
+### Fixed
 
 - Correct conntrack configuration structure for kube-proxy.
 
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to Kubernetes 1.15.5.
 
 
-[Unreleased]: https://github.com/giantswarm/aws-operator/compare/v5.7.0...legacy
-[5.7.0]: https://github.com/giantswarm/aws-operator/releases/tag/v5.6.0
+[Unreleased]: https://github.com/giantswarm/aws-operator/compare/v5.7.1...legacy
+[5.7.1]: https://github.com/giantswarm/aws-operator/releases/tag/v5.7.1
+[5.7.0]: https://github.com/giantswarm/aws-operator/releases/tag/v5.7.0
 [5.6.0]: https://github.com/giantswarm/aws-operator/releases/tag/v5.6.0
 [5.5.0]: https://github.com/giantswarm/aws-operator/releases/tag/v5.5.0


### PR DESCRIPTION
FYI @giantswarm/team-firecracker This includes two fixes discovered while preparing the 9.3.0 release. We will drop the problematic aws-operator@v5.7.0 once this is released.

## Checklist

- [x] Update changelog in CHANGELOG.md.
