### PR TITLE
add keepforcrs handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+### Added
+
+- Add `keepforcrs` handler for more reliable CR cleanup.
+
+
+
 ## [8.6.1] 2020-05-21
 
 ### Added

--- a/service/controller/resource/keepforcrs/create.go
+++ b/service/controller/resource/keepforcrs/create.go
@@ -1,0 +1,9 @@
+package keepforcrs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/keepforcrs/delete.go
+++ b/service/controller/resource/keepforcrs/delete.go
@@ -52,7 +52,6 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	if len(list.Items) != 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found object of type %T for tenant cluster %#q", r.newObjFunc(), key.ClusterID(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
 		finalizerskeptcontext.SetKept(ctx)
 	}

--- a/service/controller/resource/keepforcrs/delete.go
+++ b/service/controller/resource/keepforcrs/delete.go
@@ -1,0 +1,61 @@
+package keepforcrs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/giantswarm/aws-operator/pkg/label"
+	"github.com/giantswarm/aws-operator/service/controller/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := meta.Accessor(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var list *unstructured.UnstructuredList
+	{
+		gvk, err := apiutil.GVKForObject(r.newObjFunc(), r.k8sClient.Scheme())
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		gvk.Kind += "List"
+
+		l := &unstructured.UnstructuredList{}
+		l.SetGroupVersionKind(gvk)
+
+		list = l
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding objects of type %T for tenant cluster %#q", r.newObjFunc(), key.ClusterID(cr)))
+
+		err = r.k8sClient.CtrlClient().List(
+			ctx,
+			list,
+			client.InNamespace(cr.GetNamespace()),
+			client.MatchingLabels{label.Cluster: key.ClusterID(cr)},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d object(s) of type %T for tenant cluster %#q", len(list.Items), r.newObjFunc(), key.ClusterID(cr)))
+	}
+
+	if len(list.Items) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found object of type %T for tenant cluster %#q", r.newObjFunc(), key.ClusterID(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+		finalizerskeptcontext.SetKept(ctx)
+	}
+
+	return nil
+}

--- a/service/controller/resource/keepforcrs/error.go
+++ b/service/controller/resource/keepforcrs/error.go
@@ -1,0 +1,14 @@
+package keepforcrs
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/keepforcrs/resource.go
+++ b/service/controller/resource/keepforcrs/resource.go
@@ -1,0 +1,64 @@
+package keepforcrs
+
+import (
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	Name = "keepforcrs"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+	// NewObjFunc is to return an instance of a pointer for the CR type that
+	// should be considered for keeping finalizers.
+	//
+	//     &infrastructurev1alpha2.AWSControlPlane{}
+	//     &infrastructurev1alpha2.AWSMachineDeployment{}
+	//
+	NewObjFunc func() runtime.Object
+}
+
+// Resource receives the runtime object of the underlying controller it is wired
+// into and keeps finalizers for that very controller in case the configured
+// runtime objects do still exist. This is to initialize deletion for the
+// following CRs.
+//
+//     watch         |    delete
+//     ---------------------------------------
+//     AWSCluster    |    AWSControlPlane
+//     AWSCluster    |    AWSMachineDeployment
+//
+type Resource struct {
+	k8sClient  k8sclient.Interface
+	logger     micrologger.Logger
+	newObjFunc func() runtime.Object
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.NewObjFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.NewObjFunc must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:  config.K8sClient,
+		logger:     config.Logger,
+		newObjFunc: config.NewObjFunc,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/keepforcrs/resource.go
+++ b/service/controller/resource/keepforcrs/resource.go
@@ -25,7 +25,7 @@ type Config struct {
 
 // Resource receives the runtime object of the underlying controller it is wired
 // into and keeps finalizers for that very controller in case the configured
-// runtime objects do still exist. This is to initialize deletion for the
+// runtime objects do still exist. This is to have a reliable deletion for the
 // following CRs.
 //
 //     watch         |    delete


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



## Context 

Towards https://github.com/giantswarm/giantswarm/issues/10710. 



## Problem

* TC is deleted 
* Control Plane CRs never get deleted 
* `AWSCluster` CR is gone before the Control Plane CRs are deleted
* we need the `AWSCluster` CR in the `aws-operator` for internal reasons like creating AWS Clients
* deletion for Control Plane CRs fails because `AWSCluster` CR is gone



## Solution

Keep finalizers in the cluster controller as long as there are dependent objects. In our case I did it for `AWSControlPlane` and `AWSMachineDeployment` CRs. 

```
$ k -n giantswarm logs --tail 1000 -f aws-operator-keepforcrs-677fcd85d6-f5l9p | gg -s res:keepforcrs -f con,mes -g loo
{
    "controller": "aws-operator-cluster-controller",
    "message": "finding objects of type *v1alpha2.AWSControlPlane for tenant cluster `5wiqm`"
}
{
    "controller": "aws-operator-cluster-controller",
    "message": "found 1 object(s) of type *v1alpha2.AWSControlPlane for tenant cluster `5wiqm`"
}
{
    "controller": "aws-operator-cluster-controller",
    "message": "keeping finalizers"
}
{
    "controller": "aws-operator-cluster-controller",
    "message": "finding objects of type *v1alpha2.AWSMachineDeployment for tenant cluster `5wiqm`"
}
{
    "controller": "aws-operator-cluster-controller",
    "message": "found 1 object(s) of type *v1alpha2.AWSMachineDeployment for tenant cluster `5wiqm`"
}
{
    "controller": "aws-operator-cluster-controller",
    "message": "keeping finalizers"
}
```