### PR TITLE
'move-etcd-records-to-internal-dns-zone'

### DIFF
--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -519,11 +519,11 @@ func (r *Resource) newRecordSets(ctx context.Context, cr infrastructurev1alpha2.
 	}
 
 	recordSets := &template.ParamsMainRecordSets{
-		ClusterID:      key.ClusterID(&cr),
-		HostedZoneID:   cc.Status.TenantCluster.DNS.HostedZoneID,
-		BaseDomain:     key.ClusterBaseDomain(cl),
-		Records:        records,
-		Route53Enabled: r.route53Enabled,
+		ClusterID:            key.ClusterID(&cr),
+		InternalHostedZoneID: cc.Status.TenantCluster.DNS.InternalHostedZoneID,
+		BaseDomain:           key.ClusterBaseDomain(cl),
+		Records:              records,
+		Route53Enabled:       r.route53Enabled,
 	}
 
 	return recordSets, nil

--- a/service/controller/resource/tccpn/template/params_main_record_sets.go
+++ b/service/controller/resource/tccpn/template/params_main_record_sets.go
@@ -1,11 +1,11 @@
 package template
 
 type ParamsMainRecordSets struct {
-	BaseDomain     string
-	ClusterID      string
-	HostedZoneID   string
-	Records        []ParamsMainRecordSetsRecord
-	Route53Enabled bool
+	BaseDomain           string
+	ClusterID            string
+	InternalHostedZoneID string
+	Records              []ParamsMainRecordSetsRecord
+	Route53Enabled       bool
 }
 
 type ParamsMainRecordSetsRecord struct {

--- a/service/controller/resource/tccpn/template/template_main_record_sets.go
+++ b/service/controller/resource/tccpn/template/template_main_record_sets.go
@@ -11,7 +11,7 @@ const TemplateMainRecordSets = `
       ResourceRecords:
       - !GetAtt {{ $r.ENI.Resource }}.PrimaryPrivateIpAddress
       Name: '{{ $r.Value }}.{{ $v.ClusterID }}.k8s.{{ $v.BaseDomain }}.'
-      HostedZoneId: {{ $v.HostedZoneID }}
+      HostedZoneId: {{ $v.InternalHostedZoneID }}
       Type: A
       TTL: 60
 {{- end -}}

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -315,6 +315,6 @@ Resources:
       ResourceRecords:
       - !GetAtt MasterEni.PrimaryPrivateIpAddress
       Name: 'etcd0.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
-      HostedZoneId: hosted-zone-id
+      HostedZoneId: hosted-zone-internal-id
       Type: A
       TTL: 60

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -633,7 +633,7 @@ Resources:
       ResourceRecords:
       - !GetAtt MasterEni.PrimaryPrivateIpAddress
       Name: 'etcd1.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
-      HostedZoneId: hosted-zone-id
+      HostedZoneId: hosted-zone-internal-id
       Type: A
       TTL: 60
   ControlPlaneRecordSet2:
@@ -642,7 +642,7 @@ Resources:
       ResourceRecords:
       - !GetAtt MasterEni2.PrimaryPrivateIpAddress
       Name: 'etcd2.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
-      HostedZoneId: hosted-zone-id
+      HostedZoneId: hosted-zone-internal-id
       Type: A
       TTL: 60
   ControlPlaneRecordSet3:
@@ -651,6 +651,6 @@ Resources:
       ResourceRecords:
       - !GetAtt MasterEni3.PrimaryPrivateIpAddress
       Name: 'etcd3.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
-      HostedZoneId: hosted-zone-id
+      HostedZoneId: hosted-zone-internal-id
       Type: A
       TTL: 60


### PR DESCRIPTION
The etcd DNS records need to be in the internal DNS zone because they will be resolved inside of the cluster.
