### PR TITLE
Add explicit API/ingress records into private hosted zone if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add etcd client certificates for Prometheus.
 - Add `--service.aws.hostaccesskey.role` flag.
+- Add `api.<cluster ID>.k8s.<base domain>` and `*.<cluster ID>.k8s.<base domain>` records into CP internal hosted zone.
 
 ### Fixes
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "9.1.1"
+	version            = "9.1.2-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "9.1.2-dev"
+	version            = "9.1.1"
 )
 
 func Description() string {

--- a/service/controller/controllercontext/status_types.go
+++ b/service/controller/controllercontext/status_types.go
@@ -12,15 +12,20 @@ type ContextStatus struct {
 }
 
 type ContextStatusControlPlane struct {
-	AWSAccountID string
-	HostedZone   ContextStatusControlPlaneHostedZone
-	NATGateway   ContextStatusControlPlaneNATGateway
-	RouteTables  []*ec2.RouteTable
-	PeerRole     ContextStatusControlPlanePeerRole
-	VPC          ContextStatusControlPlaneVPC
+	AWSAccountID       string
+	HostedZone         ContextStatusControlPlaneHostedZone
+	InternalHostedZone ContextStatusControlPlaneInternalHostedZone
+	NATGateway         ContextStatusControlPlaneNATGateway
+	RouteTables        []*ec2.RouteTable
+	PeerRole           ContextStatusControlPlanePeerRole
+	VPC                ContextStatusControlPlaneVPC
 }
 
 type ContextStatusControlPlaneHostedZone struct {
+	ID string
+}
+
+type ContextStatusControlPlaneInternalHostedZone struct {
 	ID string
 }
 
@@ -64,9 +69,11 @@ type ContextStatusTenantClusterAWS struct {
 }
 
 type ContextStatusTenantClusterDNS struct {
-	HostedZoneID          string
-	HostedZoneNameServers string
-	InternalHostedZoneID  string
+	APIPublicLoadBalancer     string
+	HostedZoneID              string
+	HostedZoneNameServers     string
+	IngressPublicLoadBalancer string
+	InternalHostedZoneID      string
 }
 
 type ContextStatusTenantClusterEncryption struct {

--- a/service/controller/resource/cphostedzone/resource.go
+++ b/service/controller/resource/cphostedzone/resource.go
@@ -75,12 +75,11 @@ func (r *Resource) addHostedZoneInfoToContext(ctx context.Context, cr infrastruc
 	return nil
 }
 
-func (r *Resource) lookup(ctx context.Context, client Route53, cr infrastructurev1alpha2.AWSCluster) (string, string, error) {
+func (r *Resource) lookup(ctx context.Context, client Route53, cr infrastructurev1alpha2.AWSCluster) (cpHostedZoneID, cpInternalHostedZoneID string, err error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	// We check if we have CP public HostedZone info cached.
-	var cpHostedZoneID string
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached CP public HostedZone ID")
 
@@ -93,7 +92,6 @@ func (r *Resource) lookup(ctx context.Context, client Route53, cr infrastructure
 	}
 
 	// We check if we have CP public HostedZone info cached.
-	var cpInternalHostedZoneID string
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached CP private HostedZone ID")
 

--- a/service/controller/resource/cphostedzone/resource.go
+++ b/service/controller/resource/cphostedzone/resource.go
@@ -27,8 +27,10 @@ type Config struct {
 type Resource struct {
 	logger micrologger.Logger
 
-	cachedCPHostedZoneID string
-	mutex                sync.Mutex
+	cachedCPHostedZoneID         string
+	cachedCPInternalHostedZoneID string
+
+	mutex sync.Mutex
 
 	route53Enabled bool
 }
@@ -61,68 +63,90 @@ func (r *Resource) addHostedZoneInfoToContext(ctx context.Context, cr infrastruc
 	}
 
 	{
-		hostedZoneID, err := r.lookup(ctx, cc.Client.ControlPlane.AWS.Route53, cr)
+		cpHostedZoneID, cpInternalHostedZoneID, err := r.lookup(ctx, cc.Client.ControlPlane.AWS.Route53, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		cc.Status.ControlPlane.HostedZone.ID = hostedZoneID
+		cc.Status.ControlPlane.HostedZone.ID = cpHostedZoneID
+		cc.Status.ControlPlane.InternalHostedZone.ID = cpInternalHostedZoneID
 	}
 
 	return nil
 }
 
-func (r *Resource) lookup(ctx context.Context, client Route53, cr infrastructurev1alpha2.AWSCluster) (string, error) {
+func (r *Resource) lookup(ctx context.Context, client Route53, cr infrastructurev1alpha2.AWSCluster) (string, string, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	// We check if we have CP HostedZone info cached.
+	// We check if we have CP public HostedZone info cached.
+	var cpHostedZoneID string
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached CP public HostedZone ID")
 
 		if r.cachedCPHostedZoneID != "" {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found cached CP public HostedZone ID %#q", r.cachedCPHostedZoneID))
-			return r.cachedCPHostedZoneID, nil
+			cpHostedZoneID = r.cachedCPHostedZoneID
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cached CP public HostedZone ID")
 	}
 
-	// We do not have a cached CP public HostedZone Info for the requested
+	// We check if we have CP public HostedZone info cached.
+	var cpInternalHostedZoneID string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cached CP private HostedZone ID")
+
+		if r.cachedCPInternalHostedZoneID != "" {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found cached CP private HostedZone ID %#q", r.cachedCPInternalHostedZoneID))
+			cpInternalHostedZoneID = r.cachedCPInternalHostedZoneID
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cached CP private HostedZone ID")
+	}
+
+	if cpHostedZoneID != "" && cpInternalHostedZoneID != "" {
+		return cpHostedZoneID, cpInternalHostedZoneID, nil
+	}
+
+	// We do not have a cached CP HostedZones Info for the requested
 	// installation. So we look it up.
-	var cpHostedZoneID string
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding CP public HostedZone ID")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding CP HostedZone IDs")
 
-		hostedZonesInput := &route53.ListHostedZonesByNameInput{}
+	hostedZonesInput := &route53.ListHostedZonesByNameInput{}
 
-		o, err := client.ListHostedZonesByName(hostedZonesInput)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		baseDomain := fmt.Sprintf("%s.", key.ClusterBaseDomain(cr))
-
-		for _, zone := range o.HostedZones {
-			if *zone.Name == baseDomain && !*zone.Config.PrivateZone {
-				cpHostedZoneID = *zone.Id
-				break
-			}
-		}
-
-		if cpHostedZoneID == "" {
-			return "", microerror.Maskf(executionFailedError, "failed to find CP public HostedZone ID for base domain %#q", baseDomain)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found CP public HostedZone ID %#q", cpHostedZoneID))
+	o, err := client.ListHostedZonesByName(hostedZonesInput)
+	if err != nil {
+		return "", "", microerror.Mask(err)
 	}
 
-	// At this point we found a public HostedZone ID info and we cache it.
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "caching CP public HostedZone ID")
-		r.cachedCPHostedZoneID = cpHostedZoneID
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cached CP public HostedZone ID")
+	baseDomain := fmt.Sprintf("%s.", key.ClusterBaseDomain(cr))
+
+	for _, zone := range o.HostedZones {
+		if *zone.Name == baseDomain && !*zone.Config.PrivateZone {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found CP public HostedZone ID %#q", cpHostedZoneID))
+			cpHostedZoneID = *zone.Id
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "caching CP public HostedZone ID")
+			r.cachedCPHostedZoneID = cpHostedZoneID
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cached CP public HostedZone ID")
+
+		}
+
+		if *zone.Name == baseDomain && *zone.Config.PrivateZone {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found CP private HostedZone ID %#q", cpInternalHostedZoneID))
+			cpInternalHostedZoneID = *zone.Id
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "caching CP private HostedZone ID")
+			r.cachedCPInternalHostedZoneID = cpInternalHostedZoneID
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cached CP private HostedZone ID")
+		}
 	}
 
-	return cpHostedZoneID, nil
+	// Fail only if public hosted zone is missing as having private hosted zone in CP is not a requirement
+	if cpHostedZoneID == "" {
+		return "", "", microerror.Maskf(executionFailedError, "failed to find CP public HostedZone ID for base domain %#q", baseDomain)
+	}
+
+	return cpHostedZoneID, cpInternalHostedZoneID, nil
 }

--- a/service/controller/resource/tccp/template/template_main_outputs.go
+++ b/service/controller/resource/tccp/template/template_main_outputs.go
@@ -3,6 +3,8 @@ package template
 const TemplateMainOutputs = `
 {{- define "outputs" -}}
   {{- if .Outputs.Route53Enabled -}}
+  APIServerPublicLoadBalancer:
+    Value: !GetAtt ApiLoadBalancer.DNSName
   HostedZoneID: 
     Value: !Ref HostedZone
   InternalHostedZoneID: 

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Control Plane Cloud Formation Stack.
 Outputs:
+  APIServerPublicLoadBalancer:
+    Value: !GetAtt ApiLoadBalancer.DNSName
   HostedZoneID: 
     Value: !Ref HostedZone
   InternalHostedZoneID: 

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -174,11 +174,13 @@ func (r *Resource) newRecordSetsParams(ctx context.Context, cr infrastructurev1a
 	var recordSets *template.ParamsMainRecordSets
 	{
 		recordSets = &template.ParamsMainRecordSets{
-			BaseDomain:                     key.ClusterBaseDomain(cr),
-			ClusterID:                      key.ClusterID(&cr),
-			ControlPlanePublicHostedZoneID: cc.Status.ControlPlane.HostedZone.ID,
-			GuestHostedZoneNameServers:     cc.Status.TenantCluster.DNS.HostedZoneNameServers,
-			Route53Enabled:                 r.route53Enabled,
+			BaseDomain:                       key.ClusterBaseDomain(cr),
+			ClusterID:                        key.ClusterID(&cr),
+			ControlPlaneInternalHostedZoneID: cc.Status.ControlPlane.InternalHostedZone.ID,
+			ControlPlaneHostedZoneID:         cc.Status.ControlPlane.HostedZone.ID,
+			TenantAPIPublicLoadBalancer:      cc.Status.TenantCluster.DNS.APIPublicLoadBalancer,
+			TenantHostedZoneNameServers:      cc.Status.TenantCluster.DNS.HostedZoneNameServers,
+			Route53Enabled:                   r.route53Enabled,
 		}
 	}
 

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -290,6 +290,8 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 			return microerror.Mask(err)
 		}
 
+		fmt.Printf("voldebug template:\n%v\n", templateBody)
+
 		r.logger.LogCtx(ctx,
 			"level", "debug",
 			"message", "computed the template of the tenant cluster's control plane finalizer cloud formation stack",

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -290,7 +290,9 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 			return microerror.Mask(err)
 		}
 
-		fmt.Printf("voldebug template:\n%v\n", templateBody)
+		r.logger.LogCtx(ctx,
+			"level", "voldebug",
+			"message", fmt.Sprintf("voldebug template:\n%v\n", templateBody))
 
 		r.logger.LogCtx(ctx,
 			"level", "debug",

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -120,10 +120,6 @@ func (r *Resource) createStack(ctx context.Context, cr infrastructurev1alpha2.AW
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane finalizer cloud formation stack")
 	}
 
-	r.logger.LogCtx(ctx,
-		"level", "voldebug",
-		"message", fmt.Sprintf("voldebug template:\n%v\n", templateBody))
-
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the creation of the tenant cluster's control plane finalizer cloud formation stack")
 

--- a/service/controller/resource/tccpf/create.go
+++ b/service/controller/resource/tccpf/create.go
@@ -120,6 +120,10 @@ func (r *Resource) createStack(ctx context.Context, cr infrastructurev1alpha2.AW
 		r.logger.LogCtx(ctx, "level", "debug", "message", "computed the template of the tenant cluster's control plane finalizer cloud formation stack")
 	}
 
+	r.logger.LogCtx(ctx,
+		"level", "voldebug",
+		"message", fmt.Sprintf("voldebug template:\n%v\n", templateBody))
+
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "requesting the creation of the tenant cluster's control plane finalizer cloud formation stack")
 
@@ -289,10 +293,6 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha2.AW
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		r.logger.LogCtx(ctx,
-			"level", "voldebug",
-			"message", fmt.Sprintf("voldebug template:\n%v\n", templateBody))
 
 		r.logger.LogCtx(ctx,
 			"level", "debug",

--- a/service/controller/resource/tccpf/template/params_main_record_sets.go
+++ b/service/controller/resource/tccpf/template/params_main_record_sets.go
@@ -1,9 +1,11 @@
 package template
 
 type ParamsMainRecordSets struct {
-	BaseDomain                     string
-	ClusterID                      string
-	ControlPlanePublicHostedZoneID string
-	GuestHostedZoneNameServers     string
-	Route53Enabled                 bool
+	BaseDomain                       string
+	ClusterID                        string
+	ControlPlaneInternalHostedZoneID string
+	ControlPlaneHostedZoneID         string
+	TenantAPIPublicLoadBalancer      string
+	TenantHostedZoneNameServers      string
+	Route53Enabled                   bool
 }

--- a/service/controller/resource/tccpf/template/template_main_record_sets.go
+++ b/service/controller/resource/tccpf/template/template_main_record_sets.go
@@ -6,11 +6,31 @@ const TemplateMainRecordSets = `
   GuestNSRecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:
-      HostedZoneId: '{{ .RecordSets.ControlPlanePublicHostedZoneID }}'
+      HostedZoneId: '{{ .RecordSets.ControlPlaneHostedZoneID }}'
       Name: '{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}.'
       Type: 'NS'
       TTL: '300'
-      ResourceRecords: !Split [ ',', '{{ .RecordSets.GuestHostedZoneNameServers }}' ]
+      ResourceRecords: !Split [ ',', '{{ .RecordSets.TenantHostedZoneNameServers }}' ]
+{{- if ne .RecordSets.ControlPlaneInternalHostedZoneID "" -}}
+  TenantAPIServerRecordSet:
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      HostedZoneId: '{{ .RecordSets.ControlPlaneInternalHostedZoneID }}'
+      Name: 'api.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}.'
+      Type: 'CNAME'
+      TTL: '300'
+      ResourceRecords:
+	    - '{{.RecordSets.TenantAPIPublicLoadBalancer }}'
+  TenantIngressRecordSet:
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      HostedZoneId: '{{ .RecordSets.ControlPlaneInternalHostedZoneID }}'
+      Name: '*.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}.'
+      Type: 'CNAME'
+      TTL: '300'
+      ResourceRecords:
+	    - 'ingress.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}'
+{{- end -}}
 {{- end -}}
 {{- end -}}
 `

--- a/service/controller/resource/tccpf/template/template_main_record_sets.go
+++ b/service/controller/resource/tccpf/template/template_main_record_sets.go
@@ -11,9 +11,7 @@ const TemplateMainRecordSets = `
       Type: 'NS'
       TTL: '300'
       ResourceRecords: !Split [ ',', '{{ .RecordSets.TenantHostedZoneNameServers }}' ]
-
-{{- if ne .RecordSets.ControlPlaneInternalHostedZoneID "" -}}
-
+  {{ if ne .RecordSets.ControlPlaneInternalHostedZoneID "" }}
   TenantAPIServerRecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:
@@ -32,8 +30,7 @@ const TemplateMainRecordSets = `
       TTL: '300'
       ResourceRecords:
         - 'ingress.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}'
-{{- end -}}
-
+  {{ end }}
 {{- end -}}
 {{- end -}}
 `

--- a/service/controller/resource/tccpf/template/template_main_record_sets.go
+++ b/service/controller/resource/tccpf/template/template_main_record_sets.go
@@ -20,7 +20,7 @@ const TemplateMainRecordSets = `
       Type: 'CNAME'
       TTL: '300'
       ResourceRecords:
-	    - '{{.RecordSets.TenantAPIPublicLoadBalancer }}'
+        - '{{.RecordSets.TenantAPIPublicLoadBalancer }}'
   TenantIngressRecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:
@@ -29,7 +29,7 @@ const TemplateMainRecordSets = `
       Type: 'CNAME'
       TTL: '300'
       ResourceRecords:
-	    - 'ingress.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}'
+        - 'ingress.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}'
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/service/controller/resource/tccpf/template/template_main_record_sets.go
+++ b/service/controller/resource/tccpf/template/template_main_record_sets.go
@@ -11,7 +11,9 @@ const TemplateMainRecordSets = `
       Type: 'NS'
       TTL: '300'
       ResourceRecords: !Split [ ',', '{{ .RecordSets.TenantHostedZoneNameServers }}' ]
+
 {{- if ne .RecordSets.ControlPlaneInternalHostedZoneID "" -}}
+
   TenantAPIServerRecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:
@@ -31,6 +33,7 @@ const TemplateMainRecordSets = `
       ResourceRecords:
         - 'ingress.{{ .RecordSets.ClusterID }}.k8s.{{ .RecordSets.BaseDomain }}'
 {{- end -}}
+
 {{- end -}}
 {{- end -}}
 `

--- a/service/controller/resource/tccpf/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tccpf/testdata/case-0-basic-test.golden
@@ -10,6 +10,7 @@ Resources:
       TTL: '300'
       ResourceRecords: !Split [ ',', '1.1.1.1,8.8.8.8' ]
   
+  
   PrivateRoute0:
     Type: AWS::EC2::Route
     Properties:

--- a/service/controller/resource/tccpf/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tccpf/testdata/case-0-basic-test.golden
@@ -10,7 +10,6 @@ Resources:
       TTL: '300'
       ResourceRecords: !Split [ ',', '1.1.1.1,8.8.8.8' ]
   
-  
   PrivateRoute0:
     Type: AWS::EC2::Route
     Properties:

--- a/service/controller/resource/tccpoutputs/create.go
+++ b/service/controller/resource/tccpoutputs/create.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	HostedZoneID              = "HostedZoneID"
-	HostedZoneNameServersKey  = "HostedZoneNameServers"
-	InternalHostedZoneID      = "InternalHostedZoneID"
-	OperatorVersion           = "OperatorVersion"
-	VPCIDKey                  = "VPCID"
-	VPCPeeringConnectionIDKey = "VPCPeeringConnectionID"
+	APIServerPublicLoadBalancerKey = "APIServerPublicLoadBalancer"
+	HostedZoneID                   = "HostedZoneID"
+	HostedZoneNameServersKey       = "HostedZoneNameServers"
+	InternalHostedZoneID           = "InternalHostedZoneID"
+	OperatorVersion                = "OperatorVersion"
+	VPCIDKey                       = "VPCID"
+	VPCPeeringConnectionIDKey      = "VPCPeeringConnectionID"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -71,22 +72,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if r.route53Enabled {
 		{
-			v, err := cloudFormation.GetOutputValue(outputs, HostedZoneID)
-			// TODO migration code to dont throw error when the old TC does not yet
-			// have the new output value. Once the aws-operator graduated to v9.0.0 we
-			// can remove the check for IsOutputNotFound.
-			//
-			//     https://github.com/giantswarm/giantswarm/issues/10139
-			//
-			if cloudformation.IsOutputNotFound(err) {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster's control plane hostedZoneID output")
-			} else {
-				if err != nil {
-					return microerror.Mask(err)
-				}
-				cc.Status.TenantCluster.DNS.HostedZoneID = v
+			v, err := cloudFormation.GetOutputValue(outputs, APIServerPublicLoadBalancerKey)
+			if err != nil {
+				return microerror.Mask(err)
 			}
+			cc.Status.TenantCluster.DNS.APIPublicLoadBalancer = v
+		}
 
+		{
+			v, err := cloudFormation.GetOutputValue(outputs, HostedZoneID)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			cc.Status.TenantCluster.DNS.HostedZoneID = v
 		}
 
 		{
@@ -99,11 +97,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		{
 			v, err := cloudFormation.GetOutputValue(outputs, InternalHostedZoneID)
-			// TODO migration code to dont throw error when the old TC does not yet
-			// have the new output value. Once the aws-operator graduated to v9.0.0 we
-			// can remove the check for IsOutputNotFound.
-			//
-			//     https://github.com/giantswarm/giantswarm/issues/10139
+			// We do not throw error when the TC does not
+			// have internal hosted zone as it is not a strict requirement.
 			//
 			if cloudformation.IsOutputNotFound(err) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the tenant cluster's control plane internalHostedZoneID output")


### PR DESCRIPTION
As NS records are not supported in internal hosted zones, we need to add explicit `api`/`*.` records pointing to the TC records explicitly. 

Currently, services from GS control-plane, deployed into tenant cluster, can't reach tenant cluster, created from that control-plane.
The reason for this is that we don't create tenant cluster hosted zone delegation inside private hosted zone of CP (we actually don't even have private hosted zone in original control-plane).

Towards:
  - https://github.com/giantswarm/giantswarm/issues/13238
  - https://github.com/giantswarm/giantswarm/issues/13755

Closes: https://github.com/giantswarm/giantswarm/issues/10139


## Checklist

- [x] Update changelog in CHANGELOG.md.
