### PR TITLE
Label node pool nodes with `cgroups.giantswarm.io/version` to indicat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Label node pool nodes with `cgroups.giantswarm.io/version` to indicate which cgroup version they are running.
+
 ## [14.6.0] - 2023-01-30
 
 ### Fixed

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -11,6 +11,7 @@ const (
 	MasterID          = "giantswarm.io/master-id"
 	Organization      = "giantswarm.io/organization"
 	Provider          = "giantswarm.io/provider"
+	CGroupVersion     = "cgroups.giantswarm.io/version"
 )
 
 const (

--- a/service/internal/cloudconfig/tcnp.go
+++ b/service/internal/cloudconfig/tcnp.go
@@ -3,6 +3,7 @@ package cloudconfig
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -245,6 +246,15 @@ func (t *TCNP) NewTemplates(ctx context.Context, obj interface{}) ([]string, err
 		params.Images = im
 		params.SSOPublicKey = t.config.SSOPublicKey
 		params.Versions = v
+
+		cgroupsLabelValue := "v2"
+		if forceCGroupsV1 {
+			cgroupsLabelValue = "v1"
+		}
+		labels := params.Cluster.Kubernetes.Kubelet.Labels
+		splitted := strings.Split(labels, ",")
+		splitted = append(splitted, fmt.Sprintf("%s=%s", label.CGroupVersion, cgroupsLabelValue))
+		params.Cluster.Kubernetes.Kubelet.Labels = strings.Join(splitted, ",")
 
 		ignitionPath := k8scloudconfig.GetIgnitionPath(t.config.IgnitionPath)
 		params.Files, err = k8scloudconfig.RenderFiles(ignitionPath, params)


### PR DESCRIPTION
…e which cgroup version they are running.

## Checklist

- [x] Update changelog in CHANGELOG.md.
