### PR TITLE
use-k8s-api-healthz-httpcheck-for-api-lb

### DIFF
--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -26,9 +26,10 @@ const (
 )
 
 const (
-	EtcdPort             = 2379
-	EtcdPrefix           = "giantswarm.io"
-	KubernetesSecurePort = 443
+	EtcdPort                     = 2379
+	EtcdPrefix                   = "giantswarm.io"
+	KubernetesSecurePort         = 443
+	KubernetesApiHealthCheckPort = 8089
 )
 
 const (

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -99,7 +99,7 @@ func ELBNameEtcd(getter LabelsGetter) string {
 }
 
 func HealthCheckTarget(port int) string {
-	return fmt.Sprintf("TCP:%d", port)
+	return fmt.Sprintf("HTTP:%d/healthz", port)
 }
 
 func InternalELBNameAPI(getter LabelsGetter) string {

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -98,7 +98,11 @@ func ELBNameEtcd(getter LabelsGetter) string {
 	return fmt.Sprintf("%s-etcd", ClusterID(getter))
 }
 
-func HealthCheckTarget(port int) string {
+func HealthCheckTCPTarget(port int) string {
+	return fmt.Sprintf("TCP:%d", port)
+}
+
+func HealthCheckHTTPTarget(port int) string {
 	return fmt.Sprintf("HTTP:%d/healthz", port)
 }
 

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -403,7 +403,7 @@ func (r *Resource) newParamsMainLoadBalancers(ctx context.Context, cr infrastruc
 	var loadBalancers *template.ParamsMainLoadBalancers
 	{
 		loadBalancers = &template.ParamsMainLoadBalancers{
-			APIElbHealthCheckTarget: key.HealthCheckTarget(key.KubernetesApiHealthCheckPort),
+			APIElbHealthCheckTarget: key.HealthCheckHTTPTarget(key.KubernetesApiHealthCheckPort),
 			APIElbName:              key.ELBNameAPI(&cr),
 			APIInternalElbName:      key.InternalELBNameAPI(&cr),
 			APIElbPortsToOpen: []template.ParamsMainLoadBalancersPortPair{
@@ -412,7 +412,7 @@ func (r *Resource) newParamsMainLoadBalancers(ctx context.Context, cr infrastruc
 					PortInstance: key.KubernetesSecurePort,
 				},
 			},
-			EtcdElbHealthCheckTarget: key.HealthCheckTarget(key.EtcdPort),
+			EtcdElbHealthCheckTarget: key.HealthCheckTCPTarget(key.EtcdPort),
 			EtcdElbName:              key.ELBNameEtcd(&cr),
 			EtcdElbPortsToOpen: []template.ParamsMainLoadBalancersPortPair{
 				{

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -403,7 +403,7 @@ func (r *Resource) newParamsMainLoadBalancers(ctx context.Context, cr infrastruc
 	var loadBalancers *template.ParamsMainLoadBalancers
 	{
 		loadBalancers = &template.ParamsMainLoadBalancers{
-			APIElbHealthCheckTarget: key.HealthCheckTarget(key.KubernetesSecurePort),
+			APIElbHealthCheckTarget: key.HealthCheckTarget(key.KubernetesApiHealthCheckPort),
 			APIElbName:              key.ELBNameAPI(&cr),
 			APIInternalElbName:      key.InternalELBNameAPI(&cr),
 			APIElbPortsToOpen: []template.ParamsMainLoadBalancersPortPair{

--- a/service/controller/resource/tccp/template/template_main_security_groups.go
+++ b/service/controller/resource/tccp/template/template_main_security_groups.go
@@ -224,6 +224,17 @@ const TemplateMainSecurityGroups = `
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
+  MasterAllowAPIInternalELBHealthCheck:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn:
+      - MasterSecurityGroup
+      - APIInternalELBSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: "tcp"
+      FromPort: 8089
+      ToPort: 8089
+      SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
   MasterAllowPodsCNIIngressRule:
       Type: AWS::EC2::SecurityGroupIngress
       DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -78,7 +78,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -106,7 +106,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -133,7 +133,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:2379
+        Target: HTTP:2379/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -598,6 +598,17 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
+  MasterAllowAPIInternalELBHealthCheck:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn:
+      - MasterSecurityGroup
+      - APIInternalELBSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: "tcp"
+      FromPort: 8089
+      ToPort: 8089
+      SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
   MasterAllowPodsCNIIngressRule:
       Type: AWS::EC2::SecurityGroupIngress
       DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -133,7 +133,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: HTTP:2379/healthz
+        Target: TCP:2379
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -127,7 +127,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: HTTP:2379/healthz
+        Target: TCP:2379
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -72,7 +72,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -100,7 +100,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -127,7 +127,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:2379
+        Target: HTTP:2379/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -512,6 +512,17 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
+  MasterAllowAPIInternalELBHealthCheck:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn:
+      - MasterSecurityGroup
+      - APIInternalELBSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: "tcp"
+      FromPort: 8089
+      ToPort: 8089
+      SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
   MasterAllowPodsCNIIngressRule:
       Type: AWS::EC2::SecurityGroupIngress
       DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -72,7 +72,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -100,7 +100,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:443
+        Target: HTTP:8089/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -127,7 +127,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: TCP:2379
+        Target: HTTP:2379/healthz
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -554,6 +554,17 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref MasterSecurityGroup
+  MasterAllowAPIInternalELBHealthCheck:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn:
+      - MasterSecurityGroup
+      - APIInternalELBSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: "tcp"
+      FromPort: 8089
+      ToPort: 8089
+      SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
   MasterAllowPodsCNIIngressRule:
       Type: AWS::EC2::SecurityGroupIngress
       DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -127,7 +127,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: HTTP:2379/healthz
+        Target: TCP:2379
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:


### PR DESCRIPTION
use k8s-api-healthz service for the API health check

the service is running on the master node and does check to k8s api /healtz endpoint and etcd healtz endpoint

It was implemented  quite some time ago but we never switch to use it
https://github.com/giantswarm/k8s-api-healthz
