### PR TITLE
handle errors more gracefully when creating tenant clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/giantswarm/apiextensions/v2 v2.5.2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/certs/v3 v3.1.0
-	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/ipam v0.2.0
 	github.com/giantswarm/k8sclient/v4 v4.0.0
 	github.com/giantswarm/k8scloudconfig/v8 v8.0.2

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,6 @@ github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYa
 github.com/giantswarm/certs/v3 v3.0.0/go.mod h1:fkmIW3moxlrldZhN99fnbBohsDJaki/WCHeNyIN2sr8=
 github.com/giantswarm/certs/v3 v3.1.0 h1:DV23PHNAFds9v1kHgvL6/gWZMTumu+60qdZ6NESeMJc=
 github.com/giantswarm/certs/v3 v3.1.0/go.mod h1:fkmIW3moxlrldZhN99fnbBohsDJaki/WCHeNyIN2sr8=
-github.com/giantswarm/errors v0.2.3 h1:gE1dDSD0RNwYUah5hG6oUQh0unPyZ74tVwR1/PW3ZQ0=
-github.com/giantswarm/errors v0.2.3/go.mod h1:Oj1LIWs9Uoj6JGtK5HxTb50iZuqe9f60LDI0nLXA5vU=
 github.com/giantswarm/exporterkit v0.2.0 h1:+HTGl4fmT/1OkTox8HbV3JXeavmsZv94+2CDW8cSrq0=
 github.com/giantswarm/exporterkit v0.2.0/go.mod h1:b4fuHVjsvZgznC9OEPfn0y5zvN8SnEKTiI5zTTfck94=
 github.com/giantswarm/ipam v0.2.0 h1:nLNmDTfYUlflQsUUlouFzXfE+WaZM843BJGPsHLbgyw=

--- a/service/controller/resource/tenantclients/create.go
+++ b/service/controller/resource/tenantclients/create.go
@@ -59,7 +59,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// handled before. This is extremely painful after fact in a
 			// immutable infrastructure because it is super hard to fix once it
 			// breaks after it is released.
-			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet", "stack", microerror.JSON(err))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil
 		}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Once in a while we see errors like below. Now it appears to be more severe and we were wondering how to more sustainably fix these kind of situations. We were used to relying on our `tenant.IsAPINotAvailable` error matcher which does a whole bunch of funny regex magic under the hood. And yet it breaks over and over again. What we propose here is to just handle any error we potentially perceive gracefully since our current strategies does not seem to be better than that. We might want to reconsider our current practise also in other areas. Therefore sharing with SIG Operator as well. 

```
{
    "caller": "github.com/giantswarm/operatorkit/v2/pkg/resource/wrapper/retryresource/basic_resource.go:59",
    "controller": "aws-operator-cluster-controller",
    "event": "update",
    "level": "warning",
    "loop": "21",
    "message": "retrying due to error",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/awsclusters/cjo09",
    "resource": "tenantclients",
    "stack" {
        "annotation": "an error on the server (\"\") has prevented the request from succeeding",
        "kind": "unknown",
        "stack" [
            {
                "file": "/go/pkg/mod/github.com/giantswarm/k8sclient/v4@v4.0.0/pkg/k8sclient/clients.go",
                "line": 117
            },
            {
                "file": "/root/project/service/controller/resource/tenantclients/create.go",
                "line": 61
            },
            {
                "file": "/go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.1/pkg/resource/wrapper/retryresource/basic_resource.go",
                "line": 52
            }
        ]
    },
    "time": "12:47:47",
    "version": "32037179"
}
```