### PR TITLE
dependency checker for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
   - dependency-name: k8s.io/*
     versions:
     - ">=0.17.0"
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"
+  target-branch: master
+  reviewers:
+  - giantswarm/team-firecracker-pe


### PR DESCRIPTION
dependabot should create PR's in case we get a newer alpine image

## Checklist

- [ ] Update changelog in CHANGELOG.md.