### PR TITLE
Add annotations to configure all disks in nodepools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow disk size configuration of logging volume. New default value is 15Gb.
+- Allow different values for docker and containerd volume.
+
 ## [14.3.0] - 2022-11-29
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
 	github.com/giantswarm/k8scloudconfig/v15 v15.3.0
-	github.com/giantswarm/k8smetadata v0.16.1
+	github.com/giantswarm/k8smetadata v0.18.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0
 	github.com/giantswarm/microerror v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v15 v15.3.0 h1:0rCoab+gr2KsUGAIAeTUFbpMsEPhLI+24i3+tTAK1fY=
 github.com/giantswarm/k8scloudconfig/v15 v15.3.0/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
-github.com/giantswarm/k8smetadata v0.16.1 h1:d6dXsT1BjKBynGUYSYQ/4ZPcbq95kdzguowdlq+5KjY=
-github.com/giantswarm/k8smetadata v0.16.1/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
+github.com/giantswarm/k8smetadata v0.18.0 h1:Mnwymj/u1s7f517onaujokqp043/hFdbPKT4IuQfYdQ=
+github.com/giantswarm/k8smetadata v0.18.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=
 github.com/giantswarm/kubelock/v4 v4.0.0/go.mod h1:XbqPs1m+NafHSjXvOXsb3UjE5DvhyNk47tfGcQJl1iY=
 github.com/giantswarm/microendpoint v1.0.0 h1:vW6VXPaWXBPZc9Q99FgPcjYprAKLItufKFcydBH47Xc=

--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -20,6 +20,27 @@ func MachineDeploymentDockerVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDep
 	return strconv.Itoa(cr.Spec.NodePool.Machine.DockerVolumeSizeGB)
 }
 
+func MachineDeploymentContainerdVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDeployment) string {
+	result, ok := cr.ObjectMeta.Annotations[annotation.AWSContainerdVolumeSize]
+	if !ok {
+		//Default back to current value
+		return MachineDeploymentDockerVolumeSizeGB(cr)
+	}
+	return result
+}
+
+func MachineDeploymentLoggingVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDeployment) int {
+	result, ok := cr.ObjectMeta.Annotations[annotation.AWSLoggingVolumeSize]
+	if !ok {
+		return 10
+	}
+	value, error := strconv.Atoi(result)
+	if error != nil {
+		return 10
+	}
+	return value
+}
+
 func MachineDeploymentInstanceType(cr infrastructurev1alpha3.AWSMachineDeployment) string {
 	return cr.Spec.Provider.Worker.InstanceType
 }

--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -32,11 +32,11 @@ func MachineDeploymentContainerdVolumeSizeGB(cr infrastructurev1alpha3.AWSMachin
 func MachineDeploymentLoggingVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDeployment) int {
 	result, ok := cr.ObjectMeta.Annotations[annotation.AWSLoggingVolumeSize]
 	if !ok {
-		return 10
+		return 15
 	}
 	value, error := strconv.Atoi(result)
 	if error != nil {
-		return 10
+		return 15
 	}
 	return value
 }

--- a/service/controller/key/machine_deployment.go
+++ b/service/controller/key/machine_deployment.go
@@ -21,20 +21,30 @@ func MachineDeploymentDockerVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDep
 }
 
 func MachineDeploymentContainerdVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDeployment) string {
+	defaultValue := MachineDeploymentDockerVolumeSizeGB(cr)
+
+	//If there is no tag, default to docker volume size
 	result, ok := cr.ObjectMeta.Annotations[annotation.AWSContainerdVolumeSize]
 	if !ok {
-		//Default back to current value
-		return MachineDeploymentDockerVolumeSizeGB(cr)
+		return defaultValue
 	}
-	return result
+	//If the value of the tag is not a number, default to docker volume size
+	_, error := strconv.Atoi(result)
+	if error == nil {
+		return result
+	} else {
+		return defaultValue
+	}
 }
 
 func MachineDeploymentLoggingVolumeSizeGB(cr infrastructurev1alpha3.AWSMachineDeployment) int {
 	result, ok := cr.ObjectMeta.Annotations[annotation.AWSLoggingVolumeSize]
+	//If there is no tag, default to 15Gb
 	if !ok {
 		return 15
 	}
 	value, error := strconv.Atoi(result)
+	//If the content of the tag is not a number, default to 15Gb
 	if error != nil {
 		return 15
 	}

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -519,7 +519,7 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 		BlockDeviceMapping: template.ParamsMainLaunchTemplateBlockDeviceMapping{
 			Containerd: template.ParamsMainLaunchTemplateBlockDeviceMappingContainerd{
 				Volume: template.ParamsMainLaunchTemplateBlockDeviceMappingContainerdVolume{
-					Size: key.MachineDeploymentDockerVolumeSizeGB(cr),
+					Size: key.MachineDeploymentContainerdVolumeSizeGB(cr),
 				},
 			},
 			Docker: template.ParamsMainLaunchTemplateBlockDeviceMappingDocker{
@@ -534,7 +534,7 @@ func (r *Resource) newLaunchTemplate(ctx context.Context, cr infrastructurev1alp
 			},
 			Logging: template.ParamsMainLaunchTemplateBlockDeviceMappingLogging{
 				Volume: template.ParamsMainLaunchTemplateBlockDeviceMappingLoggingVolume{
-					Size: 100,
+					Size: key.MachineDeploymentLoggingVolumeSizeGB(cr),
 				},
 			},
 		},

--- a/service/controller/resource/tcnp/create_test.go
+++ b/service/controller/resource/tcnp/create_test.go
@@ -45,6 +45,11 @@ func Test_Controller_Resource_TCNP_Template_Render(t *testing.T) {
 			cr:   unittest.DefaultMachineDeployment(),
 			re:   unittest.DefaultRelease(),
 		},
+		{
+			name: "case 1: disk test",
+			cr:   unittest.MachineDeploymentWithDisks(unittest.DefaultMachineDeployment(), "10", 11, 12, "13"),
+			re:   unittest.DefaultRelease(),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -236,7 +236,7 @@ Resources:
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
-            VolumeSize: 10
+            VolumeSize: 15
             VolumeType: gp3
         - DeviceName: /dev/xvdi
           Ebs:

--- a/service/controller/resource/tcnp/testdata/case-1-disk-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-1-disk-test.golden
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Tenant Cluster Node Pool Cloud Formation Stack.
 Outputs:
   DockerVolumeSizeGB:
-    Value: 100
+    Value: 11
   InstanceImage:
     Value: ami-0a9a5d2b65cce04eb
   InstanceType:
@@ -224,25 +224,25 @@ Resources:
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
-            VolumeSize: 100
+            VolumeSize: 11
             VolumeType: gp3
         - DeviceName: /dev/xvdg
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
-            VolumeSize: 100
+            VolumeSize: 12
             VolumeType: gp3
         - DeviceName: /dev/xvdf
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
-            VolumeSize: 10
+            VolumeSize: 13
             VolumeType: gp3
         - DeviceName: /dev/xvdi
           Ebs:
             DeleteOnTermination: true
             Encrypted: true
-            VolumeSize: 100
+            VolumeSize: 10
             VolumeType: gp3
         IamInstanceProfile:
           Name: !Ref NodePoolInstanceProfile

--- a/service/internal/unittest/default_machine_deployment.go
+++ b/service/internal/unittest/default_machine_deployment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/pkg/label"
+	metadata "github.com/giantswarm/k8smetadata/pkg/annotation"
 )
 
 const (
@@ -59,6 +60,15 @@ func DefaultMachineDeployment() infrastructurev1alpha3.AWSMachineDeployment {
 
 func MachineDeploymentWithAZs(machineDeployment infrastructurev1alpha3.AWSMachineDeployment, azs []string) infrastructurev1alpha3.AWSMachineDeployment {
 	machineDeployment.Spec.Provider.AvailabilityZones = azs
+
+	return machineDeployment
+}
+
+func MachineDeploymentWithDisks(machineDeployment infrastructurev1alpha3.AWSMachineDeployment, containerd string, docker int, kubelet int, logging string) infrastructurev1alpha3.AWSMachineDeployment {
+	machineDeployment.ObjectMeta.Annotations[metadata.AWSContainerdVolumeSize] = containerd
+	machineDeployment.ObjectMeta.Annotations[metadata.AWSLoggingVolumeSize] = logging
+	machineDeployment.Spec.NodePool.Machine.DockerVolumeSizeGB = docker
+	machineDeployment.Spec.NodePool.Machine.KubeletVolumeSizeGB = kubelet
 
 	return machineDeployment
 }

--- a/service/internal/unittest/default_machine_deployment.go
+++ b/service/internal/unittest/default_machine_deployment.go
@@ -2,12 +2,12 @@ package unittest
 
 import (
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	metadata "github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/to"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/pkg/label"
-	metadata "github.com/giantswarm/k8smetadata/pkg/annotation"
 )
 
 const (


### PR DESCRIPTION
## Goal of this PR
- Allow disk size configuration of logging volume. New default value is 15Gb.
- Allow different values for docker and containerd volume.

## Checklist
- [x] Update changelog in CHANGELOG.md.

