### PR TITLE
Cleanup calico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
 - Cleanup `aws-node` resources after a successful migration.
+- Cleanup `calico` resources after a successful migration.
 - Use `cilium.giantswarm.io/pod-cidr` annotation as Cilium Pod CIDR.
 - Add Flatcar `3227.2.1` AMI.
 - Bump `k8scloudconfig` to support newer flatcar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleanup `aws-node` resources after a successful migration.
 - Use `cilium.giantswarm.io/pod-cidr` annotation as Cilium Pod CIDR.
 - Add Flatcar `3227.2.1` AMI.
+- Bump `k8scloudconfig` to support newer flatcar.
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.0
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.1.2
+	github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97
+	github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2 h1:Y9Ccm51GUIb16njHgoESeW37J4WwfCVszJ54I1DHGek=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.2/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97 h1:+lc5Zxbgkcd3KvXhjqBcim4FGpkklXDPfMXdfeFTBf4=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97 h1:+lc5Zxbgkcd3KvXhjqBcim4FGpkklXDPfMXdfeFTBf4=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362 h1:Tdvc9Yx87Y7LXZ1lb4d4z64Axw22lOXKBoWnjwZAALY=
+github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362 h1:Tdvc9Yx87Y7LXZ1lb4d4z64Axw22lOXKBoWnjwZAALY=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220809111455-b148c894f362/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.0 h1:7il5Xij676pjHUHuDhtK2ozv1GzmRWw3MICtkaUAhbQ=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.0/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.2 h1:Y9Ccm51GUIb16njHgoESeW37J4WwfCVszJ54I1DHGek=
-github.com/giantswarm/k8scloudconfig/v14 v14.1.2/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97 h1:+lc5Zxbgkcd3KvXhjqBcim4FGpkklXDPfMXdfeFTBf4=
 github.com/giantswarm/k8scloudconfig/v14 v14.1.3-0.20220808160011-4aefa6ee9a97/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=

--- a/service/controller/resource/awscnicleaner/resource.go
+++ b/service/controller/resource/awscnicleaner/resource.go
@@ -169,6 +169,71 @@ func New(config Config) (*Resource, error) {
 				},
 			}
 		},
+		// Calico
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-config",
+					Namespace: "kube-system",
+				},
+			}
+		},
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-typha",
+					Namespace: "kube-system",
+				},
+			}
+		},
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "DaemonSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-node",
+					Namespace: "kube-system",
+				},
+			}
+		},
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-node",
+					Namespace: "kube-system",
+				},
+			}
+		},
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRole",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "calico-node",
+				},
+			}
+		},
+		func() client.Object {
+			return &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ClusterRoleBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "calico-node",
+				},
+			}
+		},
 	}
 
 	r := &Resource{

--- a/service/controller/resource/awscnicleaner/resource.go
+++ b/service/controller/resource/awscnicleaner/resource.go
@@ -171,7 +171,7 @@ func New(config Config) (*Resource, error) {
 		},
 		// Calico
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "ConfigMap",
 				},
@@ -182,7 +182,7 @@ func New(config Config) (*Resource, error) {
 			}
 		},
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &corev1.Service{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Service",
 				},
@@ -193,7 +193,7 @@ func New(config Config) (*Resource, error) {
 			}
 		},
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &appsv1.DaemonSet{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "DaemonSet",
 				},
@@ -204,7 +204,7 @@ func New(config Config) (*Resource, error) {
 			}
 		},
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &corev1.ServiceAccount{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "ServiceAccount",
 				},
@@ -215,7 +215,7 @@ func New(config Config) (*Resource, error) {
 			}
 		},
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &rbacv1.ClusterRole{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "ClusterRole",
 				},
@@ -225,7 +225,7 @@ func New(config Config) (*Resource, error) {
 			}
 		},
 		func() client.Object {
-			return &batchv1beta1.CronJob{
+			return &rbacv1.ClusterRoleBinding{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "ClusterRoleBinding",
 				},


### PR DESCRIPTION
After a successful migration to cilium, we can cleanup calico resources as we did with aws-cni.
This PR does that, as well as bumping k8scc.


## Checklist

- [x] Update changelog in CHANGELOG.md.
