### PR TITLE
remove-autommount-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove dependency on `var-lib-etcd.automount` to avoid dependency cycle on new systemd.
+
 ## [9.1.3] - 2020-10-21
 
 ### Fixed

--- a/service/internal/cloudconfig/template/automount_etcd_volume.go
+++ b/service/internal/cloudconfig/template/automount_etcd_volume.go
@@ -3,8 +3,6 @@ package template
 const AutomountEtcdVolume = `
 [Unit]
 Description=etcd3 data volume
-After=etcd3-attach-dependencies.service
-Before=etcd3.service
 
 [Mount]
 Where=/var/lib/etcd


### PR DESCRIPTION
towards https://github.com/giantswarm/releases/pull/489


new systemd have a different dependency checker and this was creating a "cycle"

```
3-attach-dependencies.service: Found ordering cycle on basic.target/start
3-attach-dependencies.service: Found dependency on paths.target/start
3-attach-dependencies.service: Found dependency on motdgen.path/start
3-attach-dependencies.service: Found dependency on sysinit.target/start
3-attach-dependencies.service: Found dependency on local-fs.target/start
3-attach-dependencies.service: Found dependency on var-lib-etcd.automount/start
3-attach-dependencies.service: Found dependency on etcd3-attach-dependencies.service>
3-attach-dependencies.service: Job paths.target/start deleted to break ordering cycl>
3-attach-dependencies.service: Found ordering cycle on basic.target/start
3-attach-dependencies.service: Found dependency on sysinit.target/start
3-attach-dependencies.service: Found dependency on local-fs.target/start
3-attach-dependencies.service: Found dependency on var-lib-etcd.automount/start
3-attach-dependencies.service: Found dependency on etcd3-attach-dependencies.service>
3-attach-dependencies.service: Job local-fs.target/start deleted to break ordering c>
ting Attach etcd dependencies...
```
 
it often ended with different results
## Checklist

- [x] Update changelog in CHANGELOG.md.
