### PR TITLE
Bumped `k8scloudconfig` to disable `rpc-statd` service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `k8scloudconfig` to disable `rpc-statd` service.
+
 ## [10.16.0] - 2022-02-14
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0
-	github.com/giantswarm/k8scloudconfig/v11 v11.0.1
+	github.com/giantswarm/k8scloudconfig/v11 v11.1.0
 	github.com/giantswarm/k8smetadata v0.9.2
 	github.com/giantswarm/kubelock/v3 v3.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/giantswarm/k8sclient/v5 v5.0.0/go.mod h1:OhlknCs1Wgc0ErjWBgeZDGe4Y6aT
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
 github.com/giantswarm/k8sclient/v5 v5.12.0 h1:oG5k7LLqMT+OaR/jMqOAQMTCpv5OdwjcJhFYGdIPThQ=
 github.com/giantswarm/k8sclient/v5 v5.12.0/go.mod h1:KXRSG1t+XBDsXx089Jp9agMjQ4xEIWywJUchAZ2OQ6c=
-github.com/giantswarm/k8scloudconfig/v11 v11.0.1 h1:Kxes/8rNeh1zqsokNggsPh6IZp3LlLhBaaHnZ4CP8zU=
-github.com/giantswarm/k8scloudconfig/v11 v11.0.1/go.mod h1:j4+GTvBQ/io0Z3O46FEK2RsvcZzwQ/wR/7UyHAmTgjE=
+github.com/giantswarm/k8scloudconfig/v11 v11.1.0 h1:rb71Gnlq+nfhcsuDzhfGBdbxyzqByF2KFFGV1yq4D7U=
+github.com/giantswarm/k8scloudconfig/v11 v11.1.0/go.mod h1:j4+GTvBQ/io0Z3O46FEK2RsvcZzwQ/wR/7UyHAmTgjE=
 github.com/giantswarm/k8smetadata v0.9.2 h1:10lbS5DRJNES4iytNxc/5+3lsZfx+t+RvP1qZF2ymvc=
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v3 v3.0.0 h1:d7WZzRC/vol8pkVySCZxfAaHZBy0+If1GOMfDvOWBvk=


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20805

This PR bumps k8scc to disable rpc-statd and consequently rpcbind services on masters and workers