### PR TITLE
Improved CNI parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Access Control Plane AWS account using role assumption. This is to prepare
   running aws-operator inside a Tenant Cluster.
+- Changed AWS CNI parameters to be more conservative with IPs while not hitting the AWS API too hard.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Access Control Plane AWS account using role assumption. This is to prepare
   running aws-operator inside a Tenant Cluster.
-- Changed AWS CNI parameters to be more conservative with IPs while not hitting the AWS API too hard.
+- Changed AWS CNI parameters to be more conservative with preallocated IPs while not hitting the AWS API too hard.
 
 ### Changed
 

--- a/service/internal/cloudconfig/template/aws-cni.go
+++ b/service/internal/cloudconfig/template/aws-cni.go
@@ -192,8 +192,10 @@ spec:
               value: "false"
             - name: DISABLE_METRICS
               value: "false"
-            - name: WARM_ENI_TARGET
-              value: "1"
+            - name: WARM_IP_TARGET
+              value: "10"
+            - name: MINIMUM_IP_TARGET
+              value: "40"
             ## Deviation from original manifest - 1
             ## This config value is important - See here https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md#cni-configuration-variables
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

Tested on a recent upgrade with 3K pods, in total the cluster was preallocation close to 2K IPs that could not be used due to resource exhaustion in nodes. 

Most nodes had 50-60 unused IPs reserved, this way we limit the unused IPs to 10 while still reserving 40 which is the normal amount of pods in nodes in order to reduce API calls.

In the future we might want to consider to make this a parameters so customers can customize depending on their needs. @alex-dabija  