### PR TITLE
Update cluster-autoscaler permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
 - Emit event when an unhealthy node is terminated.
 - Bump `badnodedetector` to be able to use `node-problem-detector` app for unhealthy node termination.
+- Add a additional IAM permission for `cluster-autoscaler`.
 
 ## [14.23.0] - 2023-10-04
 

--- a/service/controller/resource/tccpn/template/template_main_iam_policies.go
+++ b/service/controller/resource/tccpn/template/template_main_iam_policies.go
@@ -60,6 +60,7 @@ const TemplateMainIAMPolicies = `
             Action:
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeScalingActivities"
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "autoscaling:SetInstanceHealth"

--- a/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-0-basic-test-with-encrypter-backend-KMS-route53-enabled.golden
@@ -137,6 +137,7 @@ Resources:
             Action:
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeScalingActivities"
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "autoscaling:SetInstanceHealth"

--- a/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
+++ b/service/controller/resource/tccpn/testdata/case-1-basic-test-with-encrypter-backend-KMS-route53-disabled.golden
@@ -137,6 +137,7 @@ Resources:
             Action:
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeScalingActivities"
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "autoscaling:SetInstanceHealth"

--- a/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
+++ b/service/controller/resource/tccpn/testdata/case-2-basic-test-with-encrypter-backend-KMS-ha-masters.golden
@@ -327,6 +327,7 @@ Resources:
             Action:
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeScalingActivities"
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "autoscaling:SetInstanceHealth"

--- a/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
+++ b/service/controller/resource/tccpn/testdata/case-3-basic-test-with-ebs-volume-iops-and-throughput-set.golden
@@ -139,6 +139,7 @@ Resources:
             Action:
               - "autoscaling:DescribeAutoScalingGroups"
               - "autoscaling:DescribeAutoScalingInstances"
+              - "autoscaling:DescribeScalingActivities"
               - "autoscaling:DescribeTags"
               - "autoscaling:DescribeLaunchConfigurations"
               - "autoscaling:SetInstanceHealth"


### PR DESCRIPTION
With Cluster Autoscaler 1.24.x upstream introduced an early [no capacity check](https://github.com/kubernetes/autoscaler/pull/4489) for AWS node groups.

This requires an additional IAM permission which we don’t have in the instance profile for 
master nodes.

`autoscaling:DescribeScalingActivities`

They didn’t mention it in the [release notes of 1.24.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.24.0) as a requirement, but they changed the docs quoting this permission is one of the bare [minimum permissions](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#minimal-iam-permissions-policy) for a functional autoscaler.

## Checklist

- [x] Update changelog in CHANGELOG.md.