### PR TITLE
Change image repo name for AWS CNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use aws-cni version from the release.
+- Use aws-cni image built based on https://github.com/giantswarm/aws-cni
 - `k8scloudconfig` version updated to 7.0.3.
 
 ## [8.7.3] - 2020-07-15

--- a/service/internal/cloudconfig/template/aws-cni.go
+++ b/service/internal/cloudconfig/template/aws-cni.go
@@ -101,7 +101,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: {{.RegistryDomain}}/giantswarm/amazon-k8s-cni:v{{.AWSCNIVersion}}
+        - image: {{.RegistryDomain}}/giantswarm/aws-cni:v{{.AWSCNIVersion}}
           ports:
             - containerPort: 61678
               name: metrics


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10711

Goal of this PR is to make use of the Docker image built based on https://github.com/giantswarm/aws-cni

## Warning

This will only work for `v1.6.3` after https://github.com/giantswarm/aws-cni/pull/4 is merged and released.

`v1.7.0-rc1` is already available.

## Checklist

- [x] Update changelog in CHANGELOG.md.
