### PR TITLE
Fix disabling of kube-proxy in v19+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow rolling nodes when there is a change in the AWSMachineDeployment even when CF stack was never updated before.
 - Quickly delete DrainerConfigs during cluster or machine deployment deletion to speedup cluster deletion process.
+- Fix disabling of kube-proxy in v19+.
 
 ## [14.0.0] - 2022-10-11
 

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -493,7 +493,6 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		}
 
 		params.BaseDomain = key.TenantClusterBaseDomain(cl)
-		params.DisableKubeProxy = false
 		params.Cluster = g8sConfig.Cluster
 		params.DisableEncryptionAtREST = true
 		// Ingress Controller service is not created via ignition.

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -208,7 +208,6 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 			params.DisableKubeProxy = false
 		}
 
-		params.DisableKubeProxy = false
 		params.Cluster = g8sConfig.Cluster
 		params.DockerhubToken = t.config.DockerhubToken
 		params.EnableCSIMigrationAWS = true


### PR DESCRIPTION
There was a mistake in the code, making kube-proxy enabled even with cilium

This PR fixes that mistake

## Checklist

- [x] Update changelog in CHANGELOG.md.
