### PR TITLE
Release v10.14.x efs (v16)

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -27,3 +27,8 @@ CVE-2022-21221 until=2023-01-01
 CVE-2021-20329 until=2023-01-01
 CVE-2022-32149 until=2023-01-01
 
+sonatype-2020-0921 until=2023-01-01
+sonatype-2020-1258 until=2023-01-01
+sonatype-2019-0890 until=2023-01-01
+sonatype-2021-1485 until=2023-01-01
+

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,29 @@
 # Affects all versions of archiver which is required by vault.
 # Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
 CVE-2019-10743 until=2021-10-17
+
+# Ignoring the following CVEs because I am backporting a fix for an EOL release anyway.
+# The fix is about having the EFS policy enabled by default in the node IAM role
+CVE-2022-29718 until=2023-01-01
+CVE-2021-20206 until=2023-01-01
+CVE-2020-28483 until=2023-01-01
+CVE-2022-29153 until=2023-01-01
+CVE-2021-41803 until=2023-01-01
+CVE-2022-24687 until=2023-01-01
+CVE-2022-29153 until=2023-01-01
+CVE-2021-41803 until=2023-01-01
+CVE-2022-24687 until=2023-01-01
+CVE-2021-23772 until=2023-01-01
+CVE-2022-30591 until=2023-01-01
+CVE-2021-42576 until=2023-01-01
+CVE-2021-3127  until=2023-01-01
+CVE-2022-24450 until=2023-01-01
+CVE-2022-29946 until=2023-01-01
+CVE-2022-26652 until=2023-01-01
+CVE-2022-42709 until=2023-01-01
+CVE-2022-42708 until=2023-01-01
+CVE-2022-28357 until=2023-01-01
+CVE-2022-21221 until=2023-01-01
+CVE-2021-20329 until=2023-01-01
+CVE-2022-32149 until=2023-01-01
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added EFS policy to the ec2 instance role to allow to use the EFS driver out of the box
+
 ## [10.14.1] - 2022-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - Added EFS policy to the ec2 instance role to allow to use the EFS driver out of the box
 
 ## [10.14.1] - 2022-02-02

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "10.14.2-dev"
+	version            = "10.14.1-dev"
 )
 
 func Description() string {

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -91,6 +91,27 @@ const TemplateMainIAMPolicies = `
               - ec2:CreateTags
             Resource:
               - arn:{{ .IAMPolicies.RegionARN }}:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -163,6 +163,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -163,6 +163,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -337,6 +337,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/template/template_main_iam_policies.go
+++ b/service/controller/resource/tcnp/template/template_main_iam_policies.go
@@ -113,6 +113,27 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -185,6 +185,27 @@ Resources:
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:


### PR DESCRIPTION
This PR addresses the issue that, when a customer wants to use the EFS csi driver app, additional permissions are needed in the ec2 IAM role used in the node pools, to connect to the AWS EFS Service.

The PR adds the additional policies, needed for the EFS csi driver app to create new EFS end points and mount them as volume in pods.

The additional permissions needed and added by this PR to the IAM role of the ec2 nodes are:

- EFS write CreateAccessPoints
- EFS write DeleteAccessPoints
- EFS list DescribeAccessPoints
- EFS list DescribeFileSystems
- EFS read DescribeMountTarget
- EC2 list DescribeAvailabilityZones

Unfortunately the EFS csi driver at the moment does not support IRSA, otherwise this could have potentially be solved in a different way.

- [x] Update changelog in CHANGELOG.md.
