### PR TITLE
fix issuer s3 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Issuer S3 endpoint for IRSA.
+
 ## [11.9.1] - 2022-04-20
 
 ### Fixed

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -314,7 +314,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 				awsEndpoint = "amazonaws.com.cn"
 			}
 
-			apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--service-account-issuer=https://s3-%s.%s/%s-g8s-%s-oidc-pod-identity", key.Region(cl), awsEndpoint, cc.Status.TenantCluster.AWS.AccountID, key.ClusterID(&cr)))
+			apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--service-account-issuer=https://s3.%s.%s/%s-g8s-%s-oidc-pod-identity", key.Region(cl), awsEndpoint, cc.Status.TenantCluster.AWS.AccountID, key.ClusterID(&cr)))
 			apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--api-audiences=sts.%s", awsEndpoint))
 
 			irsaSAKeyArgs = append(irsaSAKeyArgs, "--service-account-key-file=/etc/kubernetes/ssl/service-account-v2-pub.pem")


### PR DESCRIPTION
AWS is not consistent

```
host s3-eu-central-1.amazonaws.com
s3-eu-central-1.amazonaws.com is an alias for s3.eu-central-1.amazonaws.com.
s3.eu-central-1.amazonaws.com has address 52.219.169.157
```

```
host s3-cn-north-1.amazonaws.com.cn
Host s3-cn-north-1.amazonaws.com.cn not found: 3(NXDOMAIN)
```

## Checklist

- [x] Update changelog in CHANGELOG.md.