### PR TITLE
Drainerconfigs cleanup during cluster deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow rolling nodes when there is a change in the AWSMachineDeployment even when CF stack was never updated before.
+- Quickly delete DrainerConfigs during cluster or machine deployment deletion to speedup cluster deletion process.
 
 ## [14.0.0] - 2022-10-11
 

--- a/service/controller/resource/drainerfinalizer/resource.go
+++ b/service/controller/resource/drainerfinalizer/resource.go
@@ -206,11 +206,9 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 					return microerror.Mask(err)
 				}
 
-				if asgName != "" {
-					err = r.completeLifeCycleHook(ctx, instanceID, asgName)
-					if err != nil {
-						return microerror.Mask(err)
-					}
+				err = r.completeLifeCycleHook(ctx, instanceID, asgName)
+				if err != nil {
+					return microerror.Mask(err)
 				}
 
 				err = r.deleteDrainerConfig(ctx, dc)

--- a/service/controller/resource/drainerfinalizer/resource.go
+++ b/service/controller/resource/drainerfinalizer/resource.go
@@ -137,6 +137,11 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		} else if asg.IsNoDrainable(err) {
 			r.logger.Debugf(ctx, "did not find any drainable auto scaling group yet")
 
+			if key.IsDeleted(cr) {
+				r.logger.Debugf(ctx, "keeping finalizers")
+				finalizerskeptcontext.SetKept(ctx)
+			}
+
 			r.logger.Debugf(ctx, "canceling resource")
 			return nil
 

--- a/service/controller/resource/drainerfinalizer/resource.go
+++ b/service/controller/resource/drainerfinalizer/resource.go
@@ -127,7 +127,7 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 	}
 
 	var asgName string
-	if !key.IsDeleted(cr) {
+	{
 		drainable, err := r.asg.Drainable(ctx, cr)
 		if asg.IsNoASG(err) {
 			r.logger.Debugf(ctx, "did not find any auto scaling group")

--- a/service/controller/resource/drainerinitializer/resource.go
+++ b/service/controller/resource/drainerinitializer/resource.go
@@ -10,6 +10,7 @@ import (
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/finalizerskeptcontext"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,12 +142,6 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	if key.IsDeleted(cr) {
-		r.logger.Debugf(ctx, "CR being deleted")
-		r.logger.Debugf(ctx, "canceling resource")
-		return nil
-	}
-
 	var asgName string
 	{
 		drainable, err := r.asg.Drainable(ctx, cr)
@@ -157,6 +152,11 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 
 		} else if asg.IsNoDrainable(err) {
 			r.logger.Debugf(ctx, "did not find any drainable auto scaling group yet")
+
+			if key.IsDeleted(cr) {
+				r.logger.Debugf(ctx, "keeping finalizers")
+				finalizerskeptcontext.SetKept(ctx)
+			}
 
 			r.logger.Debugf(ctx, "canceling resource")
 			return nil
@@ -205,6 +205,14 @@ func (r *Resource) ensure(ctx context.Context, obj interface{}) error {
 
 		if len(instances) == 0 {
 			r.logger.Debugf(ctx, "did not find ec2 instances in %#q state", autoscaling.LifecycleStateTerminatingWait)
+
+			// In case there aren't EC2 instances in Terminating:Wait state, we cancel
+			// and keep finalizers on delete events, so we try again on the next
+			// reconciliation loop.
+			if key.IsDeleted(cr) {
+				r.logger.Debugf(ctx, "keeping finalizers")
+				finalizerskeptcontext.SetKept(ctx)
+			}
 
 			r.logger.Debugf(ctx, "canceling resource")
 			return nil


### PR DESCRIPTION
During cluster or MD deletion, we should endure nodes are deleted immediately without waiting for draining to happen or to timeout

## Checklist

- [x] Update changelog in CHANGELOG.md.
