### PR TITLE
Remove tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove tag `kubernetes.io/role/internal-elb` from machine deployment subnets.
+
 ## [11.3.0] - 2022-04-01
 
 ### Changed

--- a/service/controller/resource/tcnp/template/template_main_subnets.go
+++ b/service/controller/resource/tcnp/template/template_main_subnets.go
@@ -12,8 +12,6 @@ const TemplateMainSubnets = `
       Tags:
       - Key: Name
         Value: {{ .Name }}
-      - Key: kubernetes.io/role/internal-elb
-        Value: 1
       VpcId: {{ .TCCP.VPC.ID }}
     DependsOn: VpcCidrBlock
   {{ .RouteTableAssociation.Name }}:

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -446,8 +446,6 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnetEuCentral1a
-      - Key: kubernetes.io/role/internal-elb
-        Value: 1
       VpcId: vpc-id
     DependsOn: VpcCidrBlock
   PrivateSubnetRouteTableAssociationEuCentral1a:
@@ -464,8 +462,6 @@ Resources:
       Tags:
       - Key: Name
         Value: PrivateSubnetEuCentral1c
-      - Key: kubernetes.io/role/internal-elb
-        Value: 1
       VpcId: vpc-id
     DependsOn: VpcCidrBlock
   PrivateSubnetRouteTableAssociationEuCentral1c:


### PR DESCRIPTION
- Remove `kubernetes.io/role/internal-elb` tag from machine deployment subnets.

Issue: https://github.com/giantswarm/giantswarm/issues/21447

## Checklist

- [x] Update changelog in CHANGELOG.md.