### PR TITLE
Remove CODEOWNERS to trigger automatic creation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*    @giantswarm/team-firecracker-engineers


### PR DESCRIPTION
By removing it, our `github` automation should recreated it with the right value.