### PR TITLE
Emit metric label on instance lifecycle to count spot/on-demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing go template rendering of KMS encryption content.
 - Use `0.1.0` tag for `k8s-api-heahtz` image.
 - Use `0.1.0` tag for `k8s-setup-network-env` image.
-
+- Add `lifecycle` label to the `aws_operator_ec2_instance_status` metric to distinguish on-demand and spot.
 
 ## [8.7.0] 2020-06-19
 

--- a/service/collector/ec2_instances.go
+++ b/service/collector/ec2_instances.go
@@ -34,6 +34,9 @@ const (
 	// labelPrivateDNS will contain the private dns name
 	labelPrivateDNS = "private_dns"
 
+	// labelLifecycle shows the distinction betwen spot and on-demand.
+	labelLifecycle = "lifecycle"
+
 	// subsystemEC2 will become the second part of the metric name, right after namespace.
 	subsystemEC2 = "ec2"
 )
@@ -53,6 +56,7 @@ var (
 			labelPrivateDNS,
 			labelInstanceState,
 			labelInstanceStatus,
+			labelLifecycle,
 		},
 		nil,
 	)
@@ -218,7 +222,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 			continue
 		}
 
-		var az, cluster, instanceType, installation, organization, privateDNS, state, status string
+		var az, cluster, instanceType, installation, lifecycle, organization, privateDNS, state, status string
 		for _, tag := range instances[instanceID].Tags {
 			switch *tag.Key {
 			case tagCluster:
@@ -232,6 +236,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 
 		instanceType = *instances[instanceID].InstanceType
 		privateDNS = *instances[instanceID].PrivateDnsName
+		lifecycle = *instances[instanceID].InstanceLifecycle
 
 		up := 0
 		if statuses.InstanceState.Name != nil {
@@ -261,6 +266,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 			privateDNS,
 			state,
 			status,
+			lifecycle,
 		)
 	}
 

--- a/service/collector/ec2_instances.go
+++ b/service/collector/ec2_instances.go
@@ -22,6 +22,9 @@ const (
 	// labelInstance is the metric's label key that will hold the ec2 instance ID.
 	labelInstance = "ec2_instance"
 
+	// labelLifecycle shows the distinction betwen spot and on-demand.
+	labelInstanceLifecycle = "lifecycle"
+
 	// labelInstanceState is a label that will contain the instance state string
 	labelInstanceState = "state"
 
@@ -33,9 +36,6 @@ const (
 
 	// labelPrivateDNS will contain the private dns name
 	labelPrivateDNS = "private_dns"
-
-	// labelLifecycle shows the distinction betwen spot and on-demand.
-	labelLifecycle = "lifecycle"
 
 	// subsystemEC2 will become the second part of the metric name, right after namespace.
 	subsystemEC2 = "ec2"
@@ -56,7 +56,7 @@ var (
 			labelPrivateDNS,
 			labelInstanceState,
 			labelInstanceStatus,
-			labelLifecycle,
+			labelInstanceLifecycle,
 		},
 		nil,
 	)
@@ -236,7 +236,7 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 
 		instanceType = *instances[instanceID].InstanceType
 		privateDNS = *instances[instanceID].PrivateDnsName
-		lifecycle = *instances[instanceID].InstanceLifecycle
+		lifecycle = "unknown"
 
 		up := 0
 		if statuses.InstanceState.Name != nil {
@@ -250,6 +250,9 @@ func (e *EC2Instances) collectForAccount(ch chan<- prometheus.Metric, awsClients
 		}
 		if state == "running" && status == "ok" {
 			up = 1
+		}
+		if instances[instanceID].InstanceLifecycle != nil {
+			lifecycle = *instances[instanceID].InstanceLifecycle
 		}
 
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
The goal here is to add a label to the `aws_operator_ec2_instance_status` for the lifecycle of the instance. The value can be `"spot"` or `"on-demand"`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
