### PR TITLE
s3-propagate-tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cloud tags propagation to S3 buckets.
+
 ### Changed
 
 -  Update `aws-attach-etcd-dep` image version to `0.2.0` to include bugfixes.

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -433,7 +433,8 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	var s3BucketResource resource.Interface
 	{
 		c := s3bucket.Config{
-			Logger: config.Logger,
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
 
 			AccessLogsExpiration: config.AccessLogsExpiration,
 			DeleteLoggingBucket:  config.DeleteLoggingBucket,

--- a/service/controller/resource/s3bucket/create.go
+++ b/service/controller/resource/s3bucket/create.go
@@ -51,10 +51,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		}
 
 		if r.includeTags {
+			tagSet, err := r.getS3BucketTags(ctx, cr)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			i := &s3.PutBucketTaggingInput{
 				Bucket: aws.String(bucketInput.Name),
 				Tagging: &s3.Tagging{
-					TagSet: r.getS3BucketTags(cr),
+					TagSet: tagSet,
 				},
 			}
 

--- a/service/controller/resource/s3bucket/error.go
+++ b/service/controller/resource/s3bucket/error.go
@@ -8,6 +8,10 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/controller/resource/s3bucket/resource.go
+++ b/service/controller/resource/s3bucket/resource.go
@@ -52,9 +52,6 @@ type Resource struct {
 // New creates a new configured s3bucket resource.
 func New(config Config) (*Resource, error) {
 	// Dependencies.
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}

--- a/service/controller/resource/s3bucket/resource.go
+++ b/service/controller/resource/s3bucket/resource.go
@@ -2,16 +2,17 @@ package s3bucket
 
 import (
 	"context"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/service/s3"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
-	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 
 	"github.com/giantswarm/aws-operator/pkg/awstags"
+	"github.com/giantswarm/aws-operator/pkg/label"
 	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 

--- a/service/controller/resource/s3bucket/update.go
+++ b/service/controller/resource/s3bucket/update.go
@@ -2,13 +2,14 @@ package s3bucket
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
-	"github.com/giantswarm/aws-operator/service/controller/key"
-
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v5/pkg/resource/crud"
+
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/controller/resource/s3bucket/update.go
+++ b/service/controller/resource/s3bucket/update.go
@@ -2,12 +2,53 @@ package s3bucket
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/aws-operator/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/service/controller/key"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v5/pkg/resource/crud"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	// update bucket tags
+	cr, err := key.ToCluster(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	currentBuckets, err := toBucketState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, bucket := range currentBuckets {
+		if r.includeTags {
+			tagSet, err := r.getS3BucketTags(ctx, cr)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			i := &s3.PutBucketTaggingInput{
+				Bucket: aws.String(bucket.Name),
+				Tagging: &s3.Tagging{
+					TagSet: tagSet,
+				},
+			}
+
+			_, err = cc.Client.TenantCluster.AWS.S3.PutBucketTagging(i)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+		r.logger.Debugf(ctx, "S3 bucket %#q tags updated", bucket.Name)
+	}
+
 	return nil
 }
 
@@ -29,7 +70,9 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// newUpdateChange is a no-op because S3 buckets are not updated.
+// newUpdateChange returns all buckets in order to update tags on all buckets
 func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	return nil, nil
+	currentBuckets, err := toBucketState(currentState)
+
+	return currentBuckets, err
 }


### PR DESCRIPTION
This is `poor man` s3 bucket tag propagation.
The creation of S3 bucket is almost the same we just append the cloud tags from cluster CR

But for the update, we did not have any logic to determine the changes, to make it super simple in each update loop we simply update the tags.

I was thinking about checking if the tags are there before updating but that would be an extra AWS API call and in the end even more expensive than just blindly set the tags to desired value on every loop.


I just wanted to get rid of this ASAP  as it's just one customer who needs this.

towards https://github.com/giantswarm/giantswarm/issues/18887