### PR TITLE
Fix route53 ARN trusted entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix principal ARN for Route53 trusted entity.
+
 ### Changed
 
 - Remove `imagePullSecrets`

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -135,7 +135,7 @@ const TemplateMainIAMPolicies = `
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-provider-identity"
+              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-pod-identity"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -206,7 +206,7 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -380,7 +380,7 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -208,7 +208,7 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-provider-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:


### PR DESCRIPTION
I made a mistake by not using the correct OIDC ARN to allow external-dns assuming the role.
https://github.com/giantswarm/releases/pull/992

This fixes it.

## Checklist

- [x] Update changelog in CHANGELOG.md.