### PR TITLE
do not render KMS encrypted content via go templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cluster deletion issues in AWS using `DependsOn`.
 - Fix calico-policy only metrics endpoint.
 - Fix race condition in IPAM locking when lock already acquired.
+- Fix failing go template rendering of KMS encryption content.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add mapping between similar instance types `m4.16xlarge` and `m5.16xlarge`
+- Fix failing go template rendering of KMS encryption content.
+
 
 
 ## [8.7.0] 2020-06-19
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cluster deletion issues in AWS using `DependsOn`.
 - Fix calico-policy only metrics endpoint.
 - Fix race condition in IPAM locking when lock already acquired.
-- Fix failing go template rendering of KMS encryption content.
 
 
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.7.1-dev"
+	version            = "8.7.1-xh3b4sd"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.7.1-xh3b4sd"
+	version            = "8.7.1-dev"
 )
 
 func Description() string {

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -67,19 +67,6 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		},
 
 		{
-			AssetContent: e.randomKeyTmplSet.APIServerEncryptionKey,
-			Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",
-			Owner: k8scloudconfig.Owner{
-				Group: k8scloudconfig.Group{
-					Name: FileOwnerGroupName,
-				},
-				User: k8scloudconfig.User{
-					Name: FileOwnerUserName,
-				},
-			},
-			Permissions: 0644,
-		},
-		{
 			AssetContent: template.WaitDockerConf,
 			Path:         "/etc/systemd/system/docker.service.d/01-wait-docker.conf",
 			Owner: k8scloudconfig.Owner{
@@ -230,6 +217,24 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 
 	certsMeta := []k8scloudconfig.FileMetadata{}
 	{
+		{
+			meta := k8scloudconfig.FileMetadata{
+				AssetContent: e.randomKeyTmplSet.APIServerEncryptionKey,
+				Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",
+				Owner: k8scloudconfig.Owner{
+					Group: k8scloudconfig.Group{
+						Name: FileOwnerGroupName,
+					},
+					User: k8scloudconfig.User{
+						Name: FileOwnerUserName,
+					},
+				},
+				Permissions: 0644,
+			}
+
+			certsMeta = append(certsMeta, meta)
+		}
+
 		for _, f := range e.clusterCerts {
 			var encrypted string
 			{

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -218,6 +218,8 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	certsMeta := []k8scloudconfig.FileMetadata{}
 	{
 		{
+			// Add to certsMeta slice so the encrypted encryption config file isn't passed through
+			// k8scloudconfig.RenderFileAssetContent like other files in filesMeta.
 			meta := k8scloudconfig.FileMetadata{
 				AssetContent: e.randomKeyTmplSet.APIServerEncryptionKey,
 				Path:         "/etc/kubernetes/encryption/k8s-encryption-config.yaml.enc",


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



## Context 

Fixes https://github.com/giantswarm/giantswarm/issues/11517. It looks like so far we took the KMS encrypted apiserver encryption key and processed it in the golang templating engine for no good reason. This approach apparently fails randomly in case the KMS encrypted content sequence represents character sets invalid to the golang templating engine. Talking to @tfussell it appears to be best when handling the apiserver encryption key like the encrypted certificates which we only base64 encode instead of decrypting again. Note that we struggle with this issue for about 2 years now and never could figure a legitimate fix. 