### PR TITLE
Efs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use custom KMS key for encryption on your Amazon EBS volumes.
 - Enable IRSA by default in release v19.0.0.
 - Bump k8scc to 15.1.1.
+- Added EFS policy to the ec2 instance role to allow to use the EFS driver out of the box
 
 ### Fixed
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.0.1-dev"
+	version            = "14.1.0-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.1.0-dev"
+	version            = "14.0.1-dev"
 )
 
 func Description() string {

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -105,6 +105,27 @@ const TemplateMainIAMPolicies = `
               - ec2:CreateTags
             Resource:
               - arn:{{ .IAMPolicies.RegionARN }}:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -182,6 +182,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -182,6 +182,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -368,6 +368,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -184,6 +184,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/template/template_main_iam_policies.go
+++ b/service/controller/resource/tcnp/template/template_main_iam_policies.go
@@ -115,6 +115,27 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -187,6 +187,27 @@ Resources:
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:


### PR DESCRIPTION
This PR addresses the issue that, when a customer wants to use the EFS csi driver app, additional permissions are needed in the ec2 IAM role used in the node pools, to connect to the AWS EFS Service.

The PR adds the additional policies, needed for the EFS csi driver app to create new EFS end points and mount them as volume in pods.

The additional permissions needed and added by this PR to the IAM role of the ec2 nodes are:

- EFS write CreateAccessPoints
- EFS write DeleteAccessPoints
- EFS list DescribeAccessPoints
- EFS list DescribeFileSystems
- EFS read DescribeMountTarget
- EC2 list DescribeAvailabilityZones

Unfortunately the EFS csi driver at the moment does not support IRSA, otherwise this could have potentially be solved in a different way.

## Checklist

- [x] Update changelog in CHANGELOG.md.
