### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.34.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
@@ -29,51 +29,16 @@ workflows:
 
       # Ensure that for every commit (all branches), and for every new release tag,
       # an image is pushed to Quay.
-      - architect/push-to-docker:
+      - architect/push-to-registries:
           context: architect
-          name: push-to-quay
-          image: "quay.io/giantswarm/aws-operator"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+          name: push-to-registries
           requires:
+            - hold-push-to-aliyun-pr
             - go-build
           filters:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          context: architect
-          name: push-to-docker
-          image: "docker.io/giantswarm/aws-operator"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      # Ensure that for every commit to master, and for every new release tag,
-      # an image gets pushed to the Aliyun registry.
-      - architect/push-to-docker:
-          name: push-to-aliyun
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/aws-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          context: architect
-          requires:
-            - go-build
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^v.*/
-
-      # Allow that for every commit (to a branch other than master),
-      # and for every new tag that is not a release tag,
-      # an image _can_ get pushed to the Aliyun registry
-      # if manually approved.
       - hold-push-to-aliyun-pr:
           type: approval
           context: architect
@@ -84,22 +49,6 @@ workflows:
               ignore: master
             tags:
               ignore: /^v.*/
-      - architect/push-to-docker:
-          name: push-to-aliyun-pr
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/aws-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          context: architect
-          requires:
-            - hold-push-to-aliyun-pr
-          filters:
-            branches:
-              ignore: master
-            tags:
-              ignore: /.*/
-
-      # Ensure that for every commit to master and for every
-      # release tag, there is an app version in the catalog.
       - architect/push-to-app-catalog:
           name: push-to-app-catalog-master
           app_catalog: "control-plane-catalog"
@@ -107,9 +56,7 @@ workflows:
           chart: "aws-operator"
           context: architect
           requires:
-            - push-to-aliyun
-            - push-to-quay
-            - push-to-docker
+            - push-to-registries
           filters:
             branches:
               only: master
@@ -127,8 +74,7 @@ workflows:
           chart: "aws-operator"
           context: architect
           requires:
-            - push-to-quay
-            - push-to-docker
+            - push-to-registries
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,3 @@
-# TODO the workflow is unnecessary complicated due to some deficiencies in our
-# deployment pipeline as of time of writing. Therefore the push to Aliyun is
-# kind of optional in pull requests so that it does not block the push to the
-# app catalog. This is to have faster iterations when working on a daily basis.
-# Nevertheless we want the image push to Aliyun to be finished before we want to
-# push to the app catalog in case we merge to master or push a tag, which
-# indicates a new release. This is to have a more reliable pipeline, with the
-# caveat that it takes longer and sometimes even breaks. Once the situation got
-# improved we can simplify the circle config again as modified in the pull
-# request linked below.
-#
-#     https://github.com/giantswarm/aws-operator/pull/2347
-#
 version: 2.1
 
 orbs:
@@ -27,30 +14,17 @@ workflows:
             tags:
               only: /^v.*/
 
-      # Ensure that for every commit (all branches), and for every new release tag,
-      # an image is pushed to Quay.
       - architect/push-to-registries:
           context: architect
           name: push-to-registries
           requires:
-            - hold-push-to-aliyun-pr
             - go-build
           filters:
             tags:
               only: /^v.*/
 
-      - hold-push-to-aliyun-pr:
-          type: approval
-          context: architect
-          requires:
-            - go-build
-          filters:
-            branches:
-              ignore: master
-            tags:
-              ignore: /^v.*/
       - architect/push-to-app-catalog:
-          name: push-to-app-catalog-master
+          name: push-to-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-operator"
@@ -58,23 +32,5 @@ workflows:
           requires:
             - push-to-registries
           filters:
-            branches:
-              only: master
             tags:
               only: /^v.*/
-
-      # Ensure that for every commit (branch other than master)
-      # there is an app version in the test catalog.
-      # Note: Making this app usable in china needs manual approval
-      # of the 'hold-push-to-aliyun-pr' job.
-      - architect/push-to-app-catalog:
-          name: push-to-app-catalog-pr
-          app_catalog: "control-plane-catalog"
-          app_catalog_test: "control-plane-test-catalog"
-          chart: "aws-operator"
-          context: architect
-          requires:
-            - push-to-registries
-          filters:
-            branches:
-              ignore: master


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!