### PR TITLE
Allow usage of irsa for route53 manager role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extend permission policy of IAM role `Route53Manager-Role` for IRSA.
+
 ## [11.11.0] - 2022-05-16
 
 ### Changed

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -84,6 +84,16 @@ func AMI(region string, release releasev1alpha1.Release) (string, error) {
 	return regionAMI, nil
 }
 
+func AWSBaseDomain(region string) string {
+	baseDomain := "amazonaws.com"
+
+	if isChinaRegion(region) {
+		baseDomain += ".cn"
+	}
+
+	return baseDomain
+}
+
 func AWSCNINATRouteName(az string) string {
 	return fmt.Sprintf("AWSCNINATRoute-%s", az)
 }

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -420,11 +420,14 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 	var iamPolicies *template.ParamsMainIAMPolicies
 	{
 		iamPolicies = &template.ParamsMainIAMPolicies{
+			AccountID:            cc.Status.TenantCluster.AWS.AccountID,
+			AWSBaseDomain:        key.AWSBaseDomain(cc.Status.TenantCluster.AWS.Region),
 			ClusterID:            key.ClusterID(&cr),
 			EC2ServiceDomain:     key.EC2ServiceDomain(cc.Status.TenantCluster.AWS.Region),
 			HostedZoneID:         cc.Status.TenantCluster.DNS.HostedZoneID,
 			InternalHostedZoneID: cc.Status.TenantCluster.DNS.InternalHostedZoneID,
 			KMSKeyARN:            ek,
+			Region:               cc.Status.TenantCluster.AWS.Region,
 			RegionARN:            key.RegionARN(cc.Status.TenantCluster.AWS.Region),
 			S3Bucket:             key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
 			Route53Enabled:       r.route53Enabled,

--- a/service/controller/resource/tccpn/template/params_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/params_main_iam_policies.go
@@ -1,11 +1,14 @@
 package template
 
 type ParamsMainIAMPolicies struct {
+	AccountID            string
+	AWSBaseDomain        string
 	ClusterID            string
 	EC2ServiceDomain     string
 	HostedZoneID         string
 	InternalHostedZoneID string
 	KMSKeyARN            string
+	Region               string
 	RegionARN            string
 	S3Bucket             string
 	Route53Enabled       bool

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -129,10 +129,16 @@ const TemplateMainIAMPolicies = `
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: "Allow"
-          Principal:
-            AWS: !GetAtt IAMManagerRole.Arn
-          Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt IAMManagerRole.Arn
+            Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-provider-identity"
+            Condition:
+              StringEquals:
+                "s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -200,10 +200,16 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: "Allow"
-          Principal:
-            AWS: !GetAtt IAMManagerRole.Arn
-          Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt IAMManagerRole.Arn
+            Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+            Condition:
+              StringEquals:
+                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -374,10 +374,16 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: "Allow"
-          Principal:
-            AWS: !GetAtt IAMManagerRole.Arn
-          Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt IAMManagerRole.Arn
+            Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+            Condition:
+              StringEquals:
+                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -202,10 +202,16 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          Effect: "Allow"
-          Principal:
-            AWS: !GetAtt IAMManagerRole.Arn
-          Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt IAMManagerRole.Arn
+            Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+            Condition:
+              StringEquals:
+                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:


### PR DESCRIPTION
Changing the permission policy slightly to allow external-dns assume Route53Manager-Role via IRSA.

Issue: https://github.com/giantswarm/roadmap/issues/1101

## Checklist

- [x] Update changelog in CHANGELOG.md.