### PR TITLE
release v5.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.6] - 2020-08-31
+
+### Changed
+
+- No notable changes.
+
 ## [5.7.5] - 2020-08-28
 
 ### Added

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,12 @@
 package project
 
 var (
-	bundleVersion        = "5.7.6-dev"
+	bundleVersion        = "5.7.6"
 	description          = "The aws-operator handles Kubernetes clusters running on a Kubernetes cluster inside of AWS."
 	gitSHA               = "n/a"
 	name          string = "aws-operator"
 	source        string = "https://github.com/giantswarm/aws-operator"
-	version              = "5.7.6-dev"
+	version              = "5.7.6"
 )
 
 func BundleVersion() string {


### PR DESCRIPTION
I failed to update `bundleVersion` in v5.7.5 so I am re-releasing it as v5.7.6.

## Checklist

- [x] Update changelog in CHANGELOG.md.
