### PR TITLE
Cidr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
 - Cleanup `aws-node` resources after a successful migration.
+- Use `cilium.giantswarm.io/pod-cidr` annotation as Cilium Pod CIDR.
 
 ## [13.0.0-alpha2] - 2022-07-27
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294
+	github.com/giantswarm/k8scloudconfig/v14 v14.1.2
 	github.com/giantswarm/k8smetadata v0.11.1
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
 	github.com/giantswarm/k8scloudconfig/v14 v14.1.2
-	github.com/giantswarm/k8smetadata v0.11.1
+	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0
 	github.com/giantswarm/microerror v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.1.1
+	github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294
 	github.com/giantswarm/k8smetadata v0.11.1
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.1 h1:/wos2NazMW7mDDCysKSH0WMXvgniBgejtsqU51bOluU=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.1/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294 h1:P/f2P66LOg3qVZ9zM3DPvwPPKDSVHILkPcqtuQz0/oM=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
 github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294 h1:P/f2P66LOg3qVZ9zM3DPvwPPKDSVHILkPcqtuQz0/oM=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.2 h1:Y9Ccm51GUIb16njHgoESeW37J4WwfCVszJ54I1DHGek=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.2/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
 github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2 h1:Y9Ccm51GUIb16njHgoESeW37J4WwfCVszJ54I1DHGek=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
-github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
-github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
+github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=
 github.com/giantswarm/kubelock/v4 v4.0.0/go.mod h1:XbqPs1m+NafHSjXvOXsb3UjE5DvhyNk47tfGcQJl1iY=
 github.com/giantswarm/microendpoint v1.0.0 h1:vW6VXPaWXBPZc9Q99FgPcjYprAKLItufKFcydBH47Xc=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.1 h1:/wos2NazMW7mDDCysKSH0WMXvgniBgejtsqU51bOluU=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.1/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294 h1:P/f2P66LOg3qVZ9zM3DPvwPPKDSVHILkPcqtuQz0/oM=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2-0.20220802120337-1a7dd59e8294/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -87,6 +87,10 @@ const (
 	ComponentOS = "containerlinux"
 )
 
+const (
+	ciliumPodCidrAnnotation = "cilium.giantswarm.io/pod-cidr"
+)
+
 func ClusterAPIEndpoint(cluster infrastructurev1alpha3.AWSCluster) string {
 	return fmt.Sprintf("api.%s", TenantClusterBaseDomain(cluster))
 }
@@ -123,8 +127,12 @@ func ExternalSNAT(cluster infrastructurev1alpha3.AWSCluster) *bool {
 	return cluster.Spec.Provider.Pods.ExternalSNAT
 }
 
-func PodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+func AWSCNIPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
 	return cluster.Spec.Provider.Pods.CIDRBlock
+}
+
+func CiliumPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+	return cluster.Annotations[ciliumPodCidrAnnotation]
 }
 
 func IsChinaRegion(awsRegion string) bool {

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/aws-operator/v13/pkg/project"
@@ -87,10 +88,6 @@ const (
 	ComponentOS = "containerlinux"
 )
 
-const (
-	ciliumPodCidrAnnotation = "cilium.giantswarm.io/pod-cidr"
-)
-
 func ClusterAPIEndpoint(cluster infrastructurev1alpha3.AWSCluster) string {
 	return fmt.Sprintf("api.%s", TenantClusterBaseDomain(cluster))
 }
@@ -132,7 +129,7 @@ func AWSCNIPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
 }
 
 func CiliumPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
-	return cluster.Annotations[ciliumPodCidrAnnotation]
+	return cluster.Annotations[annotation.CiliumPodCidr]
 }
 
 func IsChinaRegion(awsRegion string) bool {

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -474,8 +474,8 @@ func (r *Resource) newParamsMainSecurityGroups(ctx context.Context, cr infrastru
 	}
 
 	podSubnet := r.cidrBlockAWSCNI
-	if key.PodsCIDRBlock(cr) != "" {
-		podSubnet = key.PodsCIDRBlock(cr)
+	if key.AWSCNIPodsCIDRBlock(cr) != "" {
+		podSubnet = key.AWSCNIPodsCIDRBlock(cr)
 	}
 
 	var securityGroups *template.ParamsMainSecurityGroups
@@ -604,8 +604,8 @@ func (r *Resource) newParamsMainVPC(ctx context.Context, cr infrastructurev1alph
 
 	// Allow the actual VPC subnet CIDR to be overwritten by the CR spec.
 	podSubnet := r.cidrBlockAWSCNI
-	if key.PodsCIDRBlock(cr) != "" {
-		podSubnet = key.PodsCIDRBlock(cr)
+	if key.AWSCNIPodsCIDRBlock(cr) != "" {
+		podSubnet = key.AWSCNIPodsCIDRBlock(cr)
 	}
 
 	var vpc *template.ParamsMainVPC

--- a/service/controller/resource/tccpazs/create.go
+++ b/service/controller/resource/tccpazs/create.go
@@ -169,8 +169,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		// Allow the actual VPC subnet CIDR to be overwritten by the CR spec.
 		podSubnet := r.cidrBlockAWSCNI
-		if key.PodsCIDRBlock(cl) != "" {
-			podSubnet = key.PodsCIDRBlock(cl)
+		if key.AWSCNIPodsCIDRBlock(cl) != "" {
+			podSubnet = key.AWSCNIPodsCIDRBlock(cl)
 		}
 
 		_, awsCNISubnet, err := net.ParseCIDR(podSubnet)

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -336,7 +336,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 
 	// Pod CIDR should never be nil.
 	if podCidr == "" {
-		return "", microerror.Maskf(executionFailedError, "Cilium Pod CIDR annotation cannot be nil in AWSCluster")
+		return "", microerror.Maskf(executionFailedError, "Pod CIDR cannot be nil in AWSCluster")
 	}
 
 	var controllerManagerExtraArgs []string

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -3,7 +3,6 @@ package cloudconfig
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -372,15 +371,6 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		params = k8scloudconfig.Params{}
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr, mapping.ID))
-
-		if key.PodsCIDRBlock(cl) != "" {
-			_, ipnet, err := net.ParseCIDR(key.PodsCIDRBlock(cl))
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-			g8sConfig.Cluster.Calico.Subnet = ipnet.IP.String()
-			_, g8sConfig.Cluster.Calico.CIDR = ipnet.Mask.Size()
-		}
 
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)
 		params.DisableCalico = true

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -335,7 +335,8 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 	var controllerManagerExtraArgs []string
 	{
 		controllerManagerExtraArgs = append(controllerManagerExtraArgs, "--allocate-node-cidrs=true")
-		controllerManagerExtraArgs = append(controllerManagerExtraArgs, "--cluster-cidr="+key.PodsCIDRBlock(cl))
+		//controllerManagerExtraArgs = append(controllerManagerExtraArgs, "--cluster-cidr="+key.PodsCIDRBlock(cl))
+		controllerManagerExtraArgs = append(controllerManagerExtraArgs, "--cluster-cidr=192.168.0.0/16")
 		controllerManagerExtraArgs = append(controllerManagerExtraArgs, "--node-cidr-mask-size=25")
 	}
 

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -3,7 +3,6 @@ package cloudconfig
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -192,15 +191,6 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 		params = k8scloudconfig.Params{}
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCNP(&cr))
-
-		if key.PodsCIDRBlock(cl) != "" {
-			_, ipnet, err := net.ParseCIDR(key.PodsCIDRBlock(cl))
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			g8sConfig.Cluster.Calico.Subnet = ipnet.IP.String()
-			_, g8sConfig.Cluster.Calico.CIDR = ipnet.Mask.Size()
-		}
 
 		params.DisableCalico = true
 		params.DisableKubeProxy = false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23061

This PR makes aws-operator use an annotation in `AWSCluster` CR as CIDR for cilium.
That is because we need a different CIDR compared to what AWS-CNI is using.

For new clusters there is no need for this and the annotation is missing.

Presence of annotation in the places where it's needed is mandated to aws-admission-controller

## Checklist

- [x] Update changelog in CHANGELOG.md.
