### PR TITLE
detach role policies upon node pool deletion

### DIFF
--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -152,6 +152,10 @@ func MachineDeploymentWorkerCountRatio(workers int, ratio float32) string {
 	return strconv.Itoa(rounded)
 }
 
+func NodeRole(cr infrastructurev1alpha2.AWSMachineDeployment) string {
+	return fmt.Sprintf("gs-cluster-%s-role-%s", ClusterID(&cr), MachineDeploymentID(&cr))
+}
+
 func ToMachineDeployment(v interface{}) (infrastructurev1alpha2.AWSMachineDeployment, error) {
 	if v == nil {
 		return infrastructurev1alpha2.AWSMachineDeployment{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &infrastructurev1alpha2.AWSMachineDeployment{}, v)

--- a/service/controller/resource/cleanupiamroles/delete.go
+++ b/service/controller/resource/cleanupiamroles/delete.go
@@ -2,8 +2,59 @@ package cleanupiamroles
 
 import (
 	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
+	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachineDeployment(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var policies []string
+	{
+		r.logger.Debugf(ctx, "finding all policies")
+
+		i := &iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(key.NodeRole(cr)),
+		}
+
+		o, err := cc.Client.TenantCluster.AWS.IAM.ListAttachedRolePolicies(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, p := range o.AttachedPolicies {
+			policies = append(policies, *p.PolicyArn)
+		}
+
+		r.logger.Debugf(ctx, "found %d policies", len(policies))
+	}
+
+	for _, p := range policies {
+		r.logger.Debugf(ctx, "detaching policy %s", p)
+
+		i := &iam.DetachRolePolicyInput{
+			PolicyArn: aws.String(p),
+			RoleName:  aws.String(key.NodeRole(cr)),
+		}
+
+		_, err := cc.Client.TenantCluster.AWS.IAM.DetachRolePolicy(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.Debugf(ctx, "detached policy %s", p)
+	}
+
 	return nil
 }

--- a/service/controller/resource/cleanupiamroles/delete.go
+++ b/service/controller/resource/cleanupiamroles/delete.go
@@ -31,7 +31,8 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 		o, err := cc.Client.TenantCluster.AWS.IAM.ListAttachedRolePolicies(i)
 		if IsNotFound(err) {
-			r.logger.Debugf(ctx, "canceling resource", "reason", "no attached policies")
+			r.logger.Debugf(ctx, "no attached policies")
+			r.logger.Debugf(ctx, "canceling resource")
 			return nil
 		} else if err != nil {
 			return microerror.Mask(err)

--- a/service/controller/resource/cleanupiamroles/delete.go
+++ b/service/controller/resource/cleanupiamroles/delete.go
@@ -30,7 +30,10 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		o, err := cc.Client.TenantCluster.AWS.IAM.ListAttachedRolePolicies(i)
-		if err != nil {
+		if IsNotFound(err) {
+			r.logger.Debugf(ctx, "canceling resource", "reason", "no attached policies")
+			return nil
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 

--- a/service/controller/resource/cleanupiamroles/delete.go
+++ b/service/controller/resource/cleanupiamroles/delete.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/service/controller/key"
-	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {

--- a/service/controller/resource/cleanupiamroles/error.go
+++ b/service/controller/resource/cleanupiamroles/error.go
@@ -1,6 +1,8 @@
 package cleanupiamroles
 
 import (
+	"strings"
+
 	"github.com/giantswarm/microerror"
 )
 
@@ -11,4 +13,30 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+//
+//     NoSuchEntity: The role with name gs-cluster-apzh0-role-4z8jm cannot be found.
+//
+func IsNotFound(err error) bool {
+	c := microerror.Cause(err)
+
+	if c == nil {
+		return false
+	}
+
+	if strings.Contains(c.Error(), "cannot be found") {
+		return true
+	}
+
+	if c == notFoundError {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Fixes https://github.com/giantswarm/giantswarm/issues/14691. I tested the cleanup manually in a little go script. There should never be more than a handful attached policies on a given role. 