### PR TITLE
fail-update-if-release-do-not-exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated OperatorKit to v4.3.1 for Kubernetes 1.20 support.
 - Cancel update loop if source or target release is not found.
+
 ### Added
 
 - Clean up VPC peerings from a cluster VPC when is cluster deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated OperatorKit to v4.3.1 for Kubernetes 1.20 support.
-
+- Cancel update loop if source or target release is not found.
 ### Added
 
 - Clean up VPC peerings from a cluster VPC when is cluster deleted.

--- a/service/internal/changedetection/tccpn.go
+++ b/service/internal/changedetection/tccpn.go
@@ -79,9 +79,7 @@ func (t *TCCPN) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSC
 	var currentRelease releasev1alpha1.Release
 	{
 		currentRelease, err = t.releases.Release(ctx, cc.Status.TenantCluster.ReleaseVersion)
-		if releases.IsNotFound(err) {
-			// fall through
-		} else if err != nil {
+		if err != nil {
 			return false, microerror.Mask(err)
 		}
 	}
@@ -89,9 +87,7 @@ func (t *TCCPN) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSC
 	var targetRelease releasev1alpha1.Release
 	{
 		targetRelease, err = t.releases.Release(ctx, key.ReleaseVersion(&cr))
-		if releases.IsNotFound(err) {
-			// fall through
-		} else if err != nil {
+		if err != nil {
 			return false, microerror.Mask(err)
 		}
 	}

--- a/service/internal/changedetection/tcnp.go
+++ b/service/internal/changedetection/tcnp.go
@@ -103,9 +103,7 @@ func (t *TCNP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSMa
 	var currentRelease releasev1alpha1.Release
 	{
 		currentRelease, err = t.releases.Release(ctx, cc.Status.TenantCluster.ReleaseVersion)
-		if releases.IsNotFound(err) {
-			// fall through
-		} else if err != nil {
+		if err != nil {
 			return false, microerror.Mask(err)
 		}
 	}
@@ -113,9 +111,7 @@ func (t *TCNP) ShouldUpdate(ctx context.Context, cr infrastructurev1alpha2.AWSMa
 	var targetRelease releasev1alpha1.Release
 	{
 		targetRelease, err = t.releases.Release(ctx, key.ReleaseVersion(&cr))
-		if releases.IsNotFound(err) {
-			// fall through
-		} else if err != nil {
+		if err != nil {
 			return false, microerror.Mask(err)
 		}
 	}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/16640

to avoid rolling nodes in a scenario when we delete an older release, we should still not remove the releases too early to avoid problems, but at least if this happens we won't have unexpected update
## Checklist

- [x] Update changelog in CHANGELOG.md.
