### PR TITLE
prevent errors from transitioning ec2 instances

### DIFF
--- a/service/internal/asg/asg.go
+++ b/service/internal/asg/asg.go
@@ -3,6 +3,7 @@ package asg
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -87,18 +88,7 @@ func (a *ASG) Drainable(ctx context.Context, obj interface{}) (string, error) {
 	// interested it.
 	var asgs []*autoscaling.Group
 	{
-		var names []string
-		{
-			m := map[string]struct{}{}
-
-			for _, i := range instances {
-				m[asgNameFromInstance(i)] = struct{}{}
-			}
-
-			for k := range m {
-				names = append(names, k)
-			}
-		}
+		names := namesFromInstances(instances)
 
 		asgs, err = a.cachedASGs(ctx, cr, names)
 		if err != nil {
@@ -179,6 +169,10 @@ func (a *ASG) lookupASGs(ctx context.Context, names []string) ([]*autoscaling.Gr
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	if len(names) == 0 {
+		return nil, microerror.Mask(noASGError)
 	}
 
 	var asgs []*autoscaling.Group
@@ -275,6 +269,34 @@ func drainable(ctx context.Context, asgs []*autoscaling.Group) (string, error) {
 	}
 
 	return "", microerror.Mask(noDrainableError)
+}
+
+func namesFromInstances(instances []*ec2.Instance) []string {
+	var names []string
+	{
+		m := map[string]struct{}{}
+
+		for _, i := range instances {
+			// While EC2 instances are transitioning due to scale in and scale
+			// out events they may not be associated with any ASG. In these
+			// cases we ignore the instances and move on to the next one.
+			// Eventually we will collect the relevant ASG names.
+			n := asgNameFromInstance(i)
+			if n == "" {
+				continue
+			}
+
+			m[n] = struct{}{}
+		}
+
+		for k := range m {
+			names = append(names, k)
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 func toPtrList(l []string) []*string {


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

In recent oncall situations we saw errors when trying to detect the ASG names based on EC2 instances. This PR fixes errors like shown below.  

```
{
    "caller": "github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:59",
    "controller": "aws-operator-drainer-controller",
    "event": "update",
    "level": "warning",
    "loop": "2",
    "message": "retrying due to error",
    "object": "/apis/infrastructure.giantswarm.io/v1alpha2/namespaces/default/awsmachinedeployments/6e3cc",
    "resource": "drainerinitializer",
    "stack" {
        "annotation": "ValidationError: 1 validation error detected: Value '[cluster-bd79d-tcnp-6e3cc-NodePoolAutoScalingGroup-1238KENFG45AX, ]' at 'autoScalingGroupNames' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 1600, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*]\n\tstatus code: 400, request id: 8691b4f0-5b08-47e1-8635-903b6e812d17",
        "kind": "unknown",
        "stack" [
            {
                "file": "/root/project/service/internal/asg/asg.go",
                "line": 192
            },
            {
                "file": "/root/project/service/internal/asg/asg.go",
                "line": 138
            },
            {
                "file": "/root/project/service/internal/asg/asg.go",
                "line": 105
            },
            {
                "file": "/root/project/service/controller/resource/drainerinitializer/resource.go",
                "line": 163
            },
            {
                "file": "/root/project/service/controller/resource/drainerinitializer/create.go",
                "line": 12
            },
            {
                "file": "/go/pkg/mod/github.com/giantswarm/operatorkit@v1.2.0/resource/wrapper/retryresource/basic_resource.go",
                "line": 52
            }
        ]
    },
    "time": "15:42:49",
    "version": "187309076"
}
```