### PR TITLE
Cleanup vpc

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -822,7 +822,8 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	var awsCniCleanerResource resource.Interface
 	{
 		c := awscnicleaner.Config{
-			Logger: config.Logger,
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
 		}
 
 		awsCniCleanerResource, err = awscnicleaner.New(c)

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -168,6 +168,12 @@ func IsAlreadyCreatedCluster(cluster infrastructurev1alpha3.AWSCluster) bool {
 	return cluster.Status.Cluster.HasCreatedCondition()
 }
 
+func IsAWSCNINeeded(cluster infrastructurev1alpha3.AWSCluster) bool {
+	_, needed := cluster.Annotations[annotation.CiliumPodCidr]
+
+	return needed
+}
+
 func MasterAvailabilityZone(cluster infrastructurev1alpha3.AWSCluster) string {
 	return cluster.Spec.Provider.Master.AvailabilityZone
 }

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -79,10 +79,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if key.CiliumPodsCIDRBlock(cr) != "" {
 		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)
 
+		cr.Spec.Provider.Pods.CIDRBlock = key.CiliumPodsCIDRBlock(cr)
+
 		annotations := cr.Annotations
 		delete(annotations, annotation.CiliumPodCidr)
-
-		cr.Spec.Provider.Pods.CIDRBlock = key.CiliumPodsCIDRBlock(cr)
 		cr.Annotations = annotations
 
 		err = r.ctrlClient.Update(ctx, &cr)

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -38,11 +38,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	ctrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
+	wcCtrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
 
 	// Ensure aws-node daemonset has zero pods.
 	ds := &v1.DaemonSet{}
-	err = ctrlClient.Get(ctx, client.ObjectKey{Name: dsName, Namespace: dsNamespace}, ds)
+	err = wcCtrlClient.Get(ctx, client.ObjectKey{Name: dsName, Namespace: dsNamespace}, ds)
 	if apierrors.IsNotFound(err) {
 		// All good.
 		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q", dsName, dsNamespace)
@@ -61,7 +61,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	for _, objToBeDel := range r.objectsToBeDeleted {
 		obj := objToBeDel()
-		err = ctrlClient.Delete(ctx, obj)
+		err = wcCtrlClient.Delete(ctx, obj)
 		if apierrors.IsNotFound(err) {
 			// All good that's what we want.
 			continue
@@ -85,7 +85,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		cr.Spec.Provider.Pods.CIDRBlock = key.CiliumPodsCIDRBlock(cr)
 		cr.Annotations = annotations
 
-		err = ctrlClient.Update(ctx, &cr)
+		err = r.ctrlClient.Update(ctx, &cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/awscnicleaner/resource.go
+++ b/service/controller/resource/awscnicleaner/resource.go
@@ -19,19 +19,24 @@ const (
 )
 
 type Config struct {
-	Logger micrologger.Logger
+	CtrlClient client.Client
+	Logger     micrologger.Logger
 }
 
 type objectToBeDeleted func() client.Object
 
 // Resource that ensures the `aws-node` resources are deleted from the cluster after migration to cilium is successful
 type Resource struct {
-	logger micrologger.Logger
+	ctrlClient client.Client
+	logger     micrologger.Logger
 
 	objectsToBeDeleted []objectToBeDeleted
 }
 
 func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -167,6 +172,7 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
+		ctrlClient:         config.CtrlClient,
 		logger:             config.Logger,
 		objectsToBeDeleted: objectsToBeDeleted,
 	}

--- a/service/controller/resource/tccp/template/params_main.go
+++ b/service/controller/resource/tccp/template/params_main.go
@@ -1,6 +1,7 @@
 package template
 
 type ParamsMain struct {
+	EnableAWSCNI    bool
 	InternetGateway *ParamsMainInternetGateway
 	LoadBalancers   *ParamsMainLoadBalancers
 	NATGateway      *ParamsMainNATGateway

--- a/service/controller/resource/tccp/template/template_main_route_tables.go
+++ b/service/controller/resource/tccp/template/template_main_route_tables.go
@@ -3,6 +3,7 @@ package template
 const TemplateMainRouteTables = `
 {{- define "route_tables" -}}
 {{- $v := .RouteTables -}}
+  {{- if .EnableAWSCNI }}
   {{- range $v.AWSCNIRouteTableNames }}
   {{ .ResourceName }}:
     Type: AWS::EC2::RouteTable
@@ -15,6 +16,7 @@ const TemplateMainRouteTables = `
         Value: {{ .AvailabilityZone }}
       - Key: giantswarm.io/route-table-type
         Value: aws-cni
+  {{- end }}
   {{- end }}
   {{- range $v.PublicRouteTableNames }}
   {{ .ResourceName }}:

--- a/service/controller/resource/tccp/template/template_main_security_groups.go
+++ b/service/controller/resource/tccp/template/template_main_security_groups.go
@@ -206,6 +206,7 @@ const TemplateMainSecurityGroups = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}-internal-api
+  {{- if .EnableAWSCNI }}
   AWSCNISecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -234,6 +235,7 @@ const TemplateMainSecurityGroups = `
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref AWSCNISecurityGroup
+{{- end }}
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -254,6 +256,7 @@ const TemplateMainSecurityGroups = `
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
+  {{- if .EnableAWSCNI }}
   MasterAllowPodsCNIIngressRule:
       Type: AWS::EC2::SecurityGroupIngress
       DependsOn: MasterSecurityGroup
@@ -264,6 +267,7 @@ const TemplateMainSecurityGroups = `
         FromPort: -1
         ToPort: -1
         SourceSecurityGroupId: !Ref AWSCNISecurityGroup
+  {{- end }}
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/template/template_main_security_groups.go
+++ b/service/controller/resource/tccp/template/template_main_security_groups.go
@@ -206,7 +206,6 @@ const TemplateMainSecurityGroups = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}-internal-api
-  {{- if .EnableAWSCNI }}
   AWSCNISecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -215,6 +214,7 @@ const TemplateMainSecurityGroups = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}-aws-cni
+  {{- if .EnableAWSCNI }}
   PodsIngressRuleFromMAsters:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: AWSCNISecurityGroup

--- a/service/controller/resource/tccp/template/template_main_subnets.go
+++ b/service/controller/resource/tccp/template/template_main_subnets.go
@@ -3,6 +3,7 @@ package template
 const TemplateMainSubnets = `
 {{- define "subnets" -}}
 {{- $v := .Subnets }}
+  {{- if .EnableAWSCNI }}
   {{- range $v.AWSCNISubnets }}
   {{ .Name }}:
     Type: AWS::EC2::Subnet
@@ -22,6 +23,7 @@ const TemplateMainSubnets = `
     Properties:
       RouteTableId: !Ref {{ .RouteTableAssociation.RouteTableName }}
       SubnetId: !Ref {{ .RouteTableAssociation.SubnetName }}
+  {{- end }}
   {{- end }}
   {{- range $v.PublicSubnets }}
   {{ .Name }}:

--- a/service/controller/resource/tccp/template/template_main_vpc.go
+++ b/service/controller/resource/tccp/template/template_main_vpc.go
@@ -12,6 +12,7 @@ const TemplateMainVPC = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}
+  {{- if .EnableAWSCNI }}
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
     DependsOn:
@@ -20,6 +21,7 @@ const TemplateMainVPC = `
     Properties:
       CidrBlock: {{ $v.CIDRBlockAWSCNI }}
       VpcId: !Ref VPC
+  {{- end }}
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -208,13 +208,6 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
-  AWSCNINATRouteEuCentral1a:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
@@ -222,24 +215,10 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
-  AWSCNINATRouteEuCentral1b:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1b
   NATRouteEuCentral1c:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1c
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1c
-  AWSCNINATRouteEuCentral1c:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
@@ -325,39 +304,6 @@ Resources:
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
-  AWSCNIRouteTableEuCentral1a:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1a
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1a
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1b:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1b
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1b
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1c:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1c
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1c
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -565,34 +511,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
-  AWSCNISecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
-      VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: 8y5ck-aws-cni
-  PodsIngressRuleFromMAsters:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from masters to pods.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  PodsAllowPodsCNIIngressRule:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from pod to pod.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -613,16 +531,6 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
-  MasterAllowPodsCNIIngressRule:
-      Type: AWS::EC2::SecurityGroupIngress
-      DependsOn: MasterSecurityGroup
-      Properties:
-        Description: Allow traffic from pod to master.
-        GroupId: !Ref MasterSecurityGroup
-        IpProtocol: -1
-        FromPort: -1
-        ToPort: -1
-        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -640,60 +548,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -818,14 +672,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
-  VPCCIDRBlockAWSCNI:
-    Type: AWS::EC2::VPCCidrBlock
-    DependsOn:
-      - VPC
-      - VPCPeeringConnection
-    Properties:
-      CidrBlock: 172.17.0.1/16
-      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -848,9 +694,6 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
-        - !Ref AWSCNIRouteTableEuCentral1a
-        - !Ref AWSCNIRouteTableEuCentral1b
-        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -511,6 +511,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
+  AWSCNISecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: 8y5ck-aws-cni
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -200,24 +200,10 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
-  AWSCNINATRouteEuCentral1a:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1b
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1b
-  AWSCNINATRouteEuCentral1b:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
@@ -228,48 +214,8 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
-  AWSCNINATRouteEuCentral1c:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1c
   
   
-  AWSCNIRouteTableEuCentral1a:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1a
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1a
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1b:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1b
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1b
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1c:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1c
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1c
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -477,34 +423,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
-  AWSCNISecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
-      VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: 8y5ck-aws-cni
-  PodsIngressRuleFromMAsters:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from masters to pods.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  PodsAllowPodsCNIIngressRule:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from pod to pod.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -525,16 +443,6 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
-  MasterAllowPodsCNIIngressRule:
-      Type: AWS::EC2::SecurityGroupIngress
-      DependsOn: MasterSecurityGroup
-      Properties:
-        Description: Allow traffic from pod to master.
-        GroupId: !Ref MasterSecurityGroup
-        IpProtocol: -1
-        FromPort: -1
-        ToPort: -1
-        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -552,60 +460,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -730,14 +584,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
-  VPCCIDRBlockAWSCNI:
-    Type: AWS::EC2::VPCCidrBlock
-    DependsOn:
-      - VPC
-      - VPCPeeringConnection
-    Properties:
-      CidrBlock: 172.17.0.1/16
-      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -760,9 +606,6 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
-        - !Ref AWSCNIRouteTableEuCentral1a
-        - !Ref AWSCNIRouteTableEuCentral1b
-        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -423,6 +423,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
+  AWSCNISecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: 8y5ck-aws-cni
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -200,24 +200,10 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
-  AWSCNINATRouteEuCentral1a:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1b
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1b
-  AWSCNINATRouteEuCentral1b:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
@@ -228,48 +214,8 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
-  AWSCNINATRouteEuCentral1c:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NATGatewayEuCentral1c
   
   
-  AWSCNIRouteTableEuCentral1a:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1a
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1a
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1b:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1b
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1b
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
-  AWSCNIRouteTableEuCentral1c:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-      - Key: Name
-        Value: 8y5ck-aws-cni-1c
-      - Key: giantswarm.io/availability-zone
-        Value: eu-central-1c
-      - Key: giantswarm.io/route-table-type
-        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -514,34 +460,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
-  AWSCNISecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
-      VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: 8y5ck-aws-cni
-  PodsIngressRuleFromMAsters:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from masters to pods.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  PodsAllowPodsCNIIngressRule:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: AWSCNISecurityGroup
-    Properties:
-      Description: Allow traffic from pod to pod.
-      GroupId: !Ref AWSCNISecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -562,16 +480,6 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
-  MasterAllowPodsCNIIngressRule:
-      Type: AWS::EC2::SecurityGroupIngress
-      DependsOn: MasterSecurityGroup
-      Properties:
-        Description: Allow traffic from pod to master.
-        GroupId: !Ref MasterSecurityGroup
-        IpProtocol: -1
-        FromPort: -1
-        ToPort: -1
-        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -589,60 +497,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -767,14 +621,6 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
-  VPCCIDRBlockAWSCNI:
-    Type: AWS::EC2::VPCCidrBlock
-    DependsOn:
-      - VPC
-      - VPCPeeringConnection
-    Properties:
-      CidrBlock: 172.17.0.1/16
-      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -797,9 +643,6 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
-        - !Ref AWSCNIRouteTableEuCentral1a
-        - !Ref AWSCNIRouteTableEuCentral1b
-        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -460,6 +460,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-internal-api
+  AWSCNISecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "AWS CNI Security Group configured to the ENIConfig CRD."
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: 8y5ck-aws-cni
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup

--- a/service/controller/resource/tcnp/template/params_main_iam_policies.go
+++ b/service/controller/resource/tcnp/template/params_main_iam_policies.go
@@ -3,6 +3,7 @@ package template
 type ParamsMainIAMPolicies struct {
 	Cluster          ParamsMainIAMPoliciesCluster
 	EC2ServiceDomain string
+	EnableAWSCNI     bool
 	KMSKeyARN        string
 	NodePool         ParamsMainIAMPoliciesNodePool
 	RegionARN        string

--- a/service/controller/resource/tcnp/template/params_main_security_groups.go
+++ b/service/controller/resource/tcnp/template/params_main_security_groups.go
@@ -3,6 +3,7 @@ package template
 type ParamsMainSecurityGroups struct {
 	ClusterID     string
 	ControlPlane  ParamsMainSecurityGroupsControlPlane
+	EnableAWSCNI  bool
 	TenantCluster ParamsMainSecurityGroupsTenantCluster
 }
 

--- a/service/controller/resource/tcnp/template/template_main_iam_policies.go
+++ b/service/controller/resource/tcnp/template/template_main_iam_policies.go
@@ -58,6 +58,7 @@ const TemplateMainIAMPolicies = `
               - "ecr:BatchGetImage"
             Resource: "*"
 
+          {{- if .IAMPolicies.EnableAWSCNI }}
           # Following rules are required to make the AWS CNI work. See also
           # https://github.com/aws/amazon-vpc-cni-k8s#setup.
           - Effect: Allow
@@ -79,6 +80,7 @@ const TemplateMainIAMPolicies = `
               - ec2:CreateTags
             Resource:
               - arn:{{ .IAMPolicies.RegionARN }}:ec2:*:*:network-interface/*
+          {{- end }}
 
           # Following rules are required for EBS snapshots.
           - Effect: Allow

--- a/service/controller/resource/tcnp/template/template_main_security_groups.go
+++ b/service/controller/resource/tcnp/template/template_main_security_groups.go
@@ -67,6 +67,7 @@ const TemplateMainSecurityGroups = `
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref GeneralSecurityGroup
+  {{- if .SecurityGroups.EnableAWSCNI }}
   PodsIngressRuleFromWorkers:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: GeneralSecurityGroup
@@ -87,6 +88,7 @@ const TemplateMainSecurityGroups = `
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: {{ .SecurityGroups.TenantCluster.AWSCNI.ID }}
+  {{- end }}
   InternalIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: GeneralSecurityGroup

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -133,28 +133,6 @@ Resources:
               - "ecr:BatchGetImage"
             Resource: "*"
 
-          # Following rules are required to make the AWS CNI work. See also
-          # https://github.com/aws/amazon-vpc-cni-k8s#setup.
-          - Effect: Allow
-            Action:
-              - ec2:AssignPrivateIpAddresses
-              - ec2:AttachNetworkInterface
-              - ec2:CreateNetworkInterface
-              - ec2:DeleteNetworkInterface
-              - ec2:DescribeInstances
-              - ec2:DescribeInstanceTypes
-              - ec2:DescribeTags
-              - ec2:DescribeNetworkInterfaces
-              - ec2:DetachNetworkInterface
-              - ec2:ModifyNetworkInterfaceAttribute
-              - ec2:UnassignPrivateIpAddresses
-            Resource: "*"
-          - Effect: Allow
-            Action:
-              - ec2:CreateTags
-            Resource:
-              - arn:aws:ec2:*:*:network-interface/*
-
           # Following rules are required for EBS snapshots.
           - Effect: Allow
             Action:
@@ -396,26 +374,6 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref GeneralSecurityGroup
-  PodsIngressRuleFromWorkers:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: GeneralSecurityGroup
-    Properties:
-      Description: Allow traffic from workers to pods.
-      GroupId: awscni-security-group-id
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: !Ref GeneralSecurityGroup
-  PodsIngressRule:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: GeneralSecurityGroup
-    Properties:
-      Description: Allow traffic from pods to the worker nodes.
-      GroupId: !Ref GeneralSecurityGroup
-      IpProtocol: -1
-      FromPort: -1
-      ToPort: -1
-      SourceSecurityGroupId: awscni-security-group-id
   InternalIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: GeneralSecurityGroup


### PR DESCRIPTION
Towards cilium.

After switching to cilium, the old resources (subnets, routing tables, etc) used by aws-cni are not needed any more and can be deleted.

Because of the dependencies between those resources and because of the migration process (while cilium and aws-cni need to run at the same time), the cleanup can't be done just yet, but in this release it needs to be prepared.

This PR:

- disables aws-cni resources for brand new clusters that don't need em
- prepares for cleanup of resources in future upgrades for clusters being upgraded from previous releases

## Checklist

- [x] Update changelog in CHANGELOG.md.
