### PR TITLE
Fix region prefix in helm chart

### DIFF
--- a/helm/aws-operator/templates/configmap.yaml
+++ b/helm/aws-operator/templates/configmap.yaml
@@ -45,7 +45,7 @@ data:
           clusterDomain: '{{ .Values.Installation.V1.Guest.Kubernetes.ClusterDomain }}'
           networkSetup:
             docker:
-              {{- if hasPrefix .Values.Installation.V1.Provider.AWS.Region "cn-" }}
+              {{- if hasPrefix "cn-" .Values.Installation.V1.Provider.AWS.Region }}
               image: '{{ .Values.Installation.V1.Registry.Domain }}/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9'
               {{ else }}
               image: 'docker.io/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9'
@@ -57,7 +57,7 @@ data:
           ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'
 
       registry:
-      {{- if hasPrefix .Values.Installation.V1.Provider.AWS.Region "cn-" }}
+      {{- if hasPrefix "cn-" .Values.Installation.V1.Provider.AWS.Region }}
         domain: '{{ .Values.Installation.V1.Registry.Domain }}'
         mirrors: '{{ range $i, $e := .Values.Installation.V1.Registry.Mirrors }}{{ if $i }},{{end}}{{ $e }}{{end}}'
       {{ else }}


### PR DESCRIPTION
Fixes region condition error.

Quote from helm docs:
> hasPrefix and hasSuffix
> The hasPrefix and hasSuffix functions test whether a string has a given prefix or suffix:
> 
> hasPrefix "cat" "catch"
> The above returns true because catch has the prefix cat.