### PR TITLE
add local caching for images service

### DIFF
--- a/service/internal/hamaster/internal/cache/aws.go
+++ b/service/internal/hamaster/internal/cache/aws.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/operatorkit/controller/context/cachekeycontext"
+	gocache "github.com/patrickmn/go-cache"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+type AWS struct {
+	cache *gocache.Cache
+}
+
+func NewAWS() *AWS {
+	r := &AWS{
+		cache: gocache.New(expiration, expiration/2),
+	}
+
+	return r
+}
+
+func (r *AWS) Get(ctx context.Context, key string) (infrastructurev1alpha2.AWSControlPlane, bool) {
+	val, ok := r.cache.Get(key)
+	if ok {
+		return val.(infrastructurev1alpha2.AWSControlPlane), true
+	}
+
+	return infrastructurev1alpha2.AWSControlPlane{}, false
+}
+
+func (r *AWS) Key(ctx context.Context, obj metav1.Object) string {
+	ck, ok := cachekeycontext.FromContext(ctx)
+	if ok {
+		return fmt.Sprintf("%s/%s", ck, key.ClusterID(obj))
+	}
+
+	return ""
+}
+
+func (r *AWS) Set(ctx context.Context, key string, val infrastructurev1alpha2.AWSControlPlane) {
+	r.cache.SetDefault(key, val)
+}

--- a/service/internal/hamaster/internal/cache/cache.go
+++ b/service/internal/hamaster/internal/cache/cache.go
@@ -1,0 +1,7 @@
+package cache
+
+import "time"
+
+const (
+	expiration = 5 * time.Minute
+)

--- a/service/internal/hamaster/internal/cache/g8s.go
+++ b/service/internal/hamaster/internal/cache/g8s.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/operatorkit/controller/context/cachekeycontext"
+	gocache "github.com/patrickmn/go-cache"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+type G8s struct {
+	cache *gocache.Cache
+}
+
+func NewG8s() *G8s {
+	r := &G8s{
+		cache: gocache.New(expiration, expiration/2),
+	}
+
+	return r
+}
+
+func (r *G8s) Get(ctx context.Context, key string) (infrastructurev1alpha2.G8sControlPlane, bool) {
+	val, ok := r.cache.Get(key)
+	if ok {
+		return val.(infrastructurev1alpha2.G8sControlPlane), true
+	}
+
+	return infrastructurev1alpha2.G8sControlPlane{}, false
+}
+
+func (r *G8s) Key(ctx context.Context, obj metav1.Object) string {
+	ck, ok := cachekeycontext.FromContext(ctx)
+	if ok {
+		return fmt.Sprintf("%s/%s", ck, key.ClusterID(obj))
+	}
+
+	return ""
+}
+
+func (r *G8s) Set(ctx context.Context, key string, val infrastructurev1alpha2.G8sControlPlane) {
+	r.cache.SetDefault(key, val)
+}

--- a/service/internal/images/images.go
+++ b/service/internal/images/images.go
@@ -4,16 +4,18 @@ import (
 	"context"
 
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
-	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/k8sclient"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/key"
+	"github.com/giantswarm/aws-operator/service/internal/images/internal/cache"
 )
 
 type Config struct {
@@ -24,6 +26,9 @@ type Config struct {
 
 type Images struct {
 	k8sClient k8sclient.Interface
+
+	clusterCache *cache.Cluster
+	releaseCache *cache.Release
 
 	registryDomain string
 }
@@ -40,6 +45,9 @@ func New(c Config) (*Images, error) {
 	i := &Images{
 		k8sClient: c.K8sClient,
 
+		clusterCache: cache.NewCluster(),
+		releaseCache: cache.NewRelease(),
+
 		registryDomain: c.RegistryDomain,
 	}
 
@@ -52,40 +60,14 @@ func (i *Images) AMI(ctx context.Context, obj interface{}) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	var cl infrastructurev1alpha2.AWSCluster
-	{
-		var list infrastructurev1alpha2.AWSClusterList
-
-		err := i.k8sClient.CtrlClient().List(
-			ctx,
-			&list,
-			client.InNamespace(cr.GetNamespace()),
-			client.MatchingLabels{label.Cluster: key.ClusterID(cr)},
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		if len(list.Items) == 0 {
-			return "", microerror.Mask(err)
-		}
-		if len(list.Items) > 1 {
-			return "", microerror.Mask(err)
-		}
-
-		cl = list.Items[0]
+	cl, err := i.cachedCluster(ctx, cr)
+	if err != nil {
+		return "", microerror.Mask(err)
 	}
 
-	var re v1alpha1.Release
-	{
-		err := i.k8sClient.CtrlClient().Get(
-			ctx,
-			types.NamespacedName{Name: key.ReleaseName(key.ReleaseVersion(cr))},
-			&re,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
+	re, err := i.cachedRelease(ctx, cr)
+	if err != nil {
+		return "", microerror.Mask(err)
 	}
 
 	ami, err := key.AMI(key.Region(cl), re)
@@ -102,16 +84,9 @@ func (i *Images) CC(ctx context.Context, obj interface{}) (k8scloudconfig.Images
 		return k8scloudconfig.Images{}, microerror.Mask(err)
 	}
 
-	var re v1alpha1.Release
-	{
-		err := i.k8sClient.CtrlClient().Get(
-			ctx,
-			types.NamespacedName{Name: key.ReleaseName(key.ReleaseVersion(cr))},
-			&re,
-		)
-		if err != nil {
-			return k8scloudconfig.Images{}, microerror.Mask(err)
-		}
+	re, err := i.cachedRelease(ctx, cr)
+	if err != nil {
+		return k8scloudconfig.Images{}, microerror.Mask(err)
 	}
 
 	var im k8scloudconfig.Images
@@ -129,4 +104,100 @@ func (i *Images) CC(ctx context.Context, obj interface{}) (k8scloudconfig.Images
 	}
 
 	return im, nil
+}
+
+func (i *Images) cachedCluster(ctx context.Context, cr metav1.Object) (infrastructurev1alpha2.AWSCluster, error) {
+	var err error
+	var ok bool
+
+	var cluster infrastructurev1alpha2.AWSCluster
+	{
+		ck := i.clusterCache.Key(ctx, cr)
+
+		if ck == "" {
+			cluster, err = i.lookupCluster(ctx, cr)
+			if err != nil {
+				return infrastructurev1alpha2.AWSCluster{}, microerror.Mask(err)
+			}
+		} else {
+			cluster, ok = i.clusterCache.Get(ctx, ck)
+			if !ok {
+				cluster, err = i.lookupCluster(ctx, cr)
+				if err != nil {
+					return infrastructurev1alpha2.AWSCluster{}, microerror.Mask(err)
+				}
+
+				i.clusterCache.Set(ctx, ck, cluster)
+			}
+		}
+	}
+
+	return cluster, nil
+}
+
+func (i *Images) cachedRelease(ctx context.Context, cr metav1.Object) (releasev1alpha1.Release, error) {
+	var err error
+	var ok bool
+
+	var re releasev1alpha1.Release
+	{
+		ck := i.releaseCache.Key(ctx, cr)
+
+		if ck == "" {
+			re, err = i.lookupRelease(ctx, cr)
+			if err != nil {
+				return releasev1alpha1.Release{}, microerror.Mask(err)
+			}
+		} else {
+			re, ok = i.releaseCache.Get(ctx, ck)
+			if !ok {
+				re, err = i.lookupRelease(ctx, cr)
+				if err != nil {
+					return releasev1alpha1.Release{}, microerror.Mask(err)
+				}
+
+				i.releaseCache.Set(ctx, ck, re)
+			}
+		}
+	}
+
+	return re, nil
+}
+
+func (i *Images) lookupCluster(ctx context.Context, cr metav1.Object) (infrastructurev1alpha2.AWSCluster, error) {
+	var list infrastructurev1alpha2.AWSClusterList
+
+	err := i.k8sClient.CtrlClient().List(
+		ctx,
+		&list,
+		client.InNamespace(cr.GetNamespace()),
+		client.MatchingLabels{label.Cluster: key.ClusterID(cr)},
+	)
+	if err != nil {
+		return infrastructurev1alpha2.AWSCluster{}, microerror.Mask(err)
+	}
+
+	if len(list.Items) == 0 {
+		return infrastructurev1alpha2.AWSCluster{}, microerror.Mask(notFoundError)
+	}
+	if len(list.Items) > 1 {
+		return infrastructurev1alpha2.AWSCluster{}, microerror.Mask(tooManyCRsError)
+	}
+
+	return list.Items[0], nil
+}
+
+func (i *Images) lookupRelease(ctx context.Context, cr metav1.Object) (releasev1alpha1.Release, error) {
+	var re releasev1alpha1.Release
+
+	err := i.k8sClient.CtrlClient().Get(
+		ctx,
+		types.NamespacedName{Name: key.ReleaseName(key.ReleaseVersion(cr))},
+		&re,
+	)
+	if err != nil {
+		return releasev1alpha1.Release{}, microerror.Mask(err)
+	}
+
+	return re, nil
 }

--- a/service/internal/images/images_test.go
+++ b/service/internal/images/images_test.go
@@ -1,0 +1,121 @@
+package images
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/operatorkit/controller/context/cachekeycontext"
+
+	"github.com/giantswarm/aws-operator/service/internal/unittest"
+)
+
+func Test_Images_Cache(t *testing.T) {
+	testCases := []struct {
+		name          string
+		ctx           context.Context
+		expectCaching bool
+	}{
+		{
+			name:          "case 0",
+			ctx:           cachekeycontext.NewContext(context.Background(), "1"),
+			expectCaching: true,
+		},
+		{
+			name:          "case 1",
+			ctx:           context.Background(),
+			expectCaching: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var ami1 string
+			var ami2 string
+
+			var im *Images
+			{
+				c := Config{
+					K8sClient: unittest.FakeK8sClient(),
+
+					RegistryDomain: "dummy",
+				}
+
+				im, err = New(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			{
+				cl := unittest.DefaultCluster()
+				cl.Spec.Provider.Region = "eu-central-1"
+				err = im.k8sClient.CtrlClient().Create(tc.ctx, &cl)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				re := unittest.DefaultRelease()
+				re.Spec.Components = []releasev1alpha1.ReleaseSpecComponent{
+					{
+						Name:    "containerlinux",
+						Version: "2345.3.0",
+					},
+				}
+				err = im.k8sClient.CtrlClient().Create(tc.ctx, &re)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			{
+				cl := unittest.DefaultCluster()
+				ami1, err = im.AMI(tc.ctx, &cl)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			{
+				cl := unittest.DefaultCluster()
+				cl.Spec.Provider.Region = "eu-west-1"
+				err = im.k8sClient.CtrlClient().Update(tc.ctx, &cl)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				re := unittest.DefaultRelease()
+				re.Spec.Components = []releasev1alpha1.ReleaseSpecComponent{
+					{
+						Name:    "containerlinux",
+						Version: "2345.3.1",
+					},
+				}
+				err = im.k8sClient.CtrlClient().Update(tc.ctx, &re)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			{
+				cl := unittest.DefaultCluster()
+				ami2, err = im.AMI(tc.ctx, &cl)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if tc.expectCaching {
+				if ami1 != ami2 {
+					t.Fatalf("expected %#q to be equal to %#q", ami1, ami2)
+				}
+			} else {
+				if ami1 == ami2 {
+					t.Fatalf("expected %#q to differ from %#q", ami1, ami2)
+				}
+			}
+		})
+	}
+}

--- a/service/internal/images/internal/cache/cache.go
+++ b/service/internal/images/internal/cache/cache.go
@@ -1,0 +1,7 @@
+package cache
+
+import "time"
+
+const (
+	expiration = 5 * time.Minute
+)

--- a/service/internal/images/internal/cache/cluster.go
+++ b/service/internal/images/internal/cache/cluster.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/operatorkit/controller/context/cachekeycontext"
+	gocache "github.com/patrickmn/go-cache"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+type Cluster struct {
+	cache *gocache.Cache
+}
+
+func NewCluster() *Cluster {
+	r := &Cluster{
+		cache: gocache.New(expiration, expiration/2),
+	}
+
+	return r
+}
+
+func (r *Cluster) Get(ctx context.Context, key string) (infrastructurev1alpha2.AWSCluster, bool) {
+	val, ok := r.cache.Get(key)
+	if ok {
+		return val.(infrastructurev1alpha2.AWSCluster), true
+	}
+
+	return infrastructurev1alpha2.AWSCluster{}, false
+}
+
+func (r *Cluster) Key(ctx context.Context, obj metav1.Object) string {
+	ck, ok := cachekeycontext.FromContext(ctx)
+	if ok {
+		return fmt.Sprintf("%s/%s", ck, key.ClusterID(obj))
+	}
+
+	return ""
+}
+
+func (r *Cluster) Set(ctx context.Context, key string, val infrastructurev1alpha2.AWSCluster) {
+	r.cache.SetDefault(key, val)
+}

--- a/service/internal/images/internal/cache/release.go
+++ b/service/internal/images/internal/cache/release.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/operatorkit/controller/context/cachekeycontext"
+	gocache "github.com/patrickmn/go-cache"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+type Release struct {
+	cache *gocache.Cache
+}
+
+func NewRelease() *Release {
+	r := &Release{
+		cache: gocache.New(expiration, expiration/2),
+	}
+
+	return r
+}
+
+func (r *Release) Get(ctx context.Context, key string) (releasev1alpha1.Release, bool) {
+	val, ok := r.cache.Get(key)
+	if ok {
+		return val.(releasev1alpha1.Release), true
+	}
+
+	return releasev1alpha1.Release{}, false
+}
+
+func (r *Release) Key(ctx context.Context, obj metav1.Object) string {
+	ck, ok := cachekeycontext.FromContext(ctx)
+	if ok {
+		return fmt.Sprintf("%s/%s", ck, key.ClusterID(obj))
+	}
+
+	return ""
+}
+
+func (r *Release) Set(ctx context.Context, key string, val releasev1alpha1.Release) {
+	r.cache.SetDefault(key, val)
+}


### PR DESCRIPTION
Following up on the refactoring efforts this adds more caching to the service implementations we started to build. This goes towards the effort of getting rid of the use of the controller context concept. I also added the internal cache package here to the HA Master service. The file structure now looks like this. 

```
$ tree ./service/internal/hamaster
./service/internal/hamaster
├── internal
│   └── cache
│       ├── aws.go
│       ├── cache.go
│       └── g8s.go
├── error.go
├── ha_master.go
├── ha_master_test.go
└── spec.go

2 directories, 7 files
```

```
$ tree ./service/internal/images
./service/internal/images
├── internal
│   └── cache
│       ├── cache.go
│       ├── cluster.go
│       └── release.go
├── error.go
├── images.go
├── images_test.go
└── spec.go

2 directories, 7 files
```