### PR TITLE
adding cache for ELB collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add caching to the ELB collector
 - Add `keepforcrs` handler for more reliable CR cleanup.
 - Add Control Plane labels to master nodes.
 - Use the alpine 3.12 base Docker image

--- a/service/collector/nat.go
+++ b/service/collector/nat.go
@@ -104,7 +104,7 @@ func newNATCache(expiration time.Duration) *natCache {
 
 func (n *natCache) Get(accID string) (*natInfoResponse, error) {
 	var c natInfoResponse
-	raw, exists := n.cache.Get(getCacheKey(accID))
+	raw, exists := n.cache.Get(getNATCacheKey(accID))
 	if exists {
 		err := json.Unmarshal(raw, &c)
 		if err != nil {
@@ -121,12 +121,12 @@ func (n *natCache) Set(accID string, content natInfoResponse) error {
 		return microerror.Mask(err)
 	}
 
-	n.cache.Set(getCacheKey(accID), contentSerialized)
+	n.cache.Set(getNATCacheKey(accID), contentSerialized)
 
 	return nil
 }
 
-func getCacheKey(accID string) string {
+func getNATCacheKey(accID string) string {
 	return prefixNATcacheKey + accID
 }
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11097
We make a lot of requests to the aws-api when we collect metrics about the load balancers in our collector. This causes throttling issues for the customer.
This PR adds a cache for the ELB collector to save api requests. It is based on the cache used in our NAT collector. The collection method itself is unchanged.

## Checklist

- [x] Update changelog in CHANGELOG.md.
