### PR TITLE
Avoid panic when AWSControlPlane CR AZs are nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't panic when AWSControlPlane CR AZs are nil.
+
 ### Changed
 
 - Updated workflows for automatic release.

--- a/service/internal/hamaster/error.go
+++ b/service/internal/hamaster/error.go
@@ -29,3 +29,13 @@ var tooManyCRsError = &microerror.Error{
 func IsTooManyCRsError(err error) bool {
 	return microerror.Cause(err) == tooManyCRsError
 }
+
+var availabilityZonesNilError = &microerror.Error{
+	Kind: "availabilityZonesNilError",
+	Desc: "The availability zones in AWSControlPlane CR must not be nil.",
+}
+
+// IsAvalailabilityZonesNilError asserts tooManyCRsError.
+func IsAvalailabilityZonesNilError(err error) bool {
+	return microerror.Cause(err) == availabilityZonesNilError
+}

--- a/service/internal/hamaster/ha_master.go
+++ b/service/internal/hamaster/ha_master.go
@@ -77,6 +77,11 @@ func (h *HAMaster) Mapping(ctx context.Context, obj interface{}) ([]Mapping, err
 		return nil, microerror.Mask(err)
 	}
 
+	if aws.Spec.AvailabilityZones == nil {
+		return nil, microerror.Mask(availabilityZonesNilError)
+
+	}
+
 	// We need a deterministic list of availability zones which we can loop over
 	// through for the required amount of masters. Eventually it happens that
 	// there is only 1 availability zone in a HA Masters setup. Therefore the

--- a/service/internal/hamaster/ha_master.go
+++ b/service/internal/hamaster/ha_master.go
@@ -79,7 +79,6 @@ func (h *HAMaster) Mapping(ctx context.Context, obj interface{}) ([]Mapping, err
 
 	if aws.Spec.AvailabilityZones == nil {
 		return nil, microerror.Mask(availabilityZonesNilError)
-
 	}
 
 	// We need a deterministic list of availability zones which we can loop over


### PR DESCRIPTION
Under certain conditions we saw aws-operator is throwing a panic. Whenever admission-controller doesn't default we do not have any safenet which protects us from panicing, in case we have this issue we should write an error (logs and events).
We want to avoid that by verifying first if there are any AZs set.

```
{"caller":"github.com/giantswarm/aws-operator/service/controller/resource/accountid/resource.go:101","controller":"aws-operator-machine-deployment-controller","event":"update","level":"debug","loop":"4","message":"found the tenant cluster's AWS account ID `270935918670`","object":"/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/awsmachinedeployments/u88jg","resource":"accountid","time":"2020-08-17T10:06:57.382154+00:00","version":"116411811"}
E0817 10:06:57.386539       1 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
goroutine 1229 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x22d2740, 0xc001c115a0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/runtime/runtime.go:48 +0x82
panic(0x22d2740, 0xc001c115a0)
	/usr/local/go/src/runtime/panic.go:967 +0x166
github.com/giantswarm/aws-operator/service/internal/hamaster.(*HAMaster).Mapping(0xc0008c4ce0, 0x29831a0, 0xc000285e00, 0x23eba00, 0xc0003b2f00, 0xc002bac040, 0xc0020d6930, 0xd, 0xc00139b400, 0x10000c001dcac30)
	/root/project/service/internal/hamaster/ha_master.go:113 +0x8d7
github.com/giantswarm/aws-operator/service/controller/resource/tccp.(*Resource).newParamsMainInstance(0xc0008a40c0, 0x29831a0, 0xc000285e00, 0x0, 0x0, 0x0, 0x0, 0xc000d40570, 0x5, 0x0, ...)
	/root/project/service/controller/resource/tccp/create.go:327 +0xcb
github.com/giantswarm/aws-operator/service/controller/resource/tccp.(*Resource).newParamsMain(0xc0008a40c0, 0x29831a0, 0xc000285e00, 0x0, 0x0, 0x0, 0x0, 0xc000d40570, 0x5, 0x0, ...)
	/root/project/service/controller/resource/tccp/create.go:268 +0x13b
github.com/giantswarm/aws-operator/service/controller/resource/tccp.(*Resource).createStack(0xc0008a40c0, 0x29831a0, 0xc000285e00, 0x0, 0x0, 0x0, 0x0, 0xc000d40570, 0x5, 0x0, ...)
	/root/project/service/controller/resource/tccp/create.go:171 +0x223
github.com/giantswarm/aws-operator/service/controller/resource/tccp.(*Resource).EnsureCreated(0xc0008a40c0, 0x29831a0, 0xc000285e00, 0x23eba00, 0xc0020ee280, 0x21bd000, 0x152dd2c)
```

## Checklist

- [x] Update changelog in CHANGELOG.md.