### PR TITLE
Allow resource limits/requests to be passed as values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow resource limits/requests to be passed as values.
+
 ## [10.18.0] - 2022-03-04
 
 ### Added

--- a/helm/aws-operator/templates/deployment.yaml
+++ b/helm/aws-operator/templates/deployment.yaml
@@ -80,11 +80,6 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 10
         resources:
-          requests:
-            cpu: 100m
-            memory: 250Mi
-          limits:
-            cpu: 250m
-            memory: 250Mi
+          {{- toYaml .Values.resources | nindent 10 }}
       imagePullSecrets:
       - name: {{ include "resource.pullSecret.name" . }}

--- a/helm/aws-operator/values.yaml
+++ b/helm/aws-operator/values.yaml
@@ -103,3 +103,11 @@ ports:
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 250Mi
+  requests:
+    cpu: 250m
+    memory: 250Mi


### PR DESCRIPTION
`aws-operator` container was restarting a lot with exit code 137. No errors showed up in the logs, the container just stopped working. I tried increasing the memory limit from 250Mi to 500Mi. No more restarting.

## Checklist

- [X] Update changelog in CHANGELOG.md.
