### PR TITLE
Add release tag to launch templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add release version tag for ec2 instances
+
 ## [8.7.5] - 2020-07-30
 
 ### Changed

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -452,6 +452,7 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 			},
 			MasterSecurityGroupID: idFromGroups(cc.Status.TenantCluster.TCCP.SecurityGroups, key.SecurityGroupName(&cr, "master")),
 			Name:                  key.ControlPlaneLaunchTemplateName(&cr, m.ID),
+			ReleaseVersion:        key.ReleaseVersion(&cr),
 			Resource:              key.ControlPlaneLaunchTemplateResourceName(&cr, m.ID),
 			SmallCloudConfig: template.ParamsMainLaunchTemplateItemSmallCloudConfig{
 				S3URL: fmt.Sprintf("s3://%s/%s", key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID), key.S3ObjectPathTCCPN(&cr, m.ID)),

--- a/service/controller/resource/tccpn/template/params_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/params_main_launch_template.go
@@ -11,6 +11,7 @@ type ParamsMainLaunchTemplateItem struct {
 	MasterSecurityGroupID string
 	Name                  string
 	Resource              string
+	ReleaseVersion        string
 }
 
 type ParamsMainLaunchTemplateItemBlockDeviceMapping struct {

--- a/service/controller/resource/tccpn/template/template_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/template_main_launch_template.go
@@ -43,10 +43,6 @@ const TemplateMainLaunchTemplate = `
           Tags:
             - Key: giantswarm.io/release
               Value: {{ .ReleaseVersion }}
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: {{ .ReleaseVersion }}
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/template/template_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/template_main_launch_template.go
@@ -38,6 +38,15 @@ const TemplateMainLaunchTemplate = `
             DeviceIndex: 0
             Groups:
             - {{ .MasterSecurityGroupID }}
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: {{ .ReleaseVersion }}
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: {{ .ReleaseVersion }}
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/template/template_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/template_main_launch_template.go
@@ -38,7 +38,7 @@ const TemplateMainLaunchTemplate = `
             DeviceIndex: 0
             Groups:
             - {{ .MasterSecurityGroupID }}
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -260,10 +260,6 @@ Resources:
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -255,6 +255,15 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -255,7 +255,7 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -230,10 +230,6 @@ Resources:
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -225,6 +225,15 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -225,7 +225,7 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -434,10 +434,6 @@ Resources:
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {
@@ -523,10 +519,6 @@ Resources:
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {
@@ -609,10 +601,6 @@ Resources:
             - master-security-group-id
         TagSpecifications:
         - ResourceType: instance
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
-        - ResourceType: launch-template
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -429,7 +429,7 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release
@@ -518,7 +518,7 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release
@@ -607,7 +607,7 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -429,6 +429,15 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {
@@ -509,6 +518,15 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {
@@ -589,6 +607,15 @@ Resources:
             DeviceIndex: 0
             Groups:
             - master-security-group-id
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -378,7 +378,8 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 			Monitoring: true,
 			Type:       key.MachineDeploymentInstanceType(cr),
 		},
-		Name: key.MachineDeploymentLaunchTemplateName(cr),
+		Name:           key.MachineDeploymentLaunchTemplateName(cr),
+		ReleaseVersion: key.ReleaseVersion(&cr),
 		SmallCloudConfig: template.ParamsMainLaunchTemplateSmallCloudConfig{
 			S3URL: fmt.Sprintf("s3://%s/%s", key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID), key.S3ObjectPathTCNP(&cr)),
 		},

--- a/service/controller/resource/tcnp/template/params_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/params_main_launch_template.go
@@ -4,6 +4,7 @@ type ParamsMainLaunchTemplate struct {
 	BlockDeviceMapping ParamsMainLaunchTemplateBlockDeviceMapping
 	Instance           ParamsMainLaunchTemplateInstance
 	Name               string
+	ReleaseVersion     string
 	SmallCloudConfig   ParamsMainLaunchTemplateSmallCloudConfig
 }
 

--- a/service/controller/resource/tcnp/template/template_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/template_main_launch_template.go
@@ -37,7 +37,7 @@ const TemplateMainLaunchTemplate = `
             DeviceIndex: 0
             Groups:
               - !Ref GeneralSecurityGroup
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release

--- a/service/controller/resource/tcnp/template/template_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/template_main_launch_template.go
@@ -42,10 +42,6 @@ const TemplateMainLaunchTemplate = `
           Tags:
             - Key: giantswarm.io/release
               Value: {{ .LaunchTemplate.ReleaseVersion }}
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: {{ .LaunchTemplate.ReleaseVersion }}
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tcnp/template/template_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/template_main_launch_template.go
@@ -37,6 +37,15 @@ const TemplateMainLaunchTemplate = `
             DeviceIndex: 0
             Groups:
               - !Ref GeneralSecurityGroup
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: {{ .LaunchTemplate.ReleaseVersion }}
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: {{ .LaunchTemplate.ReleaseVersion }}
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -191,6 +191,15 @@ Resources:
             DeviceIndex: 0
             Groups:
               - !Ref GeneralSecurityGroup
+        TagSpecification:
+        - ResourceType: instance
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
+        - ResourceType: launch-template
+          Tags:
+            - Key: giantswarm.io/release
+              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -196,10 +196,6 @@ Resources:
           Tags:
             - Key: giantswarm.io/release
               Value: 100.0.0
-        - ResourceType: launch-template
-          Tags:
-            - Key: giantswarm.io/release
-              Value: 100.0.0
         UserData:
           Fn::Base64: |
             {

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -191,7 +191,7 @@ Resources:
             DeviceIndex: 0
             Groups:
               - !Ref GeneralSecurityGroup
-        TagSpecification:
+        TagSpecifications:
         - ResourceType: instance
           Tags:
             - Key: giantswarm.io/release


### PR DESCRIPTION
This included release version for launch templates.
The goal is to use it for rolling nodes when change detection triggers.


## Checklist

- [x] Update changelog in CHANGELOG.md.