### PR TITLE
systemd cgroup driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `k8scc` to use `systemd` cgroup driver on masters and cgroups v2 worker nodes.
+
 ## [11.11.0] - 2022-05-16
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.5.0
+	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91
 	github.com/giantswarm/k8smetadata v0.11.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91
+	github.com/giantswarm/k8scloudconfig/v13 v13.6.0
 	github.com/giantswarm/k8smetadata v0.11.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.0 h1:Ht+gant0fX+CCYmUHmvEMjKw8Kp8wK/CJn7cjCeEhpM=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91 h1:LvOXsYHINounrygg8isefpf6tqj7kcHqr1Aix90TRNc=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.0 h1:XWcN0b6yBm2eH2Ael5SFFR87iRIigI+SRIfuiQBsxZ4=
 github.com/giantswarm/k8smetadata v0.11.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91 h1:LvOXsYHINounrygg8isefpf6tqj7kcHqr1Aix90TRNc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.6.0 h1:Eu5C5g2uwxyFdsozB/OhZFLfG20JTaNCqGpvEjrJ8bo=
+github.com/giantswarm/k8scloudconfig/v13 v13.6.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.0 h1:XWcN0b6yBm2eH2Ael5SFFR87iRIigI+SRIfuiQBsxZ4=
 github.com/giantswarm/k8smetadata v0.11.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1090

this PR bumps k8scc to switch to `systemd` group driver on master nodes and on cgroups v2-enabled node pools

## Checklist

- [x] Update changelog in CHANGELOG.md.
