### PR TITLE
Avoid TCCPN stack failure by checking if a control-plane tag exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Avoid TCCPN stack failure by checking if a control-plane tag exists before adding it.
 - Look up cloud tags in all namespaces
 - Find certs in all namespaces
 - Enable `terminate unhealthy node` feature by default.

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -220,7 +220,9 @@ func (r *Resource) createStack(ctx context.Context, cr infrastructurev1alpha2.AW
 
 func (r *Resource) getCloudFormationTags(ctx context.Context, cr infrastructurev1alpha2.AWSControlPlane) ([]*cloudformation.Tag, error) {
 	tags := key.AWSTags(&cr, r.installationName)
-	tags[key.TagControlPlane] = key.ControlPlaneID(&cr)
+	if cp := key.ControlPlaneID(&cr); cp != "" {
+		tags[key.TagControlPlane] = cp
+	}
 	tags[key.TagStack] = key.StackTCCPN
 
 	cloudtags, err := r.cloudTags.GetTagsByCluster(ctx, key.ClusterID(&cr))


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/17073
We want to check if the tag actually exists before adding it into the tccpn stack template and risking failure in case it does not.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
