### PR TITLE
reduce-lifecycle-hook-for-tccpn

### DIFF
--- a/service/controller/resource/tccpn/template/template_main_auto_scaling_group.go
+++ b/service/controller/resource/tccpn/template/template_main_auto_scaling_group.go
@@ -38,7 +38,7 @@ const TemplateMainAutoScalingGroup = `
       # reliably managing customer workloads.
       LifecycleHookSpecificationList:
         - DefaultResult: CONTINUE
-          HeartbeatTimeout: 3600
+          HeartbeatTimeout: 600
           LifecycleHookName: ControlPlane
           LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
       {{- end }}

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -39,7 +39,7 @@ Resources:
       # reliably managing customer workloads.
       LifecycleHookSpecificationList:
         - DefaultResult: CONTINUE
-          HeartbeatTimeout: 3600
+          HeartbeatTimeout: 600
           LifecycleHookName: ControlPlane
           LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
       # 60 seconds after a new node comes into service, the ASG checks the new
@@ -98,7 +98,7 @@ Resources:
       # reliably managing customer workloads.
       LifecycleHookSpecificationList:
         - DefaultResult: CONTINUE
-          HeartbeatTimeout: 3600
+          HeartbeatTimeout: 600
           LifecycleHookName: ControlPlane
           LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
       # 60 seconds after a new node comes into service, the ASG checks the new
@@ -157,7 +157,7 @@ Resources:
       # reliably managing customer workloads.
       LifecycleHookSpecificationList:
         - DefaultResult: CONTINUE
-          HeartbeatTimeout: 3600
+          HeartbeatTimeout: 600
           LifecycleHookName: ControlPlane
           LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
       # 60 seconds after a new node comes into service, the ASG checks the new


### PR DESCRIPTION
with the  ASG changes to update one at the time we can decrease the lifecycle hook to 600s

There is a big chance that if the node is not properly terminated in 10 mins it won't be in 1 hour as well and that 1 hour is a super long wait
