### PR TITLE
add-master-id-label-to-node

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -8,6 +8,7 @@ const (
 	Cluster           = "giantswarm.io/cluster"
 	ControlPlane      = "giantswarm.io/control-plane"
 	MachineDeployment = "giantswarm.io/machine-deployment"
+	MasterID          = "giantswarm.io/master-id"
 	Organization      = "giantswarm.io/organization"
 	Provider          = "giantswarm.io/provider"
 )

--- a/service/controller/key/aws_control_plane.go
+++ b/service/controller/key/aws_control_plane.go
@@ -60,10 +60,6 @@ func ControlPlaneLaunchTemplateResourceName(getter LabelsGetter, id int) string 
 	return fmt.Sprintf("ControlPlaneNodeLaunchTemplate%d", id)
 }
 
-func ControlPlaneNodeMasterIDLabel(id int) string {
-	return fmt.Sprintf("masterID=%d", id)
-}
-
 func ControlPlaneRecordSetsRecordValue(id int) string {
 	return fmt.Sprintf("etcd%d", id)
 }

--- a/service/controller/key/aws_control_plane.go
+++ b/service/controller/key/aws_control_plane.go
@@ -60,6 +60,10 @@ func ControlPlaneLaunchTemplateResourceName(getter LabelsGetter, id int) string 
 	return fmt.Sprintf("ControlPlaneNodeLaunchTemplate%d", id)
 }
 
+func ControlPlaneNodeMasterIDLabel(id int) string {
+	return fmt.Sprintf("masterID=%d", id)
+}
+
 func ControlPlaneRecordSetsRecordValue(id int) string {
 	return fmt.Sprintf("etcd%d", id)
 }

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -110,12 +110,13 @@ func IsDeleted(getter DeletionTimestampGetter) bool {
 	return getter.GetDeletionTimestamp() != nil
 }
 
-func KubeletLabelsTCCPN(getter LabelsGetter) string {
+func KubeletLabelsTCCPN(getter LabelsGetter, masterID int) string {
 	var labels string
 
 	labels = ensureLabel(labels, label.Provider, "aws")
 	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
 	labels = ensureLabel(labels, label.ControlPlane, ControlPlaneID(getter))
+	labels = ensureLabel(labels, label.MasterID, fmt.Sprintf("%d", masterID))
 
 	return labels
 }

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -283,8 +283,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 	{
 		params = k8scloudconfig.DefaultParams()
 
-		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr))
-		g8sConfig.Cluster.Kubernetes.Kubelet.Labels += "," + key.ControlPlaneNodeMasterIDLabel(mapping.ID)
+		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr, mapping.ID))
 
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)
 		params.Cluster = g8sConfig.Cluster

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -284,6 +284,8 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		params = k8scloudconfig.DefaultParams()
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr))
+		g8sConfig.Cluster.Kubernetes.Kubelet.Labels += key.ControlPlaneNodeMasterIDLabel(mapping.ID)
+
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)
 		params.Cluster = g8sConfig.Cluster
 		params.DisableEncryptionAtREST = true

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -284,7 +284,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		params = k8scloudconfig.DefaultParams()
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr))
-		g8sConfig.Cluster.Kubernetes.Kubelet.Labels += key.ControlPlaneNodeMasterIDLabel(mapping.ID)
+		g8sConfig.Cluster.Kubernetes.Kubelet.Labels += "," + key.ControlPlaneNodeMasterIDLabel(mapping.ID)
 
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)
 		params.Cluster = g8sConfig.Cluster


### PR DESCRIPTION
add masterID label to the kubelet node-labels to distinguish between each master in k8s

It's needed for the etcd 1 to 3 node migration