### PR TITLE
Add optional pushing to Aliyun for PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ workflows:
               only: /^v.*/
 
       # Ensure that for every commit (branch other than master)
-      # there is an app verison in the test catalog.
+      # there is an app version in the test catalog.
       # Note: Making this app usable in china needs manual approval
       # of the 'hold-push-to-aliyun-pr' job.
       - architect/push-to-app-catalog:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ workflows:
             tags:
               only: /^v.*/
 
+      # Ensure that for every commit (all branches), and for every new release tag,
+      # an image is pushed to Quay.
       - architect/push-to-docker:
           name: push-to-quay
           image: "quay.io/giantswarm/aws-operator"
@@ -38,8 +40,10 @@ workflows:
             tags:
               only: /^v.*/
 
+      # Ensure that for every commit to master, and for every new release tag,
+      # an image gets pushed to the Aliyun registry.
       - architect/push-to-docker:
-          name: push-to-aliyun-master
+          name: push-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/aws-operator"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
@@ -51,11 +55,12 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-to-aliyun-pr
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/aws-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
+      # Allow that for every commit (to a branch other than master),
+      # and for every new tag that is not a release tag,
+      # an image _can_ get pushed to the Aliyun registry
+      # if manually approved.
+      - hold-push-to-aliyun-pr:
+          type: approval
           requires:
             - go-build
           filters:
@@ -63,14 +68,28 @@ workflows:
               ignore: master
             tags:
               ignore: /^v.*/
+      - architect/push-to-docker:
+          name: push-to-aliyun-pr
+          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/aws-operator"
+          username_envar: "ALIYUN_USERNAME"
+          password_envar: "ALIYUN_PASSWORD"
+          requires:
+            - hold-push-to-aliyun-pr
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
 
+      # Ensure that for every commit to master and for every
+      # release tag, there is an app version in the catalog.
       - architect/push-to-app-catalog:
           name: push-to-app-catalog-master
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-operator"
           requires:
-            - push-to-aliyun-master
+            - push-to-aliyun
             - push-to-quay
           filters:
             branches:
@@ -78,6 +97,10 @@ workflows:
             tags:
               only: /^v.*/
 
+      # Ensure that for every commit (branch other than master)
+      # there is an app verison in the test catalog.
+      # Note: Making this app usable in china needs manual approval
+      # of the 'hold-push-to-aliyun-pr' job.
       - architect/push-to-app-catalog:
           name: push-to-app-catalog-pr
           app_catalog: "control-plane-catalog"
@@ -89,6 +112,7 @@ workflows:
             branches:
               ignore: master
 
+      # Ensure that a new app is also added to the app collection.
       - architect/push-to-app-collection:
           name: push-to-aws-app-collection
           app_name: "aws-operator"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: Add optional pusing of WIP work to Aliyun registry.
 - Removed static ip FOR ENI to avoid collision with internal API LB.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CI: Add optional pusing of WIP work to Aliyun registry.
+- CI: Add optional pushing of WIP work to Aliyun registry.
 - Removed static ip FOR ENI to avoid collision with internal API LB.
 
 


### PR DESCRIPTION
The purpose of this PR is to allow optional pushing of in-progress work on aws-operator to China.

Important: As an engineer you have to understand that

- even though Github displays "Some checks haven't completed yet", this does not have to mean that you need to wait for anything. If the only 🟡 item is the one labelled `build/hold-push-to-aliyun-pr`, then you are ready to go and test anywhere outside China.

- if you want to test your unreleased work in China, you have to follow the `Details` link on the `build/hold-push-to-aliyun-pr` item and manually approve.

History: We had this before, but it got removed. I don't know why.

## Checklist

- [x] Update changelog in CHANGELOG.md.


## Preview

Before approval on GitHub:

![image](https://user-images.githubusercontent.com/273727/82037772-e50e2800-96a2-11ea-8895-c12e7262f1c1.png)

Before approval on CircleCI:

![image](https://user-images.githubusercontent.com/273727/82037732-d889cf80-96a2-11ea-8e95-b56045ac0cab.png)

After approval on CircleCI:

![image](https://user-images.githubusercontent.com/273727/82037895-1129a900-96a3-11ea-9c53-f2a8d20ed9be.png)

After finishing on CircleCI:

![image](https://user-images.githubusercontent.com/273727/82038427-ceb49c00-96a3-11ea-93cb-3f8473877cf8.png)

And after finishing in GitHub:

![image](https://user-images.githubusercontent.com/273727/82038463-dd02b800-96a3-11ea-8ba1-81645375b975.png)
