### PR TITLE
adjust etcd3-attach-deps for new flatcar  and add k8s 1.20 support from k8scc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix issues with etcd initial cluster resolving into ELB and causing errors.
+- Update `k8scloudconfig` to version `v10.5.0` to support kubernetes `v1.20`.
 
 ## [10.2.0] - 2021-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issues with etcd initial cluster resolving into ELB and causing errors.
 - Update `k8scloudconfig` to version `v10.5.0` to support kubernetes `v1.20`.
+- Use `networkctl reload` for managing networking to avoid bug in `systemd`.
 
 ## [10.2.0] - 2021-02-08
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3
+	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764
+	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e
+	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0
+	github.com/giantswarm/k8scloudconfig/v10 v10.5.0
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.4.0
+	github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764 h1:C8sN0qggzJLftqc9QnOzBXOecusvahzUXQ6qicvVVUk=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e h1:daxyN4hwxEEhDX5Usk2Joeh02+PEVzSEhYSGFZbsEHU=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.0 h1:8Gx6LURkXgIX+nUdSlGZj5RAZLmQOqvioyNVF0C488w=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.0/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3 h1:OCAxQwLejsDAK1I7E287Za/ilFxEyNo+6Bp+3Y8XnWI=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3 h1:OCAxQwLejsDAK1I7E287Za/ilFxEyNo+6Bp+3Y8XnWI=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505081004-6111b63fbdb3/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764 h1:C8sN0qggzJLftqc9QnOzBXOecusvahzUXQ6qicvVVUk=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210505103906-a0904b482764/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0 h1:cAH6VJX7AXFJxY4p6xBDGIbdssJgHLfJvO+Jn1f8Jdg=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
+github.com/giantswarm/k8scloudconfig/v10 v10.5.0 h1:vDvLUba3GJL0grIhAuucnnm8bx1CtOcgq53IWILDxT0=
+github.com/giantswarm/k8scloudconfig/v10 v10.5.0/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e h1:daxyN4hwxEEhDX5Usk2Joeh02+PEVzSEhYSGFZbsEHU=
-github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506094216-9b85f47de14e/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0 h1:cAH6VJX7AXFJxY4p6xBDGIbdssJgHLfJvO+Jn1f8Jdg=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.1-0.20210506113805-8fdf289881c0/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -28,6 +28,7 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
 ExecStartPost=/usr/bin/systemctl daemon-reload
+ExecStartPost=/usr/bin/ip set link eth1 down
 ExecStartPost=/usr/bin/systemctl restart systemd-networkd
 
 [Install]

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -27,10 +27,9 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-device-label=etcd \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
+# use 'networkctl reload'' instead restarting systemd-networkd to avoid bug in systemd 
+# https://github.com/systemd/systemd/issues/18108
 ExecStartPost=/usr/bin/networkctl reload
-#ExecStartPost=/usr/bin/systemctl daemon-reload
-#ExecStartPost=/usr/bin/systemctl restart systemd-networkd
-#ExecStartPost=/bin/bash -c "sleep 10s && /usr/bin/ip link set eth1 down && /usr/bin/systemctl reset-failed systemd-networkd && /usr/bin/systemctl restart systemd-networkd"
 
 [Install]
 WantedBy=multi-user.target

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -27,9 +27,10 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-device-label=etcd \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
-ExecStartPost=/usr/bin/systemctl daemon-reload
-ExecStartPost=/usr/bin/systemctl restart systemd-networkd
-ExecStartPost=/bin/bash -c "sleep 10s && /usr/bin/ip link set eth1 down && /usr/bin/systemctl reset-failed systemd-networkd && /usr/bin/systemctl restart systemd-networkd"
+ExecStartPost=/usr/bin/networkctl reload
+#ExecStartPost=/usr/bin/systemctl daemon-reload
+#ExecStartPost=/usr/bin/systemctl restart systemd-networkd
+#ExecStartPost=/bin/bash -c "sleep 10s && /usr/bin/ip link set eth1 down && /usr/bin/systemctl reset-failed systemd-networkd && /usr/bin/systemctl restart systemd-networkd"
 
 [Install]
 WantedBy=multi-user.target

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -28,10 +28,8 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
 ExecStartPost=/usr/bin/systemctl daemon-reload
-ExecStartPost=/usr/bin/ip link set eth1 down
 ExecStartPost=/usr/bin/systemctl restart systemd-networkd
-ExecStartPost=/usr/bin/ip link set eth1 down
-ExecStartPost=/usr/bin/systemctl restart systemd-networkd
+ExecStartPost=/bin/bash -c "sleep 10s && /usr/bin/ip link set eth1 down && /usr/bin/systemctl reset-failed systemd-networkd && /usr/bin/systemctl restart systemd-networkd"
 
 [Install]
 WantedBy=multi-user.target

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -27,7 +27,7 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-device-label=etcd \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
-# use 'networkctl reload'' instead restarting systemd-networkd to avoid bug in systemd 
+# use 'networkctl reload' instead of restarting systemd-networkd to avoid bug in systemd 
 # https://github.com/systemd/systemd/issues/18108
 ExecStartPost=/usr/bin/networkctl reload
 

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -30,6 +30,8 @@ ExecStart=/bin/bash -c "docker run --rm -i \
 ExecStartPost=/usr/bin/systemctl daemon-reload
 ExecStartPost=/usr/bin/ip link set eth1 down
 ExecStartPost=/usr/bin/systemctl restart systemd-networkd
+ExecStartPost=/usr/bin/ip link set eth1 down
+ExecStartPost=/usr/bin/systemctl restart systemd-networkd
 
 [Install]
 WantedBy=multi-user.target

--- a/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
+++ b/service/internal/cloudconfig/template/etcd3_attach_dep_service.go
@@ -28,7 +28,7 @@ ExecStart=/bin/bash -c "docker run --rm -i \
       --volume-tag-key=Name \
       --volume-tag-value={{ .MasterEtcdVolumeName }}"
 ExecStartPost=/usr/bin/systemctl daemon-reload
-ExecStartPost=/usr/bin/ip set link eth1 down
+ExecStartPost=/usr/bin/ip link set eth1 down
 ExecStartPost=/usr/bin/systemctl restart systemd-networkd
 
 [Install]


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.



to avoid bug https://github.com/systemd/systemd/issues/18108, etcd3-attach deps will use `networkctl reload` instead of `systemctl restart systemd-networkd`

This si needed in order to run latest flatcar