### PR TITLE
Move operator version into individual stacks

### DIFF
--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpn"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpnoutputs"
+	"github.com/giantswarm/aws-operator/service/controller/resource/tccpoutputs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpvpcid"
@@ -259,6 +260,21 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		}
 	}
 
+	var tccpOutputsResource resource.Interface
+	{
+		c := tccpoutputs.Config{
+			Logger: config.Logger,
+
+			Route53Enabled: config.Route53Enabled,
+			ToClusterFunc:  newControlPlaneToClusterFunc(config.G8sClient),
+		}
+
+		tccpOutputsResource, err = tccpoutputs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var tccpSecurityGroupsResource resource.Interface
 	{
 		c := tccpsecuritygroups.Config{
@@ -350,6 +366,7 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		tccpnOutputsResource,
 		snapshotIDResource,
 		tccpAZsResource,
+		tccpOutputsResource,
 		tccpSecurityGroupsResource,
 		tccpVPCIDResource,
 		tccpVPCPCXResource,

--- a/service/controller/control_plane_resource_set.go
+++ b/service/controller/control_plane_resource_set.go
@@ -34,7 +34,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpazs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpn"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpnoutputs"
-	"github.com/giantswarm/aws-operator/service/controller/resource/tccpoutputs"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsecuritygroups"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpsubnets"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpvpcid"
@@ -260,21 +259,6 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		}
 	}
 
-	var tccpOutputsResource resource.Interface
-	{
-		c := tccpoutputs.Config{
-			Logger: config.Logger,
-
-			Route53Enabled: config.Route53Enabled,
-			ToClusterFunc:  newControlPlaneToClusterFunc(config.G8sClient),
-		}
-
-		tccpOutputsResource, err = tccpoutputs.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tccpSecurityGroupsResource resource.Interface
 	{
 		c := tccpsecuritygroups.Config{
@@ -366,7 +350,6 @@ func newControlPlaneResourceSet(config controlPlaneResourceSetConfig) (*controll
 		tccpnOutputsResource,
 		snapshotIDResource,
 		tccpAZsResource,
-		tccpOutputsResource,
 		tccpSecurityGroupsResource,
 		tccpVPCIDResource,
 		tccpVPCPCXResource,

--- a/service/controller/controllercontext/status_types.go
+++ b/service/controller/controllercontext/status_types.go
@@ -33,16 +33,15 @@ type ContextStatusControlPlaneVPC struct {
 }
 
 type ContextStatusTenantCluster struct {
-	ASG             ContextStatusTenantClusterASG
-	AWS             ContextStatusTenantClusterAWS
-	DNS             ContextStatusTenantClusterDNS
-	Encryption      ContextStatusTenantClusterEncryption
-	MasterInstance  ContextStatusTenantClusterMasterInstance
-	S3Object        ContextStatusTenantClusterS3Object
-	TCCP            ContextStatusTenantClusterTCCP
-	TCCPN           ContextStatusTenantClusterTCCPN
-	TCNP            ContextStatusTenantClusterTCNP
-	OperatorVersion string
+	ASG            ContextStatusTenantClusterASG
+	AWS            ContextStatusTenantClusterAWS
+	DNS            ContextStatusTenantClusterDNS
+	Encryption     ContextStatusTenantClusterEncryption
+	MasterInstance ContextStatusTenantClusterMasterInstance
+	S3Object       ContextStatusTenantClusterS3Object
+	TCCP           ContextStatusTenantClusterTCCP
+	TCCPN          ContextStatusTenantClusterTCCPN
+	TCNP           ContextStatusTenantClusterTCNP
 }
 
 type ContextStatusTenantClusterASG struct {
@@ -80,6 +79,7 @@ type ContextStatusTenantClusterTCCP struct {
 	AvailabilityZones []ContextStatusTenantClusterTCCPAvailabilityZone
 	IsTransitioning   bool
 	NATGateways       []*ec2.NatGateway
+	OperatorVersion   string
 	RouteTables       []*ec2.RouteTable
 	SecurityGroups    []*ec2.SecurityGroup
 	Subnets           []*ec2.Subnet
@@ -130,10 +130,12 @@ type ContextStatusTenantClusterTCCPN struct {
 	EtcdVolumeSnapshotID string
 	IsTransitioning      bool
 	InstanceType         string
+	OperatorVersion      string
 }
 
 type ContextStatusTenantClusterTCNP struct {
 	Instances        ContextStatusTenantClusterTCNPInstances
+	OperatorVersion  string
 	SecurityGroupIDs []string
 	WorkerInstance   ContextStatusTenantClusterTCNPWorkerInstance
 }

--- a/service/controller/internal/changedetection/tccp.go
+++ b/service/controller/internal/changedetection/tccp.go
@@ -46,7 +46,7 @@ func (t *TCCP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSCl
 	}
 
 	azsEqual := availabilityZonesEqual(cc.Spec.TenantCluster.TCCP.AvailabilityZones, cc.Status.TenantCluster.TCCP.AvailabilityZones)
-	operatorVersionEqual := cc.Status.TenantCluster.OperatorVersion == key.OperatorVersion(&cr)
+	operatorVersionEqual := cc.Status.TenantCluster.TCCP.OperatorVersion == key.OperatorVersion(&cr)
 
 	if !azsEqual {
 		t.logger.LogCtx(ctx,
@@ -60,7 +60,7 @@ func (t *TCCP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSCl
 		t.logger.LogCtx(ctx,
 			"level", "debug",
 			"message", "detected TCCP stack should update",
-			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.OperatorVersion, key.OperatorVersion(&cr)),
+			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.TCCP.OperatorVersion, key.OperatorVersion(&cr)),
 		)
 		return true, nil
 	}

--- a/service/controller/internal/changedetection/tccpn.go
+++ b/service/controller/internal/changedetection/tccpn.go
@@ -46,7 +46,7 @@ func (t *TCCPN) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSC
 	}
 
 	masterInstanceEqual := cc.Status.TenantCluster.TCCPN.InstanceType == key.ControlPlaneInstanceType(cr)
-	operatorVersionEqual := cc.Status.TenantCluster.OperatorVersion == key.OperatorVersion(&cr)
+	operatorVersionEqual := cc.Status.TenantCluster.TCCPN.OperatorVersion == key.OperatorVersion(&cr)
 
 	if !masterInstanceEqual {
 		t.logger.LogCtx(
@@ -61,7 +61,7 @@ func (t *TCCPN) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSC
 		t.logger.LogCtx(ctx,
 			"level", "debug",
 			"message", "detected TCCPN stack should update",
-			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.OperatorVersion, key.OperatorVersion(&cr)),
+			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.TCCPN.OperatorVersion, key.OperatorVersion(&cr)),
 		)
 		return true, nil
 	}

--- a/service/controller/internal/changedetection/tcnp.go
+++ b/service/controller/internal/changedetection/tcnp.go
@@ -86,7 +86,7 @@ func (t *TCNP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSMa
 
 	dockerVolumeEqual := cc.Status.TenantCluster.TCNP.WorkerInstance.DockerVolumeSizeGB == key.MachineDeploymentDockerVolumeSizeGB(cr)
 	instanceTypeEqual := cc.Status.TenantCluster.TCNP.WorkerInstance.Type == key.MachineDeploymentInstanceType(cr)
-	operatorVersionEqual := cc.Status.TenantCluster.OperatorVersion == key.OperatorVersion(&cr)
+	operatorVersionEqual := cc.Status.TenantCluster.TCNP.OperatorVersion == key.OperatorVersion(&cr)
 	securityGroupsEqual := securityGroupsEqual(cc.Status.TenantCluster.TCNP.SecurityGroupIDs, cc.Spec.TenantCluster.TCNP.SecurityGroupIDs)
 
 	if !dockerVolumeEqual {
@@ -109,7 +109,7 @@ func (t *TCNP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSMa
 		t.logger.LogCtx(ctx,
 			"level", "debug",
 			"message", "detected TCNP stack should update",
-			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.OperatorVersion, key.OperatorVersion(&cr)),
+			"reason", fmt.Sprintf("operator version changed from %#q to %#q", cc.Status.TenantCluster.TCNP.OperatorVersion, key.OperatorVersion(&cr)),
 		)
 		return true, nil
 	}

--- a/service/controller/internal/unittest/default_controller_context.go
+++ b/service/controller/internal/unittest/default_controller_context.go
@@ -129,8 +129,7 @@ func ChinaControllerContext() controllercontext.Context {
 					HostedZoneNameServers: "1.1.1.1,8.8.8.8",
 					InternalHostedZoneID:  "hosted-zone-internal-id",
 				},
-				MasterInstance:  controllercontext.ContextStatusTenantClusterMasterInstance{},
-				OperatorVersion: "6.3.0",
+				MasterInstance: controllercontext.ContextStatusTenantClusterMasterInstance{},
 				TCCP: controllercontext.ContextStatusTenantClusterTCCP{
 					AvailabilityZones: []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone{
 						{
@@ -189,6 +188,7 @@ func ChinaControllerContext() controllercontext.Context {
 						},
 					},
 					IsTransitioning: false,
+					OperatorVersion: "6.3.0",
 					SecurityGroups: []*ec2.SecurityGroup{
 						{
 							GroupId: aws.String("ingress-security-group-id"),
@@ -385,8 +385,7 @@ func DefaultControllerContext() controllercontext.Context {
 					HostedZoneNameServers: "1.1.1.1,8.8.8.8",
 					InternalHostedZoneID:  "hosted-zone-internal-id",
 				},
-				MasterInstance:  controllercontext.ContextStatusTenantClusterMasterInstance{},
-				OperatorVersion: "6.3.0",
+				MasterInstance: controllercontext.ContextStatusTenantClusterMasterInstance{},
 				TCCP: controllercontext.ContextStatusTenantClusterTCCP{
 					AvailabilityZones: []controllercontext.ContextStatusTenantClusterTCCPAvailabilityZone{
 						{
@@ -445,6 +444,7 @@ func DefaultControllerContext() controllercontext.Context {
 						},
 					},
 					IsTransitioning: false,
+					OperatorVersion: "6.3.0",
 					SecurityGroups: []*ec2.SecurityGroup{
 						{
 							GroupId: aws.String("ingress-security-group-id"),
@@ -516,6 +516,12 @@ func DefaultControllerContext() controllercontext.Context {
 						ID:                  "vpc-id",
 						PeeringConnectionID: "peering-connection-id",
 					},
+				},
+				TCCPN: controllercontext.ContextStatusTenantClusterTCCPN{
+					OperatorVersion: "6.3.0",
+				},
+				TCNP: controllercontext.ContextStatusTenantClusterTCNP{
+					OperatorVersion: "6.3.0",
 				},
 			},
 		},

--- a/service/controller/resource/tccpnoutputs/create.go
+++ b/service/controller/resource/tccpnoutputs/create.go
@@ -78,7 +78,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		cc.Status.TenantCluster.OperatorVersion = v
+		cc.Status.TenantCluster.TCCPN.OperatorVersion = v
 	}
 
 	return nil

--- a/service/controller/resource/tccpoutputs/create.go
+++ b/service/controller/resource/tccpoutputs/create.go
@@ -116,7 +116,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		cc.Status.TenantCluster.OperatorVersion = v
+		cc.Status.TenantCluster.TCCP.OperatorVersion = v
 	}
 
 	{

--- a/service/controller/resource/tcnpoutputs/create.go
+++ b/service/controller/resource/tcnpoutputs/create.go
@@ -96,7 +96,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		cc.Status.TenantCluster.OperatorVersion = v
+		cc.Status.TenantCluster.TCNP.OperatorVersion = v
 	}
 
 	return nil


### PR DESCRIPTION
Alternative approach to https://github.com/giantswarm/aws-operator/pull/2413

We (@xh3b4sd and @MarcelMue) discovered that change detection doesn't work for all three stacks (tccp, tccpn, tcnp) because the controllercontext only has one field for operator version which is set to the outputs from each stack. As soon as one is updated to the new version, it will overwrite the status from other outputs. By allowing each stack to have a different output version, we should be able to handle updates more robustly.