### PR TITLE
Use cloudfront for IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use Cloudfront Domain for IRSA.
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
 - Ensure `aws-node` daemonset has `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` env var set to the cilium cidr during migration to cilium.
 - Cleanup `aws-node` resources after a successful migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use Cloudfront Domain for IRSA.
+- Use Cloudfront Domain for IRSA for non-China regions.
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
 - Ensure `aws-node` daemonset has `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` env var set to the cilium cidr during migration to cilium.
 - Cleanup `aws-node` resources after a successful migration.

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -347,6 +347,10 @@ func ServiceAccountV2SecretName(clusterName string) string {
 	return fmt.Sprintf("%s-service-account-v2", clusterName)
 }
 
+func IRSACloudfrontConfigMap(clusterName string) string {
+	return fmt.Sprintf("%s-irsa-cloudfront", clusterName)
+}
+
 func SSLOnlyBucketPolicy(bucketName string, region string) string {
 	arn := RegionARN(region)
 	return fmt.Sprintf(sslOnlyBucketPolicyTemplate, arn, bucketName, arn, bucketName)

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -432,7 +432,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 
 		cloudfrontDomain = cm.Data["domain"]
 		if cloudfrontDomain == "" {
-			return nil, microerror.Maskf(emptyDataError, "irsa cloudfront configmap for cluster must not be empty")
+			return nil, microerror.Maskf(emptyDataError, "domain value in irsa cloudfront configmap for cluster must not be empty")
 		}
 
 	}

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -432,8 +432,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 
 		cloudfrontDomain = cm.Data["domain"]
 		if cloudfrontDomain == "" {
-			r.logger.Debugf(ctx, "canceling resource", "reason", "cloudfront domain cannot be empty")
-			return nil, nil
+			return nil, microerror.Maskf(emptyDataError, "irsa cloudfront configmap for cluster must not be empty")
 		}
 
 	}

--- a/service/controller/resource/tccpn/create_test.go
+++ b/service/controller/resource/tccpn/create_test.go
@@ -3,7 +3,6 @@ package tccpn
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
@@ -161,6 +160,14 @@ func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 				}
 			}
 
+			{
+				cm := unittest.DefaultIRSACloudfrontConfigMap()
+				err = k.CtrlClient().Create(ctx, &cm)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
 			var aws infrastructurev1alpha3.AWSControlPlane
 			{
 				cl := unittest.DefaultCluster()
@@ -172,8 +179,6 @@ func Test_Controller_Resource_TCCPN_Template_Render(t *testing.T) {
 				aws = unittest.DefaultAWSControlPlane()
 				aws.Spec.AvailabilityZones = tc.azs
 				for k, v := range tc.annotations {
-					fmt.Println(k)
-					fmt.Println(v)
 					aws.Annotations[k] = v
 				}
 				err = k.CtrlClient().Create(ctx, &aws)

--- a/service/controller/resource/tccpn/error.go
+++ b/service/controller/resource/tccpn/error.go
@@ -155,3 +155,7 @@ func IsUpdateInProgress(err error) bool {
 
 	return false
 }
+
+var emptyDataError = &microerror.Error{
+	Kind: "emtpyDataError",
+}

--- a/service/controller/resource/tccpn/template/params_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/params_main_iam_policies.go
@@ -3,6 +3,7 @@ package template
 type ParamsMainIAMPolicies struct {
 	AccountID            string
 	AWSBaseDomain        string
+	Cloudfront           string
 	ClusterID            string
 	EC2ServiceDomain     string
 	HostedZoneID         string

--- a/service/controller/resource/tccpn/template/params_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/params_main_iam_policies.go
@@ -3,7 +3,8 @@ package template
 type ParamsMainIAMPolicies struct {
 	AccountID            string
 	AWSBaseDomain        string
-	Cloudfront           string
+	CloudfrontEnabled    bool
+	CloudfrontDomain     string
 	ClusterID            string
 	EC2ServiceDomain     string
 	HostedZoneID         string

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -135,11 +135,11 @@ const TemplateMainIAMPolicies = `
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-pod-identity"
+              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.Cloudfront }}"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "s3.{{ .IAMPolicies.Region }}.{{ .IAMPolicies.AWSBaseDomain }}/{{ .IAMPolicies.AccountID }}-g8s-{{ .IAMPolicies.ClusterID }}-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
+                "{{ .IAMPolicies.Cloudfront }}:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -133,15 +133,15 @@ const TemplateMainIAMPolicies = `
             Principal:
               AWS: !GetAtt IAMManagerRole.Arn
             Action: "sts:AssumeRole"
-{{- if .IAMPolicies.Cloudfront }}
+          {{- if .IAMPolicies.CloudfrontEnabled }}
           - Effect: "Allow"
             Principal:
-              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.Cloudfront }}"
+              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.CloudfrontDomain }}"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "{{ .IAMPolicies.Cloudfront }}:sub": "system:serviceaccount:kube-system:external-dns"
-{{- end -}}
+                "{{ .IAMPolicies.CloudfrontDomain }}:sub": "system:serviceaccount:kube-system:external-dns"
+          {{- end }}
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -133,6 +133,7 @@ const TemplateMainIAMPolicies = `
             Principal:
               AWS: !GetAtt IAMManagerRole.Arn
             Action: "sts:AssumeRole"
+{{- if .IAMPolicies.Cloudfront }}
           - Effect: "Allow"
             Principal:
               Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.Cloudfront }}"
@@ -140,6 +141,7 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringEquals:
                 "{{ .IAMPolicies.Cloudfront }}:sub": "system:serviceaccount:kube-system:external-dns"
+{{- end -}}
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -206,11 +206,11 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/122424fd.cloudfront.net"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
+                "122424fd.cloudfront.net:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -380,11 +380,11 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/122424fd.cloudfront.net"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
+                "122424fd.cloudfront.net:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -208,11 +208,11 @@ Resources:
             Action: "sts:AssumeRole"
           - Effect: "Allow"
             Principal:
-              Federated: "arn:aws:iam::tenant-account:oidc-provider/s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity"
+              Federated: "arn:aws:iam::tenant-account:oidc-provider/122424fd.cloudfront.net"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                "s3.eu-central-1.amazonaws.com/tenant-account-g8s-8y5ck-oidc-pod-identity:sub": "system:serviceaccount:kube-system:external-dns"
+                "122424fd.cloudfront.net:sub": "system:serviceaccount:kube-system:external-dns"
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -331,7 +331,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 				awsEndpoint = "amazonaws.com.cn"
 			}
 
-			if cloudfrontDomain == "" {
+			if cloudfrontDomain == "" && !key.IsChinaRegion(key.Region(cl)) {
 				return "", microerror.Maskf(executionFailedError, "Cloudfront domain for service account issuer cannot be empty")
 			}
 

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -275,22 +275,24 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 				}
 				return nil
 			})
-			if !key.IsChinaRegion(key.Region(cl)) {
-				g.Go(func() error {
-					var cm v1.ConfigMap
-					err := t.config.K8sClient.CtrlClient().Get(
-						ctx, client.ObjectKey{
-							Name:      key.IRSACloudfrontConfigMap(key.ClusterID(&cr)),
-							Namespace: cr.Namespace,
-						},
-						&cm)
-					if err != nil {
-						return microerror.Mask(err)
-					}
-					cloudfrontDomain = cm.Data["domain"]
+			if _, ok := cl.Annotations[annotation.AWSIRSA]; ok {
+				if !key.IsChinaRegion(key.Region(cl)) {
+					g.Go(func() error {
+						var cm v1.ConfigMap
+						err := t.config.K8sClient.CtrlClient().Get(
+							ctx, client.ObjectKey{
+								Name:      key.IRSACloudfrontConfigMap(key.ClusterID(&cr)),
+								Namespace: cr.Namespace,
+							},
+							&cm)
+						if err != nil {
+							return microerror.Mask(err)
+						}
+						cloudfrontDomain = cm.Data["domain"]
 
-					return nil
-				})
+						return nil
+					})
+				}
 			}
 		}
 

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -336,7 +336,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 			}
 
 			if key.IsChinaRegion(key.Region(cl)) {
-				apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--service-account-issuer=https://s3.%s.%s/%s-g8s-%s-oidc-pod-identity", key.Region(cl), awsEndpoint, cc.Status.TenantCluster.AWS.AccountID, key.ClusterID(&cr)))
+				apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--service-account-issuer=https://s3.%s.%s/%s-g8s-%s-oidc-pod-identity-v2", key.Region(cl), awsEndpoint, cc.Status.TenantCluster.AWS.AccountID, key.ClusterID(&cr)))
 			} else {
 				apiExtraArgs = append(apiExtraArgs, fmt.Sprintf("--service-account-issuer=https://%s", cloudfrontDomain))
 			}

--- a/service/internal/unittest/default_cluster.go
+++ b/service/internal/unittest/default_cluster.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
@@ -59,6 +60,9 @@ func ChinaCluster() infrastructurev1alpha3.AWSCluster {
 func DefaultCluster() infrastructurev1alpha3.AWSCluster {
 	cr := infrastructurev1alpha3.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.AWSIRSA: "",
+			},
 			Labels: map[string]string{
 				label.Cluster:         DefaultClusterID,
 				label.OperatorVersion: "7.3.0",

--- a/service/internal/unittest/default_irsa-cloudfront-configmap.go
+++ b/service/internal/unittest/default_irsa-cloudfront-configmap.go
@@ -1,0 +1,20 @@
+package unittest
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func DefaultIRSACloudfrontConfigMap() v1.ConfigMap {
+	return v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-irsa-cloudfront", DefaultClusterID),
+			Namespace: metav1.NamespaceDefault,
+		},
+		Data: map[string]string{
+			"domain": "122424fd.cloudfront.net",
+		},
+	}
+}

--- a/service/internal/unittest/default_k8sclient.go
+++ b/service/internal/unittest/default_k8sclient.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
 	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -36,6 +37,10 @@ func FakeK8sClient(objects ...runtime.Object) k8sclient.Interface {
 			panic(err)
 		}
 		err = releasev1alpha1.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = v1.AddToScheme(scheme)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/1255

This will potentially break existing clusters when IRSA is already enabled. 

If `irsa-operator` can create Cloudfront before the upgrade, we only need to delete the OIDC configuration file in S3 bucket manually (it will be created again with the correct OIDC config). Afterwards everything should work again.

- Change API flag for IRSA service account issuer to Cloudfront Endpoint
- Change Route53Manager IAM Role to Cloudfront Endpoint

## Checklist

- [x] Update changelog in CHANGELOG.md.