### PR TITLE
Exclude default branch in some CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ workflows:
           requires:
             - go-build
           filters:
+            branches:
+              ignore:
+                - main
+                - master
             tags:
               only: /^v.*/
 
@@ -32,5 +36,9 @@ workflows:
           requires:
             - push-to-registries
           filters:
+            branches:
+              ignore:
+                - main
+                - master
             tags:
               only: /^v.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31824

This PR should exclude commits to the default branch from triggering the "push-to-registries" and "push-to-app-catalog" workflows. The assumption is that these workflows should be triggered only by pushes to non-default branches and by release tags.

The reason we are making this PR is that we have encountered problems with container image replication that are likely caused by fast pushes of the same image tag with different content. In addition, this will help us avoid obsolete CI runs.

As a code owner, please review and merge this PR if possible.

If you have reasons to keep these workflows running for the default branch, please let us (Honeybadger) know. Thank you!