### PR TITLE
add Control Plane labels to master nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `keepforcrs` handler for more reliable CR cleanup.
+- Add Control Plane labels to master nodes.
 
 ### Fixed
 

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -117,6 +117,7 @@ func KubeletLabelsTCCPN(getter LabelsGetter) string {
 
 	labels = ensureLabel(labels, label.Provider, "aws")
 	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
+	labels = ensureLabel(labels, label.ControlPlane, ControlPlaneID(getter))
 
 	return labels
 }


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



## Context 

Towards HA Masters. We already add Machine Deployment labels to the worker nodes. We thought it makes sense to add Control Plane labels to master nodes as well. 