### PR TITLE
Cilium kube proxy migration hacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
 	github.com/giantswarm/k8scloudconfig/v15 v15.0.0
-	github.com/giantswarm/k8smetadata v0.12.0
+	github.com/giantswarm/k8smetadata v0.14.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0
 	github.com/giantswarm/microerror v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v15 v15.0.0 h1:ayVqA+uOLFwaj+M41r2evNzrBLoA4QfNBShn0CEHGGU=
 github.com/giantswarm/k8scloudconfig/v15 v15.0.0/go.mod h1:xsJmGWS5qp/robXzg9D77kS7rO1KAQKtmGgg0AwqAkg=
-github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
-github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.14.0 h1:fnjtS+AanST4di0mDfmL3AfX7EV8Zf5H4SIT7Ic43lY=
+github.com/giantswarm/k8smetadata v0.14.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=
 github.com/giantswarm/kubelock/v4 v4.0.0/go.mod h1:XbqPs1m+NafHSjXvOXsb3UjE5DvhyNk47tfGcQJl1iY=
 github.com/giantswarm/microendpoint v1.0.0 h1:vW6VXPaWXBPZc9Q99FgPcjYprAKLItufKFcydBH47Xc=

--- a/service/controller/key/cilium.go
+++ b/service/controller/key/cilium.go
@@ -1,15 +1,12 @@
 package key
 
 import (
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	CiliumForceDisableKubeProxyAnnotation = "cilium-force-disable-kube-proxy-replacement"
-)
-
 func ForceDisableCiliumKubeProxyReplacement(cluster apiv1beta1.Cluster) bool {
-	v, found := cluster.Annotations[CiliumForceDisableKubeProxyAnnotation]
+	v, found := cluster.Annotations[annotation.CiliumForceDisableKubeProxyAnnotation]
 
 	return found && v == "true"
 }

--- a/service/controller/key/cilium.go
+++ b/service/controller/key/cilium.go
@@ -1,0 +1,15 @@
+package key
+
+import (
+	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const (
+	CiliumForceDisableKubeProxyAnnotation = "cilium-force-disable-kube-proxy-replacement"
+)
+
+func ForceDisableCiliumKubeProxyReplacement(cluster apiv1beta1.Cluster) bool {
+	v, found := cluster.Annotations[CiliumForceDisableKubeProxyAnnotation]
+
+	return found && v == "true"
+}

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -82,13 +82,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	// Ensure the cilium app has kube proxy enabled.
 	if key.ForceDisableCiliumKubeProxyReplacement(cluster) {
 		// Remove annotation
-		delete(cluster.Annotations, key.CiliumForceDisableKubeProxyAnnotation)
+		delete(cluster.Annotations, annotation.CiliumForceDisableKubeProxyAnnotation)
 		err = r.ctrlClient.Update(ctx, &cluster)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.Debugf(ctx, "Removed %s annotation from Cluster CR %s", key.CiliumForceDisableKubeProxyAnnotation, cluster.Name)
+		r.logger.Debugf(ctx, "Removed %s annotation from Cluster CR %s", annotation.CiliumForceDisableKubeProxyAnnotation, cluster.Name)
 		r.logger.Debugf(ctx, "canceling resource")
 		return nil
 	}

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -3,10 +3,13 @@ package awscnicleaner
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,6 +101,37 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	// Ensure the cilium app has kube proxy enabled.
 	if key.ForceDisableCiliumKubeProxyReplacement(cluster) {
+		// Ensure no kube-proxy pods are still running.
+		{
+			r.logger.Debugf(ctx, "Ensuring no kube-proxy pods are still running")
+
+			o := func() error {
+				pods := corev1.PodList{}
+				err = wcCtrlClient.List(ctx, &pods, client.MatchingLabels{"k8s-app": "kube-proxy"}, client.InNamespace("kube-system"))
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+				for _, pod := range pods.Items {
+					if pod.DeletionTimestamp == nil {
+						return microerror.Maskf(kubeProxyStillRunningError, "Kube-proxy pod %s is still running", pod.Name)
+					}
+				}
+
+				return nil
+			}
+
+			b := backoff.NewExponential(30*time.Second, 5*time.Second)
+			n := backoff.NewNotifier(r.logger, context.Background())
+
+			err := backoff.RetryNotify(o, b, n)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.Debugf(ctx, "Ensured no kube-proxy pods are still running")
+		}
+
 		// Remove annotation
 		delete(cluster.Annotations, annotation.CiliumForceDisableKubeProxyAnnotation)
 		err = r.ctrlClient.Update(ctx, &cluster)

--- a/service/controller/resource/awscnicleaner/error.go
+++ b/service/controller/resource/awscnicleaner/error.go
@@ -8,6 +8,10 @@ var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
 
+var kubeProxyStillRunningError = &microerror.Error{
+	Kind: "kubeProxyStillRunningError",
+}
+
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -108,9 +108,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if len(ds.Spec.Template.Spec.Containers) == 1 {
 		r.logger.Debugf(ctx, "Daemonset %q doesn't have routes-fixer container", dsName)
 		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, corev1.Container{
-			Name: "routes-fixer",
-			// TODO consider china
-			Image:   "docker.io/giantswarm/aws-cni:v1.11.2-nftables",
+			Name:    "routes-fixer",
+			Image:   ds.Spec.Template.Spec.Containers[0].Image,
 			Command: []string{"/usr/bin/bash"},
 			Args: []string{
 				"-c",

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -109,12 +109,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, corev1.Container{
 			Name: "routes-fixer",
 			// TODO consider china
-			Image:   "quay.io/giantswarm/bash:5.2.2",
-			Command: []string{"/bin/bash"},
+			Image:   "docker.io/giantswarm/aws-cni:v1.11.2-nftables",
+			Command: []string{"/usr/bin/bash"},
 			Args: []string{
 				"-c",
-				// TODO unhardcode CIDR
-				getScript("192.168.0.0./16"),
+				getScript(key.CiliumPodsCIDRBlock(cluster)),
 			},
 		})
 

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/to"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,6 +115,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			Args: []string{
 				"-c",
 				getScript(key.CiliumPodsCIDRBlock(cluster)),
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: to.BoolP(true),
 			},
 		})
 

--- a/service/controller/resource/prepareawscniformigration/script.go
+++ b/service/controller/resource/prepareawscniformigration/script.go
@@ -18,7 +18,7 @@ while : ; do
     ifname="$(echo "$line" | cut -d'|' -f1)"
     table="$(echo "$line" | cut -d'|' -f2)"
 
-    (ip route show table $table | grep $CILIUM_CIDR) || (echo "Adding route for dev $ifname in table $table && ip route add $CILIUM_CIDR dev cilium_host table $table)
+    (ip route show table $table | grep $CILIUM_CIDR) || (echo "Adding route for dev $ifname in table $table" && ip route add $CILIUM_CIDR dev cilium_host table $table)
   done
 
   sleep 5

--- a/service/controller/resource/prepareawscniformigration/script.go
+++ b/service/controller/resource/prepareawscniformigration/script.go
@@ -12,12 +12,16 @@ CILIUM_CIDR=%s
 
 lines="$(ip route show table all|grep "scope link" |grep -Po "dev \Keth[0-9*] table [0-9]+"|sed 's/ table /|/')"
 
-for line in $lines
-do
-ifname="$(echo "$line" | cut -d'|' -f1)"
-table="$(echo "$line" | cut -d'|' -f2)"
+while : ; do
+  for line in $lines
+  do
+    ifname="$(echo "$line" | cut -d'|' -f1)"
+    table="$(echo "$line" | cut -d'|' -f2)"
 
-(ip route show table $table | grep $CILIUM_CIDR) || ip route add $CILIUM_CIDR dev cilium_host table $table
+    (ip route show table $table | grep $CILIUM_CIDR) || (echo "Adding route for dev $ifname in table $table && ip route add $CILIUM_CIDR dev cilium_host table $table)
+  done
+
+  sleep 5
 done
 `
 

--- a/service/controller/resource/prepareawscniformigration/script.go
+++ b/service/controller/resource/prepareawscniformigration/script.go
@@ -8,7 +8,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+DEVICE=cilium_host
 CILIUM_CIDR=%s
+
+while ! ip a show dev $DEVICE
+do 
+  echo "Waiting for device $DEVICE to exist."
+  sleep 5
+done
 
 lines="$(ip route show table all|grep "scope link" |grep -Po "dev \Keth[0-9*] table [0-9]+"|sed 's/ table /|/')"
 
@@ -18,7 +25,7 @@ while : ; do
     ifname="$(echo "$line" | cut -d'|' -f1)"
     table="$(echo "$line" | cut -d'|' -f2)"
 
-    (ip route show table $table | grep $CILIUM_CIDR) || (echo "Adding route for dev $ifname in table $table" && ip route add $CILIUM_CIDR dev cilium_host table $table)
+    (ip route show table $table | grep $CILIUM_CIDR) || (echo "Adding route for dev $ifname in table $table" && ip route add $CILIUM_CIDR dev $DEVICE table $table)
   done
 
   sleep 5

--- a/service/controller/resource/prepareawscniformigration/script.go
+++ b/service/controller/resource/prepareawscniformigration/script.go
@@ -1,0 +1,25 @@
+package prepareawscniformigration
+
+import "fmt"
+
+func getScript(cidr string) string {
+	scr := `
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CILIUM_CIDR=%s
+
+lines="$(ip route show table all|grep "scope link" |grep -Po "dev \Keth[0-9*] table [0-9]+"|sed 's/ table /|/')"
+
+for line in $lines
+do
+ifname="$(echo "$line" | cut -d'|' -f1)"
+table="$(echo "$line" | cut -d'|' -f2)"
+
+(ip route show table $table | grep $CILIUM_CIDR) || ip route add $CILIUM_CIDR dev cilium_host table $table
+done
+`
+
+	return fmt.Sprintf(scr, cidr)
+}

--- a/service/controller/resource/restrictawsnodedaemonset/create.go
+++ b/service/controller/resource/restrictawsnodedaemonset/create.go
@@ -55,7 +55,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	ctrlClient := cc.Client.TenantCluster.K8s.CtrlClient()
 
-	for _, dsName := range []string{awsNodeDsName, KubeProxyDsName} {
+	for _, dsName := range []string{awsNodeDsName} {
 		ds := appsv1.DaemonSet{}
 		err = ctrlClient.Get(ctx, client.ObjectKey{
 			Namespace: dsNamespace,


### PR DESCRIPTION
This PR introduces another bunch of hacks needed to smoothly migrate between aws-cni and cilium with kube proxy replacement.

More specifically, this PR:
- manages an annotation in the Cluster CR in order to enable or disable cilium's kube-proxy feature during upgrade. Timing is very important so aws-operator has the controller role in this process.
- adds a sidecar container to aws-node pods that adjusts the node's routing tables in order for aws-cni pods to be able to connect to cilium pods during migration

Sorry this is a big PR, but there is no meaningful way to split it.


## Checklist

- [x] Update changelog in CHANGELOG.md.
