### PR TITLE
Keep aws cni subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not delete aws-cni subnets when switching to cilium.
+
 ## [14.15.0] - 2023-04-25
 
 ### Fixed

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,5 +3,6 @@ package annotation
 const (
 	Docs                    = "giantswarm.io/docs"
 	InstanceID              = "aws-operator.giantswarm.io/instance"
+	LegacyAwsCniPodCidr     = "aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr"
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
 )

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha512"
 	"fmt"
-	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/pkg/label"
 	"github.com/giantswarm/aws-operator/v14/pkg/project"
 )

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha512"
 	"fmt"
+	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"strconv"
 	"strings"
 	"time"
@@ -127,12 +128,16 @@ func ExternalSNAT(cluster infrastructurev1alpha3.AWSCluster) *bool {
 	return cluster.Spec.Provider.Pods.ExternalSNAT
 }
 
-func AWSCNIPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+func PodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
 	return cluster.Spec.Provider.Pods.CIDRBlock
 }
 
 func CiliumPodsCIDRBlock(cluster apiv1beta1.Cluster) string {
 	return cluster.Annotations[annotation.CiliumPodCidr]
+}
+
+func LegacyAWSCniCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+	return cluster.Annotations[annotation2.LegacyAwsCniPodCidr]
 }
 
 func EtcdQuotaBackendBytes(cluster apiv1beta1.Cluster) int64 {

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/pkg/label"
 	"github.com/giantswarm/aws-operator/v14/pkg/project"
 )
@@ -137,7 +137,7 @@ func CiliumPodsCIDRBlock(cluster apiv1beta1.Cluster) string {
 }
 
 func LegacyAWSCniCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
-	return cluster.Annotations[annotation2.LegacyAwsCniPodCidr]
+	return cluster.Annotations[awsoperatorannotation.LegacyAwsCniPodCidr]
 }
 
 func EtcdQuotaBackendBytes(cluster apiv1beta1.Cluster) int64 {

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -14,7 +14,7 @@ import (
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/v14/service/controller/key"
 )
@@ -146,11 +146,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
-		r.logger.Debugf(ctx, "Migrating AWS CNI pod cidr from AWSCluster.Spec.Provider.Pods.CIDRBlock to %q annotation", annotation2.LegacyAwsCniPodCidr)
+		r.logger.Debugf(ctx, "Migrating AWS CNI pod cidr from AWSCluster.Spec.Provider.Pods.CIDRBlock to %q annotation", awsoperatorannotation.LegacyAwsCniPodCidr)
 		if cr.Annotations == nil {
 			cr.Annotations = make(map[string]string)
 		}
-		cr.Annotations[annotation2.LegacyAwsCniPodCidr] = cr.Spec.Provider.Pods.CIDRBlock
+		cr.Annotations[awsoperatorannotation.LegacyAwsCniPodCidr] = cr.Spec.Provider.Pods.CIDRBlock
 
 		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)
 		// Update pod cidr on AWSCluster CR

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -3,7 +3,6 @@ package awscnicleaner
 import (
 	"context"
 	"fmt"
-	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"time"
 
 	"github.com/giantswarm/backoff"
@@ -15,6 +14,7 @@ import (
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/v14/service/controller/key"
 )

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -147,6 +147,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
 		r.logger.Debugf(ctx, "Migrating AWS CNI pod cidr from AWSCluster.Spec.Provider.Pods.CIDRBlock to %q annotation", annotation2.LegacyAwsCniPodCidr)
+		if cr.Annotations == nil {
+			cr.Annotations = make(map[string]string)
+		}
 		cr.Annotations[annotation2.LegacyAwsCniPodCidr] = cr.Spec.Provider.Pods.CIDRBlock
 
 		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -3,6 +3,7 @@ package awscnicleaner
 import (
 	"context"
 	"fmt"
+	annotation2 "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"time"
 
 	"github.com/giantswarm/backoff"
@@ -145,8 +146,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
-		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)
+		r.logger.Debugf(ctx, "Migrating AWS CNI pod cidr from AWSCluster.Spec.Provider.Pods.CIDRBlock to %q annotation", annotation2.LegacyAwsCniPodCidr)
+		cr.Annotations[annotation2.LegacyAwsCniPodCidr] = cr.Spec.Provider.Pods.CIDRBlock
 
+		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)
 		// Update pod cidr on AWSCluster CR
 		cr.Spec.Provider.Pods.CIDRBlock = key.CiliumPodsCIDRBlock(cluster)
 		err = r.ctrlClient.Update(ctx, &cr)

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -144,7 +144,7 @@ func (r *Resource) createStack(ctx context.Context, cl apiv1beta1.Cluster, cr in
 	{
 		r.logger.Debugf(ctx, "computing the template of the tenant cluster's control plane cloud formation stack")
 
-		params, err := r.newParamsMain(ctx, cl, cr, time.Now(), true)
+		params, err := r.newParamsMain(ctx, cl, cr, time.Now())
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -202,7 +202,7 @@ func (r *Resource) getCloudFormationTags(ctx context.Context, cr infrastructurev
 	return awstags.NewCloudFormation(tags), nil
 }
 
-func (r *Resource) newParamsMain(ctx context.Context, cl apiv1beta1.Cluster, cr infrastructurev1alpha3.AWSCluster, t time.Time, newCluster bool) (*template.ParamsMain, error) {
+func (r *Resource) newParamsMain(ctx context.Context, cl apiv1beta1.Cluster, cr infrastructurev1alpha3.AWSCluster, t time.Time) (*template.ParamsMain, error) {
 	var params *template.ParamsMain
 	{
 		internetGateway, err := r.newParamsMainInternetGateway(ctx, cr)
@@ -524,8 +524,6 @@ func (r *Resource) newParamsMainSubnets(ctx context.Context, cr infrastructurev1
 		return zones[i].Name < zones[j].Name
 	})
 
-	fmt.Println(zones)
-
 	var awsCNISubnets []template.ParamsMainSubnetsSubnet
 	for _, az := range zones {
 		if az.Subnet.AWSCNI.CIDR.IP != nil && az.Subnet.AWSCNI.CIDR.Mask != nil {
@@ -662,7 +660,7 @@ func (r *Resource) updateStack(ctx context.Context, cl apiv1beta1.Cluster, cr in
 	{
 		r.logger.Debugf(ctx, "computing the template of the tenant cluster's control plane cloud formation stack")
 
-		params, err := r.newParamsMain(ctx, cl, cr, time.Now(), false)
+		params, err := r.newParamsMain(ctx, cl, cr, time.Now())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -612,7 +612,6 @@ func (r *Resource) newParamsMainVPC(ctx context.Context, cl apiv1beta1.Cluster, 
 
 	legacyAWSCniPodSubnet := ""
 	if enableAWSCNI {
-		r.logger.Debug(ctx, "newParamsMainVPC inside if enableAWSCNI")
 		for _, az := range cc.Spec.TenantCluster.TCCP.AvailabilityZones {
 			rtName := template.ParamsMainVPCRouteTableName{
 				ResourceName: key.SanitizeCFResourceName(key.AWSCNIRouteTableName(az.Name)),
@@ -626,7 +625,6 @@ func (r *Resource) newParamsMainVPC(ctx context.Context, cl apiv1beta1.Cluster, 
 			legacyAWSCniPodSubnet = key.PodsCIDRBlock(cr)
 		}
 	} else {
-		r.logger.Debug(ctx, "newParamsMainVPC inside else")
 		// If there is an aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr annotation set, means we are running cilium but still want the AWS cni subnets to be created using the old CIDR
 		if key.LegacyAWSCniCIDRBlock(cr) != "" {
 			legacyAWSCniPodSubnet = key.LegacyAWSCniCIDRBlock(cr)

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -524,6 +524,8 @@ func (r *Resource) newParamsMainSubnets(ctx context.Context, cr infrastructurev1
 		return zones[i].Name < zones[j].Name
 	})
 
+	fmt.Println(zones)
+
 	var awsCNISubnets []template.ParamsMainSubnetsSubnet
 	for _, az := range zones {
 		if az.Subnet.AWSCNI.CIDR.IP != nil && az.Subnet.AWSCNI.CIDR.Mask != nil {

--- a/service/controller/resource/tccp/create.go
+++ b/service/controller/resource/tccp/create.go
@@ -612,6 +612,7 @@ func (r *Resource) newParamsMainVPC(ctx context.Context, cl apiv1beta1.Cluster, 
 
 	legacyAWSCniPodSubnet := ""
 	if enableAWSCNI {
+		r.logger.Debug(ctx, "newParamsMainVPC inside if enableAWSCNI")
 		for _, az := range cc.Spec.TenantCluster.TCCP.AvailabilityZones {
 			rtName := template.ParamsMainVPCRouteTableName{
 				ResourceName: key.SanitizeCFResourceName(key.AWSCNIRouteTableName(az.Name)),
@@ -625,6 +626,7 @@ func (r *Resource) newParamsMainVPC(ctx context.Context, cl apiv1beta1.Cluster, 
 			legacyAWSCniPodSubnet = key.PodsCIDRBlock(cr)
 		}
 	} else {
+		r.logger.Debug(ctx, "newParamsMainVPC inside else")
 		// If there is an aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr annotation set, means we are running cilium but still want the AWS cni subnets to be created using the old CIDR
 		if key.LegacyAWSCniCIDRBlock(cr) != "" {
 			legacyAWSCniPodSubnet = key.LegacyAWSCniCIDRBlock(cr)

--- a/service/controller/resource/tccp/create_test.go
+++ b/service/controller/resource/tccp/create_test.go
@@ -198,7 +198,7 @@ func Test_Controller_Resource_TCCP_Template_Render(t *testing.T) {
 
 			cl := unittest.DefaultCAPIClusterWithLabels(tc.cr.Name, map[string]string{})
 
-			params, err := r.newParamsMain(tc.ctx, cl, tc.cr, time.Time{}, true)
+			params, err := r.newParamsMain(tc.ctx, cl, tc.cr, time.Time{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/controller/resource/tccp/create_test.go
+++ b/service/controller/resource/tccp/create_test.go
@@ -198,7 +198,7 @@ func Test_Controller_Resource_TCCP_Template_Render(t *testing.T) {
 
 			cl := unittest.DefaultCAPIClusterWithLabels(tc.cr.Name, map[string]string{})
 
-			params, err := r.newParamsMain(tc.ctx, cl, tc.cr, time.Time{})
+			params, err := r.newParamsMain(tc.ctx, cl, tc.cr, time.Time{}, true)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/controller/resource/tccp/template/template_main_route_tables.go
+++ b/service/controller/resource/tccp/template/template_main_route_tables.go
@@ -3,7 +3,6 @@ package template
 const TemplateMainRouteTables = `
 {{- define "route_tables" -}}
 {{- $v := .RouteTables -}}
-  {{- if .EnableAWSCNI }}
   {{- range $v.AWSCNIRouteTableNames }}
   {{ .ResourceName }}:
     Type: AWS::EC2::RouteTable
@@ -16,7 +15,6 @@ const TemplateMainRouteTables = `
         Value: {{ .AvailabilityZone }}
       - Key: giantswarm.io/route-table-type
         Value: aws-cni
-  {{- end }}
   {{- end }}
   {{- range $v.PublicRouteTableNames }}
   {{ .ResourceName }}:

--- a/service/controller/resource/tccp/template/template_main_subnets.go
+++ b/service/controller/resource/tccp/template/template_main_subnets.go
@@ -3,7 +3,6 @@ package template
 const TemplateMainSubnets = `
 {{- define "subnets" -}}
 {{- $v := .Subnets }}
-  {{- if .EnableAWSCNI }}
   {{- range $v.AWSCNISubnets }}
   {{ .Name }}:
     Type: AWS::EC2::Subnet
@@ -23,7 +22,6 @@ const TemplateMainSubnets = `
     Properties:
       RouteTableId: !Ref {{ .RouteTableAssociation.RouteTableName }}
       SubnetId: !Ref {{ .RouteTableAssociation.SubnetName }}
-  {{- end }}
   {{- end }}
   {{- range $v.PublicSubnets }}
   {{ .Name }}:

--- a/service/controller/resource/tccp/template/template_main_vpc.go
+++ b/service/controller/resource/tccp/template/template_main_vpc.go
@@ -12,7 +12,7 @@ const TemplateMainVPC = `
       Tags:
         - Key: Name
           Value: {{ $v.ClusterID }}
-  {{- if .EnableAWSCNI }}
+  {{- if $v.CIDRBlockAWSCNI }}
   VPCCIDRBlockAWSCNI:
     Type: AWS::EC2::VPCCidrBlock
     DependsOn:

--- a/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-0-basic-test-route53-enabled.golden
@@ -640,60 +640,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:

--- a/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
+++ b/service/controller/resource/tccp/testdata/case-1-basic-test-route53-disabled.golden
@@ -552,60 +552,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:

--- a/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
+++ b/service/controller/resource/tccp/testdata/case-2-basic-test-with-api-whitelist-enabled.golden
@@ -589,60 +589,6 @@ Resources:
       IpProtocol: -1
       CidrIp: 127.0.0.1/32
   
-  AWSCNISubnetEuCentral1a:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1a
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1a
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1a:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1a
-      SubnetId: !Ref AWSCNISubnetEuCentral1a
-  AWSCNISubnetEuCentral1b:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1b
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1b
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1b:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1b
-      SubnetId: !Ref AWSCNISubnetEuCentral1b
-  AWSCNISubnetEuCentral1c:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-    - VPCCIDRBlockAWSCNI
-    Properties:
-      AvailabilityZone: eu-central-1c
-      CidrBlock: <nil>
-      Tags:
-      - Key: Name
-        Value: AWSCNISubnetEuCentral1c
-      - Key: giantswarm.io/subnet-type
-        Value: aws-cni
-      VpcId: !Ref VPC
-  AWSCNISubnetRouteTableAssociationEuCentral1c:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref AWSCNIRouteTableEuCentral1c
-      SubnetId: !Ref AWSCNISubnetEuCentral1c
   PublicSubnetEuCentral1a:
     Type: AWS::EC2::Subnet
     Properties:

--- a/service/controller/resource/tccpazs/create.go
+++ b/service/controller/resource/tccpazs/create.go
@@ -196,6 +196,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		var awsCNISubnet net.IPNet
 		if key.IsAWSCNINeeded(cluster) {
+			r.logger.Debug(ctx, "EnsureCreated inside if key.IsAWSCNINeeded(cluster)")
 			// Allow the actual VPC subnet CIDR to be overwritten by the CR spec.
 			podSubnet := r.cidrBlockAWSCNI
 			if key.PodsCIDRBlock(awsCluster) != "" {
@@ -209,6 +210,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 			awsCNISubnet = *sn
 		} else {
+			r.logger.Debug(ctx, "EnsureCreated inside else")
 			// If there is an aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr annotation set, means we are running cilium but still want the AWS cni subnets to be created using the old CIDR
 			if key.LegacyAWSCniCIDRBlock(awsCluster) != "" {
 				podSubnet := key.LegacyAWSCniCIDRBlock(awsCluster)

--- a/service/controller/resource/tccpazs/create.go
+++ b/service/controller/resource/tccpazs/create.go
@@ -400,6 +400,8 @@ func (r *Resource) ensureAZsAreAssignedWithSubnet(ctx context.Context, awsCNISub
 			// Needed when switching from aws-cni to cilium, in order to delete aws-cni subnets.
 			mapping.AWSCNI.Subnet.CIDR = net.IPNet{}
 			mapping.AWSCNI.Subnet.ID = ""
+
+			azMapping[az] = mapping
 		}
 	}
 

--- a/service/controller/resource/tccpazs/create.go
+++ b/service/controller/resource/tccpazs/create.go
@@ -395,11 +395,11 @@ func (r *Resource) ensureAZsAreAssignedWithSubnet(ctx context.Context, awsCNISub
 				} else {
 					return nil, microerror.Maskf(invalidConfigError, "no free subnets left for allocation despite additional availability zone %#q", az)
 				}
-			} else {
-				// Needed when switching from aws-cni to cilium, in order to delete aws-cni subnets.
-				mapping.AWSCNI.Subnet.CIDR = net.IPNet{}
-				mapping.AWSCNI.Subnet.ID = ""
 			}
+		} else {
+			// Needed when switching from aws-cni to cilium, in order to delete aws-cni subnets.
+			mapping.AWSCNI.Subnet.CIDR = net.IPNet{}
+			mapping.AWSCNI.Subnet.ID = ""
 		}
 	}
 

--- a/service/controller/resource/tccpazs/create.go
+++ b/service/controller/resource/tccpazs/create.go
@@ -169,8 +169,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		// Allow the actual VPC subnet CIDR to be overwritten by the CR spec.
 		podSubnet := r.cidrBlockAWSCNI
-		if key.AWSCNIPodsCIDRBlock(cl) != "" {
-			podSubnet = key.AWSCNIPodsCIDRBlock(cl)
+		if key.PodsCIDRBlock(cl) != "" {
+			podSubnet = key.PodsCIDRBlock(cl)
+		}
+		// If there is an TODO annotation set, means we are running cilium but still want the AWS cni subnets to be created using the old CIDR
+		if key.LegacyAWSCniCIDRBlock(cl) != "" {
+			podSubnet = key.LegacyAWSCniCIDRBlock(cl)
 		}
 
 		_, awsCNISubnet, err := net.ParseCIDR(podSubnet)

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -380,7 +380,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 	// Pod CIDR precedence:
 	// 1) cilium-specific annotation (used during upgrades from v17 to v18+)
 	// 2) awscluster podcidr field (used for new clusters where overlap with VPC is not important).
-	podCidr := key.AWSCNIPodsCIDRBlock(cl)
+	podCidr := key.PodsCIDRBlock(cl)
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
 		podCidr = key.CiliumPodsCIDRBlock(cluster)
 	}

--- a/service/internal/unittest/default_cluster.go
+++ b/service/internal/unittest/default_cluster.go
@@ -99,6 +99,9 @@ func DefaultCluster() infrastructurev1alpha3.AWSCluster {
 }
 
 func DefaultCAPIClusterWithLabels(clusterID string, labels map[string]string) apiv1beta1.Cluster {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	labels[label.Cluster] = clusterID
 	cr := apiv1beta1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2407

I tested:

- new v18 cluster with this aws operator
- new v19 cluster with this aws operator
- upgrade v18 to v19 (aws cni subnets kept)
- remove annotation after upgrade, aws cni subnet deleted after kicking cloudformation

## Checklist

- [x] Update changelog in CHANGELOG.md.
