### PR TITLE
use-annotations-from-apiextensions

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -4,15 +4,4 @@ const (
 	Docs                    = "giantswarm.io/docs"
 	InstanceID              = "aws-operator.giantswarm.io/instance"
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
-	// AWSMetadataV2 configures token usage for your AWS EC2 instance metadata requests.
-	// If the value is 'optional', you can choose to retrieve instance metadata with or without a signed token
-	// header on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role
-	// credentials are returned. If you retrieve the IAM role credentials using a valid signed token, the version
-	// 2.0 role credentials are returned.
-	// If the state is 'required', you must send a signed token header with any instance metadata retrieval
-	// requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the
-	// version 1.0 credentials are not available.
-	// Default: 'optional'
-	// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-httptokens
-	AWSMetadata = "alpha.aws.giantswarm.io/metadata-v2"
 )

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -4,7 +4,6 @@ const (
 	Docs                    = "giantswarm.io/docs"
 	InstanceID              = "aws-operator.giantswarm.io/instance"
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
-	NodeTerminateUnhealthy  = "alpha.node.giantswarm.io/terminate-unhealthy"
 	// AWSMetadataV2 configures token usage for your AWS EC2 instance metadata requests.
 	// If the value is 'optional', you can choose to retrieve instance metadata with or without a signed token
 	// header on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role
@@ -16,19 +15,4 @@ const (
 	// Default: 'optional'
 	// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-httptokens
 	AWSMetadata = "alpha.aws.giantswarm.io/metadata-v2"
-	// AWSSubnetSize is the aws update annotation used for configuring
-	// the subnet size of AWSCluster or AWSMachineDeployment.
-	// The value is a number that will represent the subnet mask used when creating the subnet. This value must be smaller than 28 due to AWS restrictions.
-	AWSSubnetSize = "alpha.aws.giantswarm.io/aws-subnet-size"
-	// UpdateMaxBatchSize is the aws update annotation used for configuring
-	// maximum batch size for instances during ASG update.
-	// The value can be either a whole number specifying the number of instances
-	// or a percentage of total instances as decimal number ie: `0.3` for 30%.
-	// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-maxbatchsize
-	UpdateMaxBatchSize = "alpha.aws.giantswarm.io/update-max-batch-size"
-	// UpdatePauseTime is the aws update annotation used for configuring
-	// time pause between rolling a single batch during ASG update.
-	// The value must be in ISO 8601 duration format, e. g. "PT5M" for five minutes or "PT10S" for 10 seconds.
-	// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-pausetime
-	UpdatePauseTime = "alpha.aws.giantswarm.io/update-pause-time"
 )

--- a/service/controller/key/aws_control_plane.go
+++ b/service/controller/key/aws_control_plane.go
@@ -3,10 +3,10 @@ package key
 import (
 	"fmt"
 
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/pkg/label"
 )
 
@@ -86,7 +86,7 @@ func ControlPlaneVolumeResourceName(id int) string {
 }
 
 func ControlPlaneMetadataV2(cr infrastructurev1alpha2.AWSControlPlane) string {
-	result, ok := cr.ObjectMeta.Annotations[annotation.AWSMetadata]
+	result, ok := cr.ObjectMeta.Annotations[annotation.AWSMetadataV2]
 	if !ok {
 		return "optional"
 	}

--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 
 	"github.com/dylanmei/iso8601"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/service/controller/resource/tcnp/template"
 )
 
@@ -194,7 +194,7 @@ func MachineDeploymentInstanceType(cr infrastructurev1alpha2.AWSMachineDeploymen
 }
 
 func MachineDeploymentMetadataV2(cr infrastructurev1alpha2.AWSMachineDeployment) string {
-	result, ok := cr.ObjectMeta.Annotations[annotation.AWSMetadata]
+	result, ok := cr.ObjectMeta.Annotations[annotation.AWSMetadataV2]
 	if !ok {
 		return "optional"
 	}

--- a/service/controller/resource/ipam/create.go
+++ b/service/controller/resource/ipam/create.go
@@ -6,13 +6,13 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
 	"github.com/giantswarm/ipam"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 	"github.com/giantswarm/aws-operator/service/internal/locker"
 )

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -7,11 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
+
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/pkg/awstags"
 	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
@@ -319,13 +320,13 @@ func (r *Resource) newAutoScalingGroup(ctx context.Context, cr infrastructurev1a
 	var minInstancesInService string
 	{
 		// try read the value from cluster CR
-		if val, ok := cl.Annotations[annotation.UpdateMaxBatchSize]; ok {
+		if val, ok := cl.Annotations[annotation.AWSUpdateMaxBatchSize]; ok {
 			maxBatchSize = key.MachineDeploymentParseMaxBatchSize(val, minDesiredNodes)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "value of MaxBatchSize for ASG updates set by annotation from AWSCluster CR")
 		}
 		// override the value with machine deployment value if its set
-		if val, ok := cr.Annotations[annotation.UpdateMaxBatchSize]; ok {
+		if val, ok := cr.Annotations[annotation.AWSUpdateMaxBatchSize]; ok {
 			maxBatchSize = key.MachineDeploymentParseMaxBatchSize(val, minDesiredNodes)
 
 			r.logger.LogCtx(ctx, "level", "debug", "message", "value of MaxBatchSize for ASG updates overridden by annotation from AWSMachineDeployment CR")
@@ -344,7 +345,7 @@ func (r *Resource) newAutoScalingGroup(ctx context.Context, cr infrastructurev1a
 	var pauseTime string
 	{
 		// try read the value from cluster CR
-		if val, ok := cl.Annotations[annotation.UpdatePauseTime]; ok {
+		if val, ok := cl.Annotations[annotation.AWSUpdatePauseTime]; ok {
 			if key.MachineDeploymentPauseTimeIsValid(val) {
 				pauseTime = val
 
@@ -352,7 +353,7 @@ func (r *Resource) newAutoScalingGroup(ctx context.Context, cr infrastructurev1a
 			}
 		}
 		// override the value with machine deployment value if its set
-		if val, ok := cr.Annotations[annotation.UpdatePauseTime]; ok {
+		if val, ok := cr.Annotations[annotation.AWSUpdatePauseTime]; ok {
 			if key.MachineDeploymentPauseTimeIsValid(val) {
 				pauseTime = val
 

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
-
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/service/controller/resource/terminateunhealthynode/create.go
+++ b/service/controller/resource/terminateunhealthynode/create.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/badnodedetector/pkg/detector"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/aws-operator/pkg/annotation"
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 )


### PR DESCRIPTION
use annotations from apiextensionsv3 and clean aws-operator annotation package

## Checklist

- [ ] Update changelog in CHANGELOG.md.
