### PR TITLE
Handle karpenter nodes in node-termination-handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [15.0.1] - 2024-01-31
-
 ### Fixed
 
-- Fix Route53 list hosted zones to avoid pagination issue.
+- Handle karpenter nodes in node-termination-handler.
 
 ## [16.0.0] - 2024-01-16
 
@@ -1080,8 +1078,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-[Unreleased]: https://github.com/giantswarm/aws-operator/compare/v15.0.1...HEAD
-[15.0.1]: https://github.com/giantswarm/aws-operator/compare/v16.0.0...v15.0.1
+[Unreleased]: https://github.com/giantswarm/aws-operator/compare/v16.0.0...HEAD
 [16.0.0]: https://github.com/giantswarm/aws-operator/compare/v15.0.0...v16.0.0
 [15.0.0]: https://github.com/giantswarm/aws-operator/compare/v14.24.1...v15.0.0
 [14.24.1]: https://github.com/giantswarm/aws-operator/compare/v14.24.0...v14.24.1


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30092

node-problem-detector based node termination for disk full does not work with karpenter nodes.
this PR fixes that

## Checklist

- [x] Update changelog in CHANGELOG.md.
