### PR TITLE
Disable ccm

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -9,3 +9,5 @@ CVE-2021-23772 until=2022-08-25
 # Affects github.com/urfave/negroni. v2.0.2 is availabe but still affected.
 # Issue is an open redirect (user can manipulate a link served to other users).
 sonatype-2021-1485 until=2023-06-25
+
+CVE-2021-23772

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enable Cilium or AWS-CNI conditionally based on the release number.
+- Disable external cloud controller manager because of upstream bug affecting 1.23 release. 
 
 ## [13.0.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enable Cilium or AWS-CNI conditionally based on the release number.
-- Disable external cloud controller manager because of upstream bug affecting 1.23 release. 
+- Disable external cloud controller manager because of upstream bug affecting 1.23 release.
 
 ## [13.0.0] - 2022-08-17
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19
+	github.com/giantswarm/k8scloudconfig/v14 v14.3.0
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.1
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7
+	github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19
 	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7 h1:zpUe7DqqGny1+YnDKodaWbofywVZfsrJjhhK0MAy2F0=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19 h1:oILvd1OjzHeRqaGzcWoJM5rKSkFj9yXaVLbFqGXW8sE=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.1 h1:bK27ONmtxeVHk0HGlKWCNMtofxAFSP3XQXtThQCBgnE=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.1/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9 h1:YTPYo8swTs+TXuPni/8fOIpVrz/pIuhDeKBc5hr+ZQc=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19 h1:oILvd1OjzHeRqaGzcWoJM5rKSkFj9yXaVLbFqGXW8sE=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8scloudconfig/v14 v14.3.0 h1:5Fbn9FYC61LN0Jg1XIYRGOVXVb4rLDr0tIj0lZ3Y9yQ=
 github.com/giantswarm/k8scloudconfig/v14 v14.3.0/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19 h1:oILvd1OjzHeRqaGzcWoJM5rKSkFj9yXaVLbFqGXW8sE=
 github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825134057-6ec3d2e68d19/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.3.0 h1:5Fbn9FYC61LN0Jg1XIYRGOVXVb4rLDr0tIj0lZ3Y9yQ=
+github.com/giantswarm/k8scloudconfig/v14 v14.3.0/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9 h1:YTPYo8swTs+TXuPni/8fOIpVrz/pIuhDeKBc5hr+ZQc=
-github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825125205-acd7d096f0b9/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7 h1:zpUe7DqqGny1+YnDKodaWbofywVZfsrJjhhK0MAy2F0=
+github.com/giantswarm/k8scloudconfig/v14 v14.2.2-0.20220825131522-2023782cd5d7/go.mod h1:XYSG+atEtJq4qablG3KWKe1fpiaS9KZCy66QzsFTyow=
 github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
 github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -524,6 +524,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 			ext.awsCNIWarmIPTarget = awsCNIWarmIPTarget
 		}
 		params.Extension = &ext
+		params.ExternalCloudControllerManager = false
 
 		params.IrsaSAKeyArgs = irsaSAKeyArgs
 		params.Kubernetes.Apiserver.CommandExtraArgs = apiExtraArgs

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -220,6 +220,7 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 			externalSNAT:   externalSNAT,
 			registryDomain: t.config.RegistryDomain,
 		}
+		params.ExternalCloudControllerManager = false
 		params.ForceCGroupsV1 = forceCGroupsV1
 		params.Kubernetes.Kubelet.CommandExtraArgs = kubeletExtraArgs
 		params.ImagePullProgressDeadline = t.config.ImagePullProgressDeadline


### PR DESCRIPTION
Disable external cloud controller manager because it's buggy in 1.23

## Checklist

- [x] Update changelog in CHANGELOG.md.
