### PR TITLE
Add support for customizing `controller-manager` `terminated-pod-gc-threshold` value through annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for customizing `controller-manager` `terminated-pod-gc-threshold` value through annotation `controllermanager.giantswarm.io/terminated-pod-gc-threshold`
+
 ### Changed
 
 - Check if all nodes are rolled before deleting AWS CNI resources when upgrading from v18 to v19.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd
+	github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d
 	github.com/giantswarm/k8smetadata v0.20.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0
@@ -51,7 +51,6 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
 	github.com/giantswarm/exporterkit v1.0.0 // indirect
-	github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d // indirect
 	github.com/giantswarm/microstorage v0.2.0 // indirect
 	github.com/giantswarm/versionbundle v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v16 v16.2.0
+	github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd
 	github.com/giantswarm/k8smetadata v0.20.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0
@@ -51,6 +51,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
 	github.com/giantswarm/exporterkit v1.0.0 // indirect
+	github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d // indirect
 	github.com/giantswarm/microstorage v0.2.0 // indirect
 	github.com/giantswarm/versionbundle v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/certs/v4 v4.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d
+	github.com/giantswarm/k8scloudconfig/v16 v16.4.0
 	github.com/giantswarm/k8smetadata v0.20.0
 	github.com/giantswarm/kubelock/v4 v4.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d h1:1Y+PQNzroWM4DP8i2SW50p3sAFw7uIbz94HwxKtcthw=
-github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
 github.com/giantswarm/k8scloudconfig/v16 v16.4.0 h1:WCYNSfdrPfN/rGmQDwkUjnkNd3cmKr+SktyX/l7WfBI=
 github.com/giantswarm/k8scloudconfig/v16 v16.4.0/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
 github.com/giantswarm/k8smetadata v0.20.0 h1:wvKD2SkFsNxQkbnvRbq/e2DHVqoQVeNxehGOmcIdTL8=

--- a/go.sum
+++ b/go.sum
@@ -232,12 +232,8 @@ github.com/giantswarm/ipam v0.3.0 h1:QNb4k5Zu6nGsqJkAM7dLM1J6TiUP+LGjo9CPR+ewZBk
 github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73XCECdk+I=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v16 v16.2.0 h1:10CurD+EPF7ALoqyZCvqKG1jZ6hLWlH/B8XFugmSRdo=
-github.com/giantswarm/k8scloudconfig/v16 v16.2.0/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
 github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d h1:1Y+PQNzroWM4DP8i2SW50p3sAFw7uIbz94HwxKtcthw=
 github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
-github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd h1:l0szjFGwsUtAjWAzo3b+dU5togcnHu8keuRkOvtwjFQ=
-github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd/go.mod h1:peChY0p9SloYvoQfx5zCXIU6T//QdkG4y8LgFEWyuE4=
 github.com/giantswarm/k8smetadata v0.20.0 h1:wvKD2SkFsNxQkbnvRbq/e2DHVqoQVeNxehGOmcIdTL8=
 github.com/giantswarm/k8smetadata v0.20.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,10 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v16 v16.2.0 h1:10CurD+EPF7ALoqyZCvqKG1jZ6hLWlH/B8XFugmSRdo=
 github.com/giantswarm/k8scloudconfig/v16 v16.2.0/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
+github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d h1:1Y+PQNzroWM4DP8i2SW50p3sAFw7uIbz94HwxKtcthw=
+github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
+github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd h1:l0szjFGwsUtAjWAzo3b+dU5togcnHu8keuRkOvtwjFQ=
+github.com/giantswarm/k8scloudconfig/v17 v17.1.1-0.20230629130752-558a07b6fbbd/go.mod h1:peChY0p9SloYvoQfx5zCXIU6T//QdkG4y8LgFEWyuE4=
 github.com/giantswarm/k8smetadata v0.20.0 h1:wvKD2SkFsNxQkbnvRbq/e2DHVqoQVeNxehGOmcIdTL8=
 github.com/giantswarm/k8smetadata v0.20.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d h1:1Y+PQNzroWM4DP8i2SW50p3sAFw7uIbz94HwxKtcthw=
 github.com/giantswarm/k8scloudconfig/v16 v16.3.1-0.20230629142511-142d629b2e1d/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
+github.com/giantswarm/k8scloudconfig/v16 v16.4.0 h1:WCYNSfdrPfN/rGmQDwkUjnkNd3cmKr+SktyX/l7WfBI=
+github.com/giantswarm/k8scloudconfig/v16 v16.4.0/go.mod h1:9QNKXwjyBCWup2ek+kRZ356zw38QhQ2QgwuHuK9zzQo=
 github.com/giantswarm/k8smetadata v0.20.0 h1:wvKD2SkFsNxQkbnvRbq/e2DHVqoQVeNxehGOmcIdTL8=
 github.com/giantswarm/k8smetadata v0.20.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubelock/v4 v4.0.0 h1:qvFGOIlDthAD8r32WcorT8R4gp3c1dpnDbHuLsDU2ZA=

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.17.2-dev"
+	version            = "14.17.2-dev-fc1"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "aws-operator"
 	source      string = "https://github.com/giantswarm/aws-operator"
-	version            = "14.17.2-dev-fc1"
+	version            = "14.17.2-dev"
 )
 
 func Description() string {

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -159,14 +159,14 @@ func ControllerManagerTerminatedPodGcThreshold(cluster apiv1beta1.Cluster) int {
 	if str != "" {
 		i, err := strconv.Atoi(str)
 		if err != nil {
-      // when 0 is returned than the default value configured in k8scloudconfig will be used
+			// when 0 is returned than the default value configured in k8scloudconfig will be used
 			return 0
 		}
 
 		return int(i)
 	}
 
-  // when 0 is returned than the default value configured in k8scloudconfig will be used
+	// when 0 is returned than the default value configured in k8scloudconfig will be used
 	return 0
 }
 

--- a/service/controller/key/cluster.go
+++ b/service/controller/key/cluster.go
@@ -154,6 +154,22 @@ func EtcdQuotaBackendBytes(cluster apiv1beta1.Cluster) int64 {
 	return 0
 }
 
+func ControllerManagerTerminatedPodGcThreshold(cluster apiv1beta1.Cluster) int {
+	str := cluster.Annotations["controllermanager.giantswarm.io/terminated-pod-gc-threshold"]
+	if str != "" {
+		i, err := strconv.Atoi(str)
+		if err != nil {
+      // when 0 is returned than the default value configured in k8scloudconfig will be used
+			return 0
+		}
+
+		return int(i)
+	}
+
+  // when 0 is returned than the default value configured in k8scloudconfig will be used
+	return 0
+}
+
 // HasCilium returns true if the release uses cilium as CNI. Cilium will be added in v19, so any release >= v19.0.0
 func HasCilium(cluster LabelsGetter) (bool, error) {
 	release := cluster.GetLabels()[label.Release]

--- a/service/internal/cloudconfig/tccpn.go
+++ b/service/internal/cloudconfig/tccpn.go
@@ -542,6 +542,7 @@ func (t *TCCPN) newTemplate(ctx context.Context, obj interface{}, mapping hamast
 		params.Kubernetes.Apiserver.ServiceAccountSigningKeyFilePath = serviceAccountSigningKeyFilePath
 		params.Kubernetes.Kubelet.CommandExtraArgs = kubeletExtraArgs
 		params.Kubernetes.ControllerManager.CommandExtraArgs = controllerManagerExtraArgs
+		params.ControllerManagerTerminatedPodGcThreshold = key.ControllerManagerTerminatedPodGcThreshold(cluster)
 		params.RegistryMirrors = t.config.RegistryMirrors
 		params.SSOPublicKey = t.config.SSOPublicKey
 		params.Images = im


### PR DESCRIPTION
annotation `controllermanager.giantswarm.io/terminated-pod-gc-threshold`

Towards https://github.com/giantswarm/klingel/issues/91

## Tests

- [x] Create new WC cluster with default value
  - [x] update annotation value 
- [x] create cluster with old release and update release

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Release `k8scloudconfig` v16.4.0 and update go.mod - see https://github.com/giantswarm/k8scloudconfig/tree/allow-customizing-terminated-pod-gc-threshold-v16
- [x] revert fake version in project.go
