### PR TITLE
Cloudfront alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable IRSA by default in release v19.0.0.
 - Bump k8scc to 15.1.1.
 - Added EFS policy to the ec2 instance role to allow to use the EFS driver out of the box
+- Add both the cloudfront domain and alias domain in route53manager role policy.
 
 ### Fixed
 

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -442,6 +442,7 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 	}
 
 	var cloudfrontDomain string
+	var cloudfrontAliasDomain string
 	var cloudfrontEnabled bool
 	{
 		// ignore China, Cloudfront does not work.
@@ -458,16 +459,8 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 						return nil, microerror.Mask(err)
 					}
 
-					// First try using the alias domain (irsa.bla12.k8s. ... ).
-					cloudfrontDomain = cm.Data["domainAlias"]
-					if cloudfrontDomain == "" {
-						// Default to cloudfront domain if there is no alias.
-						cloudfrontDomain = cm.Data["domain"]
-						if cloudfrontDomain == "" {
-							return nil, microerror.Maskf(emptyDataError, "domain value in irsa cloudfront configmap for cluster must not be empty")
-						}
-					}
-
+					cloudfrontDomain = cm.Data["domain"]
+					cloudfrontAliasDomain = cm.Data["domainAlias"]
 				}
 				cloudfrontEnabled = true
 			}
@@ -477,19 +470,20 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 	var iamPolicies *template.ParamsMainIAMPolicies
 	{
 		iamPolicies = &template.ParamsMainIAMPolicies{
-			AccountID:            cc.Status.TenantCluster.AWS.AccountID,
-			AWSBaseDomain:        key.AWSBaseDomain(cc.Status.TenantCluster.AWS.Region),
-			CloudfrontEnabled:    cloudfrontEnabled,
-			CloudfrontDomain:     cloudfrontDomain,
-			ClusterID:            key.ClusterID(&cr),
-			EC2ServiceDomain:     key.EC2ServiceDomain(cc.Status.TenantCluster.AWS.Region),
-			HostedZoneID:         cc.Status.TenantCluster.DNS.HostedZoneID,
-			InternalHostedZoneID: cc.Status.TenantCluster.DNS.InternalHostedZoneID,
-			KMSKeyARN:            ek,
-			Region:               cc.Status.TenantCluster.AWS.Region,
-			RegionARN:            key.RegionARN(cc.Status.TenantCluster.AWS.Region),
-			S3Bucket:             key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
-			Route53Enabled:       r.route53Enabled,
+			AccountID:             cc.Status.TenantCluster.AWS.AccountID,
+			AWSBaseDomain:         key.AWSBaseDomain(cc.Status.TenantCluster.AWS.Region),
+			CloudfrontEnabled:     cloudfrontEnabled,
+			CloudfrontDomain:      cloudfrontDomain,
+			CloudfrontAliasDomain: cloudfrontAliasDomain,
+			ClusterID:             key.ClusterID(&cr),
+			EC2ServiceDomain:      key.EC2ServiceDomain(cc.Status.TenantCluster.AWS.Region),
+			HostedZoneID:          cc.Status.TenantCluster.DNS.HostedZoneID,
+			InternalHostedZoneID:  cc.Status.TenantCluster.DNS.InternalHostedZoneID,
+			KMSKeyARN:             ek,
+			Region:                cc.Status.TenantCluster.AWS.Region,
+			RegionARN:             key.RegionARN(cc.Status.TenantCluster.AWS.Region),
+			S3Bucket:              key.BucketName(&cr, cc.Status.TenantCluster.AWS.AccountID),
+			Route53Enabled:        r.route53Enabled,
 		}
 	}
 

--- a/service/controller/resource/tccpn/create.go
+++ b/service/controller/resource/tccpn/create.go
@@ -443,7 +443,6 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 
 	var cloudfrontDomain string
 	var cloudfrontAliasDomain string
-	var cloudfrontEnabled bool
 	{
 		// ignore China, Cloudfront does not work.
 		if r.route53Enabled {
@@ -461,8 +460,11 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 
 					cloudfrontDomain = cm.Data["domain"]
 					cloudfrontAliasDomain = cm.Data["domainAlias"]
+
+					if cloudfrontDomain == "" {
+						return nil, microerror.Maskf(emptyDataError, "domain value in irsa cloudfront configmap for cluster must not be empty")
+					}
 				}
-				cloudfrontEnabled = true
 			}
 		}
 	}
@@ -472,7 +474,6 @@ func (r *Resource) newIAMPolicies(ctx context.Context, cr infrastructurev1alpha3
 		iamPolicies = &template.ParamsMainIAMPolicies{
 			AccountID:             cc.Status.TenantCluster.AWS.AccountID,
 			AWSBaseDomain:         key.AWSBaseDomain(cc.Status.TenantCluster.AWS.Region),
-			CloudfrontEnabled:     cloudfrontEnabled,
 			CloudfrontDomain:      cloudfrontDomain,
 			CloudfrontAliasDomain: cloudfrontAliasDomain,
 			ClusterID:             key.ClusterID(&cr),

--- a/service/controller/resource/tccpn/error.go
+++ b/service/controller/resource/tccpn/error.go
@@ -14,8 +14,7 @@ import (
 // This error should never be matched against and therefore there is no matcher
 // implement. For further information see:
 //
-//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
-//
+//	https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
 }
@@ -154,8 +153,4 @@ func IsUpdateInProgress(err error) bool {
 	}
 
 	return false
-}
-
-var emptyDataError = &microerror.Error{
-	Kind: "emtpyDataError",
 }

--- a/service/controller/resource/tccpn/error.go
+++ b/service/controller/resource/tccpn/error.go
@@ -154,3 +154,7 @@ func IsUpdateInProgress(err error) bool {
 
 	return false
 }
+
+var emptyDataError = &microerror.Error{
+	Kind: "emtpyDataError",
+}

--- a/service/controller/resource/tccpn/template/params_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/params_main_iam_policies.go
@@ -3,7 +3,6 @@ package template
 type ParamsMainIAMPolicies struct {
 	AccountID             string
 	AWSBaseDomain         string
-	CloudfrontEnabled     bool
 	CloudfrontAliasDomain string
 	CloudfrontDomain      string
 	ClusterID             string

--- a/service/controller/resource/tccpn/template/params_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/params_main_iam_policies.go
@@ -1,17 +1,18 @@
 package template
 
 type ParamsMainIAMPolicies struct {
-	AccountID            string
-	AWSBaseDomain        string
-	CloudfrontEnabled    bool
-	CloudfrontDomain     string
-	ClusterID            string
-	EC2ServiceDomain     string
-	HostedZoneID         string
-	InternalHostedZoneID string
-	KMSKeyARN            string
-	Region               string
-	RegionARN            string
-	S3Bucket             string
-	Route53Enabled       bool
+	AccountID             string
+	AWSBaseDomain         string
+	CloudfrontEnabled     bool
+	CloudfrontAliasDomain string
+	CloudfrontDomain      string
+	ClusterID             string
+	EC2ServiceDomain      string
+	HostedZoneID          string
+	InternalHostedZoneID  string
+	KMSKeyARN             string
+	Region                string
+	RegionARN             string
+	S3Bucket              string
+	Route53Enabled        bool
 }

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -167,7 +167,7 @@ const TemplateMainIAMPolicies = `
             Principal:
               AWS: !GetAtt IAMManagerRole.Arn
             Action: "sts:AssumeRole"
-          {{- if .IAMPolicies.CloudfrontEnabled }}
+          {{- if ne .IAMPolicies.CloudfrontDomain "" }}
           - Effect: "Allow"
             Principal:
               Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.CloudfrontDomain }}"
@@ -175,6 +175,7 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringEquals:
                 "{{ .IAMPolicies.CloudfrontDomain }}:sub": "system:serviceaccount:kube-system:external-dns"
+          {{- end }}
           {{- if ne .IAMPolicies.CloudfrontAliasDomain "" }}
           - Effect: "Allow"
             Principal:
@@ -183,7 +184,6 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringEquals:
                 "{{ .IAMPolicies.CloudfrontAliasDomain }}:sub": "system:serviceaccount:kube-system:external-dns"
-          {{- end }}
           {{- end }}
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -175,6 +175,15 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringEquals:
                 "{{ .IAMPolicies.CloudfrontDomain }}:sub": "system:serviceaccount:kube-system:external-dns"
+          {{- if ne .IAMPolicies.CloudfrontAliasDomain "" }}
+          - Effect: "Allow"
+            Principal:
+              Federated: "arn:{{ .IAMPolicies.RegionARN }}:iam::{{ .IAMPolicies.AccountID }}:oidc-provider/{{ .IAMPolicies.CloudfrontAliasDomain }}"
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Condition:
+              StringEquals:
+                "{{ .IAMPolicies.CloudfrontAliasDomain }}:sub": "system:serviceaccount:kube-system:external-dns"
+          {{- end }}
           {{- end }}
   Route53ManagerRolePolicy:
     Type: "AWS::IAM::Policy"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1546

we added a custom domain to the cloudfront distribution we use for irsa, but we didn't edit the IAM role that allows assuming the route53 manager role when authenticated through IRSA with the new domain name.
This PR fixes this problem

## Checklist

- [x] Update changelog in CHANGELOG.md.
