### PR TITLE
add verification hash calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add verification hash calculation for Cloud Formation stack update improvements.
+
 ## [8.7.5] - 2020-07-30
 
 ### Changed

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -380,12 +380,13 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 	var tccpnResource resource.Interface
 	{
 		c := tccpn.Config{
-			Detection: tccpnChangeDetection,
-			Event:     config.Event,
-			HAMaster:  config.HAMaster,
-			Images:    config.Images,
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
+			CloudConfig: tccpnCloudConfig,
+			Detection:   tccpnChangeDetection,
+			Event:       config.Event,
+			HAMaster:    config.HAMaster,
+			Images:      config.Images,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
 
 			InstallationName: config.InstallationName,
 			Route53Enabled:   config.Route53Enabled,

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -510,11 +510,12 @@ func newMachineDeploymentResources(config MachineDeploymentConfig) ([]resource.I
 	var tcnpResource resource.Interface
 	{
 		c := tcnp.Config{
-			Detection: tcnpChangeDetection,
-			Event:     config.Event,
-			Images:    config.Images,
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
+			CloudConfig: tcnpCloudConfig,
+			Detection:   tcnpChangeDetection,
+			Event:       config.Event,
+			Images:      config.Images,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
 
 			InstallationName: config.InstallationName,
 		}

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -425,8 +425,16 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 		}
 	}
 
+	var hashes []string
+	{
+		hashes, err = r.cloudConfig.NewHashes(ctx, cr)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	launchTemplate := &template.ParamsMainLaunchTemplate{}
-	for _, m := range mappings {
+	for i, m := range mappings {
 		item := template.ParamsMainLaunchTemplateItem{
 			BlockDeviceMapping: template.ParamsMainLaunchTemplateItemBlockDeviceMapping{
 				Docker: template.ParamsMainLaunchTemplateItemBlockDeviceMappingDocker{
@@ -454,6 +462,7 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 			Name:                  key.ControlPlaneLaunchTemplateName(&cr, m.ID),
 			Resource:              key.ControlPlaneLaunchTemplateResourceName(&cr, m.ID),
 			SmallCloudConfig: template.ParamsMainLaunchTemplateItemSmallCloudConfig{
+				Hash:  hashes[i],
 				S3URL: fmt.Sprintf("s3://%s/%s", key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID), key.S3ObjectPathTCCPN(&cr, m.ID)),
 			},
 		}

--- a/service/controller/resource/tccpn/create_test.go
+++ b/service/controller/resource/tccpn/create_test.go
@@ -148,12 +148,13 @@ func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 			var r *Resource
 			{
 				c := Config{
-					Event:     e,
-					K8sClient: k,
-					Detection: d,
-					HAMaster:  h,
-					Images:    i,
-					Logger:    microloggertest.New(),
+					CloudConfig: &unittest.CloudConfig{},
+					Event:       e,
+					K8sClient:   k,
+					Detection:   d,
+					HAMaster:    h,
+					Images:      i,
+					Logger:      microloggertest.New(),
 
 					InstallationName: "dummy",
 					Route53Enabled:   tc.route53Enabled,

--- a/service/controller/resource/tccpn/template/params_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/params_main_launch_template.go
@@ -50,5 +50,6 @@ type ParamsMainLaunchTemplateItemBlockDeviceMappingLoggingVolume struct {
 }
 
 type ParamsMainLaunchTemplateItemSmallCloudConfig struct {
+	Hash  string
 	S3URL string
 }

--- a/service/controller/resource/tccpn/template/template_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/template_main_launch_template.go
@@ -46,7 +46,10 @@ const TemplateMainLaunchTemplate = `
                 "config": {
                   "append": [
                     {
-                      "source": "{{ .SmallCloudConfig.S3URL }}"
+                      "source": "{{ .SmallCloudConfig.S3URL }}",
+                      "verification": {
+                        "hash": "{{ .SmallCloudConfig.Hash }}"
+                      }
                     }
                   ]
                 }

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -263,7 +263,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-0"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-0",
+                      "verification": {
+                        "hash": "sha512-foobar1"
+                      }
                     }
                   ]
                 }

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -233,7 +233,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-0"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-0",
+                      "verification": {
+                        "hash": "sha512-foobar1"
+                      }
                     }
                   ]
                 }

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -437,7 +437,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-1"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-1",
+                      "verification": {
+                        "hash": "sha512-foobar1"
+                      }
                     }
                   ]
                 }
@@ -517,7 +520,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-2"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-2",
+                      "verification": {
+                        "hash": "sha512-foobar2"
+                      }
                     }
                   ]
                 }
@@ -597,7 +603,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-3"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tccpn-3",
+                      "verification": {
+                        "hash": "sha512-foobar3"
+                      }
                     }
                   ]
                 }

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -355,6 +355,16 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 		}
 	}
 
+	var hash string
+	{
+		hashes, err := r.cloudConfig.NewHashes(ctx, cr)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		hash = hashes[0]
+	}
+
 	launchTemplate := &template.ParamsMainLaunchTemplate{
 		BlockDeviceMapping: template.ParamsMainLaunchTemplateBlockDeviceMapping{
 			Docker: template.ParamsMainLaunchTemplateBlockDeviceMappingDocker{
@@ -380,6 +390,7 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 		},
 		Name: key.MachineDeploymentLaunchTemplateName(cr),
 		SmallCloudConfig: template.ParamsMainLaunchTemplateSmallCloudConfig{
+			Hash:  hash,
 			S3URL: fmt.Sprintf("s3://%s/%s", key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID), key.S3ObjectPathTCNP(&cr)),
 		},
 	}

--- a/service/controller/resource/tcnp/create_test.go
+++ b/service/controller/resource/tcnp/create_test.go
@@ -110,11 +110,12 @@ func Test_Controller_Resource_TCNP_Template_Render(t *testing.T) {
 			var r *Resource
 			{
 				c := Config{
-					Detection: d,
-					Event:     e,
-					Images:    i,
-					K8sClient: k,
-					Logger:    microloggertest.New(),
+					CloudConfig: &unittest.CloudConfig{},
+					Detection:   d,
+					Event:       e,
+					Images:      i,
+					K8sClient:   k,
+					Logger:      microloggertest.New(),
 
 					InstallationName: "dummy",
 				}

--- a/service/controller/resource/tcnp/resource.go
+++ b/service/controller/resource/tcnp/resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/micrologger"
 
 	"github.com/giantswarm/aws-operator/service/internal/changedetection"
+	"github.com/giantswarm/aws-operator/service/internal/cloudconfig"
 	"github.com/giantswarm/aws-operator/service/internal/images"
 	event "github.com/giantswarm/aws-operator/service/internal/recorder"
 )
@@ -16,11 +17,12 @@ const (
 )
 
 type Config struct {
-	Detection *changedetection.TCNP
-	Event     event.Interface
-	Images    images.Interface
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
+	CloudConfig cloudconfig.Interface
+	Detection   *changedetection.TCNP
+	Event       event.Interface
+	Images      images.Interface
+	K8sClient   k8sclient.Interface
+	Logger      micrologger.Logger
 
 	InstallationName string
 }
@@ -28,16 +30,20 @@ type Config struct {
 // Resource implements the TCNP resource, which stands for Tenant Cluster Data
 // Plane. We manage a dedicated Cloud Formation stack for each node pool.
 type Resource struct {
-	detection *changedetection.TCNP
-	event     event.Interface
-	images    images.Interface
-	k8sClient k8sclient.Interface
-	logger    micrologger.Logger
+	cloudConfig cloudconfig.Interface
+	detection   *changedetection.TCNP
+	event       event.Interface
+	images      images.Interface
+	k8sClient   k8sclient.Interface
+	logger      micrologger.Logger
 
 	installationName string
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CloudConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CloudConfig must not be empty", config)
+	}
 	if config.Detection == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Detection must not be empty", config)
 	}
@@ -59,11 +65,12 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		detection: config.Detection,
-		event:     config.Event,
-		images:    config.Images,
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		cloudConfig: config.CloudConfig,
+		detection:   config.Detection,
+		event:       config.Event,
+		images:      config.Images,
+		k8sClient:   config.K8sClient,
+		logger:      config.Logger,
 
 		installationName: config.InstallationName,
 	}

--- a/service/controller/resource/tcnp/template/params_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/params_main_launch_template.go
@@ -44,5 +44,6 @@ type ParamsMainLaunchTemplateBlockDeviceMappingLoggingVolume struct {
 }
 
 type ParamsMainLaunchTemplateSmallCloudConfig struct {
+	Hash  string
 	S3URL string
 }

--- a/service/controller/resource/tcnp/template/template_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/template_main_launch_template.go
@@ -45,7 +45,10 @@ const TemplateMainLaunchTemplate = `
                 "config": {
                   "append": [
                     {
-                      "source": "{{ .LaunchTemplate.SmallCloudConfig.S3URL }}"
+                      "source": "{{ .LaunchTemplate.SmallCloudConfig.S3URL }}",
+                      "verification": {
+                        "hash": "{{ .LaunchTemplate.SmallCloudConfig.Hash }}"
+                      }
                     }
                   ]
                 }

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -199,7 +199,10 @@ Resources:
                 "config": {
                   "append": [
                     {
-                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tcnp-al9qy"
+                      "source": "s3://tenant-account-g8s-8y5ck/version/7.3.0/cloudconfig/v_6_1_0/cluster-8y5ck-tcnp-al9qy",
+                      "verification": {
+                        "hash": "sha512-foobar1"
+                      }
                     }
                   ]
                 }

--- a/service/internal/cloudconfig/spec.go
+++ b/service/internal/cloudconfig/spec.go
@@ -5,6 +5,10 @@ import (
 )
 
 type Interface interface {
+	// NewHashes generates the ignition verification hashes according to the
+	// generated templates. All calls are indempotent and alligned within the
+	// same reconciliation loop.
+	NewHashes(ctx context.Context, obj interface{}) ([]string, error)
 	// NewPaths returns a list of S3 Object paths aligned with the templates
 	// returned by NewTemplates.
 	NewPaths(ctx context.Context, obj interface{}) ([]string, error)

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -2,6 +2,7 @@ package cloudconfig
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sync"
 
@@ -38,6 +39,23 @@ func NewTCCPN(config TCCPNConfig) (*TCCPN, error) {
 	}
 
 	return t, nil
+}
+
+func (t *TCCPN) NewHashes(ctx context.Context, obj interface{}) ([]string, error) {
+	var hashes []string
+
+	templates, err := t.NewTemplates(ctx, obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, t := range templates {
+		h := sha256.New()
+		h.Write([]byte(t))
+		hashes = append(hashes, string(h.Sum(nil)))
+	}
+
+	return hashes, nil
 }
 
 func (t *TCCPN) NewPaths(ctx context.Context, obj interface{}) ([]string, error) {

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -51,7 +51,10 @@ func (t *TCCPN) NewHashes(ctx context.Context, obj interface{}) ([]string, error
 
 	for _, t := range templates {
 		h := sha512.New()
-		h.Write([]byte("sha512-" + t))
+		_, err := h.Write([]byte("sha512-" + t))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 		hashes = append(hashes, string(h.Sum(nil)))
 	}
 

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -2,7 +2,7 @@ package cloudconfig
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"sync"
 
@@ -50,8 +50,8 @@ func (t *TCCPN) NewHashes(ctx context.Context, obj interface{}) ([]string, error
 	}
 
 	for _, t := range templates {
-		h := sha256.New()
-		h.Write([]byte(t))
+		h := sha512.New()
+		h.Write([]byte("sha512-" + t))
 		hashes = append(hashes, string(h.Sum(nil)))
 	}
 

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -2,7 +2,7 @@ package cloudconfig
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"sync"
 
@@ -50,8 +50,8 @@ func (t *TCNP) NewHashes(ctx context.Context, obj interface{}) ([]string, error)
 	}
 
 	for _, t := range templates {
-		h := sha256.New()
-		h.Write([]byte(t))
+		h := sha512.New()
+		h.Write([]byte("sha512-" + t))
 		hashes = append(hashes, string(h.Sum(nil)))
 	}
 

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -2,6 +2,7 @@ package cloudconfig
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sync"
 
@@ -38,6 +39,23 @@ func NewTCNP(config TCNPConfig) (*TCNP, error) {
 	}
 
 	return t, nil
+}
+
+func (t *TCNP) NewHashes(ctx context.Context, obj interface{}) ([]string, error) {
+	var hashes []string
+
+	templates, err := t.NewTemplates(ctx, obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, t := range templates {
+		h := sha256.New()
+		h.Write([]byte(t))
+		hashes = append(hashes, string(h.Sum(nil)))
+	}
+
+	return hashes, nil
 }
 
 func (t *TCNP) NewPaths(ctx context.Context, obj interface{}) ([]string, error) {

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -51,7 +51,10 @@ func (t *TCNP) NewHashes(ctx context.Context, obj interface{}) ([]string, error)
 
 	for _, t := range templates {
 		h := sha512.New()
-		h.Write([]byte("sha512-" + t))
+		_, err := h.Write([]byte("sha512-" + t))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 		hashes = append(hashes, string(h.Sum(nil)))
 	}
 

--- a/service/internal/unittest/default_cloudconfig.go
+++ b/service/internal/unittest/default_cloudconfig.go
@@ -1,0 +1,18 @@
+package unittest
+
+import "context"
+
+type CloudConfig struct {
+}
+
+func (c *CloudConfig) NewHashes(ctx context.Context, obj interface{}) ([]string, error) {
+	return []string{"sha512-foobar1", "sha512-foobar2", "sha512-foobar3"}, nil
+}
+
+func (c *CloudConfig) NewPaths(ctx context.Context, obj interface{}) ([]string, error) {
+	return nil, nil
+}
+
+func (c *CloudConfig) NewTemplates(ctx context.Context, obj interface{}) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

We noticed that there are some issues with the update detection. In order to have a more reliable update mechanism we need to notice template changes based on crypto hashes. This became necessary since e.g. the Kubernetes versions are not baked into the "k8scc" packages anymore. Here Vaclav gave the hint to use the ignition verification hash. Nick is driving. 🎉 