### PR TITLE
Keep aws cni redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [14.15.0] - 2023-04-25
 
+### Changed
+
+- Do not delete aws-cni subnets when switching to cilium.
+
 ### Fixed
 
 - Allow to enable ACLs for a S3 buckets.

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,5 +3,6 @@ package annotation
 const (
 	Docs                    = "giantswarm.io/docs"
 	InstanceID              = "aws-operator.giantswarm.io/instance"
+	LegacyAwsCniPodCidr     = "aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr"
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
 )

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/blang/semver"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -127,12 +128,16 @@ func ExternalSNAT(cluster infrastructurev1alpha3.AWSCluster) *bool {
 	return cluster.Spec.Provider.Pods.ExternalSNAT
 }
 
-func AWSCNIPodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+func PodsCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
 	return cluster.Spec.Provider.Pods.CIDRBlock
 }
 
 func CiliumPodsCIDRBlock(cluster apiv1beta1.Cluster) string {
 	return cluster.Annotations[annotation.CiliumPodCidr]
+}
+
+func LegacyAWSCniCIDRBlock(cluster infrastructurev1alpha3.AWSCluster) string {
+	return cluster.Annotations[awsoperatorannotation.LegacyAwsCniPodCidr]
 }
 
 func EtcdQuotaBackendBytes(cluster apiv1beta1.Cluster) int64 {

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/blang/semver"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
-	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/pkg/label"
 	"github.com/giantswarm/aws-operator/v14/pkg/project"
 )

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
@@ -145,6 +146,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
+		r.logger.Debugf(ctx, "Migrating AWS CNI pod cidr from AWSCluster.Spec.Provider.Pods.CIDRBlock to %q annotation", awsoperatorannotation.LegacyAwsCniPodCidr)
+		if cr.Annotations == nil {
+			cr.Annotations = make(map[string]string)
+		}
+		cr.Annotations[awsoperatorannotation.LegacyAwsCniPodCidr] = cr.Spec.Provider.Pods.CIDRBlock
+
 		r.logger.Debugf(ctx, "Migrating cilium pod cidr from %q annotation to AWSCluster.Spec.Provider.Pods.CIDRBlock", annotation.CiliumPodCidr)
 
 		// Update pod cidr on AWSCluster CR

--- a/service/controller/resource/awscnicleaner/create.go
+++ b/service/controller/resource/awscnicleaner/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
@@ -15,6 +14,7 @@ import (
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	awsoperatorannotation "github.com/giantswarm/aws-operator/v14/pkg/annotation"
 	"github.com/giantswarm/aws-operator/v14/service/controller/controllercontext"
 	"github.com/giantswarm/aws-operator/v14/service/controller/key"
 )

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -380,7 +380,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 	// Pod CIDR precedence:
 	// 1) cilium-specific annotation (used during upgrades from v17 to v18+)
 	// 2) awscluster podcidr field (used for new clusters where overlap with VPC is not important).
-	podCidr := key.AWSCNIPodsCIDRBlock(cl)
+	podCidr := key.PodsCIDRBlock(cl)
 	if key.CiliumPodsCIDRBlock(cluster) != "" {
 		podCidr = key.CiliumPodsCIDRBlock(cluster)
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2407

Before upgrading to v18, we have the aws-cni resources:

![before-upgrade](https://user-images.githubusercontent.com/868430/235108754-208d762e-2068-4360-aaea-b3fdcddd3616.png)
![before-upgrade-resources](https://user-images.githubusercontent.com/868430/235108760-152a34f3-3262-48de-bf6a-6352e718a6a1.png)

During migration, an annotation `aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr` is set and the aws cni resources are kept (except one NAT routing rule but that's fine)

![after-upgrade-with-annotation](https://user-images.githubusercontent.com/868430/235108879-e8d92fd7-2376-4d0d-924e-350f1fbda6b6.png)
![after-upgrade-with-annotation-resources](https://user-images.githubusercontent.com/868430/235108885-527a3485-e643-45e1-97e5-6da301f8df86.png)

you can cleanup aws cni resources by manually removing the `aws-operator.giantswarm.io/legacy-aws-cni-pod-cidr` annotation

![after-upgrade-without-annotation](https://user-images.githubusercontent.com/868430/235109074-5dbb9f7f-0b0b-44fb-abe2-b1483848994b.png)
![after-upgrade-without-annotation-resources](https://user-images.githubusercontent.com/868430/235109078-97823515-c136-433a-b700-e074b4426507.png)



## Checklist

- [x] Update changelog in CHANGELOG.md.
