### PR TITLE
k8s events for CF failures for tcnpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Emit Kubernetes events for tcnpf Cloudformation stack failures
 - Emit Kubernetes events for tccpi and tccpf Cloudformation stack failures 
 - Add monitoring label
 - Handle the case when there are both public and private hosted zones for CP

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -544,6 +544,7 @@ func newMachineDeploymentResources(config MachineDeploymentConfig) ([]resource.I
 	var tcnpfResource resource.Interface
 	{
 		c := tcnpf.Config{
+			Event:  config.Event,
 			Logger: config.Logger,
 
 			InstallationName: config.InstallationName,

--- a/service/controller/resource/tcnpf/create.go
+++ b/service/controller/resource/tcnpf/create.go
@@ -57,7 +57,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Maskf(executionFailedError, "expected one stack, got %d", len(o.Stacks))
 
 		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusCreateFailed {
-			return microerror.Maskf(executionFailedError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+			return microerror.Maskf(eventCFCreateError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusRollbackFailed {
+			return microerror.Maskf(eventCFRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
+		} else if *o.Stacks[0].StackStatus == cloudformation.StackStatusUpdateRollbackFailed {
+			return microerror.Maskf(eventCFUpdateRollbackError, "expected successful status, got %#q", *o.Stacks[0].StackStatus)
 
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found the tenant cluster's node pool finalizer cloud formation stack already exists")

--- a/service/controller/resource/tcnpf/delete.go
+++ b/service/controller/resource/tcnpf/delete.go
@@ -2,6 +2,7 @@ package tcnpf
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -33,6 +34,17 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		_, err = cc.Client.ControlPlane.AWS.CloudFormation.UpdateTerminationProtection(i)
 		if IsDeleteInProgress(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's node pool finalizer cloud formation stack is being deleted")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
+			finalizerskeptcontext.SetKept(ctx)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+
+		} else if IsDeleteFailed(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "the tenant cluster's node pool finalizer cloud formation stack failed to delete")
+			r.event.Emit(ctx, &cr, "CFDeleteFailed", fmt.Sprintf("the tenant cluster's node pool finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed))
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
 			finalizerskeptcontext.SetKept(ctx)

--- a/service/controller/resource/tcnpf/error.go
+++ b/service/controller/resource/tcnpf/error.go
@@ -1,6 +1,7 @@
 package tcnpf
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -17,6 +18,45 @@ import (
 //
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
+}
+
+// event... is an error type for situations where we want to create an Kubernetes event in operatorkit.
+var eventCFCreateError = &microerror.Error{
+	Kind: "CFCreateFailed",
+	Desc: fmt.Sprintf("The tenant cluster's node pool finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusCreateFailed),
+}
+var eventCFUpdateRollbackError = &microerror.Error{
+	Kind: "CFUpdateRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's node pool finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusUpdateRollbackFailed),
+}
+
+var eventCFRollbackError = &microerror.Error{
+	Kind: "CFRollbackFailed",
+	Desc: fmt.Sprintf("The tenant cluster's node pool finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusRollbackFailed),
+}
+
+var eventCFDeleteError = &microerror.Error{
+	Kind: "CFDeleteFailed",
+	Desc: fmt.Sprintf("The tenant cluster's node pool finalizer cloud formation stack has stack status %#q", cloudformation.StackStatusDeleteFailed),
+}
+
+// IsDeleteFailed asserts eventCFDeleteError.
+func IsDeleteFailed(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), cloudformation.ResourceStatusDeleteFailed) {
+		return true
+	}
+
+	if c == eventCFDeleteError {
+		return true
+	}
+
+	return false
 }
 
 var deleteInProgressError = &microerror.Error{

--- a/service/controller/resource/tcnpf/resource.go
+++ b/service/controller/resource/tcnpf/resource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
 	"github.com/giantswarm/aws-operator/service/controller/key"
+	"github.com/giantswarm/aws-operator/service/internal/recorder"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 )
 
 type Config struct {
+	Event  recorder.Interface
 	Logger micrologger.Logger
 
 	InstallationName string
@@ -26,6 +28,7 @@ type Config struct {
 // Connections made between the AWS Control Plane Accounts and the AWS Tenant
 // Cluster Accounts.
 type Resource struct {
+	event  recorder.Interface
 	logger micrologger.Logger
 
 	installationName string
@@ -37,6 +40,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
+		event:  config.Event,
 		logger: config.Logger,
 
 		installationName: config.InstallationName,


### PR DESCRIPTION
Follow up on https://github.com/giantswarm/aws-operator/pull/2701

This adds K8s events in case of CF stack errors for node pool finalizer

## Checklist

- [x] Update changelog in CHANGELOG.md.