### PR TITLE
prevent master instance termination of different stacks

### DIFF
--- a/service/controller/resource/tccp/resource.go
+++ b/service/controller/resource/tccp/resource.go
@@ -134,6 +134,12 @@ func (r *Resource) searchMasterInstanceID(ctx context.Context, cr infrastructure
 					},
 				},
 				{
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagStack)),
+					Values: []*string{
+						aws.String(key.StackTCCP),
+					},
+				},
+				{
 					Name: aws.String("instance-state-name"),
 					Values: []*string{
 						aws.String(ec2.InstanceStateNamePending),


### PR DESCRIPTION
During testing we noticed that the master instance running in the TCCPN ASG is being terminated by the TCCP handler logic. I was thinking to maintain the old deletion code for upgrade reasons in case older clusters are still being migrated. To fix the problem we just add an additional tag filter to figure the right EC2 instance. With the newer versions we should then just not find any EC2 instance and be fine. Later we can drop the code eventually. No biggy. 