### PR TITLE
scope cloudformation collector to reconciled version

### DIFF
--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -71,6 +71,10 @@ const (
 )
 
 const (
+	OutputOperatorVersion = "OperatorVersion"
+)
+
+const (
 	LifeCycleHookControlPlane = "ControlPlane"
 	LifeCycleHookNodePool     = "NodePool"
 )

--- a/service/controller/resource/tccpnoutputs/create.go
+++ b/service/controller/resource/tccpnoutputs/create.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	InstanceTypeKey    = "InstanceType"
-	OperatorVersionKey = "OperatorVersion"
-	MasterReplicasKey  = "MasterReplicas"
+	InstanceTypeKey   = "InstanceType"
+	MasterReplicasKey = "MasterReplicas"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -76,7 +75,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, OperatorVersionKey)
+		v, err := cloudFormation.GetOutputValue(outputs, key.OutputOperatorVersion)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/tccpoutputs/create.go
+++ b/service/controller/resource/tccpoutputs/create.go
@@ -15,7 +15,6 @@ const (
 	HostedZoneID              = "HostedZoneID"
 	HostedZoneNameServersKey  = "HostedZoneNameServers"
 	InternalHostedZoneID      = "InternalHostedZoneID"
-	OperatorVersion           = "OperatorVersion"
 	VPCIDKey                  = "VPCID"
 	VPCPeeringConnectionIDKey = "VPCPeeringConnectionID"
 )
@@ -118,7 +117,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, OperatorVersion)
+		v, err := cloudFormation.GetOutputValue(outputs, key.OutputOperatorVersion)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/tcnpoutputs/create.go
+++ b/service/controller/resource/tcnpoutputs/create.go
@@ -15,7 +15,6 @@ const (
 	DockerVolumeSizeGBKey = "DockerVolumeSizeGB"
 	InstanceImageKey      = "InstanceImage"
 	InstanceTypeKey       = "InstanceType"
-	OperatorVersionKey    = "OperatorVersion"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -92,7 +91,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		v, err := cloudFormation.GetOutputValue(outputs, OperatorVersionKey)
+		v, err := cloudFormation.GetOutputValue(outputs, key.OutputOperatorVersion)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

In the scope of the Team Firecracker Alerts Session I checked our collectors and noticed that we still emit metrics multiple times due to running multiple operators. I tried to improve the situation and noticed that further code improvements only increase complexity. I asked in `#sig-monitoring` about possible options. It seems on Azure we run a separate collector app. I think we should do the same on AWS. See https://gigantic.slack.com/archives/C0E0V16DC/p1594121192266400. I wanted to share my thought process here and only create the PR for documentation purposes. I will close it once created. 