### PR TITLE
Set internal elb tag on private subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Setting `kubernetes.io/replace/internal-elb` tag on private subnet TCNP stack.
+
 ## [10.10.0] - 2021-11-23
 
 ### Added

--- a/service/controller/resource/tcnp/template/template_main_subnets.go
+++ b/service/controller/resource/tcnp/template/template_main_subnets.go
@@ -12,7 +12,7 @@ const TemplateMainSubnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
-      - Key: kubernetes.io/role/elb
+      - Key: kubernetes.io/role/internal-elb
         Value: 1
       VpcId: {{ .TCCP.VPC.ID }}
     DependsOn: VpcCidrBlock

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -410,7 +410,7 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnetEuCentral1a
-      - Key: kubernetes.io/role/elb
+      - Key: kubernetes.io/role/internal-elb
         Value: 1
       VpcId: vpc-id
     DependsOn: VpcCidrBlock
@@ -428,7 +428,7 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnetEuCentral1c
-      - Key: kubernetes.io/role/elb
+      - Key: kubernetes.io/role/internal-elb
         Value: 1
       VpcId: vpc-id
     DependsOn: VpcCidrBlock


### PR DESCRIPTION
Currently we're setting `kubernetes.io/role/elb` as tag on private subnets for all TCPN stacks.

This leads to erros when using alb controller, because the auto-discovery assumes creating a
public ALB in such private subnets.

Changing the tag to `kubernetes.io/role/internal-elb` alb controller will be able to create the right LB (internal load balancers).

## Checklist

- [x] Update changelog in CHANGELOG.md.