### PR TITLE
Roll nodes when Vm type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow rolling nodes when there is a change in the AWSMachineDeployment even when CF stack was never updated before.
+
 ## [14.0.0] - 2022-10-11
 
 ### Added

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -875,8 +875,8 @@ func isTCCPNUpdated(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDep
 		}
 
 		if s != cloudformation.StackStatusUpdateComplete && s != cloudformation.StackStatusCreateComplete {
-			// when TCCPN stack is updated, only  good status that we want to see is `StackStatusUpdateComplete`
-			// anything else indicate either CF stack not updated, update in progress or an error
+			// Any status but `StackStatusUpdateComplete` or `StackStatusCreateComplete`
+			// is considered as invalid for upgrade purposes.
 			return false, microerror.Mask(tccpnNotUpdatedError)
 		}
 

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -302,14 +302,13 @@ func (r *Resource) updateStack(ctx context.Context, cr infrastructurev1alpha3.AW
 // Example 2:
 // When end user is scaling cluster and adding restrictions to its size, it
 // might be that initial ASG configuration is following:
-// 		- Min: 3
-//		- Max: 10
-// 		- Desired: 10
+//   - Min: 3
+//   - Max: 10
+//   - Desired: 10
 //
 // Now end user decides that it must be scaled down so maximum size is decreased
 // to 7. When desired number of instances is temporarily bigger than maximum
 // number of instances, it must be fixed to be maximum number of instances.
-//
 func minDesiredWorkers(minWorkers, maxWorkers, statusDesiredCapacity int) int {
 	if statusDesiredCapacity > maxWorkers {
 		return maxWorkers
@@ -875,7 +874,7 @@ func isTCCPNUpdated(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDep
 			return false, microerror.Mask(err)
 		}
 
-		if s != cloudformation.StackStatusUpdateComplete {
+		if s != cloudformation.StackStatusUpdateComplete && s != cloudformation.StackStatusCreateComplete {
 			// when TCCPN stack is updated, only  good status that we want to see is `StackStatusUpdateComplete`
 			// anything else indicate either CF stack not updated, update in progress or an error
 			return false, microerror.Mask(tccpnNotUpdatedError)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23630

We only rolled nodes on Node Pools on instance type change if they were rolled/upgraded at least once.
This PR make the feature work on new node pools as well

## Checklist

- [x] Update changelog in CHANGELOG.md.
