### PR TITLE
use images service in tcnp handler

### DIFF
--- a/service/controller/machine_deployment_resource_set.go
+++ b/service/controller/machine_deployment_resource_set.go
@@ -422,7 +422,7 @@ func newMachineDeploymentResourceSet(config machineDeploymentResourceSetConfig) 
 	{
 		c := tcnp.Config{
 			Detection: tcnpChangeDetection,
-			G8sClient: config.K8sClient.G8sClient(),
+			Images:    config.Images,
 			Logger:    config.Logger,
 
 			InstallationName: config.InstallationName,

--- a/service/controller/resource/tccpn/create_test.go
+++ b/service/controller/resource/tccpn/create_test.go
@@ -2,7 +2,6 @@ package tccpn
 
 import (
 	"bytes"
-	"context"
 	"flag"
 	"io/ioutil"
 	"path/filepath"
@@ -35,28 +34,24 @@ var update = flag.Bool("update", false, "update .golden CF template file")
 func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 	testCases := []struct {
 		name           string
-		ctx            context.Context
 		azs            []string
 		replicas       int
 		route53Enabled bool
 	}{
 		{
 			name:           "case 0: basic test with encrypter backend KMS, route53 enabled",
-			ctx:            unittest.DefaultContextControlPlane(),
 			azs:            []string{"eu-central-1b"},
 			replicas:       1,
 			route53Enabled: true,
 		},
 		{
 			name:           "case 1: basic test with encrypter backend KMS, route53 disabled",
-			ctx:            unittest.DefaultContextControlPlane(),
 			azs:            []string{"eu-central-1b"},
 			replicas:       1,
 			route53Enabled: false,
 		},
 		{
 			name:           "case 2: basic test with encrypter backend KMS, ha masters",
-			ctx:            unittest.DefaultContextControlPlane(),
 			azs:            []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
 			replicas:       3,
 			route53Enabled: true,
@@ -67,7 +62,7 @@ func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var err error
 
-			ctx := unittest.DefaultContext()
+			ctx := unittest.DefaultContextControlPlane()
 			k := unittest.FakeK8sClient()
 
 			var d *changedetection.TCCPN
@@ -156,7 +151,7 @@ func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 				}
 			}
 
-			params, err := r.newTemplateParams(tc.ctx, aws)
+			params, err := r.newTemplateParams(ctx, aws)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -140,25 +140,11 @@ func (r *Resource) createStack(ctx context.Context, cr infrastructurev1alpha2.AW
 		return microerror.Mask(err)
 	}
 
-	var release *releasev1alpha1.Release
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the release corresponding to the machine deployment release label")
-
-		releaseVersion := key.ReleaseVersion(&cr)
-		releaseName := key.ReleaseName(releaseVersion)
-		release, err = r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the machine deployment release label")
-	}
-
 	var templateBody string
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computing the template of the tenant cluster's node pool cloud formation stack")
 
-		params, err := newTemplateParams(ctx, cr, *release)
+		params, err := newTemplateParams(ctx, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -208,25 +194,11 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 		return microerror.Mask(err)
 	}
 
-	var release *releasev1alpha1.Release
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding the release corresponding to the machine deployment release label")
-
-		releaseVersion := key.ReleaseVersion(&cr)
-		releaseName := key.ReleaseName(releaseVersion)
-		release, err = r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found the release corresponding to the machine deployment release label")
-	}
-
 	var templateBody string
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computing the template of the tenant cluster's node pool cloud formation stack")
 
-		params, err := newTemplateParams(ctx, cr, *release)
+		params, err := newTemplateParams(ctx, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -256,6 +228,7 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requested the update of the tenant cluster's node pool cloud formation stack")
 	}
+
 	return nil
 }
 

--- a/service/controller/resource/tcnp/create_test.go
+++ b/service/controller/resource/tcnp/create_test.go
@@ -2,7 +2,6 @@ package tcnp
 
 import (
 	"bytes"
-	"context"
 	"flag"
 	"io/ioutil"
 	"path/filepath"
@@ -12,9 +11,12 @@ import (
 	"github.com/ghodss/yaml"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnp/template"
+	"github.com/giantswarm/aws-operator/service/internal/changedetection"
+	"github.com/giantswarm/aws-operator/service/internal/images"
 	"github.com/giantswarm/aws-operator/service/internal/unittest"
 )
 
@@ -32,21 +34,84 @@ var update = flag.Bool("update", false, "update .golden CF template file")
 func Test_Controller_Resource_TCNP_Template_Render(t *testing.T) {
 	testCases := []struct {
 		name string
-		ctx  context.Context
 		cr   infrastructurev1alpha2.AWSMachineDeployment
-		r    releasev1alpha1.Release
+		re   releasev1alpha1.Release
 	}{
 		{
 			name: "case 0: basic test",
-			ctx:  unittest.DefaultContext(),
 			cr:   unittest.DefaultMachineDeployment(),
-			r:    unittest.DefaultRelease(),
+			re:   unittest.DefaultRelease(),
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			params, err := newTemplateParams(tc.ctx, tc.cr, tc.r)
+			var err error
+
+			ctx := unittest.DefaultContext()
+			k := unittest.FakeK8sClient()
+
+			var d *changedetection.TCNP
+			{
+				c := changedetection.TCNPConfig{
+					Logger: microloggertest.New(),
+				}
+
+				d, err = changedetection.NewTCNP(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var i images.Interface
+			{
+				c := images.Config{
+					K8sClient: k,
+
+					RegistryDomain: "dummy",
+				}
+
+				i, err = images.New(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			{
+				cl := unittest.DefaultCluster()
+				err = k.CtrlClient().Create(ctx, &cl)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = k.CtrlClient().Create(ctx, &tc.cr)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = k.CtrlClient().Create(ctx, &tc.re)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var r *Resource
+			{
+				c := Config{
+					Detection: d,
+					Images:    i,
+					Logger:    microloggertest.New(),
+
+					InstallationName: "dummy",
+				}
+
+				r, err = New(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			params, err := r.newTemplateParams(ctx, tc.cr)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/controller/resource/tcnp/resource.go
+++ b/service/controller/resource/tcnp/resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/micrologger"
 
 	"github.com/giantswarm/aws-operator/service/internal/changedetection"
+	"github.com/giantswarm/aws-operator/service/internal/images"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 type Config struct {
 	G8sClient versioned.Interface
 	Detection *changedetection.TCNP
+	Images    images.Interface
 	Logger    micrologger.Logger
 
 	InstallationName string
@@ -26,6 +28,7 @@ type Config struct {
 type Resource struct {
 	g8sClient versioned.Interface
 	detection *changedetection.TCNP
+	images    images.Interface
 	logger    micrologger.Logger
 
 	installationName string
@@ -38,6 +41,9 @@ func New(config Config) (*Resource, error) {
 	if config.Detection == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Detection must not be empty", config)
 	}
+	if config.Images == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Images must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -49,6 +55,7 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		g8sClient: config.G8sClient,
 		detection: config.Detection,
+		images:    config.Images,
 		logger:    config.Logger,
 
 		installationName: config.InstallationName,

--- a/service/controller/resource/tcnp/resource.go
+++ b/service/controller/resource/tcnp/resource.go
@@ -1,7 +1,6 @@
 package tcnp
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
@@ -15,7 +14,6 @@ const (
 )
 
 type Config struct {
-	G8sClient versioned.Interface
 	Detection *changedetection.TCNP
 	Images    images.Interface
 	Logger    micrologger.Logger
@@ -26,7 +24,6 @@ type Config struct {
 // Resource implements the TCNP resource, which stands for Tenant Cluster Data
 // Plane. We manage a dedicated Cloud Formation stack for each node pool.
 type Resource struct {
-	g8sClient versioned.Interface
 	detection *changedetection.TCNP
 	images    images.Interface
 	logger    micrologger.Logger
@@ -35,9 +32,6 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
-	if config.G8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
-	}
 	if config.Detection == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Detection must not be empty", config)
 	}
@@ -53,7 +47,6 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		g8sClient: config.G8sClient,
 		detection: config.Detection,
 		images:    config.Images,
 		logger:    config.Logger,


### PR DESCRIPTION
I am trying to get the design a little bit more right and get rid of controller context usage. To enable Ludacris to move forward there was code added to simply fetch release information directly within the handler. I started to work on something like this for HA Masters already and will add local caching to the images service next. 