### PR TITLE
Add `POD_SECURITY_GROUP_ENFORCING_MODE` to `aws-node` Daemonset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `POD_SECURITY_GROUP_ENFORCING_MODE` to `aws-node` Daemonset.
+
 ## [11.8.0] - 2022-04-19
 
 ### Added

--- a/service/internal/cloudconfig/template/aws-cni.go
+++ b/service/internal/cloudconfig/template/aws-cni.go
@@ -188,6 +188,8 @@ spec:
               value: "true"
             - name: ENABLE_IPv6
               value: "false"
+            - name: POD_SECURITY_GROUP_ENFORCING_MODE
+              value: standard
             ## If CNI prefix validation is enabled we remove WARM_IP_TARGET and MINIMUM_IP_TARGET because it will take precedence over WARM_PREFIX_TARGET.
             {{- if eq .AWSCNIPrefix false }}
             - name: WARM_IP_TARGET


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/828

In order to make node-local-dns to work on AWS with AWS-cni, we need to set the new flag POD_SECURITY_GROUP_ENFORCING_MODE to `standard`.

I tested this by creating a cluster with both the flag set and node-local DNS installed and running sonobuoy conformance tests: all good.

## Checklist

- [x] Update changelog in CHANGELOG.md.
