### PR TITLE
Reenable aws cni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable Cilium or AWS-CNI conditionally based on the release number.
+
 ## [13.0.0] - 2022-08-17
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.1
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/aws/amazon-vpc-cni-k8s v1.11.2
 	github.com/aws/aws-sdk-go v1.44.67
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/giantswarm/apiextensions/v6 v6.4.0
@@ -41,7 +42,6 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.0
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.0 h1:7il5Xij676pjHUHuDhtK2ozv1GzmRWw3MICtkaUAhbQ=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.0/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8 h1:cTcUah7OEMThc8Frgy09LTzSJg8gyO8/zjlMxQ7Voi0=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8 h1:cTcUah7OEMThc8Frgy09LTzSJg8gyO8/zjlMxQ7Voi0=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.1-0.20220824122515-0eeff251d5f8/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.1 h1:bK27ONmtxeVHk0HGlKWCNMtofxAFSP3XQXtThQCBgnE=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.1/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -42,6 +42,7 @@ import (
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/cpvpc"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/encryptionensurer"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/endpoints"
+	"github.com/giantswarm/aws-operator/v13/service/controller/resource/eniconfigcrs"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/ipam"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/keepforcrs"
 	"github.com/giantswarm/aws-operator/v13/service/controller/resource/natgatewayaddresses"
@@ -778,6 +779,18 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var eniConfigCRsResource resource.Interface
+	{
+		c := eniconfigcrs.Config{
+			Logger: config.Logger,
+		}
+
+		eniConfigCRsResource, err = eniconfigcrs.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var cpVPCResource resource.Interface
 	{
 		c := cpvpc.Config{
@@ -864,6 +877,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		tccpfResource,
 		serviceResource,
 		endpointsResource,
+		eniConfigCRsResource,
 		secretFinalizerResource,
 		awsCniCleanerResource,
 

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -136,7 +136,7 @@ func CiliumPodsCIDRBlock(cluster apiv1beta1.Cluster) string {
 }
 
 // HasCilium returns true if the release uses cilium as CNI. Cilium will be added in v19, so any release >= v19.0.0
-func HasCilium(cluster infrastructurev1alpha3.AWSCluster) (bool, error) {
+func HasCilium(cluster LabelsGetter) (bool, error) {
 	release := cluster.GetLabels()[label.Release]
 
 	version, err := semver.Parse(release)
@@ -188,6 +188,11 @@ func IsAlreadyCreatedCluster(cluster infrastructurev1alpha3.AWSCluster) bool {
 }
 
 func IsAWSCNINeeded(cluster apiv1beta1.Cluster) bool {
+	hasCilium, _ := HasCilium(&cluster)
+	if !hasCilium {
+		return true
+	}
+
 	_, needed := cluster.Annotations[annotation.CiliumPodCidr]
 
 	return needed

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	AWSCNIComponentName          = "aws-cni"
 	AWSCNIDefaultMinimumIPTarget = "40"
 	AWSCNIDefaultWarmIPTarget    = "10"
 
@@ -293,8 +294,7 @@ func RoleARNWorker(getter LabelsGetter, region string, accountID string) string 
 // Tenant Clusters may be Single Master or HA Masters, where the suffix -0
 // indicates a Single Master configuration.
 //
-//     version/3.4.0/cloudconfig/v_3_2_5/cluster-al9qy-tccpn-a2wax-2
-//
+//	version/3.4.0/cloudconfig/v_3_2_5/cluster-al9qy-tccpn-a2wax-2
 func S3ObjectPathTCCPN(cr LabelsGetter, id int) string {
 	return fmt.Sprintf("version/%s/cloudconfig/%s/%s-%d", OperatorVersion(cr), CloudConfigVersion, StackNameTCCPN(cr), id)
 }
@@ -302,8 +302,7 @@ func S3ObjectPathTCCPN(cr LabelsGetter, id int) string {
 // S3ObjectPathTCNP computes the S3 object path to the cloud config uploaded for
 // the TCCP stack.
 //
-//     version/3.4.0/cloudconfig/v_3_2_5/cluster-al9qy-tcnp-g3j50
-//
+//	version/3.4.0/cloudconfig/v_3_2_5/cluster-al9qy-tcnp-g3j50
 func S3ObjectPathTCNP(getter LabelsGetter) string {
 	return fmt.Sprintf("version/%s/cloudconfig/%s/%s", OperatorVersion(getter), CloudConfigVersion, StackNameTCNP(getter))
 }
@@ -311,10 +310,9 @@ func S3ObjectPathTCNP(getter LabelsGetter) string {
 // SanitizeCFResourceName filters out all non-ascii alphanumberics from input
 // string.
 //
-//     SanitizeCFResourceName("abc-123") == "abc123"
-//     SanitizeCFResourceName("abc", "123") == "abc123"
-//     SanitizeCFResourceName("Dear god why? щ（ﾟДﾟщ）") == "Deargodwhy"
-//
+//	SanitizeCFResourceName("abc-123") == "abc123"
+//	SanitizeCFResourceName("abc", "123") == "abc123"
+//	SanitizeCFResourceName("Dear god why? щ（ﾟДﾟщ）") == "Deargodwhy"
 func SanitizeCFResourceName(l ...string) string {
 	var rs []rune
 

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -27,7 +27,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	hasCilium, err := key.HasCilium(cr)
+	hasCilium, err := key.HasCilium(&cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -27,6 +27,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	hasCilium, err := key.HasCilium(cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !hasCilium {
+		r.logger.Debugf(ctx, "This cluster has no Cilium.")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/eniconfigcrs/create.go
+++ b/service/controller/resource/eniconfigcrs/create.go
@@ -1,0 +1,111 @@
+package eniconfigcrs
+
+import (
+	"context"
+
+	"github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/aws-operator/v12/pkg/annotation"
+	"github.com/giantswarm/aws-operator/v12/pkg/awstags"
+	"github.com/giantswarm/aws-operator/v12/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/v12/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if cc.Client.TenantCluster.K8s == nil {
+		r.logger.Debugf(ctx, "kubernetes clients are not available in controller context yet")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
+	// We need to configure our security group ID to all the ENIConfig CRs.
+	// Therefore we look it up from the controller context, where it is already
+	// available.
+	var securityGroupID string
+	{
+		securityGroupID = idFromGroups(cc.Status.TenantCluster.TCCP.SecurityGroups, key.SecurityGroupName(&cr, "aws-cni"))
+	}
+
+	// Now we compute the desired state of the ENIConfig CRs, so we can apply them
+	// to the Tenant Cluster.
+	var eniConfigs []*v1alpha1.ENIConfig
+	for _, az := range cc.Spec.TenantCluster.TCCP.AvailabilityZones {
+		ec := &v1alpha1.ENIConfig{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeBuilder.GroupVersion.String(),
+				Kind:       "ENIConfig",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotation.Docs: "https://godoc.org/github.com/aws/amazon-vpc-cni-k8s/pkg/apis/crd/v1alpha1#ENIConfig",
+				},
+				Name:      az.Name,
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: v1alpha1.ENIConfigSpec{
+				SecurityGroups: []string{
+					securityGroupID,
+				},
+				Subnet: az.Subnet.AWSCNI.ID,
+			},
+		}
+
+		eniConfigs = append(eniConfigs, ec)
+	}
+
+	// Here we create the ENIConfig CRs if they do not exist. If they are already
+	// present, we update them according to our desired state. This is some simple
+	// fire and forget approach for now.
+	for _, ec := range eniConfigs {
+		r.logger.Debugf(ctx, "ensuring ENIConfig CR")
+
+		err := cc.Client.TenantCluster.K8s.CtrlClient().Create(ctx, ec)
+		if errors.IsAlreadyExists(err) {
+			var latest v1alpha1.ENIConfig
+
+			err := cc.Client.TenantCluster.K8s.CtrlClient().Get(ctx, types.NamespacedName{Name: ec.GetName(), Namespace: ec.GetNamespace()}, &latest)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			ec.ResourceVersion = latest.GetResourceVersion()
+
+			err = cc.Client.TenantCluster.K8s.CtrlClient().Update(ctx, ec)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.Debugf(ctx, "ensured ENIConfig CR")
+	}
+
+	return nil
+}
+
+func idFromGroups(groups []*ec2.SecurityGroup, name string) string {
+	for _, g := range groups {
+		if awstags.ValueForKey(g.Tags, "Name") == name {
+			return *g.GroupId
+		}
+	}
+
+	return ""
+}

--- a/service/controller/resource/eniconfigcrs/create.go
+++ b/service/controller/resource/eniconfigcrs/create.go
@@ -22,6 +22,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	hasCilium, err := key.HasCilium(&cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if hasCilium {
+		r.logger.Debugf(ctx, "This cluster does not have AWS CNI.")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/eniconfigcrs/create.go
+++ b/service/controller/resource/eniconfigcrs/create.go
@@ -11,10 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/giantswarm/aws-operator/v12/pkg/annotation"
-	"github.com/giantswarm/aws-operator/v12/pkg/awstags"
-	"github.com/giantswarm/aws-operator/v12/service/controller/controllercontext"
-	"github.com/giantswarm/aws-operator/v12/service/controller/key"
+	"github.com/giantswarm/aws-operator/v13/pkg/annotation"
+	"github.com/giantswarm/aws-operator/v13/pkg/awstags"
+	"github.com/giantswarm/aws-operator/v13/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/v13/service/controller/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {

--- a/service/controller/resource/eniconfigcrs/delete.go
+++ b/service/controller/resource/eniconfigcrs/delete.go
@@ -1,0 +1,9 @@
+package eniconfigcrs
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/eniconfigcrs/error.go
+++ b/service/controller/resource/eniconfigcrs/error.go
@@ -1,0 +1,14 @@
+package eniconfigcrs
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/eniconfigcrs/resource.go
+++ b/service/controller/resource/eniconfigcrs/resource.go
@@ -1,0 +1,34 @@
+package eniconfigcrs
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "eniconfigcrs"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -28,7 +28,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	hasCilium, err := key.HasCilium(cr)
+	hasCilium, err := key.HasCilium(&cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -28,6 +28,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	hasCilium, err := key.HasCilium(cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !hasCilium {
+		r.logger.Debugf(ctx, "This cluster has no Cilium.")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/restrictawsnodedaemonset/create.go
+++ b/service/controller/resource/restrictawsnodedaemonset/create.go
@@ -28,7 +28,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	hasCilium, err := key.HasCilium(cr)
+	hasCilium, err := key.HasCilium(&cr)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/restrictawsnodedaemonset/create.go
+++ b/service/controller/resource/restrictawsnodedaemonset/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/aws-operator/v13/pkg/label"
 	"github.com/giantswarm/aws-operator/v13/pkg/project"
 	"github.com/giantswarm/aws-operator/v13/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/v13/service/controller/key"
 )
 
 const (
@@ -21,6 +22,24 @@ const (
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var err error
+
+	cr, err := key.ToCluster(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	hasCilium, err := key.HasCilium(cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !hasCilium {
+		r.logger.Debugf(ctx, "This cluster has no Cilium.")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return nil
+	}
+
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -208,6 +208,13 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
+  AWSCNINATRouteEuCentral1a:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
@@ -215,10 +222,24 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
+  AWSCNINATRouteEuCentral1b:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1b
   NATRouteEuCentral1c:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1c
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1c
+  AWSCNINATRouteEuCentral1c:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
@@ -304,6 +325,39 @@ Resources:
       ResourceRecords:
         - 'ingress.8y5ck.k8s.gauss.eu-central-1.aws.gigantic.io.'
   
+  AWSCNIRouteTableEuCentral1a:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1a
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1a
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1b:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1b
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1b
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1c:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1c
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1c
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -519,6 +573,26 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-aws-cni
+  PodsIngressRuleFromMAsters:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from masters to pods.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+  PodsAllowPodsCNIIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from pod to pod.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -539,6 +613,16 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
+  MasterAllowPodsCNIIngressRule:
+      Type: AWS::EC2::SecurityGroupIngress
+      DependsOn: MasterSecurityGroup
+      Properties:
+        Description: Allow traffic from pod to master.
+        GroupId: !Ref MasterSecurityGroup
+        IpProtocol: -1
+        FromPort: -1
+        ToPort: -1
+        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -556,6 +640,60 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
+  AWSCNISubnetEuCentral1a:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1a
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1a
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1a:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      SubnetId: !Ref AWSCNISubnetEuCentral1a
+  AWSCNISubnetEuCentral1b:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1b
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1b
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1b:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
+      SubnetId: !Ref AWSCNISubnetEuCentral1b
+  AWSCNISubnetEuCentral1c:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1c
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1c
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1c:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
+      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -680,6 +818,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+  VPCCIDRBlockAWSCNI:
+    Type: AWS::EC2::VPCCidrBlock
+    DependsOn:
+      - VPC
+      - VPCPeeringConnection
+    Properties:
+      CidrBlock: 172.17.0.1/16
+      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -702,6 +848,9 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
+        - !Ref AWSCNIRouteTableEuCentral1a
+        - !Ref AWSCNIRouteTableEuCentral1b
+        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -200,10 +200,24 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
+  AWSCNINATRouteEuCentral1a:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1b
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1b
+  AWSCNINATRouteEuCentral1b:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
@@ -214,8 +228,48 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
+  AWSCNINATRouteEuCentral1c:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1c
   
   
+  AWSCNIRouteTableEuCentral1a:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1a
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1a
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1b:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1b
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1b
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1c:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1c
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1c
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -431,6 +485,26 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-aws-cni
+  PodsIngressRuleFromMAsters:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from masters to pods.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+  PodsAllowPodsCNIIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from pod to pod.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -451,6 +525,16 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
+  MasterAllowPodsCNIIngressRule:
+      Type: AWS::EC2::SecurityGroupIngress
+      DependsOn: MasterSecurityGroup
+      Properties:
+        Description: Allow traffic from pod to master.
+        GroupId: !Ref MasterSecurityGroup
+        IpProtocol: -1
+        FromPort: -1
+        ToPort: -1
+        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -468,6 +552,60 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
+  AWSCNISubnetEuCentral1a:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1a
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1a
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1a:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      SubnetId: !Ref AWSCNISubnetEuCentral1a
+  AWSCNISubnetEuCentral1b:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1b
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1b
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1b:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
+      SubnetId: !Ref AWSCNISubnetEuCentral1b
+  AWSCNISubnetEuCentral1c:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1c
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1c
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1c:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
+      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -592,6 +730,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+  VPCCIDRBlockAWSCNI:
+    Type: AWS::EC2::VPCCidrBlock
+    DependsOn:
+      - VPC
+      - VPCPeeringConnection
+    Properties:
+      CidrBlock: 172.17.0.1/16
+      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -614,6 +760,9 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
+        - !Ref AWSCNIRouteTableEuCentral1a
+        - !Ref AWSCNIRouteTableEuCentral1b
+        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -200,10 +200,24 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1a
+  AWSCNINATRouteEuCentral1a:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1a
   NATRouteEuCentral1b:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId: !Ref PrivateRouteTableEuCentral1b
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1b
+  AWSCNINATRouteEuCentral1b:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1b
@@ -214,8 +228,48 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NATGatewayEuCentral1c
+  AWSCNINATRouteEuCentral1c:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NATGatewayEuCentral1c
   
   
+  AWSCNIRouteTableEuCentral1a:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1a
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1a
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1b:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1b
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1b
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
+  AWSCNIRouteTableEuCentral1c:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: 8y5ck-aws-cni-1c
+      - Key: giantswarm.io/availability-zone
+        Value: eu-central-1c
+      - Key: giantswarm.io/route-table-type
+        Value: aws-cni
   PublicRouteTableEuCentral1a:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -468,6 +522,26 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck-aws-cni
+  PodsIngressRuleFromMAsters:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from masters to pods.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+  PodsAllowPodsCNIIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: AWSCNISecurityGroup
+    Properties:
+      Description: Allow traffic from pod to pod.
+      GroupId: !Ref AWSCNISecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowCalicoIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -488,6 +562,16 @@ Resources:
       FromPort: 8089
       ToPort: 8089
       SourceSecurityGroupId: !Ref APIInternalELBSecurityGroup
+  MasterAllowPodsCNIIngressRule:
+      Type: AWS::EC2::SecurityGroupIngress
+      DependsOn: MasterSecurityGroup
+      Properties:
+        Description: Allow traffic from pod to master.
+        GroupId: !Ref MasterSecurityGroup
+        IpProtocol: -1
+        FromPort: -1
+        ToPort: -1
+        SourceSecurityGroupId: !Ref AWSCNISecurityGroup
   MasterAllowEtcdIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: MasterSecurityGroup
@@ -505,6 +589,60 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
+  AWSCNISubnetEuCentral1a:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1a
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1a
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1a:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
+      SubnetId: !Ref AWSCNISubnetEuCentral1a
+  AWSCNISubnetEuCentral1b:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1b
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1b
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1b:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
+      SubnetId: !Ref AWSCNISubnetEuCentral1b
+  AWSCNISubnetEuCentral1c:
+    Type: AWS::EC2::Subnet
+    DependsOn:
+    - VPCCIDRBlockAWSCNI
+    Properties:
+      AvailabilityZone: eu-central-1c
+      CidrBlock: <nil>
+      Tags:
+      - Key: Name
+        Value: AWSCNISubnetEuCentral1c
+      - Key: giantswarm.io/subnet-type
+        Value: aws-cni
+      VpcId: !Ref VPC
+  AWSCNISubnetRouteTableAssociationEuCentral1c:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
+      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:
@@ -629,6 +767,14 @@ Resources:
       Tags:
         - Key: Name
           Value: 8y5ck
+  VPCCIDRBlockAWSCNI:
+    Type: AWS::EC2::VPCCidrBlock
+    DependsOn:
+      - VPC
+      - VPCPeeringConnection
+    Properties:
+      CidrBlock: 172.17.0.1/16
+      VpcId: !Ref VPC
   VPCPeeringConnection:
     Type: 'AWS::EC2::VPCPeeringConnection'
     Properties:
@@ -651,6 +797,9 @@ Resources:
         - !Ref PrivateRouteTableEuCentral1a
         - !Ref PrivateRouteTableEuCentral1b
         - !Ref PrivateRouteTableEuCentral1c
+        - !Ref AWSCNIRouteTableEuCentral1a
+        - !Ref AWSCNIRouteTableEuCentral1b
+        - !Ref AWSCNIRouteTableEuCentral1c
       ServiceName: com.amazonaws.eu-central-1.s3
       PolicyDocument:
         Version: "2012-10-17"

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -132,6 +132,27 @@ Resources:
               - "ecr:ListImages"
               - "ecr:BatchGetImage"
             Resource: "*"
+          # Following rules are required to make the AWS CNI work. See also
+          # https://github.com/aws/amazon-vpc-cni-k8s#setup.
+          - Effect: Allow
+            Action:
+              - ec2:AssignPrivateIpAddresses
+              - ec2:AttachNetworkInterface
+              - ec2:CreateNetworkInterface
+              - ec2:DeleteNetworkInterface
+              - ec2:DescribeInstances
+              - ec2:DescribeInstanceTypes
+              - ec2:DescribeTags
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DetachNetworkInterface
+              - ec2:ModifyNetworkInterfaceAttribute
+              - ec2:UnassignPrivateIpAddresses
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - ec2:CreateTags
+            Resource:
+              - arn:aws:ec2:*:*:network-interface/*
 
           # Following rules are required for EBS snapshots.
           - Effect: Allow
@@ -375,6 +396,26 @@ Resources:
       FromPort: -1
       ToPort: -1
       SourceSecurityGroupId: !Ref GeneralSecurityGroup
+  PodsIngressRuleFromWorkers:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: GeneralSecurityGroup
+    Properties:
+      Description: Allow traffic from workers to pods.
+      GroupId: awscni-security-group-id
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref GeneralSecurityGroup
+  PodsIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: GeneralSecurityGroup
+    Properties:
+      Description: Allow traffic from pods to the worker nodes.
+      GroupId: !Ref GeneralSecurityGroup
+      IpProtocol: -1
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: awscni-security-group-id
   InternalIngressRule:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: GeneralSecurityGroup

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -422,6 +422,8 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		if hasCilium {
 			params.DisableCalico = true
 			params.EnableAWSCNI = false
+		} else {
+			params.CalicoPolicyOnly = true
 		}
 
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -457,6 +457,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 			encryptionKey:        ek,
 			externalSNAT:         externalSNAT,
 			haMasters:            multiMasterEnabled,
+			hasCilium:            hasCilium,
 			masterID:             mapping.ID,
 			encryptionConfig:     encryptedEncryptionConfig,
 			registryDomain:       t.config.RegistryDomain,

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -146,7 +146,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		cl = list.Items[0]
 	}
 
-	hasCilium, err := key.HasCilium(cl)
+	hasCilium, err := key.HasCilium(&cl)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -420,9 +420,12 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCCPN(&cr, mapping.ID))
 
 		if hasCilium {
-			params.DisableCalico = true
 			params.EnableAWSCNI = false
+			params.DisableCalico = true
+			params.CalicoPolicyOnly = false
 		} else {
+			params.EnableAWSCNI = true
+			params.DisableCalico = false
 			params.CalicoPolicyOnly = true
 		}
 

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -29,6 +29,7 @@ type TCCPNExtension struct {
 	encryptionKey        string
 	externalSNAT         bool
 	haMasters            bool
+	hasCilium            bool
 	masterID             int
 	encryptionConfig     string
 	serviceAccountV2Pub  string
@@ -203,6 +204,22 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			Permissions: 0644,
 		}
 		filesMeta = append(filesMeta, etcdClusterMigratorManifest, etcdClusterMigratorInstaller)
+	}
+
+	if e.hasCilium {
+		filesMeta = append(filesMeta, k8scloudconfig.FileMetadata{
+			AssetContent: template.AwsCNIManifest,
+			Path:         "/srv/aws-cni.yaml",
+			Owner: k8scloudconfig.Owner{
+				Group: k8scloudconfig.Group{
+					Name: FileOwnerGroupName,
+				},
+				User: k8scloudconfig.User{
+					Name: FileOwnerUserName,
+				},
+			},
+			Permissions: 0644,
+		})
 	}
 
 	certsMeta := []k8scloudconfig.FileMetadata{}

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -17,24 +17,25 @@ import (
 )
 
 type TCCPNExtension struct {
-	// TODO Pass context to k8scloudconfig rendering fucntions
-	//
-	//     https://github.com/giantswarm/giantswarm/issues/4329.
-	//
-	baseDomain           string
-	cc                   *controllercontext.Context
-	cluster              infrastructurev1alpha3.AWSCluster
-	clusterCerts         []certs.File
-	encrypter            encrypter.Interface
-	encryptionKey        string
-	externalSNAT         bool
-	haMasters            bool
-	hasCilium            bool
-	masterID             int
-	encryptionConfig     string
-	serviceAccountV2Pub  string
-	serviceAccountv2Priv string
-	registryDomain       string
+	awsCNIAdditionalTags  string
+	awsCNIMinimumIPTarget string
+	awsCNIPrefix          bool
+	awsCNIVersion         string
+	awsCNIWarmIPTarget    string
+	baseDomain            string
+	cc                    *controllercontext.Context
+	cluster               infrastructurev1alpha3.AWSCluster
+	clusterCerts          []certs.File
+	encrypter             encrypter.Interface
+	encryptionKey         string
+	externalSNAT          bool
+	haMasters             bool
+	hasCilium             bool
+	masterID              int
+	encryptionConfig      string
+	serviceAccountV2Pub   string
+	serviceAccountv2Priv  string
+	registryDomain        string
 }
 
 func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
@@ -306,13 +307,18 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	var fileAssets []k8scloudconfig.FileAsset
 
 	data := TemplateData{
-		AWSRegion:            key.Region(e.cluster),
-		BaseDomain:           e.baseDomain,
-		ExternalSNAT:         e.externalSNAT,
-		IsChinaRegion:        key.IsChinaRegion(key.Region(e.cluster)),
-		MasterENIName:        key.ControlPlaneENIName(&e.cluster, e.masterID),
-		MasterEtcdVolumeName: key.ControlPlaneVolumeName(&e.cluster, e.masterID),
-		RegistryDomain:       e.registryDomain,
+		AWSCNIAdditionalTags:  e.awsCNIAdditionalTags,
+		AWSCNIMinimumIPTarget: e.awsCNIMinimumIPTarget,
+		AWSCNIPrefix:          e.awsCNIPrefix,
+		AWSCNIVersion:         e.awsCNIVersion,
+		AWSCNIWarmIPTarget:    e.awsCNIWarmIPTarget,
+		AWSRegion:             key.Region(e.cluster),
+		BaseDomain:            e.baseDomain,
+		ExternalSNAT:          e.externalSNAT,
+		IsChinaRegion:         key.IsChinaRegion(key.Region(e.cluster)),
+		MasterENIName:         key.ControlPlaneENIName(&e.cluster, e.masterID),
+		MasterEtcdVolumeName:  key.ControlPlaneVolumeName(&e.cluster, e.masterID),
+		RegistryDomain:        e.registryDomain,
 	}
 
 	for _, fm := range filesMeta {

--- a/service/internal/cloudconfig/tccpn_extension.go
+++ b/service/internal/cloudconfig/tccpn_extension.go
@@ -206,7 +206,7 @@ func (e *TCCPNExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		filesMeta = append(filesMeta, etcdClusterMigratorManifest, etcdClusterMigratorInstaller)
 	}
 
-	if e.hasCilium {
+	if !e.hasCilium {
 		filesMeta = append(filesMeta, k8scloudconfig.FileMetadata{
 			AssetContent: template.AwsCNIManifest,
 			Path:         "/srv/aws-cni.yaml",

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -197,9 +197,12 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 			return nil, microerror.Mask(err)
 		}
 		if hasCilium {
-			params.DisableCalico = true
 			params.EnableAWSCNI = false
+			params.DisableCalico = true
+			params.CalicoPolicyOnly = false
 		} else {
+			params.EnableAWSCNI = true
+			params.DisableCalico = false
 			params.CalicoPolicyOnly = true
 		}
 

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -192,7 +192,7 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCNP(&cr))
 
-		hasCilium, err := key.HasCilium(cl)
+		hasCilium, err := key.HasCilium(&cl)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -199,6 +199,8 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 		if hasCilium {
 			params.DisableCalico = true
 			params.EnableAWSCNI = false
+		} else {
+			params.CalicoPolicyOnly = true
 		}
 
 		params.DisableKubeProxy = false

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -192,11 +192,18 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 
 		g8sConfig := cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCNP(&cr))
 
-		params.DisableCalico = true
+		hasCilium, err := key.HasCilium(cl)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if hasCilium {
+			params.DisableCalico = true
+			params.EnableAWSCNI = false
+		}
+
 		params.DisableKubeProxy = false
 		params.Cluster = g8sConfig.Cluster
 		params.DockerhubToken = t.config.DockerhubToken
-		params.EnableAWSCNI = false
 		params.EnableCSIMigrationAWS = true
 		params.Extension = &TCNPExtension{
 			awsConfigSpec:  cmaClusterToG8sConfig(t.config, cl, key.KubeletLabelsTCNP(&cr)),

--- a/service/internal/cloudconfig/template/aws_cni.go
+++ b/service/internal/cloudconfig/template/aws_cni.go
@@ -1,0 +1,411 @@
+package template
+
+const AwsCNIManifest = `
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/aws-k8s-cni.yaml
+
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: aws-cni
+spec:
+    allowPrivilegeEscalation: true
+    privileged: true
+    allowedCapabilities:
+      - 'NET_ADMIN'
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    hostNetwork: true
+    hostPorts:
+    - min: 0
+      max: 65535
+    volumes:
+    - secret
+    - configMap
+    - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-node
+rules:
+- apiGroups:
+  - crd.k8s.amazonaws.com
+  resources:
+  - eniconfigs
+  verbs: ["list", "watch", "get"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch", "get"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch", "get"]        
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch", "get", "update"]
+- apiGroups: ["extensions"]
+  resources:
+  - '*'
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["aws-cni"]
+  verbs: ["use", "get", "create"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    k8s-app: aws-node
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        k8s-app: aws-node
+    spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: "kubernetes.io/os"
+                  operator: In
+                  values:
+                    - linux
+                - key: "kubernetes.io/arch"
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate
+      serviceAccountName: aws-node
+      hostNetwork: true
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - image: {{.RegistryDomain}}/giantswarm/aws-cni-init:v{{.AWSCNIVersion}}
+          imagePullPolicy: Always
+          name: aws-vpc-cni-init
+          env:
+            - name: DISABLE_TCP_EARLY_DEMUX
+              value: "false"
+            - name: ENABLE_IPv4
+              value: "true"
+            - name: ENABLE_IPv6
+              value: "false"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+      containers:
+        - image: {{.RegistryDomain}}/giantswarm/aws-cni:v{{.AWSCNIVersion}}
+          ports:
+            - containerPort: 61678
+              name: metrics
+          name: aws-node
+          livenessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+          env:
+            - name: ADDITIONAL_ENI_TAGS
+              value: '{{ .AWSCNIAdditionalTags }}'
+            - name: AWS_VPC_K8S_CNI_LOGLEVEL
+              value: INFO
+            - name: AWS_VPC_K8S_PLUGIN_LOG_LEVEL
+              value: INFO
+            - name: AWS_VPC_K8S_CNI_LOG_FILE
+              value: stdout
+            - name: AWS_VPC_K8S_PLUGIN_LOG_FILE
+              value: /host/var/log/aws-routed-eni/plugin.log
+            - name: AWS_VPC_ENI_MTU
+              value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
+            - name: DISABLE_INTROSPECTION
+              value: "false"
+            - name: DISABLE_METRICS
+              value: "false"
+            - name: ENABLE_IPv4
+              value: "true"
+            - name: ENABLE_IPv6
+              value: "false"
+            - name: POD_SECURITY_GROUP_ENFORCING_MODE
+              value: standard
+            ## If CNI prefix validation is enabled we remove WARM_IP_TARGET and MINIMUM_IP_TARGET because it will take precedence over WARM_PREFIX_TARGET.
+            {{- if eq .AWSCNIPrefix false }}
+            - name: WARM_IP_TARGET
+              value: "{{ .AWSCNIWarmIPTarget }}"
+            - name: MINIMUM_IP_TARGET
+              value: "{{ .AWSCNIMinimumIPTarget }}"
+            {{- end }}
+            ## Deviation from original manifest - 1
+            ## This config value is important - See here https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md#cni-configuration-variables
+            - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+              value: "true"
+            ## Deviation from original manifest - 2
+            ## setting custom ENI config annotation
+            - name: ENI_CONFIG_LABEL_DEF
+              value: "failure-domain.beta.kubernetes.io/zone"
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            ## Deviation from original manifest - 3
+            ## disable SNAT as we setup NATGW in the route tables
+            - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
+              value: "{{.ExternalSNAT}}"
+            {{- if eq .ExternalSNAT false }}
+            ## Deviation from original manifest - 4
+            ## If we left this enabled, cross subnet communication doesn't work. Only affects ExternalSNAT=false.
+            - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+              value: "none"
+            {{- else }}
+            ## When enabling ExternalSNAT, we need to set this to prng (default).
+            - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+              value: prng
+            {{- end }}
+            ## Deviation from original manifest - 5
+            ## Explicit interface naming
+            - name: AWS_VPC_K8S_CNI_VETHPREFIX
+              value: eni
+            {{- if eq .AWSCNIPrefix true }}
+            ## Deviation from original manifest - 6
+            ## If CNI prefix validation is enabled it will improve the speed of allocating IPs on a nitro based node (e.g. m5.2xlarge) 
+            ## By setting a annotation on the Cluster CR it can be enabled or disabled.
+            - name: ENABLE_PREFIX_DELEGATION
+              value: "true"
+            - name: "WARM_PREFIX_TARGET"
+              value: "1"
+            {{- end }}
+          resources:
+            requests:
+              cpu: 30m
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/var/log/aws-routed-eni
+              name: log-dir
+            - mountPath: /var/run/aws-node
+              name: run-dir
+            - mountPath: /var/run/cri.sock
+              name: cri
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+      volumes:
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cri
+          hostPath:
+            path: /var/run/containerd/containerd.sock
+        - hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+          name: xtables-lock
+        - hostPath:
+            path: /var/log/aws-routed-eni
+            type: DirectoryOrCreate
+          name: log-dir
+        - hostPath:
+            path: /var/run/aws-node
+            type: DirectoryOrCreate
+          name: run-dir
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
+---
+## AWS CNI restarter, to be removed when AWS CNI is able to detect new Additional CIDRs https://github.com/giantswarm/giantswarm/issues/11077
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-cni-restarter
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-cni-restarter
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "create", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["aws-cni-restarter"]
+  verbs: ["use", "get", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-cni-restarter-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: aws-cni-restarter
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: aws-cni-restarter
+  apiGroup: ""
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: aws-cni-restarter
+spec:
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - secret
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: aws-cni-restarter
+  name: aws-cni-restarter
+  namespace: kube-system
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app: aws-cni-restarter
+  policyTypes:
+  - Egress
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: aws-cni-restarter
+  namespace: kube-system
+spec:
+  suspend: true
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 10
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: aws-cni-restarter
+        spec:
+          serviceAccountName: aws-cni-restarter
+          hostNetwork: true
+          containers:
+            - name: aws-cni-restarter
+              image: {{.RegistryDomain}}/giantswarm/aws-cni-restarter:1.0.2
+          restartPolicy: OnFailure
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: role
+                      operator: In
+                      values:
+                      - master
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+`

--- a/service/internal/cloudconfig/types.go
+++ b/service/internal/cloudconfig/types.go
@@ -1,12 +1,17 @@
 package cloudconfig
 
 type TemplateData struct {
-	AWSRegion            string
-	BaseDomain           string
-	ExternalSNAT         bool
-	IsChinaRegion        bool
-	MasterENIName        string
-	MasterEtcdVolumeName string
-	MasterID             int
-	RegistryDomain       string
+	AWSCNIAdditionalTags  string
+	AWSCNIMinimumIPTarget string
+	AWSCNIPrefix          bool
+	AWSCNIWarmIPTarget    string
+	AWSCNIVersion         string
+	AWSRegion             string
+	BaseDomain            string
+	ExternalSNAT          bool
+	IsChinaRegion         bool
+	MasterENIName         string
+	MasterEtcdVolumeName  string
+	MasterID              int
+	RegistryDomain        string
 }

--- a/service/internal/images/images.go
+++ b/service/internal/images/images.go
@@ -78,6 +78,26 @@ func (i *Images) AMI(ctx context.Context, obj interface{}) (string, error) {
 	return ami, nil
 }
 
+func (i *Images) AWSCNI(ctx context.Context, obj interface{}) (string, error) {
+	cr, err := meta.Accessor(obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	re, err := i.cachedRelease(ctx, cr)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	for _, c := range re.Spec.Components {
+		if c.Name == key.AWSCNIComponentName {
+			return c.Version, nil
+		}
+	}
+
+	return "", microerror.Maskf(notFoundError, "aws cni version not found in the release")
+}
+
 func (i *Images) CC(ctx context.Context, obj interface{}) (k8scloudconfig.Images, error) {
 	var im k8scloudconfig.Images
 	{

--- a/service/internal/images/spec.go
+++ b/service/internal/images/spec.go
@@ -12,6 +12,10 @@ type Interface interface {
 	// metav1.Object and contain the Giant Swarm specific cluster ID label and
 	// release version label.
 	AMI(ctx context.Context, obj interface{}) (string, error)
+	// AWSCNI looks up aws-cni version to compute the relevant Cloud Config
+	// images for the given object's release version. Paramter obj must be a
+	// metav1.Object and contain the Giant Swarm specific release version label.
+	AWSCNI(ctx context.Context, obj interface{}) (string, error)
 	// CC looks up necessary information to compute the relevant Cloud Config
 	// images for the given object's release version. Paramter obj must be a
 	// metav1.Object and contain the Giant Swarm specific release version label.


### PR DESCRIPTION
This PR adds back the things that were removed when switching to cilium.
It also adds a feature gate to selectively choose cilium or aws-cni configuration based on the release version:

- `< 19` -> AWS CNI
- `>= 19` -> CILIUM

Both scenarios have been tested, although the cilium path only briefly

## Checklist

- [x] Update changelog in CHANGELOG.md.
