### PR TITLE
bump version to v8.7.3-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "8.7.2"
+	version            = "8.7.3-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Bumping version after release manually. Actions failed because of branch protection: https://github.com/giantswarm/aws-operator/actions/runs/168751560 