### PR TITLE
Add similar instance types mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add mapping between similar instance types `m4.16xlarge` and `m5.16xlarge`
+
 
 ## [8.7.0] 2020-06-19
 

--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -47,6 +47,16 @@ var (
 				WeightedCapacity: 1,
 			},
 		},
+		"m4.16xlarge": {
+			template.LaunchTemplateOverride{
+				InstanceType:     "m5.16xlarge",
+				WeightedCapacity: 1,
+			},
+			template.LaunchTemplateOverride{
+				InstanceType:     "m4.16xlarge",
+				WeightedCapacity: 1,
+			},
+		},
 		"m5.xlarge": {
 			template.LaunchTemplateOverride{
 				InstanceType:     "m5.xlarge",
@@ -74,6 +84,16 @@ var (
 			},
 			template.LaunchTemplateOverride{
 				InstanceType:     "m4.4xlarge",
+				WeightedCapacity: 1,
+			},
+		},
+		"m5.16xlarge": {
+			template.LaunchTemplateOverride{
+				InstanceType:     "m5.16xlarge",
+				WeightedCapacity: 1,
+			},
+			template.LaunchTemplateOverride{
+				InstanceType:     "m4.16xlarge",
 				WeightedCapacity: 1,
 			},
 		},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10730

This PR adds mappings of similar instance types for the following types:

- From `m4.16xlarge` to `m5.16xlarge`
- From `m5.16xlarge` to `m4.16xlarge`

## Checklist

- [x] Update changelog in CHANGELOG.md.
