### PR TITLE
Only return running or pending NAT GWs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix upgrade problems with pending volume snapshots.
 - Fix cluster deletion issues in AWS using `DependsOn`.
 - Fix calico-policy only metrics endpoint.
+- Never return deleted NAT GWs #2527
 
 
 ## [8.6.1] 2020-05-21

--- a/service/controller/resource/tccpnatgateways/create.go
+++ b/service/controller/resource/tccpnatgateways/create.go
@@ -34,6 +34,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		i := &ec2.DescribeNatGatewaysInput{
 			Filter: []*ec2.Filter{
 				{
+					Name: aws.String("state"),
+					Values: []*string{
+						aws.String("available"),
+						aws.String("pending"),
+					},
+				},
+				{
 					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
 					Values: []*string{
 						aws.String(key.ClusterID(&cr)),


### PR DESCRIPTION
If cluster ID is reused in quick succession (after deleting), it is possible
that a deleted NAT GW is returned. This commit, adds the state of the NAT GW to
the filter, so that only running and pending NAT GW are returned.

This fixes https://github.com/giantswarm/giantswarm/issues/11727

## Checklist

- [x] Update changelog in CHANGELOG.md.