### PR TITLE
Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.
+
 ## [14.17.0] - 2023-05-05
 
 ### Changed

--- a/service/internal/cloudconfig/template/aws_cni.go
+++ b/service/internal/cloudconfig/template/aws_cni.go
@@ -143,6 +143,18 @@ spec:
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+        - image: {{.RegistryDomain}}/giantswarm/alpine:3.17.3
+          imagePullPolicy: Always
+          name: setup-sysctl
+          command:
+          - ash
+          - "-c"
+          - "echo 'net.ipv4.conf.eth0.rp_filter=2' >/host/etc/sysctl.d/99-aws-node.conf"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/etc/sysctl.d
+              name: sysctl-d
       containers:
         - image: {{.RegistryDomain}}/giantswarm/aws-cni:v{{.AWSCNIVersion}}
           ports:
@@ -282,6 +294,10 @@ spec:
             path: /var/run/aws-node
             type: DirectoryOrCreate
           name: run-dir
+        - hostPath:
+            path: /etc/sysctl.d
+            type: DirectoryOrCreate
+          name: sysctl-d
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26858

during cilium app installation, the cilium agent pod runs `systemctl restart systemd-sysctl.service`.
This makes sysctl restore default settings and clean up any changes made "by hand".
This includes one important setting, set by aws-cni during initialization: `net.ipv4.conf.eth0.rp_filter`.

This made aws-CNI break during upgrades from v18 to v19 as soon as the cilium app was installed.

This PR writes the aforementioned sysctl setting into the /etc/sysctl.d directory in order to make it survive systemd-sysctl restarts.

## Checklist

- [x] Update changelog in CHANGELOG.md.
