### PR TITLE
Kube proxy vpa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped k8scc to CHANGEME to enable VPA for kube-proxy.
+
 ## [11.3.0] - 2022-04-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped k8scc to CHANGEME to enable VPA for kube-proxy.
+- Bumped k8scc to 13.4.0 to enable VPA for kube-proxy.
 
 ## [11.3.0] - 2022-04-01
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713
+	github.com/giantswarm/k8scloudconfig/v13 v13.4.0
 	github.com/giantswarm/k8smetadata v0.10.1
 	github.com/giantswarm/kubelock/v3 v3.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1
+	github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713
 	github.com/giantswarm/k8smetadata v0.10.1
 	github.com/giantswarm/kubelock/v3 v3.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v3 v3.1.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.3.0
+	github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1
 	github.com/giantswarm/k8smetadata v0.10.1
 	github.com/giantswarm/kubelock/v3 v3.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.0 h1:j8GMKowY++SuGOeb/ry8p76JDIZ6faofluYPP3aPcvU=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1 h1:b8mp2vL1FeRj3VZJGEmB2tISY3vY1fg49Y9h2KHhGKo=
+github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.10.1 h1:JHTgTavRtcnmzq0j8TC9EXtGG4+trCkBwuwJPAH+EWE=
 github.com/giantswarm/k8smetadata v0.10.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1 h1:b8mp2vL1FeRj3VZJGEmB2tISY3vY1fg49Y9h2KHhGKo=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404085134-34a479a0a1b1/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713 h1:mMxREkWnBcFDXlMSGVvO4qPmvO7FZEUCXiRS4ImLyFk=
+github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.10.1 h1:JHTgTavRtcnmzq0j8TC9EXtGG4+trCkBwuwJPAH+EWE=
 github.com/giantswarm/k8smetadata v0.10.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713 h1:mMxREkWnBcFDXlMSGVvO4qPmvO7FZEUCXiRS4ImLyFk=
-github.com/giantswarm/k8scloudconfig/v13 v13.3.1-0.20220404095412-dc2ad205f713/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.4.0 h1:n2CrxEwKgi3SZ79sDz+JQGmERrN5vzeGmrQ9QwQOadM=
+github.com/giantswarm/k8scloudconfig/v13 v13.4.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.10.1 h1:JHTgTavRtcnmzq0j8TC9EXtGG4+trCkBwuwJPAH+EWE=
 github.com/giantswarm/k8smetadata v0.10.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21494

bump k8scc to get VPA for kube-proxy

## Checklist

- [x] Update changelog in CHANGELOG.md.
