### PR TITLE
Containerd EBS Volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Containerd EBS Volume.
+
+### Fixed
+
+- Fix `crictl.yaml` on worker nodes.
+
 ## [12.0.0] - 2022-07-14
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.0.0
+	github.com/giantswarm/k8scloudconfig/v14 v14.0.1
 	github.com/giantswarm/k8smetadata v0.11.1
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.0.0 h1:noaFEwREsTPOCC1mpWyfODTKHraTpHEQpQFMy7tsxL4=
-github.com/giantswarm/k8scloudconfig/v14 v14.0.0/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.0.1 h1:JKKwl0EUHirKOPJ43hCCkrq9qGgz7vq6taPA6kBmYtM=
+github.com/giantswarm/k8scloudconfig/v14 v14.0.1/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
 github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -463,6 +463,11 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 	for _, m := range mappings {
 		item := template.ParamsMainLaunchTemplateItem{
 			BlockDeviceMapping: template.ParamsMainLaunchTemplateItemBlockDeviceMapping{
+				Containerd: template.ParamsMainLaunchTemplateItemBlockDeviceMappingContainerd{
+					Volume: template.ParamsMainLaunchTemplateItemBlockDeviceMappingContainerdVolume{
+						Size: defaultVolumeSize,
+					},
+				},
 				Docker: template.ParamsMainLaunchTemplateItemBlockDeviceMappingDocker{
 					Volume: template.ParamsMainLaunchTemplateItemBlockDeviceMappingDockerVolume{
 						Size: defaultVolumeSize,

--- a/service/controller/resource/tccpn/template/params_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/params_main_launch_template.go
@@ -16,9 +16,10 @@ type ParamsMainLaunchTemplateItem struct {
 }
 
 type ParamsMainLaunchTemplateItemBlockDeviceMapping struct {
-	Docker  ParamsMainLaunchTemplateItemBlockDeviceMappingDocker
-	Kubelet ParamsMainLaunchTemplateItemBlockDeviceMappingKubelet
-	Logging ParamsMainLaunchTemplateItemBlockDeviceMappingLogging
+	Containerd ParamsMainLaunchTemplateItemBlockDeviceMappingContainerd
+	Docker     ParamsMainLaunchTemplateItemBlockDeviceMappingDocker
+	Kubelet    ParamsMainLaunchTemplateItemBlockDeviceMappingKubelet
+	Logging    ParamsMainLaunchTemplateItemBlockDeviceMappingLogging
 }
 
 type ParamsMainLaunchTemplateItemInstance struct {
@@ -29,6 +30,14 @@ type ParamsMainLaunchTemplateItemInstance struct {
 
 type ParamsMainLaunchTemplateMetadata struct {
 	HttpTokens string
+}
+
+type ParamsMainLaunchTemplateItemBlockDeviceMappingContainerd struct {
+	Volume ParamsMainLaunchTemplateItemBlockDeviceMappingContainerdVolume
+}
+
+type ParamsMainLaunchTemplateItemBlockDeviceMappingContainerdVolume struct {
+	Size int
 }
 
 type ParamsMainLaunchTemplateItemBlockDeviceMappingDocker struct {

--- a/service/controller/resource/tccpn/template/template_main_launch_template.go
+++ b/service/controller/resource/tccpn/template/template_main_launch_template.go
@@ -27,6 +27,12 @@ const TemplateMainLaunchTemplate = `
             Encrypted: true
             VolumeSize: {{ .BlockDeviceMapping.Logging.Volume.Size }}
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: {{ .BlockDeviceMapping.Containerd.Volume.Size }}
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref ControlPlaneNodesInstanceProfile
         ImageId: {{ .Instance.Image }}
@@ -84,6 +90,15 @@ const TemplateMainLaunchTemplate = `
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -254,6 +254,12 @@ Resources:
             Encrypted: true
             VolumeSize: 100
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref ControlPlaneNodesInstanceProfile
         ImageId: ami-0a9a5d2b65cce04eb
@@ -311,6 +317,15 @@ Resources:
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -217,6 +217,12 @@ Resources:
             Encrypted: true
             VolumeSize: 100
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref ControlPlaneNodesInstanceProfile
         ImageId: ami-0a9a5d2b65cce04eb
@@ -274,6 +280,15 @@ Resources:
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -428,6 +428,12 @@ Resources:
             Encrypted: true
             VolumeSize: 100
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref ControlPlaneNodesInstanceProfile
         ImageId: ami-0a9a5d2b65cce04eb
@@ -487,6 +493,15 @@ Resources:
                       "label": "log",
                       "format": "xfs"
                     }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
+                      "format": "xfs"
+                    }
                   }
                 ]
               }
@@ -510,6 +525,12 @@ Resources:
             VolumeSize: 100
             VolumeType: gp3
         - DeviceName: /dev/xvdf
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
+        - DeviceName: /dev/xvdi
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
@@ -574,6 +595,15 @@ Resources:
                       "label": "log",
                       "format": "xfs"
                     }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
+                      "format": "xfs"
+                    }
                   }
                 ]
               }
@@ -597,6 +627,12 @@ Resources:
             VolumeSize: 100
             VolumeType: gp3
         - DeviceName: /dev/xvdf
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
+        - DeviceName: /dev/xvdi
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
@@ -659,6 +695,15 @@ Resources:
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -256,6 +256,12 @@ Resources:
             Encrypted: true
             VolumeSize: 100
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref ControlPlaneNodesInstanceProfile
         ImageId: ami-0a9a5d2b65cce04eb
@@ -313,6 +319,15 @@ Resources:
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -488,6 +488,11 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 
 	launchTemplate := &template.ParamsMainLaunchTemplate{
 		BlockDeviceMapping: template.ParamsMainLaunchTemplateBlockDeviceMapping{
+			Containerd: template.ParamsMainLaunchTemplateBlockDeviceMappingContainerd{
+				Volume: template.ParamsMainLaunchTemplateBlockDeviceMappingContainerdVolume{
+					Size: key.MachineDeploymentDockerVolumeSizeGB(cr),
+				},
+			},
 			Docker: template.ParamsMainLaunchTemplateBlockDeviceMappingDocker{
 				Volume: template.ParamsMainLaunchTemplateBlockDeviceMappingDockerVolume{
 					Size: key.MachineDeploymentDockerVolumeSizeGB(cr),

--- a/service/controller/resource/tcnp/template/params_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/params_main_launch_template.go
@@ -10,9 +10,10 @@ type ParamsMainLaunchTemplate struct {
 }
 
 type ParamsMainLaunchTemplateBlockDeviceMapping struct {
-	Docker  ParamsMainLaunchTemplateBlockDeviceMappingDocker
-	Kubelet ParamsMainLaunchTemplateBlockDeviceMappingKubelet
-	Logging ParamsMainLaunchTemplateBlockDeviceMappingLogging
+	Containerd ParamsMainLaunchTemplateBlockDeviceMappingContainerd
+	Docker     ParamsMainLaunchTemplateBlockDeviceMappingDocker
+	Kubelet    ParamsMainLaunchTemplateBlockDeviceMappingKubelet
+	Logging    ParamsMainLaunchTemplateBlockDeviceMappingLogging
 }
 
 type ParamsMainLaunchTemplateInstance struct {
@@ -23,6 +24,14 @@ type ParamsMainLaunchTemplateInstance struct {
 
 type ParamsMainLaunchTemplateMetadata struct {
 	HttpTokens string
+}
+
+type ParamsMainLaunchTemplateBlockDeviceMappingContainerd struct {
+	Volume ParamsMainLaunchTemplateBlockDeviceMappingContainerdVolume
+}
+
+type ParamsMainLaunchTemplateBlockDeviceMappingContainerdVolume struct {
+	Size string
 }
 
 type ParamsMainLaunchTemplateBlockDeviceMappingDocker struct {

--- a/service/controller/resource/tcnp/template/template_main_launch_template.go
+++ b/service/controller/resource/tcnp/template/template_main_launch_template.go
@@ -26,6 +26,12 @@ const TemplateMainLaunchTemplate = `
             Encrypted: true
             VolumeSize: {{ .LaunchTemplate.BlockDeviceMapping.Logging.Volume.Size }}
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: {{ .LaunchTemplate.BlockDeviceMapping.Containerd.Volume.Size }}
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref NodePoolInstanceProfile
         ImageId: {{ .LaunchTemplate.Instance.Image }}
@@ -83,6 +89,15 @@ const TemplateMainLaunchTemplate = `
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -218,6 +218,12 @@ Resources:
             Encrypted: true
             VolumeSize: 100
             VolumeType: gp3
+        - DeviceName: /dev/xvdi
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeSize: 100
+            VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref NodePoolInstanceProfile
         ImageId: ami-0a9a5d2b65cce04eb
@@ -275,6 +281,15 @@ Resources:
                       "device": "/dev/xvdf",
                       "wipeFilesystem": true,
                       "label": "log",
+                      "format": "xfs"
+                    }
+                  },
+                  {
+                    "name": "containerd",
+                    "mount": {
+                      "device": "/dev/xvdi",
+                      "wipeFilesystem": true,
+                      "label": "containerd",
                       "format": "xfs"
                     }
                   }

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -416,6 +416,11 @@ func (e *TCCPNExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 			Name:         "var-lib-docker.mount",
 			Enabled:      true,
 		},
+		{
+			AssetContent: template.EphemeralVarLibContainerdMount,
+			Name:         "var-lib-containerd.mount",
+			Enabled:      true,
+		},
 		// Attach etcd3 dependencies (EBS and ENI).
 		{
 			AssetContent: template.Etcd3AttachDepService,

--- a/service/internal/cloudconfig/tcnp_extension.go
+++ b/service/internal/cloudconfig/tcnp_extension.go
@@ -159,6 +159,11 @@ func (e *TCNPExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 			Name:         "var-lib-docker.mount",
 			Enabled:      true,
 		},
+		{
+			AssetContent: template.PersistentVarLibContainerdMount,
+			Name:         "var-lib-containerd.mount",
+			Enabled:      true,
+		},
 		// Set bigger timeouts for NVME driver.
 		// Workaround for https://github.com/coreos/bugs/issues/2484
 		// TODO issue: https://github.com/giantswarm/giantswarm/issues/4255

--- a/service/internal/cloudconfig/template/ephemeral_var_lib_containerd_mount.go
+++ b/service/internal/cloudconfig/template/ephemeral_var_lib_containerd_mount.go
@@ -1,0 +1,12 @@
+package template
+
+const EphemeralVarLibContainerdMount = `
+[Unit]
+Description=Mount ephemeral volume on /var/lib/containerd
+[Mount]
+What=/dev/disk/by-label/containerd
+Where=/var/lib/containerd
+Type=xfs
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/internal/cloudconfig/template/instance_storage_class.go
+++ b/service/internal/cloudconfig/template/instance_storage_class.go
@@ -3,7 +3,7 @@ package template
 const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: gp2
+  name: gp3
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
@@ -11,7 +11,7 @@ provisioner: kubernetes.io/aws-ebs
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: gp2
+  type: gp3
 `
 const InstanceStorageClassEncryptedContent = InstanceStorageClassContent + `
   encrypted: "true"

--- a/service/internal/cloudconfig/template/instance_storage_class.go
+++ b/service/internal/cloudconfig/template/instance_storage_class.go
@@ -3,7 +3,7 @@ package template
 const InstanceStorageClassContent = `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: gp3
+  name: gp2
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
@@ -11,7 +11,7 @@ provisioner: kubernetes.io/aws-ebs
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: gp3
+  type: gp2
 `
 const InstanceStorageClassEncryptedContent = InstanceStorageClassContent + `
   encrypted: "true"

--- a/service/internal/cloudconfig/template/persistent_var_lib_containerd_mount.go
+++ b/service/internal/cloudconfig/template/persistent_var_lib_containerd_mount.go
@@ -1,0 +1,12 @@
+package template
+
+const PersistentVarLibContainerdMount = `
+[Unit]
+Description=Mount persistent volume on /var/lib/containerd
+[Mount]
+What=/dev/disk/by-label/containerd
+Where=/var/lib/containerd
+Type=xfs
+[Install]
+RequiredBy=local-fs.target
+`

--- a/service/internal/cloudconfig/testdata/case-0-tcnp-test.golden
+++ b/service/internal/cloudconfig/testdata/case-0-tcnp-test.golden
@@ -348,6 +348,11 @@
         "name": "var-lib-docker.mount"
       },
       {
+        "contents": "\n[Unit]\nDescription=Mount persistent volume on /var/lib/containerd\n[Mount]\nWhat=/dev/disk/by-label/containerd\nWhere=/var/lib/containerd\nType=xfs\n[Install]\nRequiredBy=local-fs.target\n",
+        "enabled": true,
+        "name": "var-lib-containerd.mount"
+      },
+      {
         "contents": "[Unit]\nDescription=Set NVME timeouts\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"\\\n  [ -d /sys/module/nvme_core/parameters ] \u0026\u0026 \\\n  echo 10 \u003e /sys/module/nvme_core/parameters/max_retries \u0026\u0026 \\\n  echo 255 \u003e /sys/module/nvme_core/parameters/io_timeout || echo 'No NVMe present.'\"\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "nvme-set-timeouts.service"

--- a/service/internal/cloudconfig/testdata/case-1-tcnp-test-china.golden
+++ b/service/internal/cloudconfig/testdata/case-1-tcnp-test-china.golden
@@ -348,6 +348,11 @@
         "name": "var-lib-docker.mount"
       },
       {
+        "contents": "\n[Unit]\nDescription=Mount persistent volume on /var/lib/containerd\n[Mount]\nWhat=/dev/disk/by-label/containerd\nWhere=/var/lib/containerd\nType=xfs\n[Install]\nRequiredBy=local-fs.target\n",
+        "enabled": true,
+        "name": "var-lib-containerd.mount"
+      },
+      {
         "contents": "[Unit]\nDescription=Set NVME timeouts\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \"\\\n  [ -d /sys/module/nvme_core/parameters ] \u0026\u0026 \\\n  echo 10 \u003e /sys/module/nvme_core/parameters/max_retries \u0026\u0026 \\\n  echo 255 \u003e /sys/module/nvme_core/parameters/io_timeout || echo 'No NVMe present.'\"\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "nvme-set-timeouts.service"


### PR DESCRIPTION
```
giantswarm@ip-10-1-14-43 ~ $ df -h
Filesystem       Size  Used Avail Use% Mounted on
...
/dev/nvme0n1p9   5.5G  209M  5.0G   4% /
...
/dev/nvme4n1     100G  144M  100G   1% /var/log
/dev/nvme2n1     100G  725M  100G   1% /var/lib/docker
/dev/nvme3n1     100G  1.7G   99G   2% /var/lib/containerd
```

```
Disk /dev/nvme3n1: 100 GiB, 107374182400 bytes, 209715200 sectors
Disk model: Amazon Elastic Block Store
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
```

## Checklist

- [x] Update changelog in CHANGELOG.md.