### PR TITLE
Revert "update dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,6 @@
 #
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  target-branch: master
-  reviewers:
-  - giantswarm/team-firecracker-engineers
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  target-branch: master
-  reviewers:
-  - giantswarm/team-firecracker-engineers
 - package-ecosystem: gomod
   directory: "/"
   schedule:
@@ -31,4 +15,12 @@ updates:
   ignore:
   - dependency-name: k8s.io/*
     versions:
-    - ">=0.19.0"
+    - ">=0.17.0"
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  target-branch: master
+  reviewers:
+  - giantswarm/team-firecracker-engineers


### PR DESCRIPTION
Reverts giantswarm/aws-operator#2764. I am not sure if the changes broke anything. The update was just hanging for hours so I want to revert the change made earlier and see if dependabot gets its act together again. 