### PR TITLE
Filter out data for irrelevant regions in service limit metrics

### DIFF
--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -140,6 +140,7 @@ func NewSet(config SetConfig) (*Set, error) {
 		c := TrustedAdvisorConfig{
 			Helper: h,
 			Logger: config.Logger,
+			Region: config.AWSConfig.Region,
 		}
 
 		trustedAdvisorCollector, err = NewTrustedAdvisor(c)


### PR DESCRIPTION
Aims to close https://github.com/giantswarm/giantswarm/issues/11114 by filtering out service limit data that is related to regions we are not interested in. We should be only interested in the installation's region plus the special one `-` which is reported for global (not region specific) service limits.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
