### PR TITLE
Events for tccpi and tccpf CF stack failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Emit Kubernetes events for tccpi and tccpf Cloudformation stack failures 
 - Add monitoring label
 - Handle the case when there are both public and private hosted zones for CP
   base domain.

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -565,6 +565,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	{
 		c := tccpf.Config{
 			Detection: tccpfChangeDetection,
+			Event:     config.Event,
 			Logger:    config.Logger,
 
 			InstallationName: config.InstallationName,
@@ -580,6 +581,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	var tccpiResource resource.Interface
 	{
 		c := tccpi.Config{
+			Event:  config.Event,
 			Logger: config.Logger,
 
 			InstallationName: config.InstallationName,

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -61,7 +61,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
 
 		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
-			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+			return microerror.Maskf(eventCFCreateError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusRollbackFailed {
+			return microerror.Maskf(eventCFRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusUpdateRollbackFailed {
+			return microerror.Maskf(eventCFUpdateRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
 
 		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateInProgress {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusCreateInProgress))

--- a/service/controller/resource/tccpf/create_test.go
+++ b/service/controller/resource/tccpf/create_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/service/controller/resource/tccpf/template"
 	"github.com/giantswarm/aws-operator/service/internal/changedetection"
+	"github.com/giantswarm/aws-operator/service/internal/recorder"
 	"github.com/giantswarm/aws-operator/service/internal/unittest"
 )
 
@@ -55,6 +56,8 @@ func Test_Controller_Resource_TCCPF_Template_Render(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var err error
 
+			k := unittest.FakeK8sClient()
+
 			var d *changedetection.TCCPF
 			{
 				c := changedetection.TCCPFConfig{
@@ -67,10 +70,22 @@ func Test_Controller_Resource_TCCPF_Template_Render(t *testing.T) {
 				}
 			}
 
+			var e recorder.Interface
+			{
+				c := recorder.Config{
+					K8sClient: k,
+
+					Component: "dummy",
+				}
+
+				e = recorder.New(c)
+			}
+
 			var r *Resource
 			{
 				c := Config{
 					Detection: d,
+					Event:     e,
 					Logger:    microloggertest.New(),
 
 					InstallationName: "dummy",

--- a/service/controller/resource/tccpf/delete.go
+++ b/service/controller/resource/tccpf/delete.go
@@ -2,6 +2,7 @@ package tccpf
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -33,6 +34,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane finalizer cloud formation stack is being deleted")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if IsDeleteFailed(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane finalizer cloud formation stack failed to delete")
+			r.event.Emit(ctx, &cr, "CFDeleteFailed", fmt.Sprintf("the tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed))
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
 			finalizerskeptcontext.SetKept(ctx)

--- a/service/controller/resource/tccpf/error.go
+++ b/service/controller/resource/tccpf/error.go
@@ -1,6 +1,7 @@
 package tccpf
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -28,6 +29,45 @@ var (
 //
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
+}
+
+// event... is an error type for situations where we want to create an Kubernetes event in operatorkit.
+var eventCFCreateError = &microerror.Error{
+	Kind: "CFCreateFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusCreateFailed),
+}
+var eventCFUpdateRollbackError = &microerror.Error{
+	Kind: "CFUpdateRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusUpdateRollbackFailed),
+}
+
+var eventCFRollbackError = &microerror.Error{
+	Kind: "CFRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusRollbackFailed),
+}
+
+var eventCFDeleteError = &microerror.Error{
+	Kind: "CFDeleteFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed),
+}
+
+// IsDeleteFailed asserts eventCFDeleteError.
+func IsDeleteFailed(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusDeleteFailed) {
+		return true
+	}
+
+	if c == eventCFDeleteError {
+		return true
+	}
+
+	return false
 }
 
 var deleteInProgressError = &microerror.Error{

--- a/service/controller/resource/tccpf/resource.go
+++ b/service/controller/resource/tccpf/resource.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/micrologger"
 
 	"github.com/giantswarm/aws-operator/service/internal/changedetection"
+	"github.com/giantswarm/aws-operator/service/internal/recorder"
 )
 
 const (
@@ -14,6 +15,7 @@ const (
 
 type Config struct {
 	Detection *changedetection.TCCPF
+	Event     recorder.Interface
 	Logger    micrologger.Logger
 
 	InstallationName string
@@ -25,6 +27,7 @@ type Config struct {
 // manage a dedicated CF stack for the record sets and routing tables setup.
 type Resource struct {
 	detection *changedetection.TCCPF
+	event     recorder.Interface
 	logger    micrologger.Logger
 
 	installationName string
@@ -35,12 +38,16 @@ func New(config Config) (*Resource, error) {
 	if config.Detection == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Detection must not be empty", config)
 	}
+	if config.Event == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Event must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
 	r := &Resource{
 		detection: config.Detection,
+		event:     config.Event,
 		logger:    config.Logger,
 
 		installationName: config.InstallationName,

--- a/service/controller/resource/tccpi/create.go
+++ b/service/controller/resource/tccpi/create.go
@@ -45,7 +45,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
 
 		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
-			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+			return microerror.Maskf(eventCFCreateError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusRollbackFailed {
+			return microerror.Maskf(eventCFRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusUpdateRollbackFailed {
+			return microerror.Maskf(eventCFUpdateRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
 
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's control plane initializer cloud formation stack already exists")

--- a/service/controller/resource/tccpi/delete.go
+++ b/service/controller/resource/tccpi/delete.go
@@ -2,6 +2,7 @@ package tccpi
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -33,6 +34,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer cloud formation stack is being deleted")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if IsDeleteFailed(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's control plane initializer cloud formation stack failed to delete")
+			r.event.Emit(ctx, &cr, "CFDeleteFailed", fmt.Sprintf("the tenant cluster's control plane initializer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed))
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
 			finalizerskeptcontext.SetKept(ctx)

--- a/service/controller/resource/tccpi/error.go
+++ b/service/controller/resource/tccpi/error.go
@@ -1,6 +1,7 @@
 package tccpi
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -17,6 +18,45 @@ import (
 //
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
+}
+
+// event... is an error type for situations where we want to create an Kubernetes event in operatorkit.
+var eventCFCreateError = &microerror.Error{
+	Kind: "CFCreateFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane initializer cloud formation stack has stack status %#q", cloudformation.StackStatusCreateFailed),
+}
+var eventCFUpdateRollbackError = &microerror.Error{
+	Kind: "CFUpdateRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane initializer cloud formation stack has stack status %#q", cloudformation.StackStatusUpdateRollbackFailed),
+}
+
+var eventCFRollbackError = &microerror.Error{
+	Kind: "CFRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane initializer cloud formation stack has stack status %#q", cloudformation.StackStatusRollbackFailed),
+}
+
+var eventCFDeleteError = &microerror.Error{
+	Kind: "CFDeleteFailed",
+	Desc: fmt.Sprintf("The tenant cluster's control plane initializer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed),
+}
+
+// IsDeleteFailed asserts eventCFDeleteError.
+func IsDeleteFailed(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusDeleteFailed) {
+		return true
+	}
+
+	if c == eventCFDeleteError {
+		return true
+	}
+
+	return false
 }
 
 var deleteInProgressError = &microerror.Error{

--- a/service/controller/resource/tccpi/resource.go
+++ b/service/controller/resource/tccpi/resource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
 	"github.com/giantswarm/aws-operator/service/controller/key"
+	"github.com/giantswarm/aws-operator/service/internal/recorder"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 )
 
 type Config struct {
+	Event  recorder.Interface
 	Logger micrologger.Logger
 
 	InstallationName string
@@ -25,17 +27,22 @@ type Config struct {
 // Initializer. This was formerly known as the host pre stack. We manage a
 // dedicated CF stack for the IAM role and VPC Peering setup.
 type Resource struct {
+	event  recorder.Interface
 	logger micrologger.Logger
 
 	installationName string
 }
 
 func New(config Config) (*Resource, error) {
+	if config.Event == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Event must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
 	r := &Resource{
+		event:  config.Event,
 		logger: config.Logger,
 
 		installationName: config.InstallationName,


### PR DESCRIPTION
Since tccpi and tccpf stacks are created in controlplane account, I think it would make sense to show failures on the AWSCluster CR in case we have some issues. It would help us and the customer to see what's going on easily.

This will write K8s events in case something is wrong.

I'll create a separate PR for tcnpf stacks to make this PR a bit smaller.

## Checklist

- [x] Update changelog in CHANGELOG.md.