### PR TITLE
Adjust ALBController IAM Role Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust ALBController IAM role name.
+
 ## [14.5.0] - 2023-01-26
 
 ### Added

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -158,7 +158,7 @@ const TemplateMainIAMPolicies = `
   ALBControllerRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: {{ .IAMPolicies.ClusterID }}-ALBController-Role
+      RoleName: gs-{{ .IAMPolicies.ClusterID }}-ALBController-Role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -196,7 +196,7 @@ const TemplateMainIAMPolicies = `
   ALBControllerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: {{ .IAMPolicies.ClusterID }}-ALBController-Policy
+      PolicyName: gs-{{ .IAMPolicies.ClusterID }}-ALBController-Policy
       Roles:
         - Ref: "ALBControllerRole"
       PolicyDocument:

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -235,7 +235,7 @@ Resources:
   ALBControllerRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: 8y5ck-ALBController-Role
+      RoleName: gs-8y5ck-ALBController-Role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -253,7 +253,7 @@ Resources:
   ALBControllerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: 8y5ck-ALBController-Policy
+      PolicyName: gs-8y5ck-ALBController-Policy
       Roles:
         - Ref: "ALBControllerRole"
       PolicyDocument:

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -235,7 +235,7 @@ Resources:
   ALBControllerRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: 8y5ck-ALBController-Role
+      RoleName: gs-8y5ck-ALBController-Role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -246,7 +246,7 @@ Resources:
   ALBControllerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: 8y5ck-ALBController-Policy
+      PolicyName: gs-8y5ck-ALBController-Policy
       Roles:
         - Ref: "ALBControllerRole"
       PolicyDocument:

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -421,7 +421,7 @@ Resources:
   ALBControllerRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: 8y5ck-ALBController-Role
+      RoleName: gs-8y5ck-ALBController-Role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -439,7 +439,7 @@ Resources:
   ALBControllerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: 8y5ck-ALBController-Policy
+      PolicyName: gs-8y5ck-ALBController-Policy
       Roles:
         - Ref: "ALBControllerRole"
       PolicyDocument:

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -237,7 +237,7 @@ Resources:
   ALBControllerRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: 8y5ck-ALBController-Role
+      RoleName: gs-8y5ck-ALBController-Role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -255,7 +255,7 @@ Resources:
   ALBControllerRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:
-      PolicyName: 8y5ck-ALBController-Policy
+      PolicyName: gs-8y5ck-ALBController-Policy
       Roles:
         - Ref: "ALBControllerRole"
       PolicyDocument:


### PR DESCRIPTION
I checked some AWS accounts to see if ALBController IAM Role can be created.
There's a catch in some AWSOperator IAM Role which only allows creating IAM roles with a specific name match.

```
  "Resource": [
      "${arn_prefix}:iam::${account_id}:role/*-EC2-K8S-Role",
      "${arn_prefix}:iam::${account_id}:role/*-IAMManager-Role",
      "${arn_prefix}:iam::${account_id}:role/*-Route53Manager-Role",
      "${arn_prefix}:iam::${account_id}:role/*-vpc-peer-access",
      "${arn_prefix}:iam::${account_id}:role/gs-*"
  ]
```

This would mean we either need to update the AWSOperator IAM policies again in all accounts or we change the name of the ALBController starting with `gs-`

## Checklist

- [x] Update changelog in CHANGELOG.md.