### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for new control-plane taint.
+
 ### Fixed
 
 - Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.

--- a/service/internal/cloudconfig/template/aws_cni.go
+++ b/service/internal/cloudconfig/template/aws_cni.go
@@ -428,4 +428,6 @@ spec:
           tolerations:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
 `


### PR DESCRIPTION
This PR adds a toleration for the node-role.kubernetes.io/control-plane taint to resources that already have a toleration to the deprecated node-role.kubernetes.io/master taint.
Towards https://github.com/giantswarm/roadmap/issues/2471

## Checklist

- [x] Update changelog in CHANGELOG.md.
