### PR TITLE
fix RBAC rules for Control Plane CR migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Fixed
+
+- Fix RBAC rules for Control Plane CR migration.
+
+
+
 ## [8.5.0] 2020-05-11
 
 ### Added

--- a/helm/aws-operator/templates/rbac.yaml
+++ b/helm/aws-operator/templates/rbac.yaml
@@ -24,12 +24,15 @@ rules:
       - get
 
   # The aws-operator needs read and write access to the CAPI Cluster CR in order
-  # to set the API endpoint in its status.
+  # to set the API endpoint in its status. Note that the get permission is used
+  # within the ensurecpcrs handler, which is for migration purposes and can be
+  # removed at some point.
   - apiGroups:
       - cluster.x-k8s.io
     resources:
       - clusters
     verbs:
+      - get
       - list
   - apiGroups:
       - cluster.x-k8s.io


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



## Context

During some recent cleanup we forgot to set permissions necessary during the Control Plane CR migration. See also https://gigantic.slack.com/archives/C2MS2VB37/p1589276181148200.