### PR TITLE
Dont update endpoints when empty

### DIFF
--- a/service/controller/resource/endpoints/desired.go
+++ b/service/controller/resource/endpoints/desired.go
@@ -142,5 +142,9 @@ func (r Resource) searchMasterInstances(ctx context.Context, cr infrastructurev1
 		}
 	}
 
+	if len(instances) == 0 {
+		return nil, microerror.Maskf(notFoundError, "no healthy master instances found")
+	}
+
 	return instances, nil
 }


### PR DESCRIPTION
to fix endpoint error during updates for single master

```
{"caller":"github.com/giantswarm/operatorkit/controller/controller.go:228","controller":"aws-operator-cluster-controller","event":"update","level":"error","loop":"387","message":"failed to reconcile","object":"/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/awsclusters/k9xu5","stack":{"annotation":"Endpoints \"master\" is invalid: subsets[0]: Required value: must specify `addresses` or `notReadyAddresses`","kind":"unknown","stack":[{"file":"/root/project/service/controller/resource/endpoints/update.go","line":30},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/resource/wrapper/retryresource/crud_resource.go","line":198},{"file":"/go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go","line":23},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/resource/wrapper/retryresource/crud_resource.go","line":210},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/resource/wrapper/metricsresource/crud_resource.go","line":149},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/resource/crud/resource.go","line":189},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/controller/controller.go","line":515},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/controller/controller.go","line":433},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/controller/controller.go","line":409}]},"time":"2020-05-27T06:45:29.250916+00:00","version":"31365879"}

```