### PR TITLE
drop asgstatus handler from drainer controllers

### DIFF
--- a/service/controller/control_plane_drainer.go
+++ b/service/controller/control_plane_drainer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/controller/resource/asgname"
-	"github.com/giantswarm/aws-operator/service/controller/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/resource/awsclient"
 	"github.com/giantswarm/aws-operator/service/controller/resource/drainerfinalizer"
 	"github.com/giantswarm/aws-operator/service/controller/resource/drainerinitializer"
@@ -106,18 +105,6 @@ func newControlPlaneDrainerResources(config ControlPlaneDrainerConfig) ([]resour
 		}
 	}
 
-	var asgStatusResource resource.Interface
-	{
-		c := asgstatus.Config{
-			Logger: config.Logger,
-		}
-
-		asgStatusResource, err = asgstatus.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var awsClientResource resource.Interface
 	{
 		c := awsclient.Config{
@@ -169,7 +156,6 @@ func newControlPlaneDrainerResources(config ControlPlaneDrainerConfig) ([]resour
 	resources := []resource.Interface{
 		awsClientResource,
 		asgNameResource,
-		asgStatusResource,
 		drainerInitializerResource,
 		drainerFinalizerResource,
 	}

--- a/service/controller/machine_deployment_drainer.go
+++ b/service/controller/machine_deployment_drainer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/controller/resource/asgname"
-	"github.com/giantswarm/aws-operator/service/controller/resource/asgstatus"
 	"github.com/giantswarm/aws-operator/service/controller/resource/awsclient"
 	"github.com/giantswarm/aws-operator/service/controller/resource/drainerfinalizer"
 	"github.com/giantswarm/aws-operator/service/controller/resource/drainerinitializer"
@@ -106,18 +105,6 @@ func newMachineDeploymentDrainerResources(config MachineDeploymentDrainerConfig)
 		}
 	}
 
-	var asgStatusResource resource.Interface
-	{
-		c := asgstatus.Config{
-			Logger: config.Logger,
-		}
-
-		asgStatusResource, err = asgstatus.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var awsClientResource resource.Interface
 	{
 		c := awsclient.Config{
@@ -169,7 +156,6 @@ func newMachineDeploymentDrainerResources(config MachineDeploymentDrainerConfig)
 	resources := []resource.Interface{
 		awsClientResource,
 		asgNameResource,
-		asgStatusResource,
 		drainerInitializerResource,
 		drainerFinalizerResource,
 	}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Towards HA Masters. We need to figure out how to get draining right for the 3 ASGs we run for the masters. While getting around the code and trying to come up with an idea I saw that the `asgstatus` handler is wired in the drainer controllers but apparently not used for anything. Feel free to sanity check. 