### PR TITLE
s3-security-compliance-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add security settings to S3 bucket to comply with aws policies `s3-bucket-public-read-prohibited,s3-bucket-ssl-requests-only,s3-bucket-public-write-prohibited,s3-bucket-server-side-encryption-enabled,s3-bucket-logging-enabled`
+
 ## [10.6.1] - 2021-07-01
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add security settings to S3 bucket to comply with aws policies `s3-bucket-public-read-prohibited,s3-bucket-ssl-requests-only,s3-bucket-public-write-prohibited,s3-bucket-server-side-encryption-enabled,s3-bucket-logging-enabled`
+- Add security settings to S3 bucket to comply with aws policies `s3-bucket-public-read-prohibited,s3-bucket-ssl-requests-only,s3-bucket-public-write-prohibited,s3-bucket-server-side-encryption-enabled,s3-bucket-logging-enabled`, `aws-operator` will need additonal permissions `s3:PutBucketPublicAccessBlock` and `s3:PutBucketPolicy`.
 
 ## [10.6.1] - 2021-07-01
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "10.6.2-dev"
+	version            = "10.6.2-calvix"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "10.6.2-calvix"
+	version            = "10.6.2-dev"
 )
 
 func Description() string {

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -35,6 +35,28 @@ const (
 	TerminateUnhealthyNodeResyncPeriod = time.Minute * 3
 )
 
+const sslOnlyBucketPolicyTemplate = `{
+  "Id": "GiantswarmSecureBucketPolicy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Action": "s3:*",
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:s3:::%s",
+        "arn:aws:s3:::%s/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}`
+
 // AMI returns the EC2 AMI for the configured region and given version.
 func AMI(region string, release releasev1alpha1.Release) (string, error) {
 	osVersion, err := OSVersion(release)
@@ -299,6 +321,10 @@ func SanitizeCFResourceName(l ...string) string {
 
 func SecurityGroupName(getter LabelsGetter, groupName string) string {
 	return fmt.Sprintf("%s-%s", ClusterID(getter), groupName)
+}
+
+func SSLOnlyBucketPolicy(bucketName string) string {
+	return fmt.Sprintf(sslOnlyBucketPolicyTemplate, bucketName, bucketName)
 }
 
 func StackComplete(status string) bool {

--- a/service/controller/resource/s3bucket/create.go
+++ b/service/controller/resource/s3bucket/create.go
@@ -146,7 +146,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketPolicy(i)
 			if IsAccessDenied(err) {
 				// fall thru if the aws operator do not have permission to create the policy
-				r.logger.Log(ctx, "failed to put S3 bucket policy to allow only SSL connection for bucket  %#q", bucketInput.Name)
+				r.logger.Debugf(ctx, "failed to put S3 bucket policy to allow only SSL connection for bucket %#q due lack of permissions", bucketInput.Name)
 			} else if err != nil {
 				return microerror.Mask(err)
 			}
@@ -169,7 +169,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			_, err = cc.Client.TenantCluster.AWS.S3.PutPublicAccessBlock(i)
 			if IsAccessDenied(err) {
 				// fall thru if the aws operator do not have permission to create the policy
-				r.logger.Log(ctx, "failed to block public access to  S3 bucket %#q", bucketInput.Name)
+				r.logger.Debugf(ctx, "failed to block public access to S3 bucket %#q due lack of permissions", bucketInput.Name)
 			} else if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/s3bucket/create.go
+++ b/service/controller/resource/s3bucket/create.go
@@ -144,7 +144,10 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 				Policy: aws.String(key.SSLOnlyBucketPolicy(bucketInput.Name)),
 			}
 			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketPolicy(i)
-			if err != nil {
+			if IsAccessDenied(err) {
+				// fall thru if the aws operator do not have permission to create the policy
+				r.logger.Log(ctx, "failed to put S3 bucket policy to allow only SSL connection for bucket  %#q", bucketInput.Name)
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 		}
@@ -164,7 +167,10 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			}
 
 			_, err = cc.Client.TenantCluster.AWS.S3.PutPublicAccessBlock(i)
-			if err != nil {
+			if IsAccessDenied(err) {
+				// fall thru if the aws operator do not have permission to create the policy
+				r.logger.Log(ctx, "failed to block public access to  S3 bucket %#q", bucketInput.Name)
+			} else if err != nil {
 				return microerror.Mask(err)
 			}
 		}

--- a/service/controller/resource/s3bucket/error.go
+++ b/service/controller/resource/s3bucket/error.go
@@ -1,6 +1,8 @@
 package s3bucket
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
@@ -74,6 +76,14 @@ func IsBucketAlreadyOwnedByYou(err error) bool {
 		return true
 	}
 
+	return false
+}
+
+// IsAccessDenied asserts access denied error on s3 bucket operation.
+func IsAccessDenied(err error) bool {
+	if strings.Contains(err.Error(), "AccessDenied") {
+		return true
+	}
 	return false
 }
 

--- a/service/controller/resource/s3bucket/error.go
+++ b/service/controller/resource/s3bucket/error.go
@@ -85,7 +85,6 @@ func IsAccessDenied(err error) bool {
 		return strings.Contains(err.Error(), "AccessDenied")
 	}
 	return false
-
 }
 
 var bucketNotEmptyError = &microerror.Error{

--- a/service/controller/resource/s3bucket/error.go
+++ b/service/controller/resource/s3bucket/error.go
@@ -81,7 +81,11 @@ func IsBucketAlreadyOwnedByYou(err error) bool {
 
 // IsAccessDenied asserts access denied error on s3 bucket operation.
 func IsAccessDenied(err error) bool {
-	return strings.Contains(err.Error(), "AccessDenied")
+	if err != nil {
+		return strings.Contains(err.Error(), "AccessDenied")
+	}
+	return false
+
 }
 
 var bucketNotEmptyError = &microerror.Error{

--- a/service/controller/resource/s3bucket/error.go
+++ b/service/controller/resource/s3bucket/error.go
@@ -81,10 +81,7 @@ func IsBucketAlreadyOwnedByYou(err error) bool {
 
 // IsAccessDenied asserts access denied error on s3 bucket operation.
 func IsAccessDenied(err error) bool {
-	if strings.Contains(err.Error(), "AccessDenied") {
-		return true
-	}
-	return false
+	return strings.Contains(err.Error(), "AccessDenied")
 }
 
 var bucketNotEmptyError = &microerror.Error{


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/18199

add extra security settings to comply with security settings for a customer

- s3-bucket-public-read-prohibited
- s3-bucket-ssl-requests-only
- s3-bucket-public-write-prohibited
- s3-bucket-server-side-encryption-enabled
- s3-bucket-logging-enabled 

- [X] Update changelog in CHANGELOG.md.
