### PR TITLE
Fix routes fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.
+- Make `routes-fixer` script compatible with alpine.
 
 ## [14.17.0] - 2023-05-05
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.17.1-whites"
+	version            = "14.17.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.17.1-dev"
+	version            = "14.17.1-whites"
 )
 
 func Description() string {

--- a/service/controller/resource/prepareawscniformigration/script.go
+++ b/service/controller/resource/prepareawscniformigration/script.go
@@ -17,7 +17,7 @@ do
   sleep 5
 done
 
-lines="$(ip route show table all|grep "scope link" |grep -Po "dev \Keth[0-9*] table [0-9]+"|sed 's/ table /|/')"
+lines="$(ip route show table all|grep "scope link"|grep -E "dev eth[0-9]+ table [0-9]+"|awk '{ print $3 "|" $5 }')"
 
 while : ; do
   for line in $lines


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26915

the script we use to set up routes between aws-cni and cilium during upgrade does not work on alpine because we used an unsupported flag of `grep`.
This PR changes the script to make it work with alpine

## Checklist

- [x] Update changelog in CHANGELOG.md.
