### PR TITLE
Use `alpine` as image for aws-cni's `routes-fixer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `alpine` as image for aws-cni's `routes-fixer`. 
+
 ## [14.12.1] - 2023-04-05
 
 ### Added

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -94,6 +94,7 @@ type ClusterConfig struct {
 	IncludeTags                bool
 	InstallationName           string
 	IPAMNetworkRange           net.IPNet
+	RegistryDomain             string
 	RouteTables                string
 	Route53Enabled             bool
 }
@@ -836,8 +837,9 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	var prepareAwsCniForMigrationResource resource.Interface
 	{
 		c := prepareawscniformigration.Config{
-			Logger:     config.Logger,
-			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:         config.Logger,
+			CtrlClient:     config.K8sClient.CtrlClient(),
+			RegistryDomain: config.RegistryDomain,
 		}
 
 		prepareAwsCniForMigrationResource, err = prepareawscniformigration.New(c)

--- a/service/controller/resource/prepareawscniformigration/create.go
+++ b/service/controller/resource/prepareawscniformigration/create.go
@@ -2,6 +2,7 @@ package prepareawscniformigration
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
@@ -109,8 +110,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.Debugf(ctx, "Daemonset %q doesn't have routes-fixer container", dsName)
 		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, corev1.Container{
 			Name:    "routes-fixer",
-			Image:   ds.Spec.Template.Spec.Containers[0].Image,
-			Command: []string{"/usr/bin/bash"},
+			Image:   fmt.Sprintf("%s/giantswarm/alpine:3.17.3", r.registryDomain),
+			Command: []string{"/bin/sh"},
 			Args: []string{
 				"-c",
 				getScript(key.CiliumPodsCIDRBlock(cluster)),

--- a/service/controller/resource/prepareawscniformigration/resource.go
+++ b/service/controller/resource/prepareawscniformigration/resource.go
@@ -11,14 +11,16 @@ const (
 )
 
 type Config struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
+	CtrlClient     client.Client
+	Logger         micrologger.Logger
+	RegistryDomain string
 }
 
 // Resource that ensures the `aws-node` daemonset is configured correctly for migration to cilum
 type Resource struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
+	ctrlClient     client.Client
+	logger         micrologger.Logger
+	registryDomain string
 }
 
 func New(config Config) (*Resource, error) {
@@ -28,10 +30,14 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.RegistryDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
+	}
 
 	r := &Resource{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
+		ctrlClient:     config.CtrlClient,
+		logger:         config.Logger,
+		registryDomain: config.RegistryDomain,
 	}
 
 	return r, nil

--- a/service/service.go
+++ b/service/service.go
@@ -252,6 +252,7 @@ func New(config Config) (*Service, error) {
 			IncludeTags:                config.Viper.GetBool(config.Flag.Service.AWS.IncludeTags),
 			InstallationName:           config.Viper.GetString(config.Flag.Service.Installation.Name),
 			IPAMNetworkRange:           ipamNetworkRange,
+			RegistryDomain:             config.Viper.GetString(config.Flag.Service.Registry.Domain),
 			Route53Enabled:             config.Viper.GetBool(config.Flag.Service.AWS.Route53.Enabled),
 			RouteTables:                config.Viper.GetString(config.Flag.Service.AWS.RouteTables),
 		}


### PR DESCRIPTION
Since latest update of aws-cni, the image does not have the tools needed to run `routes-fixer` any more.
Thus we need to run alpine

## Checklist

- [x] Update changelog in CHANGELOG.md.
