### PR TITLE
Tag disable autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `badnodedetector` to be able to use `node-problem-detector` app for unhealthy node termination.
 - Add a additional IAM permission for `cluster-autoscaler`.
 
+### Changed
+
+- Disable cluster autoscaler during rollouts of node pool ASGs.
+
 ## [14.23.0] - 2023-10-04
 
 ### Fixed

--- a/service/controller/resource/tcnp/autoscaler.go
+++ b/service/controller/resource/tcnp/autoscaler.go
@@ -1,0 +1,125 @@
+package tcnp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-operator/v14/service/controller/controllercontext"
+	"github.com/giantswarm/aws-operator/v14/service/controller/key"
+)
+
+func (r *Resource) getASGName(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDeployment) (string, error) {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	find := autoscaling.DescribeAutoScalingGroupsInput{
+		Filters: []*autoscaling.Filter{
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", key.TagInstallation)),
+				Values: []*string{
+					aws.String(r.installationName),
+				},
+			},
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
+				Values: []*string{
+					aws.String(key.ClusterID(&cr)),
+				},
+			},
+			{
+				Name: aws.String(fmt.Sprintf("tag:%s", key.TagMachineDeployment)),
+				Values: []*string{
+					aws.String(key.MachineDeploymentID(&cr)),
+				},
+			},
+		},
+		MaxRecords: aws.Int64(2),
+	}
+
+	// get ASG name
+	asgs, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(&find)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if len(asgs.AutoScalingGroups) != 1 {
+		return "", microerror.Maskf(asgLookupError, "Expected to find exactly 1 ASG, got %d", len(asgs.AutoScalingGroups))
+	}
+
+	return *asgs.AutoScalingGroups[0].AutoScalingGroupName, nil
+}
+
+func (r *Resource) ensureAutoscalerTag(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDeployment) error {
+	r.logger.Debugf(ctx, "Ensuring ASG for nodepool %s has %q tag", cr.Name, clusterAutoscalerEnabledTagName)
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	asgName, err := r.getASGName(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	input := autoscaling.CreateOrUpdateTagsInput{
+		Tags: []*autoscaling.Tag{
+			{
+				Key:               aws.String(clusterAutoscalerEnabledTagName),
+				PropagateAtLaunch: aws.Bool(false),
+				ResourceId:        aws.String(asgName),
+				ResourceType:      aws.String("auto-scaling-group"),
+				Value:             aws.String("true"),
+			},
+		},
+	}
+
+	_, err = cc.Client.TenantCluster.AWS.AutoScaling.CreateOrUpdateTags(&input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "Ensured ASG for nodepool %s has %q tag", cr.Name, clusterAutoscalerEnabledTagName)
+
+	return nil
+}
+
+func (r *Resource) removeAutoscalerTag(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDeployment) error {
+	r.logger.Debugf(ctx, "Removing tag %q from ASG for nodepool %s", clusterAutoscalerEnabledTagName, cr.Name)
+
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	asgName, err := r.getASGName(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	input := autoscaling.DeleteTagsInput{
+		Tags: []*autoscaling.Tag{
+			{
+				Key:          aws.String(clusterAutoscalerEnabledTagName),
+				ResourceId:   aws.String(asgName),
+				ResourceType: aws.String("auto-scaling-group"),
+			},
+		},
+	}
+
+	_, err = cc.Client.TenantCluster.AWS.AutoScaling.DeleteTags(&input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "Removed tag %q from ASG for nodepool %s", clusterAutoscalerEnabledTagName, cr.Name)
+
+	return nil
+}

--- a/service/controller/resource/tcnp/create.go
+++ b/service/controller/resource/tcnp/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -27,6 +26,8 @@ import (
 
 const (
 	capabilityNamesIAM = "CAPABILITY_NAMED_IAM"
+
+	clusterAutoscalerEnabledTagName = "k8s.io/cluster-autoscaler/enabled"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -155,12 +156,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 
 			if tccpnUpdated {
+				// Disable autoscaler for this node pool.
+				err = r.removeAutoscalerTag(ctx, cr)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
 				err = r.updateStack(ctx, cr)
 				if err != nil {
 					return microerror.Mask(err)
 				}
 			}
 		} else {
+			// Enable autoscaler for this node pool.
 			err = r.ensureAutoscalerTag(ctx, cr)
 			if err != nil {
 				return microerror.Mask(err)
@@ -928,64 +936,4 @@ func isTCCPNUpdated(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDep
 	}
 	// tccpn CF stack is updated and all master nodes have new operator version
 	return true, nil
-}
-
-func (r *Resource) ensureAutoscalerTag(ctx context.Context, cr infrastructurev1alpha3.AWSMachineDeployment) error {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	find := autoscaling.DescribeAutoScalingGroupsInput{
-		Filters: []*autoscaling.Filter{
-			{
-				Name: aws.String(fmt.Sprintf("tag:%s", key.TagInstallation)),
-				Values: []*string{
-					aws.String(r.installationName),
-				},
-			},
-			{
-				Name: aws.String(fmt.Sprintf("tag:%s", key.TagCluster)),
-				Values: []*string{
-					aws.String(key.ClusterID(&cr)),
-				},
-			},
-			{
-				Name: aws.String(fmt.Sprintf("tag:%s", key.TagMachineDeployment)),
-				Values: []*string{
-					aws.String(key.MachineDeploymentID(&cr)),
-				},
-			},
-		},
-		MaxRecords: aws.Int64(2),
-	}
-
-	// get ASG name
-	asgs, err := cc.Client.TenantCluster.AWS.AutoScaling.DescribeAutoScalingGroups(&find)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if len(asgs.AutoScalingGroups) != 1 {
-		return microerror.Maskf(asgLookupError, "Expected to find exactly 1 ASG, got %d", len(asgs.AutoScalingGroups))
-	}
-
-	input := autoscaling.CreateOrUpdateTagsInput{
-		Tags: []*autoscaling.Tag{
-			{
-				Key:               aws.String("k8s.io/cluster-autoscaler/enabled"),
-				PropagateAtLaunch: aws.Bool(false),
-				ResourceId:        asgs.AutoScalingGroups[0].AutoScalingGroupName,
-				ResourceType:      aws.String("auto-scaling-group"),
-				Value:             aws.String("true"),
-			},
-		},
-	}
-
-	_, err = cc.Client.TenantCluster.AWS.AutoScaling.CreateOrUpdateTags(&input)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
 }

--- a/service/controller/resource/tcnp/error.go
+++ b/service/controller/resource/tcnp/error.go
@@ -153,3 +153,12 @@ var tccpnNotUpdatedError = &microerror.Error{
 func IsTccpnNotUpdated(err error) bool {
 	return microerror.Cause(err) == tccpnNotUpdatedError
 }
+
+var asgLookupError = &microerror.Error{
+	Kind: "asgLookupError",
+}
+
+// IsAsgLookup asserts asgLookupError.
+func IsAsgLookup(err error) bool {
+	return microerror.Cause(err) == asgLookupError
+}

--- a/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
+++ b/service/controller/resource/tcnp/template/template_main_auto_scaling_group.go
@@ -54,9 +54,6 @@ const TemplateMainAutoScalingGroup = `
         - Key: Name
           Value: {{ .AutoScalingGroup.Cluster.ID }}-worker
           PropagateAtLaunch: true
-        - Key: k8s.io/cluster-autoscaler/enabled
-          Value: true
-          PropagateAtLaunch: false
         - Key: k8s.io/cluster-autoscaler/{{ .AutoScalingGroup.Cluster.ID }}
           Value: true
           PropagateAtLaunch: false

--- a/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-0-basic-test.golden
@@ -60,9 +60,6 @@ Resources:
         - Key: Name
           Value: 8y5ck-worker
           PropagateAtLaunch: true
-        - Key: k8s.io/cluster-autoscaler/enabled
-          Value: true
-          PropagateAtLaunch: false
         - Key: k8s.io/cluster-autoscaler/8y5ck
           Value: true
           PropagateAtLaunch: false

--- a/service/controller/resource/tcnp/testdata/case-1-disk-test.golden
+++ b/service/controller/resource/tcnp/testdata/case-1-disk-test.golden
@@ -60,9 +60,6 @@ Resources:
         - Key: Name
           Value: 8y5ck-worker
           PropagateAtLaunch: true
-        - Key: k8s.io/cluster-autoscaler/enabled
-          Value: true
-          PropagateAtLaunch: false
         - Key: k8s.io/cluster-autoscaler/8y5ck
           Value: true
           PropagateAtLaunch: false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28720

goal of this PR is disable autoscaler on a node pool while the asg is rolling nodes.

# Cluster creation:

CF stack for a NP does not contain the `k8s.io/cluster-autoscaler/enabled` tag as desired

![Screenshot_20231114_140752](https://github.com/giantswarm/aws-operator/assets/868430/df6803f1-8006-4fd0-b98a-42df8035bc03)

ASG gets correctly created without the tag as well

![Screenshot_20231114_141039](https://github.com/giantswarm/aws-operator/assets/868430/76b6b1fe-ae9b-4332-8093-cc99556338ab)

AWS operator does another reconciliation loop and adds the tag:

![Screenshot_20231114_141345](https://github.com/giantswarm/aws-operator/assets/868430/8f33ba2e-324f-400c-96ed-cd1a739b31f0)

# Upgrade

The tag is removed fine and CF does not add it back.

after CF is correctly updated, the tag is added back. works nicely!


## Checklist

- [x] Update changelog in CHANGELOG.md.
