### PR TITLE
Fix aws cni env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Ensure `aws-node` daemonset does not schedule on upgraded nodes.
+- Ensure `aws-node` daemonset has `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` env var set to the cilium cidr during migration to cilium.
 - Cleanup `aws-node` resources after a successful migration.
 - Cleanup `calico` resources after a successful migration.
 - Use `cilium.giantswarm.io/pod-cidr` annotation as Cilium Pod CIDR.

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -46,6 +46,7 @@ import (
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/keepforcrs"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/natgatewayaddresses"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/peerrolearn"
+	"github.com/giantswarm/aws-operator/v13/service/controller/resource/prepareawscniformigration"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/region"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/restrictawsnodedaemonset"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/s3bucket"
@@ -819,6 +820,19 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var prepareAwsCniForMigrationResource resource.Interface
+	{
+		c := prepareawscniformigration.Config{
+			Logger:     config.Logger,
+			CtrlClient: config.K8sClient.CtrlClient(),
+		}
+
+		prepareAwsCniForMigrationResource, err = prepareawscniformigration.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// All these resources only fetch information from remote APIs and put them
 		// into the controller context.
@@ -843,6 +857,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		bridgeZoneResource,
 		tccpSecurityGroupsResource,
 		s3BucketResource,
+		prepareAwsCniForMigrationResource,
 		tccpAZsResource,
 		tccpiResource,
 		tccpResource,

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -25,6 +25,7 @@ import (
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/awsclient"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cleanuptccpniamroles"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cpvpc"
+	"github.com/giantswarm/aws-operator/v13/service/controller/resource/prepareawscniformigration"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/region"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/snapshotid"
@@ -469,6 +470,19 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 		}
 	}
 
+	var prepareAwsCniForMigrationResource resource.Interface
+	{
+		c := prepareawscniformigration.Config{
+			Logger:     config.Logger,
+			CtrlClient: config.K8sClient.CtrlClient(),
+		}
+
+		prepareAwsCniForMigrationResource, err = prepareawscniformigration.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		// All these resources only fetch information from remote APIs and put them
 		// into the controller context.
@@ -488,6 +502,7 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 		// All these resources implement certain business logic and operate based on
 		// the information given in the controller context.
 		s3ObjectResource,
+		prepareAwsCniForMigrationResource,
 		tccpnResource,
 
 		// All these resources implement cleanup functionality only being executed

--- a/service/controller/control_plane.go
+++ b/service/controller/control_plane.go
@@ -25,7 +25,6 @@ import (
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/awsclient"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cleanuptccpniamroles"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cpvpc"
-	"github.com/giantswarm/aws-operator/v13/service/controller/resource/prepareawscniformigration"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/region"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/s3object"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/snapshotid"
@@ -470,19 +469,6 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 		}
 	}
 
-	var prepareAwsCniForMigrationResource resource.Interface
-	{
-		c := prepareawscniformigration.Config{
-			Logger:     config.Logger,
-			CtrlClient: config.K8sClient.CtrlClient(),
-		}
-
-		prepareAwsCniForMigrationResource, err = prepareawscniformigration.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	resources := []resource.Interface{
 		// All these resources only fetch information from remote APIs and put them
 		// into the controller context.
@@ -502,7 +488,6 @@ func newControlPlaneResources(config ControlPlaneConfig) ([]resource.Interface, 
 		// All these resources implement certain business logic and operate based on
 		// the information given in the controller context.
 		s3ObjectResource,
-		prepareAwsCniForMigrationResource,
 		tccpnResource,
 
 		// All these resources implement cleanup functionality only being executed

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,12 +70,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if env.Name == envVarName {
 			if env.Value == key.CiliumPodsCIDRBlock(cluster) {
 				// Env var found and correct. Check if daemonset is updated.
-
-				if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled {
-					r.logger.Debugf(ctx, "Daemonset %q has needed env var %q but not all replicas are healthy. Canceling reconciliation", dsName)
-					reconciliationcanceledcontext.SetCanceled(ctx)
-				}
-
 				return nil
 			} else {
 				env.Value = key.CiliumPodsCIDRBlock(cluster)
@@ -102,8 +95,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	// Wait for next reconciliation loop.
-	r.logger.Debugf(ctx, "Daemonset %q was updated, canceling reconciliation", dsName)
-	reconciliationcanceledcontext.SetCanceled(ctx)
+	r.logger.Debugf(ctx, "Daemonset %q was updated", dsName)
 
 	return nil
 }

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -1,0 +1,108 @@
+package prepareawscniformigration
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/aws-operator/v13/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/v13/service/controller/key"
+)
+
+const (
+	dsNamespace = "kube-system"
+	dsName      = "aws-node"
+	envVarName  = "AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	var err error
+	cr, err := key.ToCluster(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if cc.Client.TenantCluster.K8s == nil {
+		r.logger.Debugf(ctx, "kubernetes clients are not available in controller context yet")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
+	// Only run this if the Cluster CR has the cilium pod annotation
+	cluster := apiv1beta1.Cluster{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Name}, &cluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if key.CiliumPodsCIDRBlock(cluster) == "" {
+		r.logger.Debugf(ctx, "Cluster CR has no %q annotation, nothing to do", annotation.CiliumPodCidr)
+	}
+
+	wcCtrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
+
+	ds := &v1.DaemonSet{}
+	err = wcCtrlClient.Get(ctx, client.ObjectKey{Name: dsName, Namespace: dsNamespace}, ds)
+	if apierrors.IsNotFound(err) {
+		// All good.
+		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q", dsName, dsNamespace)
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Ensure aws-node daemonset has needed env var.
+	found := false
+	for _, env := range ds.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == envVarName {
+			if env.Value == key.CiliumPodsCIDRBlock(cluster) {
+				// Env var found and correct. Check if daemonset is updated.
+
+				if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled {
+					r.logger.Debugf(ctx, "Daemonset %q has needed env var %q but not all replicas are healthy. Canceling reconciliation", dsName)
+					reconciliationcanceledcontext.SetCanceled(ctx)
+				}
+
+				return nil
+			} else {
+				env.Value = key.CiliumPodsCIDRBlock(cluster)
+				r.logger.Debugf(ctx, "Daemonset %q has needed env var %q but value is wrong", dsName, envVarName)
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		// Add env var.
+		r.logger.Debugf(ctx, "Daemonset %q doesn't have needed env var %q", dsName, envVarName)
+		ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  envVarName,
+			Value: key.CiliumPodsCIDRBlock(cluster),
+		})
+	}
+
+	err = wcCtrlClient.Update(ctx, ds)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Wait for next reconciliation loop.
+	r.logger.Debugf(ctx, "Daemonset %q was updated, canceling reconciliation", dsName)
+	reconciliationcanceledcontext.SetCanceled(ctx)
+
+	return nil
+}

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -50,6 +50,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if key.CiliumPodsCIDRBlock(cluster) == "" {
 		r.logger.Debugf(ctx, "Cluster CR has no %q annotation, nothing to do", annotation.CiliumPodCidr)
+		return nil
 	}
 
 	wcCtrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
@@ -58,7 +59,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	err = wcCtrlClient.Get(ctx, client.ObjectKey{Name: dsName, Namespace: dsNamespace}, ds)
 	if apierrors.IsNotFound(err) {
 		// All good.
-		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q", dsName, dsNamespace)
+		r.logger.Debugf(ctx, "Daemonset %q was not found in namespace %q, nothing to do", dsName, dsNamespace)
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -24,7 +24,7 @@ const (
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var err error
-	cr, err := key.ToCluster(ctx, obj)
+	cr, err := key.ToControlPlane(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -43,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	// Only run this if the Cluster CR has the cilium pod annotation
 	cluster := apiv1beta1.Cluster{}
-	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Name}, &cluster)
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: key.ClusterID(&cr)}, &cluster)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -24,7 +24,7 @@ const (
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var err error
-	cr, err := key.ToControlPlane(obj)
+	cr, err := key.ToCluster(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/prepareawscniformigration/delete.go
+++ b/service/controller/resource/prepareawscniformigration/delete.go
@@ -1,0 +1,9 @@
+package prepareawscniformigration
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/prepareawscniformigration/error.go
+++ b/service/controller/resource/prepareawscniformigration/error.go
@@ -1,0 +1,14 @@
+package prepareawscniformigration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/prepareawscniformigration/resource.go
+++ b/service/controller/resource/prepareawscniformigration/resource.go
@@ -1,0 +1,42 @@
+package prepareawscniformigration
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	Name = "prepareawscniformigration"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource that ensures the `aws-node` daemonset is configured correctly for migration to cilum
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
During migration between aws-cni and cilium, there is a moment where nodes are running both aws-cni and cilium at the same time.
This is generally ok, but in order for cilium traffic to work, aws-cni has to be configured in order to not perform SNAT on cilium CIDR.

This PR adds a new resource that patches the `aws-node` deamonset to add such configuration.

## Checklist

- [x] Update changelog in CHANGELOG.md.
