### PR TITLE
Fix cpvpc && routetable resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add etcd client certificates for Prometheus.
 - Add `--service.aws.hostaccesskey.role` flag.
 
+### Fixes
+
+- Fix `vpc`/`route-table` lookups.
+
 ### Changed
 
 - Access Control Plane AWS account using role assumption. This is to prepare

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "9.1.1"
+	version            = "9.1.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "9.1.2-pawel"
+	version            = "9.1.1"
 )
 
 func Description() string {

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -675,11 +675,18 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 
 	var cpRouteTablesResource resource.Interface
 	{
+		var routeTableNames []string
+		{
+			if config.RouteTables != "" {
+				routeTableNames = strings.Split(config.RouteTables, ",")
+			}
+		}
+
 		c := cproutetables.Config{
 			Logger:       config.Logger,
 			Installation: config.InstallationName,
 
-			Names: strings.Split(config.RouteTables, ","),
+			Names: routeTableNames,
 		}
 
 		cpRouteTablesResource, err = cproutetables.New(c)

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -48,18 +48,18 @@ const (
 
 // AWS Tags used for cost analysis and general resource tagging.
 const (
-	TagAvailabilityZone        = "giantswarm.io/availability-zone"
-	TagCluster                 = "giantswarm.io/cluster"
-	TagClusterType             = "giantswarm.io/cluster-type"
-	TagClusterTypeControlPlane = "control-plane"
-	TagControlPlane            = "giantswarm.io/control-plane"
-	TagInstallation            = "giantswarm.io/installation"
-	TagMachineDeployment       = "giantswarm.io/machine-deployment"
-	TagOrganization            = "giantswarm.io/organization"
-	TagRouteTableType          = "giantswarm.io/route-table-type"
-	TagStack                   = "giantswarm.io/stack"
-	TagSnapshot                = "giantswarm.io/snapshot"
-	TagSubnetType              = "giantswarm.io/subnet-type"
+	TagAvailabilityZone  = "giantswarm.io/availability-zone"
+	TagCluster           = "giantswarm.io/cluster"
+	TagClusterType       = "giantswarm.io/cluster-type"
+	TagControlPlane      = "giantswarm.io/control-plane"
+	TagInstallation      = "giantswarm.io/installation"
+	TagMachineDeployment = "giantswarm.io/machine-deployment"
+	TagName              = "Name"
+	TagOrganization      = "giantswarm.io/organization"
+	TagRouteTableType    = "giantswarm.io/route-table-type"
+	TagStack             = "giantswarm.io/stack"
+	TagSnapshot          = "giantswarm.io/snapshot"
+	TagSubnetType        = "giantswarm.io/subnet-type"
 )
 
 const (

--- a/service/controller/machine_deployment.go
+++ b/service/controller/machine_deployment.go
@@ -352,11 +352,18 @@ func newMachineDeploymentResources(config MachineDeploymentConfig) ([]resource.I
 
 	var cpRouteTablesResource resource.Interface
 	{
+		var routeTableNames []string
+		{
+			if config.RouteTables != "" {
+				routeTableNames = strings.Split(config.RouteTables, ",")
+			}
+		}
+
 		c := cproutetables.Config{
 			Logger:       config.Logger,
 			Installation: config.InstallationName,
 
-			Names: strings.Split(config.RouteTables, ","),
+			Names: routeTableNames,
 		}
 
 		cpRouteTablesResource, err = cproutetables.New(c)

--- a/service/controller/resource/cpvpc/resource.go
+++ b/service/controller/resource/cpvpc/resource.go
@@ -100,35 +100,26 @@ func (r *Resource) lookup(ctx context.Context, client EC2, installationName stri
 	var vpcCIDR string
 	var vpcID string
 	{
-		i := &ec2.DescribeVpcsInput{}
-
-		o, err := client.DescribeVpcs(i)
-		if err != nil {
-			return "", "", microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "volmessage", fmt.Sprintf("vpcs: %v", o.Vpcs))
-
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding vpc info for %#q", installationName))
 
-		i = &ec2.DescribeVpcsInput{
+		i := &ec2.DescribeVpcsInput{
 			Filters: []*ec2.Filter{
 				{
-					Name: aws.String(fmt.Sprintf("tag:%s", key.TagInstallation)),
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagName)),
 					Values: []*string{
 						aws.String(installationName),
 					},
 				},
 				{
-					Name: aws.String(fmt.Sprintf("tag:%s", key.TagClusterType)),
+					Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
 					Values: []*string{
-						aws.String(key.TagClusterTypeControlPlane),
+						aws.String(installationName),
 					},
 				},
 			},
 		}
 
-		o, err = client.DescribeVpcs(i)
+		o, err := client.DescribeVpcs(i)
 		if err != nil {
 			return "", "", microerror.Mask(err)
 		}

--- a/service/controller/resource/cpvpc/resource.go
+++ b/service/controller/resource/cpvpc/resource.go
@@ -100,9 +100,18 @@ func (r *Resource) lookup(ctx context.Context, client EC2, installationName stri
 	var vpcCIDR string
 	var vpcID string
 	{
+		i := &ec2.DescribeVpcsInput{}
+
+		o, err := client.DescribeVpcs(i)
+		if err != nil {
+			return "", "", microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "volmessage", fmt.Sprintf("vpcs: %v", o.Vpcs))
+
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding vpc info for %#q", installationName))
 
-		i := &ec2.DescribeVpcsInput{
+		i = &ec2.DescribeVpcsInput{
 			Filters: []*ec2.Filter{
 				{
 					Name: aws.String(fmt.Sprintf("tag:%s", key.TagInstallation)),
@@ -119,7 +128,7 @@ func (r *Resource) lookup(ctx context.Context, client EC2, installationName stri
 			},
 		}
 
-		o, err := client.DescribeVpcs(i)
+		o, err = client.DescribeVpcs(i)
 		if err != nil {
 			return "", "", microerror.Mask(err)
 		}


### PR DESCRIPTION
While deploying aws-operator in tenant-cluster, we get into the issue where current lookup process for VPC/routing tables doesn't work with tenant cluster tags.

With this change lookup is done by name instead of inconsistent tags. So that it works in CP and TC

## Checklist

- [x] Update changelog in CHANGELOG.md.
