### PR TITLE
Update architect-orb to 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@1.1.1
+  architect: giantswarm/architect@2.1.0
 
 workflows:
   build:


### PR DESCRIPTION
Update architect-orb to 2.1.0 which will use giantswarm.github.io as catalog base url.

Towards giantswarm/giantswarm#15898