### PR TITLE
Release v11.16.x efs (v17)

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,10 +2,29 @@
 # Waiting for more direct dependencies to move away.
 CVE-2022-29153 until=2023-06-25
 CVE-2022-24687 until=2023-06-25
+CVE-2021-41803 until=2023-06-25
+CVE-2021-41803 until=2023-06-25
 
 # Pending github.com/kataras/iris release > 12.1.8
-CVE-2021-23772 until=2022-08-25
+CVE-2021-23772 until=2023-08-25
+
+### github.com/nats-io/nats-server
+# Stack-based Buffer Overflow
+CVE-2022-42709 until=2023-08-25
+# Denial of Service (DoS)
+CVE-2022-42708 until=2023-08-25
+
+### pkg:golang/golang.org/x/text@v0.3.7
+# Missing Release of Resource after Effective Lifetime
+CVE-2022-32149 until=2023-08-25
 
 # Affects github.com/urfave/negroni. v2.0.2 is availabe but still affected.
 # Issue is an open redirect (user can manipulate a link served to other users).
 sonatype-2021-1485 until=2023-06-25
+
+# https://ossindex.sonatype.org/vulnerability/sonatype-2022-5436
+sonatype-2022-5436 until=2023-06-25
+
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added EFS policy to the ec2 instance role to allow to use the EFS driver out of the box
+
 ## [11.16.0] - 2022-07-04
 
 ### Added

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -92,6 +92,27 @@ const TemplateMainIAMPolicies = `
               - ec2:CreateTags
             Resource:
               - arn:{{ .IAMPolicies.RegionARN }}:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -164,6 +164,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -164,6 +164,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -338,6 +338,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -166,6 +166,27 @@ Resources:
               - ec2:CreateTags
             Resource:
               - arn:aws:ec2:*:*:network-interface/*
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   ControlPlaneNodesInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/template/template_main_iam_policies.go
+++ b/service/controller/resource/tcnp/template/template_main_iam_policies.go
@@ -113,6 +113,27 @@ const TemplateMainIAMPolicies = `
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -188,6 +188,27 @@ Resources:
             Condition:
               StringLike:
                 ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+          #### Used for EFS
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:DescribeAccessPoints
+            - elasticfilesystem:DescribeFileSystems
+            - elasticfilesystem:DescribeMountTargets
+            - ec2:DescribeAvailabilityZones
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - elasticfilesystem:CreateAccessPoint
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/efs.csi.aws.com/cluster: 'true'
+          - Effect: Allow
+            Action: elasticfilesystem:DeleteAccessPoint
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:ResourceTag/efs.csi.aws.com/cluster: 'true'
   NodePoolInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:


### PR DESCRIPTION
This PR addresses the issue that, when a customer wants to use the EFS csi driver app, additional permissions are needed in the ec2 IAM role used in the node pools, to connect to the AWS EFS Service.

The PR adds the additional policies, needed for the EFS csi driver app to create new EFS end points and mount them as volume in pods.

The additional permissions needed and added by this PR to the IAM role of the ec2 nodes are:

    EFS write CreateAccessPoints
    EFS write DeleteAccessPoints
    EFS list DescribeAccessPoints
    EFS list DescribeFileSystems
    EFS read DescribeMountTarget
    EC2 list DescribeAvailabilityZones

Unfortunately the EFS csi driver at the moment does not support IRSA, otherwise this could have potentially be solved in a different way.

## Checklist

- [x] Update changelog in CHANGELOG.md.
