### PR TITLE
Add annotation to ASG to make cluster-autoscaler work when scaling fr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add annotation to ASG to make cluster-autoscaler work when scaling from zero replicas.
+
 ## [11.0.0] - 2022-03-29
 
 ### Changed

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -51,6 +51,7 @@ const TemplateMainIAMPolicies = `
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "ec2:DescribeLaunchTemplateVersions"
+              - "ec2:DescribeInstanceTypes"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -123,6 +123,7 @@ Resources:
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "ec2:DescribeLaunchTemplateVersions"
+              - "ec2:DescribeInstanceTypes"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -123,6 +123,7 @@ Resources:
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "ec2:DescribeLaunchTemplateVersions"
+              - "ec2:DescribeInstanceTypes"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -297,6 +297,7 @@ Resources:
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "ec2:DescribeLaunchTemplateVersions"
+              - "ec2:DescribeInstanceTypes"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -125,6 +125,7 @@ Resources:
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "ec2:DescribeLaunchTemplateVersions"
+              - "ec2:DescribeInstanceTypes"
             Resource: "*"
           - Effect: "Allow"
             Action:

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -417,6 +417,9 @@ func (r *Resource) newAutoScalingGroup(ctx context.Context, cr infrastructurev1a
 		Cluster: template.ParamsMainAutoScalingGroupCluster{
 			ID: key.ClusterID(&cr),
 		},
+		NodePool: template.ParamsMainIAMPoliciesNodePool{
+			ID: key.MachineDeploymentID(&cr),
+		},
 		DesiredCapacity:                     minDesiredNodes,
 		MaxBatchSize:                        maxBatchSize,
 		MaxSize:                             key.MachineDeploymentScalingMax(cr),

--- a/service/controller/resource/tcnp/template/params_main_auto_scaling_group.go
+++ b/service/controller/resource/tcnp/template/params_main_auto_scaling_group.go
@@ -9,6 +9,7 @@ type ParamsMainAutoScalingGroup struct {
 	MaxSize               int
 	MinInstancesInService string
 	MinSize               int
+	NodePool              ParamsMainIAMPoliciesNodePool
 	Subnets               []string
 	// OnDemandPercentageAboveBaseCapacity controls the percentages of On-Demand
 	// Instances and Spot Instances for your additional capacity beyond

--- a/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
+++ b/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
@@ -60,6 +60,9 @@ const TemplateMainAutoScalingGroup = `
         - Key: k8s.io/cluster-autoscaler/{{ .AutoScalingGroup.Cluster.ID }}
           Value: true
           PropagateAtLaunch: false
+        - Key: k8s.io/cluster-autoscaler/node-template/label/giantswarm.io/machine-deployment
+          Value: {{ .AutoScalingGroup.NodePool.ID }}
+          PropagateAtLaunch: false
     UpdatePolicy:
       AutoScalingRollingUpdate:
 

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -66,6 +66,9 @@ Resources:
         - Key: k8s.io/cluster-autoscaler/8y5ck
           Value: true
           PropagateAtLaunch: false
+        - Key: k8s.io/cluster-autoscaler/node-template/label/giantswarm.io/machine-deployment
+          Value: al9qy
+          PropagateAtLaunch: false
     UpdatePolicy:
       AutoScalingRollingUpdate:
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21523

According to [the documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-scale-a-node-group-to-0), in order to make cluster autoscaler be able to scale up a zero replicas ASG, when there is a `nodeSelector`, all labels used in the node selector must be added as tags in the ASG.

This PR adds the `giantswarm.io/machine-deployment` label.

Also it adjusts the IAM role used by nodes (and by autoscaler) to add one missing permission that is listed in the CA docs.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
