### PR TITLE
Aws node cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
+- Cleanup `aws-node` resources after a successful migration.
 
 ## [13.0.0-alpha2] - 2022-07-27
 

--- a/helm/aws-operator/templates/rbac.yaml
+++ b/helm/aws-operator/templates/rbac.yaml
@@ -142,6 +142,14 @@ rules:
       - get
       - create
       - update
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    resourceNames:
+      - eniconfigs.crd.k8s.amazonaws.com
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/apiendpoint"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/appsconfig"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/awsclient"
+	"github.com/giantswarm/aws-operator/v13/service/controller/resource/awscnicleaner"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/bridgezone"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cleanupebsvolumes"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cleanupenis"
@@ -818,6 +819,18 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var awsCniCleanerResource resource.Interface
+	{
+		c := awscnicleaner.Config{
+			Logger: config.Logger,
+		}
+
+		awsCniCleanerResource, err = awscnicleaner.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// All these resources only fetch information from remote APIs and put them
 		// into the controller context.
@@ -850,6 +863,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		endpointsResource,
 		secretFinalizerResource,
 		appsConfigResource,
+		awsCniCleanerResource,
 
 		// All these resources implement logic to update CR status information.
 		tccpVPCIDStatusResource,

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -1,0 +1,75 @@
+package awscnicleaner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	v1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/aws-operator/v13/service/controller/controllercontext"
+)
+
+const (
+	dsNamespace = "kube-system"
+	dsName      = "aws-node"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	var err error
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if cc.Client.TenantCluster.K8s == nil {
+		r.logger.Debugf(ctx, "kubernetes clients are not available in controller context yet")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
+	ctrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
+
+	// Ensure aws-node daemonset has zero pods.
+	ds := &v1.DaemonSet{}
+	err = ctrlClient.Get(ctx, client.ObjectKey{Name: dsName, Namespace: dsNamespace}, ds)
+	if apierrors.IsNotFound(err) {
+		// All good.
+		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q", dsName, dsNamespace)
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if ds != nil {
+		if ds.Status.DesiredNumberScheduled > 0 {
+			r.logger.Debugf(ctx, "Daemonset %q/%q still has %d replicas", dsNamespace, dsName, ds.Status.DesiredNumberScheduled)
+			r.logger.Debugf(ctx, "canceling resource")
+
+			return nil
+		}
+	}
+
+	r.logger.Debugf(ctx, "Daemonset %q/%q has no replicas, deleting all resources", dsNamespace, dsName)
+
+	for _, objToBeDel := range r.objectsToBeDeleted {
+		obj := objToBeDel()
+		err = ctrlClient.Delete(ctx, obj)
+		if apierrors.IsNotFound(err) {
+			// All good that's what we want.
+			continue
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		name := obj.GetName()
+		if obj.GetNamespace() != "" {
+			name = fmt.Sprintf("%s/%s", obj.GetNamespace(), name)
+		}
+		r.logger.Debugf(ctx, "Deleted %s %s", obj.GetObjectKind().GroupVersionKind().Kind, name)
+	}
+
+	return nil
+}

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -41,9 +41,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q", dsName, dsNamespace)
 	} else if err != nil {
 		return microerror.Mask(err)
-	}
-
-	if ds != nil {
+	} else {
 		if ds.Status.DesiredNumberScheduled > 0 {
 			r.logger.Debugf(ctx, "Daemonset %q/%q still has %d replicas", dsNamespace, dsName, ds.Status.DesiredNumberScheduled)
 			r.logger.Debugf(ctx, "canceling resource")

--- a/service/controller/resource/awscnicleaner/delete.go
+++ b/service/controller/resource/awscnicleaner/delete.go
@@ -1,0 +1,9 @@
+package awscnicleaner
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/awscnicleaner/error.go
+++ b/service/controller/resource/awscnicleaner/error.go
@@ -1,0 +1,14 @@
+package awscnicleaner
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/awscnicleaner/resource.go
+++ b/service/controller/resource/awscnicleaner/resource.go
@@ -39,6 +39,9 @@ func New(config Config) (*Resource, error) {
 	objectsToBeDeleted := []objectToBeDeleted{
 		func() client.Object {
 			return &v1beta1.PodSecurityPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "PodSecurityPolicy",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aws-cni",
 				},
@@ -46,6 +49,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &rbacv1.ClusterRole{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRole",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aws-node",
 				},
@@ -53,6 +59,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ServiceAccount",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-node",
 					Namespace: "kube-system",
@@ -61,6 +70,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &rbacv1.ClusterRoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRoleBinding",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aws-node",
 				},
@@ -68,6 +80,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &appsv1.DaemonSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "DaemonSet",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-node",
 					Namespace: "kube-system",
@@ -76,6 +91,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "CustomResourceDefinition",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "eniconfigs.crd.k8s.amazonaws.com",
 				},
@@ -83,6 +101,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ServiceAccount",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-cni-restarter",
 					Namespace: "kube-system",
@@ -91,6 +112,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &rbacv1.Role{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Role",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-cni-restarter",
 					Namespace: "kube-system",
@@ -99,6 +123,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &rbacv1.RoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RoleBinding",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-cni-restarter-binding",
 					Namespace: "kube-system",
@@ -107,6 +134,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &v1beta1.PodSecurityPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "PodSecurityPolicy",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aws-cni-restarter",
 				},
@@ -114,6 +144,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &networkingv1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "NetworkPolicy",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-cni-restarter",
 					Namespace: "kube-system",
@@ -122,6 +155,9 @@ func New(config Config) (*Resource, error) {
 		},
 		func() client.Object {
 			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "CronJob",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "aws-cni-restarter",
 					Namespace: "kube-system",

--- a/service/controller/resource/tenantclients/create.go
+++ b/service/controller/resource/tenantclients/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/tenantcluster/v6/pkg/tenantcluster"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/giantswarm/aws-operator/v13/service/controller/controllercontext"
@@ -47,6 +48,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				// the Tenant Cluster in order to properly configure the AWS CNI.
 				// Therefore it is important to add its specific scheme builders.
 				v1alpha1.AddToScheme,
+				// The Tenant Clients are used to delete the ENIConfig CRD after the migration to Cilium.
+				apiextensionsv1.AddToScheme,
 			},
 		}
 


### PR DESCRIPTION
After a successful migration to cilium, we can safely delete all resources regarding aws-cni.
This PR adds a new resource that waits until aws-node deamonset has zero replicas before deleting all resources.

## Checklist

- [x] Update changelog in CHANGELOG.md.
